### PR TITLE
Fix Codecov badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeneCoder: Simulated DNA Data Encoding & Exploration
 
-[![Codecov Coverage](https://codecov.io/gh/your-org/GeneCoder/branch/main/graph/badge.svg)](https://codecov.io/gh/your-org/GeneCoder)
+[![Codecov Coverage](https://codecov.io/gh/d0tTino/GeneCoder/branch/main/graph/badge.svg)](https://codecov.io/gh/d0tTino/GeneCoder)
 
 **An open, educational software toolkit for simulating DNA data encoding and decoding, bringing the concepts of molecular data storage to your fingertips.**
 


### PR DESCRIPTION
## Summary
- fix Codecov badge link in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AttributeError: module 'genecoder.encoders' has no attribute 'encode_base4')*

------
https://chatgpt.com/codex/tasks/task_e_6844cb9650308326b2a74edd7cab9bbd