### PR TITLE
Refactor DNA maps into shared utils

### DIFF
--- a/dna_encoder/encoder.py
+++ b/dna_encoder/encoder.py
@@ -1,3 +1,6 @@
+from genecoder.utils import DNA_ENCODE_MAP, DNA_DECODE_MAP
+
+
 def encode_base4(data: bytes) -> str:
     """
     Encodes a bytes object into a DNA sequence string using a base-4 representation.
@@ -20,14 +23,7 @@ def encode_base4(data: bytes) -> str:
     dna_sequence = ""
     for i in range(0, len(binary_string), 2):
         chunk = binary_string[i:i+2]
-        if chunk == "00":
-            dna_sequence += "A"
-        elif chunk == "01":
-            dna_sequence += "C"
-        elif chunk == "10":
-            dna_sequence += "G"
-        elif chunk == "11":
-            dna_sequence += "T"
+        dna_sequence += DNA_ENCODE_MAP[chunk]
         # It's guaranteed that chunks will be one of these, so no else is needed.
         # However, if the binary_string length is odd, the last chunk will be a single bit.
         # The problem description implies that the concatenated 8-bit strings will always
@@ -56,15 +52,9 @@ def decode_base4(dna_sequence: str) -> bytes:
         return b""
 
     binary_string = ""
-    dna_to_binary_map = {
-        'A': "00",
-        'C': "01",
-        'G': "10",
-        'T': "11"
-    }
 
     for char in dna_sequence:
-        binary_chunk = dna_to_binary_map.get(char)
+        binary_chunk = DNA_DECODE_MAP.get(char)
         if binary_chunk is None:
             raise ValueError(f"Invalid character in DNA sequence: {char}")
         binary_string += binary_chunk

--- a/src/genecoder/encoders.py
+++ b/src/genecoder/encoders.py
@@ -18,6 +18,7 @@ from .gc_constrained_encoder import (
     get_max_homopolymer_length
 )
 from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat
+from .utils import DNA_ENCODE_MAP, DNA_DECODE_MAP
 
 __all__ = [
     "encode_base4_direct",
@@ -42,19 +43,19 @@ def encode_base4_direct(
 
   The mapping from 2-bit binary pairs to DNA nucleotides is as follows:
     - `00` (binary) -> 'A'
-    - `01` (binary) -> 'T'
-    - `10` (binary) -> 'C'
-    - `11` (binary) -> 'G'
+    - `01` (binary) -> 'C'
+    - `10` (binary) -> 'G'
+    - `11` (binary) -> 'T'
 
   Each input byte (8 bits) is processed by reading its bits in four 2-bit pairs,
   starting from the Most Significant Bit (MSB) pair to the Least Significant Bit 
   (LSB) pair. For example, the byte `0b01000001` (ASCII 'A', decimal 65) is 
   processed as:
-    - First 2 bits (MSB): `01` -> 'T'
+    - First 2 bits (MSB): `01` -> 'C'
     - Next 2 bits:        `00` -> 'A'
     - Next 2 bits:        `00` -> 'A'
-    - Last 2 bits (LSB):  `01` -> 'T'
-  This results in the DNA sequence "TAAT".
+    - Last 2 bits (LSB):  `01` -> 'C'
+  This results in the DNA sequence "CAAC".
 
   Args:
     data (bytes): The byte string to encode.
@@ -74,21 +75,23 @@ def encode_base4_direct(
     NotImplementedError: If `add_parity` is True and `parity_rule` is unknown.
   """
   dna_sequence_parts: list[str] = []
