### PR TITLE
Document workflow for CLI and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ pip install -r requirements.txt
 ### Command-Line Interface (CLI)
 
 To use GeneCoder CLI, navigate to the project's root directory. The main script is `src/cli.py`.
+See [WORKFLOWS.md](WORKFLOWS.md) for a step-by-step overview of the encoding and decoding process.
 
 **General Command Structure (Batch and Single File):**
 `python src/cli.py <command> --input-files <path1> [<path2> ...] [--output-file <path>] [--output-dir <dir>] --method <method_name> [options]`
@@ -154,7 +155,7 @@ Run the Flet application:
 ```bash
 python src/flet_app.py
 ```
-The GUI provides controls for most encoding methods, parity, and Triple-Repeat FEC, along with metric displays and some visual analysis plots. GUI operations are asynchronous to keep the interface responsive.
+The GUI provides controls for most encoding methods, parity, and Triple-Repeat FEC, along with metric displays and some visual analysis plots. GUI operations are asynchronous to keep the interface responsive. See [WORKFLOWS.md](WORKFLOWS.md) for the underlying processing steps.
 
 ---
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -1,0 +1,86 @@
+# GeneCoder Workflows
+
+This document outlines the high level steps for encoding and decoding data with GeneCoder. Both the command line interface (CLI) and the Flet based graphical interface share the same processing pipeline under the hood.
+
+## Encoding a File to DNA
+
+### CLI
+1. `src/cli.py` reads the input file.
+2. If `--fec hamming_7_4` is selected, `genecoder.hamming_codec.encode_data_with_hamming` adds binary level FEC.
+3. The chosen encoder from `genecoder.encoders` or `genecoder.huffman_coding` converts the bytes to DNA:
+   - `encode_base4_direct`
+   - `encode_huffman`
+   - `encode_gc_balanced`
+4. Optional parity bits are applied via `genecoder.error_detection` when using base‑4 or Huffman.
+5. Optional Triple‑Repeat FEC is applied with `genecoder.error_correction.encode_triple_repeat`.
+6. `genecoder.formats.to_fasta` creates the FASTA record which is written to disk.
+
+### Flet GUI
+1. `src/flet_app.py` loads the selected file asynchronously when *Encode* is clicked.
+2. The same encoding functions (`encode_base4_direct`, `encode_huffman`, `encode_gc_balanced`) are executed.
+3. Triple‑Repeat FEC, if enabled, is applied using `encode_triple_repeat`.
+4. The output FASTA string is displayed and can be saved from the interface.
+5. Metrics and plots are produced using helpers in `genecoder.plotting`.
+
+### Encoding Flow (text diagram)
+```
+Input File
+  ↓
+[Optional] Hamming FEC → encode_data_with_hamming
+  ↓
+Encoding Method → encode_base4_direct | encode_huffman | encode_gc_balanced
+  ↓
+[Optional] Parity via error_detection
+  ↓
+[Optional] Triple‑Repeat FEC → encode_triple_repeat
+  ↓
+FASTA formatting → to_fasta
+  ↓
+Encoded FASTA file
+```
+
+## Decoding DNA back to a File
+
+### CLI
+1. `src/cli.py` reads the FASTA file and parses it with `genecoder.formats.from_fasta`.
+2. If `fec=triple_repeat` is indicated, `genecoder.error_correction.decode_triple_repeat` is invoked.
+3. The primary decoding function is chosen based on the header:
+   - `decode_base4_direct`
+   - `decode_huffman`
+   - `decode_gc_balanced`
+4. Parity checks occur through `genecoder.error_detection` when applicable.
+5. If the header contains `fec=hamming_7_4`, `genecoder.hamming_codec.decode_data_with_hamming` restores the original bytes.
+6. The resulting data is written to the specified output file.
+
+### Flet GUI
+1. When *Decode* is clicked in `src/flet_app.py`, the selected FASTA file is parsed by `from_fasta`.
+2. Triple‑Repeat FEC and then the main decoding method are applied using the same modules as in the CLI.
+3. Decoded bytes can be saved from the interface.
+
+### Decoding Flow (text diagram)
+```
+FASTA file
+  ↓
+Parse records → from_fasta
+  ↓
+[Optional] Triple‑Repeat decode → decode_triple_repeat
+  ↓
+Primary decode → decode_base4_direct | decode_huffman | decode_gc_balanced
+  ↓
+[Optional] Parity checking
+  ↓
+[Optional] Hamming decode → decode_data_with_hamming
+  ↓
+Output file
+```
+
+Both interfaces rely primarily on modules under `genecoder/`:
+- `encoders.py` and `gc_constrained_encoder.py`
+- `huffman_coding.py`
+- `error_detection.py`
+- `error_correction.py`
+- `hamming_codec.py`
+- `formats.py`
+- `plotting.py` (GUI metrics)
+
+These modules contain the core logic used by `src/cli.py` and `src/flet_app.py`.


### PR DESCRIPTION
## Summary
- add new `WORKFLOWS.md` to describe encode/decode steps
- link to workflow doc from CLI and GUI sections of README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843089783888326afe20c2edfa18ad4