### PR TITLE
Implement Hamming FEC decode in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
     *   For `gc_balanced`: Actual GC content and max homopolymer length of the payload (pre-FEC).
 *   **Graphical User Interface (GUI):**
     *   A Flet-based GUI (`src/flet_app.py`) provides an interactive way to use most encoding/decoding features.
-    *   Includes options for GC-Balanced encoding and Triple-Repeat FEC. (Note: Hamming(7,4) FEC integration in the GUI is currently deferred due to a temporary technical issue and is planned for a future update).
+*   Includes options for GC-Balanced encoding, Triple-Repeat FEC, and Hamming(7,4) FEC.
     *   GUI operations are now asynchronous for improved responsiveness.
     *   Displays encoding metrics and analysis plots:
         *   Huffman codeword lengths histogram.


### PR DESCRIPTION
## Summary
- hook up binary-level Hamming(7,4) decode in the GUI after primary DNA decoding
- display the number of corrected errors
- document that the GUI now supports Hamming FEC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c10d855883268c1f4ea5f812af55