### PR TITLE
Add GC-balanced CLI customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
     *   **Base-4 Direct Mapping:** (As described before)
     *   **Huffman-4 Coding:** (As described before)
     *   **GC-Balanced Encoder (`gc_balanced`):**
-        *   Aims to produce DNA sequences within a target GC content range (currently fixed at 45-55%) and with a maximum homopolymer run length (currently fixed at 3).
+        *   Aims to produce DNA sequences within a target GC content range and with a maximum homopolymer run length.
+        *   These constraints can be tuned via `--gc-min`, `--gc-max`, and `--max-homopolymer` (defaults: `0.45`, `0.55`, `3`).
         *   It first attempts to encode data directly (using Base-4 Direct). If constraints are met, the sequence is prefixed with '0'.
         *   If constraints are violated, the input data bits are inverted, re-encoded, and the sequence is prefixed with '1'. This provides an alternative sequence that might meet constraints.
         *   The FASTA header includes `method=gc_balanced`, `gc_min`, `gc_max`, and `max_homopolymer` (target constraint values).
@@ -133,7 +134,9 @@ To use GeneCoder CLI, navigate to the project's root directory. The main script 
 
 6.  **Batch encode multiple files using GC-Balanced method to a specified directory:**
     ```bash
-    python src/cli.py encode --input-files file1.txt notes.md image.png --output-dir gc_encoded_batch/ --method gc_balanced
+    python src/cli.py encode --input-files file1.txt notes.md image.png \
+        --output-dir gc_encoded_batch/ --method gc_balanced \
+        --gc-min 0.40 --gc-max 0.60 --max-homopolymer 4
     ```
     *Output: `gc_encoded_batch/file1.txt.fasta`, `gc_encoded_batch/notes.md.fasta`, etc.*
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -77,7 +77,9 @@ def process_single_encode(input_file_path: str, output_file_path: str, args: arg
                 fasta_header_parts.extend([f"parity_k={args.k_value}", f"parity_rule={args.parity_rule}"])
 
         elif args.method == 'gc_balanced':
-            target_gc_min, target_gc_max, max_homopolymer_constraint = 0.45, 0.55, 3
+            target_gc_min = args.gc_min
+            target_gc_max = args.gc_max
+            max_homopolymer_constraint = args.max_homopolymer
             if should_add_parity: # Parity is not part of gc_balanced's core logic
                 print(f"Warning for {input_file_path}: --add-parity not directly used by 'gc_balanced' core logic.", file=sys.stderr)
             raw_encoded_dna = encode_gc_balanced(
@@ -351,6 +353,24 @@ def main() -> None:
         default=None,
         choices=[None, 'triple_repeat', 'hamming_7_4'], # Added hamming_7_4
         help='Forward Error Correction method to apply. Optional. (Note: hamming_7_4 is applied to binary data before DNA encoding; triple_repeat is applied to DNA sequence after encoding).'
+    )
+    encode_parser.add_argument(
+        "--gc-min",
+        type=float,
+        default=0.45,
+        help="Minimum GC content for gc_balanced encoding (default: 0.45)."
+    )
+    encode_parser.add_argument(
+        "--gc-max",
+        type=float,
+        default=0.55,
+        help="Maximum GC content for gc_balanced encoding (default: 0.55)."
+    )
+    encode_parser.add_argument(
+        "--max-homopolymer",
+        type=int,
+        default=3,
+        help="Maximum homopolymer length for gc_balanced encoding (default: 3)."
     )
 
     # Decode command parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,64 @@ def test_batch_encode_single_file_with_output_dir(temp_dir: Path):
     expected_output_file = output_dir / ("file1.txt.fasta")
     assert expected_output_file.exists(), f"Output file {expected_output_file} was not created."
 
+
+def test_gc_balanced_params_in_header_default_and_custom(temp_dir: Path):
+    """Verify gc_balanced CLI parameters are parsed and appear in FASTA headers."""
+    input_dir = temp_dir / "input_gc"
+    output_dir = temp_dir / "output_gc"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    # File for default parameters
+    default_file = input_dir / "default.txt"
+    default_file.write_text("default")
+
+    cmd_default = [
+        "encode",
+        "--input-files",
+        str(default_file),
+        "--output-dir",
+        str(output_dir),
+        "--method",
+        "gc_balanced",
+    ]
+    result_default = run_cli_command(cmd_default)
+    assert result_default.returncode == 0, f"Default encode failed: {result_default.stderr}"
+    default_out = output_dir / "default.txt.fasta"
+    assert default_out.exists()
+    header_default = default_out.read_text().splitlines()[0]
+    assert "gc_min=0.45" in header_default
+    assert "gc_max=0.55" in header_default
+    assert "max_homopolymer=3" in header_default
+
+    # File for custom parameters
+    custom_file = input_dir / "custom.txt"
+    custom_file.write_text("custom")
+
+    cmd_custom = [
+        "encode",
+        "--input-files",
+        str(custom_file),
+        "--output-dir",
+        str(output_dir),
+        "--method",
+        "gc_balanced",
+        "--gc-min",
+        "0.4",
+        "--gc-max",
+        "0.6",
+        "--max-homopolymer",
+        "4",
+    ]
+    result_custom = run_cli_command(cmd_custom)
+    assert result_custom.returncode == 0, f"Custom encode failed: {result_custom.stderr}"
+    custom_out = output_dir / "custom.txt.fasta"
+    assert custom_out.exists()
+    header_custom = custom_out.read_text().splitlines()[0]
+    assert "gc_min=0.4" in header_custom
+    assert "gc_max=0.6" in header_custom
+    assert "max_homopolymer=4" in header_custom
+
 # --- Test Scenarios for Batch Decoding ---
 
 def create_dummy_fasta_file(file_path: Path, content: str, method: str = "base4_direct", input_filename: str = "dummy.txt"):


### PR DESCRIPTION
## Summary
- expose `--gc-min`, `--gc-max` and `--max-homopolymer` CLI args
- pass these parameters to `encode_gc_balanced`
- document options in README and update example
- test GC-balanced defaults and custom values in CLI

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bbe5934c8326b03cb377c41ac99d