### PR TITLE
Fix mixed-case homopolymer detection

### DIFF
--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -112,6 +112,8 @@ def get_max_homopolymer_length(dna_sequence: str) -> int:
     if not dna_sequence:
         return 0
 
+    dna_sequence = dna_sequence.upper()
+
     max_len = 0
     current_len = 0
     if len(dna_sequence) > 0:

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -59,6 +59,7 @@ def test_calculate_gc_content(sequence, expected_gc):
     ("GATTACA", 1, True),
     ("GATTACCA", 1, True), # CC violates
     ("aaaatttt", 3, True), # Lowercase test
+    ("aAaAaA", 5, True), # Mixed-case violates length 5 (run of 6 As)
 ])
 def test_check_homopolymer_length(sequence, max_len, expected_bool):
     assert check_homopolymer_length(sequence, max_len) == expected_bool
@@ -75,6 +76,7 @@ def test_check_homopolymer_length(sequence, max_len, expected_bool):
     ("GG", 2),
     ("AAABBCDDDDEFF", 4), # DDDD
     ("aaabbcddddeff", 4), # Lowercase
+    ("AaAaAa", 6), # Mixed-case sequence
 ])
 def test_get_max_homopolymer_length(sequence, expected_len):
     assert get_max_homopolymer_length(sequence) == expected_len


### PR DESCRIPTION
## Summary
- handle mixed case in `get_max_homopolymer_length`
- extend GC constrained encoder tests for mixed case sequences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843565135e0832689bdaef3a175109c