### PR TITLE
Centralize test path handling

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import sys
+from pathlib import Path
+
+# Add the project's root and src directories to sys.path so tests can import the package
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / 'src'
+
+for path in (SRC_PATH, PROJECT_ROOT):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,10 +5,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
-
 # Helper to get the root of the project
 PROJECT_ROOT = Path(__file__).parent.parent
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,10 +1,5 @@
 import unittest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from dna_encoder import encoder  # noqa: E402
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,10 +1,5 @@
 import unittest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.encoders import encode_base4_direct, decode_base4_direct  # noqa: E402
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T  # noqa: E402

--- a/tests/test_error_correction.py
+++ b/tests/test_error_correction.py
@@ -1,10 +1,5 @@
 import pytest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat  # noqa: E402
 

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -1,10 +1,5 @@
 import unittest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.error_detection import (  # noqa: E402
     _calculate_gc_parity,

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,10 +1,5 @@
 import unittest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.formats import to_fasta, from_fasta  # noqa: E402 - Import from_fasta
 

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -1,12 +1,6 @@
 import pytest
 import re
-import os
-import sys
 from unittest.mock import patch, call  # call is needed for checking multiple calls to a mock
-
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.gc_constrained_encoder import (  # noqa: E402
     calculate_gc_content,

--- a/tests/test_hamming_codec.py
+++ b/tests/test_hamming_codec.py
@@ -1,10 +1,5 @@
 import pytest
-import os
-import sys
 
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.hamming_codec import (  # noqa: E402
     encode_hamming_7_4_nibble,

--- a/tests/test_huffman_coding.py
+++ b/tests/test_huffman_coding.py
@@ -1,13 +1,7 @@
 import unittest
-import os
-import sys
 # collections.Counter is not directly used in these tests, but it's fundamental
 # to the huffman_coding module itself. Keep if needed for other tests, or remove if strictly not used.
 # from collections import Counter
-
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.huffman_coding import encode_huffman, decode_huffman  # noqa: E402
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T  # noqa: E402

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,15 +1,9 @@
 
 import unittest
 import io
-import os
-import sys
 from collections import Counter
 import pytest
 
-
-SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-if SRC_PATH not in sys.path:
-    sys.path.insert(0, SRC_PATH)
 
 from genecoder.plotting import (  # noqa: E402
     prepare_huffman_codeword_length_data,


### PR DESCRIPTION
## Summary
- add a `conftest.py` that adds the repository root and `src/` to `sys.path`
- remove per-file path tweaks from tests
- drop unused imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bbe4ca3083269da82e4b40329c0a