-  # Mapping of 2-bit integers to DNA characters.
-  # 0b00 (0) -> 'A', 0b01 (1) -> 'T', 0b10 (2) -> 'C', 0b11 (3) -> 'G'
-  mapping = { 
-      0: 'A', 1: 'T', 2: 'C', 3: 'G'
+  # Mapping of 2-bit integers to DNA characters derived from ``DNA_ENCODE_MAP``.
+  mapping = {
+      0: DNA_ENCODE_MAP["00"],
+      1: DNA_ENCODE_MAP["01"],
+      2: DNA_ENCODE_MAP["10"],
+      3: DNA_ENCODE_MAP["11"],
   }
 
   for byte_val in data:
     # Process bits from most significant to least significant.
     # Each byte is split into four 2-bit segments.
     # Example: byte_val = 0b11001001 (decimal 201)
-    # - (byte_val >> 6) & 0b11 results in 0b11 ('G')
+    # - (byte_val >> 6) & 0b11 results in 0b11 ('T')
     # - (byte_val >> 4) & 0b11 results in 0b00 ('A')
-    # - (byte_val >> 2) & 0b11 results in 0b10 ('C')
-    # - (byte_val >> 0) & 0b11 results in 0b01 ('T')
-    # The resulting DNA sequence for this byte is "GACT".
+    # - (byte_val >> 2) & 0b11 results in 0b10 ('G')
+    # - (byte_val >> 0) & 0b11 results in 0b01 ('C')
+    # The resulting DNA sequence for this byte is "TAGC".
 
     # Extract the four 2-bit pairs from the byte.
     pairs = [
@@ -127,18 +130,18 @@ def decode_base4_direct(
   This function reverses the `encode_base4_direct` process. The mapping from
   DNA nucleotides to 2-bit binary pairs is:
     - 'A' -> `00` (binary)
-    - 'T' -> `01` (binary)
-    - 'C' -> `10` (binary)
-    - 'G' -> `11` (binary)
+    - 'C' -> `01` (binary)
+    - 'G' -> `10` (binary)
+    - 'T' -> `11` (binary)
 
   Each set of 4 DNA characters in the input sequence corresponds to one output byte.
   The first character of a 4-character block maps to the Most Significant Bit 
   (MSB) pair of the resulting byte, and the last character maps to the Least 
-  Significant Bit (LSB) pair. For example, the DNA sequence "TAAT" is processed as:
-    - 'T' -> `01` (becomes the MSB pair of the byte)
+  Significant Bit (LSB) pair. For example, the DNA sequence "CAAC" is processed as:
+    - 'C' -> `01` (becomes the MSB pair of the byte)
     - 'A' -> `00`
     - 'A' -> `00`
-    - 'T' -> `01` (becomes the LSB pair of the byte)
+    - 'C' -> `01` (becomes the LSB pair of the byte)
   This results in the byte `0b01000001` (ASCII 'A', decimal 65).
 
   Args:
@@ -186,21 +189,24 @@ def decode_base4_direct(
     )
 
   decoded_bytes: list[int] = [] 
-  # Mapping of DNA characters to their 2-bit integer values.
-  # 'A' -> 0b00 (0), 'T' -> 0b01 (1), 'C' -> 0b10 (2), 'G' -> 0b11 (3)
+  # Mapping of DNA characters to their 2-bit integer values derived from
+  # ``DNA_DECODE_MAP``.
   reverse_mapping = {
-      'A': 0, 'T': 1, 'C': 2, 'G': 3
+      'A': int(DNA_DECODE_MAP['A'], 2),
+      'C': int(DNA_DECODE_MAP['C'], 2),
+      'G': int(DNA_DECODE_MAP['G'], 2),
+      'T': int(DNA_DECODE_MAP['T'], 2),
   }
 
   for i in range(0, len(sequence_to_decode), 4):
     chars = sequence_to_decode[i:i+4]  # Get a 4-character block from the (potentially stripped) sequence
     current_byte_val = 0
     # Convert the 4 DNA characters back into one byte.
-    # Example: chars = "GACT" (G=0b11, A=0b00, C=0b10, T=0b01)
-    # - 'G' (0b11) shifted left by 6 bits: 0b11000000
+    # Example: chars = "TAGC" (T=0b11, A=0b00, G=0b10, C=0b01)
+    # - 'T' (0b11) shifted left by 6 bits: 0b11000000
     # - 'A' (0b00) shifted left by 4 bits: 0b00000000
-    # - 'C' (0b10) shifted left by 2 bits: 0b00001000
-    # - 'T' (0b01) shifted left by 0 bits: 0b00000001
+    # - 'G' (0b10) shifted left by 2 bits: 0b00001000
+    # - 'C' (0b01) shifted left by 0 bits: 0b00000001
     # Resulting byte: 0b11000000 | 0b00000000 | 0b00001000 | 0b00000001 = 0b11001001 (201)
 
     current_byte_val |= reverse_mapping[chars[0]] << 6 # 1st char is MSB pair

--- a/src/genecoder/huffman_coding.py
+++ b/src/genecoder/huffman_coding.py
@@ -12,6 +12,7 @@ This module provides functions to:
 import collections
 import heapq
 from typing import Dict, Tuple, List, Union # For type hints
+from .utils import DNA_ENCODE_MAP, DNA_DECODE_MAP
 from genecoder.error_detection import (
     add_parity_to_sequence, 
     strip_and_verify_parity, 
@@ -208,10 +209,8 @@ def encode_huffman(
 
     # Convert the padded binary string to a DNA sequence.
     dna_sequence_parts: List[str] = []
-    # Map every pair of bits to a nucleotide.  This fixed mapping allows the
-    # variable-length Huffman output to be represented using only the alphabet
-    # {A,T,C,G}.  Two bits are consumed at a time during conversion.
-    dna_mapping = {"00": 'A', "01": 'T', "10": 'C', "11": 'G'}
+    # Map every pair of bits to a nucleotide using the shared mapping.
+    dna_mapping = DNA_ENCODE_MAP
 
     # This check covers cases where data was non-empty but resulted in an empty
     # encoded_binary_string (e.g., if all Huffman codes were empty strings, which
@@ -315,9 +314,8 @@ def decode_huffman(
 
     # 1. Convert DNA sequence (potentially stripped of parity) to its binary string.
     binary_digits_list: List[str] = []
-    dna_to_binary_map = {'A': "00", 'T': "01", 'C': "10", 'G': "11"}
-    for char_dna in sequence_for_huffman_decode: # Use the (potentially) stripped sequence
-        binary_pair = dna_to_binary_map.get(char_dna)
+    for char_dna in sequence_for_huffman_decode:  # Use the (potentially) stripped sequence
+        binary_pair = DNA_DECODE_MAP.get(char_dna)
         if binary_pair is None:
             raise ValueError(
                 f"Invalid DNA character '{char_dna}' in sequence for Huffman decoding."

--- a/src/genecoder/utils.py
+++ b/src/genecoder/utils.py
@@ -1,0 +1,10 @@
+"""Utility constants shared across GeneCoder modules."""
+
+DNA_ENCODE_MAP = {"00": "A", "01": "C", "10": "G", "11": "T"}
+"""Mapping from 2-bit binary strings to DNA nucleotides."""
+
+DNA_DECODE_MAP = {v: k for k, v in DNA_ENCODE_MAP.items()}
+"""Inverse mapping from DNA nucleotides to 2-bit binary strings."""
+
+__all__ = ["DNA_ENCODE_MAP", "DNA_DECODE_MAP"]
+

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -15,18 +15,18 @@ class TestBase4DirectMapping(unittest.TestCase):
         self.assertEqual(encode_base4_direct(b'\x00'), "AAAA")
 
     def test_encode_single_byte_max(self):
-        # 0b11111111 -> GGGG
-        self.assertEqual(encode_base4_direct(b'\xff'), "GGGG")
+        # 0b11111111 -> TTTT
+        self.assertEqual(encode_base4_direct(b'\xff'), "TTTT")
 
     def test_encode_ascii_char(self):
         # 'A' (ASCII 65) is 0b01000001
-        # 01 -> T
+        # 01 -> C
         # 00 -> A
         # 00 -> A
-        # 01 -> T
-        # Expected: TAAT (Correction: The prompt example says "ATAA", let's re-verify. 01000001 -> 01 00 00 01 -> T A A T. The prompt image has 00->A, 01->T, 10->C, 11->G. So 01->T, 00->A, 00->A, 01->T is "TAAT". I will use "TAAT" as per the mapping logic.)
+        # 01 -> C
+        # Expected: CAAC
         # The prompt example had 'A' (01000001) -> "ATAA". Let's check that.
-        # 01 (T) 00 (A) 00 (A) 01 (T) -> "TAAT"
+        # 01 (C) 00 (A) 00 (A) 01 (C) -> "CAAC"
         # If "ATAA" is expected for 'A' (01000001):
         # A (00) T (01) A (00) A (00) -> 00010000. This is not 65.
         # The prompt description for encode_base4_direct states:
@@ -35,51 +35,44 @@ class TestBase4DirectMapping(unittest.TestCase):
         # 3rd pair: (byte >> 2) & 0b11
         # 4th pair: (byte >> 0) & 0b11
         # For byte 'A' = 0b01000001:
-        # 1st pair: (01000001 >> 6) & 0b11 = 0b01 & 0b11 = 0b01 -> T
-        # 2nd pair: (01000001 >> 4) & 0b11 = 0b0100 & 0b11 = 0b00 -> A
-        # 3rd pair: (01000001 >> 2) & 0b11 = 0b010000 & 0b11 = 0b00 -> A
-        # 4th pair: (01000001 >> 0) & 0b11 = 0b01000001 & 0b11 = 0b01 -> T
-        # So, b'A' (01000001) should indeed be "TAAT". I will use this. The example "ATAA" in the prompt might be a typo.
-        self.assertEqual(encode_base4_direct(b'A'), "TAAT")
+        # 1st pair: (01000001 >> 6) & 0b11 = 0b01 -> C
+        # 2nd pair: (01000001 >> 4) & 0b11 = 0b0100 -> A
+        # 3rd pair: (01000001 >> 2) & 0b11 = 0b010000 -> A
+        # 4th pair: (01000001 >> 0) & 0b11 = 0b01000001 -> C
+        # So, b'A' (01000001) should indeed be "CAAC".
+        self.assertEqual(encode_base4_direct(b'A'), "CAAC")
 
 
     def test_encode_multiple_bytes(self):
         # 'H' (ASCII 72) is 0b01001000
-        # 01 -> T
+        # 01 -> C
         # 00 -> A
-        # 10 -> C
+        # 10 -> G
         # 00 -> A
-        # Result: "TACA"
+        # Result: "CAGA"
         # 'i' (ASCII 105) is 0b01101001
-        # 01 -> T
-        # 10 -> C
-        # 10 -> C
-        # 01 -> T
-        # Result: "TCCT"
-        # Expected for "Hi": "TACATCCT"
+        # 01 -> C
+        # 10 -> G
+        # 10 -> G
+        # 01 -> C
+        # Result: "CGGC"
+        # Expected for "Hi": "CAGACGGC"
         # The prompt example is "ATCAATTG". Let's verify this.
         # 'H' = 01001000. If "ATCA":
         # A (00) T (01) C (10) A (00) -> 00011000 (Decimal 24). This is not 'H' (72).
         # Using the defined mapping:
-        # H (01001000): 01(T) 00(A) 10(C) 00(A) -> "TACA"
-        # i (01101001): 01(T) 10(C) 10(C) 01(T) -> "TCCT"
-        # So "Hi" -> "TACATCCT". I will use this.
-        self.assertEqual(encode_base4_direct(b'Hi'), "TACATCCT")
+        # H (01001000): 01(C) 00(A) 10(G) 00(A) -> "CAGA"
+        # i (01101001): 01(C) 10(G) 10(G) 01(C) -> "CGGC"
+        # So "Hi" -> "CAGACGGC".
+        self.assertEqual(encode_base4_direct(b'Hi'), "CAGACGGC")
 
     def test_encode_byte_sequence(self):
-        # \x12 -> 00010010 -> A(00)A(00)T(01)C(10) -> AATC (Corrected from prompt's AATA)
-        # \x34 -> 00110100 -> A(00)C(10)T(01)A(00) -> ACTA (Corrected from prompt's ACTA)
-        # \xAB -> 10101011 -> C(10)G(11)C(10)G(11) -> CGCG (Corrected from prompt's CGTG)
-        # \xCD -> 11001101 -> G(11)A(00)G(11)T(01) -> GAGT (Corrected from prompt's GCGT)
-        # Expected: "AATCACTACGCGGAGT"
-        # The prompt example: "AATAACTACGTGCGTG"
-        # Let's re-calculate based on the implemented encoder:
-        # \x12 (00010010): (00)(A) (01)(T) (00)(A) (10)(C) -> "ATAC"
-        # \x34 (00110100): (00)(A) (11)(G) (01)(T) (00)(A) -> "AGTA"
-        # \xAB (10101011): (10)(C) (10)(C) (10)(C) (11)(G) -> "CCCG"
-        # \xCD (11001101): (11)(G) (00)(A) (11)(G) (01)(T) -> "GAGT"
-        # Expected: "ATACAGTACCCGGAGT"
-        self.assertEqual(encode_base4_direct(b'\x12\x34\xAB\xCD'), "ATACAGTACCCGGAGT")
+        # \x12 -> 00010010 -> A(00)C(01)A(00)G(10) -> ACAG
+        # \x34 -> 00110100 -> A(00)T(11)C(01)A(00) -> ATCA
+        # \xAB -> 10101011 -> G(10)G(10)G(10)T(11) -> GGGT
+        # \xCD -> 11001101 -> T(11)A(00)T(11)C(01) -> TATC
+        # Expected: "ACAGATCAGGGTTATC"
+        self.assertEqual(encode_base4_direct(b'\x12\x34\xAB\xCD'), "ACAGATCAGGGTTATC")
 
     # Tests for decode_base4_direct
     def test_decode_empty(self):
@@ -93,25 +86,25 @@ class TestBase4DirectMapping(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_decode_valid_sequence_gggg(self):
-        decoded_data, errors = decode_base4_direct("GGGG")
+        decoded_data, errors = decode_base4_direct("TTTT")
         self.assertEqual(decoded_data, b'\xff')
         self.assertEqual(errors, [])
 
     def test_decode_ascii_char_reverse(self):
-        # Corresponds to b'A' (01000001) which encodes to "TAAT"
-        decoded_data, errors = decode_base4_direct("TAAT")
+        # Corresponds to b'A' (01000001) which encodes to "CAAC"
+        decoded_data, errors = decode_base4_direct("CAAC")
         self.assertEqual(decoded_data, b'A')
         self.assertEqual(errors, [])
 
     def test_decode_multiple_bytes_reverse(self):
-        # Corresponds to b'Hi' which encodes to "TACATCCT"
-        decoded_data, errors = decode_base4_direct("TACATCCT")
+        # Corresponds to b'Hi' which encodes to "CAGACGGC"
+        decoded_data, errors = decode_base4_direct("CAGACGGC")
         self.assertEqual(decoded_data, b'Hi')
         self.assertEqual(errors, [])
 
     def test_decode_byte_sequence_reverse(self):
-        # Corresponds to b'\x12\x34\xAB\xCD' which encodes to "ATACAGTACCCGGAGT"
-        decoded_data, errors = decode_base4_direct("ATACAGTACCCGGAGT")
+        # Corresponds to b'\x12\x34\xAB\xCD' which encodes to "ACAGATCAGGGTTATC"
+        decoded_data, errors = decode_base4_direct("ACAGATCAGGGTTATC")
         self.assertEqual(decoded_data, b'\x12\x34\xAB\xCD')
         self.assertEqual(errors, [])
 
@@ -156,21 +149,21 @@ class TestBase4DirectMapping(unittest.TestCase):
 
     # --- Tests for Parity Integration ---
     def test_encode_base4_with_parity(self):
-        # b'\x12\x34' -> "ATACAGTA" (corrected from "AATAACTA" in prompt based on current encoder)
-        # Parity for "ATA" (0 GC) -> A.
-        # Parity for "CAG" (1 GC) -> T.
-        # Parity for "TA" (0 GC) -> A.
-        # Expected: "ATAA CAGT TAA"
+        # b'\x12\x34' -> "ACAGATCA" with the current mapping
+        # Parity for "ACA" (1 GC) -> T.
+        # Parity for "GAT" (1 GC) -> T.
+        # Parity for "CA" (1 GC) -> T.
+        # Expected: blocks "ACAT", "GATT", "CAT"
         # Let's re-verify \x12\x34 with my encoder:
-        # \x12 (00010010): 00(A) 01(T) 00(A) 10(C) -> "ATAC"
-        # \x34 (00110100): 00(A) 11(G) 01(T) 00(A) -> "AGTA"
-        # Raw DNA: "ATACAGTA"
+        # \x12 (00010010): 00(A) 01(C) 00(A) 10(G) -> "ACAG"
+        # \x34 (00110100): 00(A) 11(T) 01(C) 00(A) -> "ATCA"
+        # Raw DNA: "ACAGATCA"
         # k_value=3
-        # Block 1: "ATA" (GC=0, even) -> Parity 'A'. Output: "ATAA"
-        # Block 2: "CAG" (GC=1, odd)  -> Parity 'T'. Output: "CAGT"
-        # Block 3: "TA"  (GC=0, even) -> Parity 'A'. Output: "TAA"
-        # Expected DNA with parity: "ATAACAGATAA"
-        expected_dna_with_parity = "ATAACAGATAA"
+        # Block 1: "ACA" (GC=1, odd) -> Parity 'T'. Output: "ACAT"
+        # Block 2: "GAT" (GC=1, odd) -> Parity 'T'. Output: "GATT"
+        # Block 3: "CA"  (GC=1, odd) -> Parity 'T'. Output: "CAT"
+        # Expected DNA with parity: "ACATGATTCAT"
+        expected_dna_with_parity = "ACATGATTCAT"
         actual_dna_with_parity = encode_base4_direct(
             b'\x12\x34', add_parity=True, k_value=3, parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T
         )
@@ -178,7 +171,7 @@ class TestBase4DirectMapping(unittest.TestCase):
 
     def test_decode_base4_with_parity_no_errors(self):
         # Using the corrected expected_dna_with_parity from above
-        dna_with_parity = "ATAACAGATAA"  # Corresponds to b'\x12\x34' with k=3 parity
+        dna_with_parity = "ACATGATTCAT"  # Corresponds to b'\x12\x34' with k=3 parity
         original_data = b'\x12\x34'
         
         decoded_data, errors = decode_base4_direct(
@@ -188,12 +181,10 @@ class TestBase4DirectMapping(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_decode_base4_with_parity_with_errors(self):
-        # dna_with_parity = "ATAACAGATAA" (correct)
-        # Corrupt first parity bit: "ATATCAGATAA" (A -> T)
-        # Block 1: "ATA", Parity "T". Expected for "ATA" (0 GC, even) is "A". Error.
-        # Block 2: "CAG", Parity "T". Expected for "CAG" (1 GC, odd) is "T". OK.
-        # Block 3: "TA",  Parity "A". Expected for "TA"  (0 GC, even) is "A". OK.
-        corrupted_dna = "ATATCAGATAA"
+        # dna_with_parity = "ACATGATTCAT" (correct)
+        # Corrupt first parity bit: "ACAAGATTCAT" (T -> A)
+        # Block 1: "ACA", Parity "A". Expected for "ACA" (GC=1, odd) is "T". Error.
+        corrupted_dna = "ACAAGATTCAT"
         original_data_stripped = b'\x12\x34' # This should still be decodable
         
         decoded_data, errors = decode_base4_direct(

--- a/tests/test_huffman_coding.py
+++ b/tests/test_huffman_coding.py
@@ -128,8 +128,8 @@ class TestHuffmanCoding(unittest.TestCase):
 
     def test_decode_code_not_in_table(self):
         dna_no_parity, table_no_parity, pad_no_parity = encode_huffman(b"A", add_parity=False)
-        with self.assertRaisesRegex(ValueError, "Invalid padding bits: expected all '0's but found '1'."):
-            decode_huffman("G", table_no_parity, pad_no_parity, check_parity=False)  # "G" is "11", unpadded "1"
+        with self.assertRaisesRegex(ValueError, "Corrupted data or incorrect Huffman table: remaining unparsed bits '1'."):
+            decode_huffman("G", table_no_parity, pad_no_parity, check_parity=False)  # "G" decodes to bits '10', leaving '1' after unpadding
 
     def test_decode_incomplete_code_at_end(self):
         custom_table = {ord('X'): "001"} 


### PR DESCRIPTION
## Summary
- add `src/genecoder/utils.py` with `DNA_ENCODE_MAP` and `DNA_DECODE_MAP`
- refactor base4 encoder, Huffman coder and base4 direct encoder to use the constants
- update unit tests for the new A/C/G/T mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843564e4c8883269febd09a56cd3193