### PR TITLE
Fix GC constrained encoder test imports

### DIFF
--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -1,10 +1,5 @@
 import os
 import sys
-import pytest
-import re
-from unittest.mock import patch, call  # call is needed for checking multiple calls to a mock
-
-from genecoder.encoders import encode_base4_direct  # noqa: E402
 from genecoder.gc_constrained_encoder import (
     calculate_gc_content,
     check_homopolymer_length,
@@ -12,6 +7,11 @@ from genecoder.gc_constrained_encoder import (
     encode_gc_balanced,
     decode_gc_balanced,
 )
+import pytest
+import re
+from unittest.mock import patch, call  # call is needed for checking multiple calls to a mock
+
+from genecoder.encoders import encode_base4_direct  # noqa: E402
 
 SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
 if SRC_PATH not in sys.path:


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_gc_constrained_encoder.py`
- ensure `encode_base4_direct` import preserved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ea800a008326a933d8924b0d0d4e