### PR TITLE
Add pytest-cov and upload coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,5 +35,11 @@ jobs:
 
     - name: Run unit tests
       run: |
-        python -m pip install pytest
-        pytest -vv
+        python -m pip install pytest pytest-cov
+        pytest --cov=src -vv
+        coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,3 +1,4 @@
 flet==0.28.3
 matplotlib==3.10.3
 pytest==8.3.5
+pytest-cov==6.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 
 # Packages used for running the test suite
 pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- collect coverage data in CI
- upload coverage report to Codecov
- pin pytest-cov dependency

## Testing
- `pip install -r requirements.txt`
- `pytest --cov=src -vv`
- `coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_6844c75db0c88326827a136a6c8bab1b