### PR TITLE
Fix missing utility import

### DIFF
--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -16,7 +16,7 @@ required.
 """
 
 from typing import Optional
-from .utils import check_homopolymer_length
+from .utils import check_homopolymer_length, get_max_homopolymer_length
 
 def calculate_gc_content(dna_sequence: str) -> float:
     """Calculates the GC content of a DNA sequence.


### PR DESCRIPTION
## Summary
- fix missing import for `get_max_homopolymer_length` in constrained encoder

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68448afe7288832691df985fbfb0629f