### PR TITLE
Add GC/homopolymer checks in decode

### DIFF
--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -164,4 +164,24 @@ def decode_gc_balanced(
     else:
         raise ValueError(f"Invalid signal bit: '{signal_bit}'. Expected '0' or '1'.")
 
+    # Calculate constraints on the payload DNA sequence
+    gc_content = calculate_gc_content(payload_dna_sequence)
+    max_homopolymer_len = get_max_homopolymer_length(payload_dna_sequence)
+
+    if expected_gc_min is not None and gc_content < expected_gc_min:
+        raise ValueError(
+            f"GC content of decoded payload ({gc_content}) is lower than expected minimum {expected_gc_min}."
+        )
+    if expected_gc_max is not None and gc_content > expected_gc_max:
+        raise ValueError(
+            f"GC content of decoded payload ({gc_content}) exceeds expected maximum {expected_gc_max}."
+        )
+    if (
+        expected_max_homopolymer is not None
+        and max_homopolymer_len > expected_max_homopolymer
+    ):
+        raise ValueError(
+            f"Longest homopolymer in decoded payload ({max_homopolymer_len}) exceeds expected maximum {expected_max_homopolymer}."
+        )
+
     return decoded_data


### PR DESCRIPTION
## Summary
- enforce GC content and homopolymer validation when decoding
- adjust decode tests to expect these checks
- add new tests for GC/homopolymer constraint violations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ecac0b8c8326bd813214ad50cc6c