### PR TITLE
Improve coverage for plotting and error simulation

### DIFF
--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -36,3 +36,33 @@ def test_deterministic_deletions():
         rng=rng,
     )
     assert result == "T"
+
+
+def test_apply_functions_and_edge_cases():
+    rng = random.Random(123)
+    from genecoder.error_simulation import apply_substitutions, apply_insertions, apply_deletions
+
+    # apply_substitutions with probability 0 should return the original sequence
+    assert apply_substitutions("ATGC", prob=0.0, rng=rng) == "ATGC"
+
+    # apply_insertions with probability 0 should return the original sequence
+    assert apply_insertions("ATGC", prob=0.0, rng=rng) == "ATGC"
+
+    # apply_deletions with probability 1.0 removes all characters
+    assert apply_deletions("ATGC", prob=1.0, rng=rng) == ""
+
+
+def test_introduce_errors_combined_operations():
+    rng = random.Random(1)
+    result = introduce_errors(
+        "AT",
+        substitution_prob=0.5,
+        insertion_prob=0.5,
+        deletion_prob=0.5,
+        rng=rng,
+    )
+    assert result == "TG"
+
+
+def test_introduce_errors_empty_sequence():
+    assert introduce_errors("", substitution_prob=1.0, insertion_prob=1.0, deletion_prob=1.0, rng=random.Random(0)) == ""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,7 +11,8 @@ from genecoder.plotting import (  # noqa: E402
     prepare_nucleotide_frequency_data,
     generate_nucleotide_frequency_plot,
     calculate_windowed_gc_content,
-    identify_homopolymer_regions
+    identify_homopolymer_regions,
+    generate_sequence_analysis_plot
 )
 
 class TestPlotting(unittest.TestCase):
@@ -232,6 +233,21 @@ class TestPlotting(unittest.TestCase):
         self.assertEqual(identify_homopolymer_regions("GGXXAAA", min_len=2), [(0,1,'G'), (2,3,'X'), (4,6,'A')])
         # "CCC YYYY Z", min_len=3 -> [(0,2,'C'), (4,7,'Y')] Space breaks
         self.assertEqual(identify_homopolymer_regions("CCC YYYY Z", min_len=3), [(0,2,'C'), (4,7,'Y')])
+
+    def test_generate_sequence_analysis_plot_basic(self):
+        gc_data = ([0, 2, 4], [0.5, 0.0, 1.0])
+        homos = [(1, 3, 'A')]
+        buf = generate_sequence_analysis_plot(gc_data, homos, sequence_length=6)
+        self.assertIsInstance(buf, io.BytesIO)
+        self.assertTrue(buf.getvalue().startswith(b'\x89PNG\r\n\x1a\n'))
+        buf.close()
+
+    def test_generate_sequence_analysis_plot_empty(self):
+        buf = generate_sequence_analysis_plot(([], []), [], sequence_length=0)
+        self.assertIsInstance(buf, io.BytesIO)
+        self.assertTrue(buf.getvalue().startswith(b'\x89PNG\r\n\x1a\n'))
+        buf.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- test `apply_*` helpers and additional introduce_errors cases
- test generate_sequence_analysis_plot and expose it via import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684307bf00588326bf023d1e1bceb9e6