### PR TITLE
Implement streaming encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ See [WORKFLOWS.md](WORKFLOWS.md) for a step-by-step overview of the encoding and
     ```
     *Output: `decoded_batch/file1_decoded.bin`, `decoded_batch/notes_decoded.bin`, etc. (assuming original input names were file1.txt, notes.md)*
 
+8.  **Stream encode and decode a large file:**
+    ```bash
+    python src/cli.py encode --input-files big.bin --output-file big.fasta --stream --method base4_direct
+    python src/cli.py decode --input-files big.fasta --output-file big_decoded.bin --stream --method base4_direct
+    ```
+    *Processes the file in chunks to avoid high memory usage (currently only for base4_direct without FEC).* 
+
 
 ### Graphical User Interface (GUI)
 

--- a/src/flet_app.py
+++ b/src/flet_app.py
@@ -119,6 +119,11 @@ def main(page: ft.Page):
         on_change=lambda e: setattr(k_value_input, 'disabled', not e.control.value) or page.update()
     )
 
+    stream_checkbox = ft.Checkbox(
+        label="Stream large files",
+        value=False,
+    )
+
     def on_fec_change(e: ft.ControlEvent):
         """Handle FEC selection updates."""
         if e.control.value == "Hamming(7,4)":
@@ -397,6 +402,8 @@ def main(page: ft.Page):
 
     decode_button = ft.ElevatedButton("Decode")
 
+    decode_stream_checkbox = ft.Checkbox(label="Stream large files", value=False)
+
     async def on_decode_file_picker_result(e: ft.FilePickerResultEvent): # Made async
         if e.files and len(e.files) > 0:
             selected_decode_input_file_path.current = e.files[0].path
@@ -500,6 +507,7 @@ def main(page: ft.Page):
         controls=[
             ft.Row([decode_browse_button, decode_selected_input_file_text], alignment=ft.MainAxisAlignment.START),
             ft.Row([decode_button, decode_progress_ring]), # Added progress ring
+            decode_stream_checkbox,
             ft.Divider(),
             ft.Text("Status:", weight=ft.FontWeight.BOLD),
             decode_status_text,
@@ -547,8 +555,9 @@ def main(page: ft.Page):
                         controls=[
                             ft.Row([encode_browse_button, encode_selected_input_file_text]),
                             method_dropdown,
-                            ft.Row([parity_checkbox, k_value_input]),
-                            fec_dropdown,
+                              ft.Row([parity_checkbox, k_value_input]),
+                              stream_checkbox,
+                              fec_dropdown,
                             fec_info_text,
 
                             ft.Row([encode_button, encode_progress_ring]), # Added progress ring

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -1,0 +1,94 @@
+"""Streaming helpers for large file processing."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Iterator
+
+from .encoders import encode_base4_direct, decode_base4_direct
+from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+
+
+def stream_encode_file(
+    input_path: str,
+    output_path: str,
+    *,
+    header: str,
+    chunk_size: int = 1_000_000,
+    add_parity: bool = False,
+    k_value: int = 7,
+    parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
+) -> int:
+    """Encode ``input_path`` to ``output_path`` streaming chunks.
+
+    Returns the total encoded DNA length.
+    """
+
+    def data_iter() -> Iterator[bytes]:
+        with open(input_path, "rb") as f_in:
+            while True:
+                chunk = f_in.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+    total_len = 0
+    line_width = 80
+    buffer = ""
+    with open(output_path, "w", encoding="utf-8") as f_out:
+        f_out.write(f">{header}\n")
+        for dna_chunk in encode_base4_direct(
+            data_iter(),
+            add_parity=add_parity,
+            k_value=k_value,
+            parity_rule=parity_rule,
+            stream=True,
+        ):
+            total_len += len(dna_chunk)
+            buffer += dna_chunk
+            while len(buffer) >= line_width:
+                f_out.write(buffer[:line_width] + "\n")
+                buffer = buffer[line_width:]
+        if buffer:
+            f_out.write(buffer + "\n")
+    return total_len
+
+
+def stream_decode_file(
+    input_path: str,
+    output_path: str,
+    *,
+    chunk_size: int = 1_000_000,
+    check_parity: bool = False,
+    k_value: int = 7,
+    parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
+) -> None:
+    """Decode ``input_path`` FASTA file to ``output_path`` streaming chunks."""
+
+    with open(input_path, "r", encoding="utf-8") as f_in:
+        header_line = f_in.readline()
+        if not header_line.startswith(">"):
+            raise ValueError("Invalid FASTA input")
+
+        def dna_iter() -> Iterator[str]:
+            buffer = ""
+            for line in f_in:
+                line = line.strip()
+                if not line or line.startswith(">"):
+                    continue
+                buffer += line
+                while len(buffer) >= chunk_size * 4:
+                    yield buffer[: chunk_size * 4]
+                    buffer = buffer[chunk_size * 4 :]
+            if buffer:
+                yield buffer
+
+        with open(output_path, "wb") as f_out:
+            for decoded_chunk, _ in decode_base4_direct(
+                dna_iter(),
+                check_parity=check_parity,
+                k_value=k_value,
+                parity_rule=parity_rule,
+                stream=True,
+            ):
+                f_out.write(decoded_chunk)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+import tempfile
+
+from genecoder.streaming import stream_encode_file, stream_decode_file, encode_base4_direct, decode_base4_direct
+
+
+def test_stream_round_trip(tmp_path, monkeypatch):
+    data = os.urandom(1_500_000)
+    input_file = tmp_path / "input.bin"
+    encoded_file = tmp_path / "encoded.fasta"
+    decoded_file = tmp_path / "decoded.bin"
+    input_file.write_bytes(data)
+
+    enc_calls = []
+    orig_encode = encode_base4_direct
+
+    def mock_encode(*args, **kwargs):
+        enc_calls.append(kwargs.get("stream"))
+        return orig_encode(*args, **kwargs)
+
+    monkeypatch.setattr("genecoder.streaming.encode_base4_direct", mock_encode)
+
+    header = "method=base4_direct input_file=test.bin"
+    stream_encode_file(str(input_file), str(encoded_file), header=header)
+    assert True in enc_calls
+
+    dec_calls = []
+    orig_decode = decode_base4_direct
+
+    def mock_decode(*args, **kwargs):
+        dec_calls.append(kwargs.get("stream"))
+        return orig_decode(*args, **kwargs)
+
+    monkeypatch.setattr("genecoder.streaming.decode_base4_direct", mock_decode)
+
+    stream_decode_file(str(encoded_file), str(decoded_file))
+    assert True in dec_calls
+
+    assert decoded_file.read_bytes() == data


### PR DESCRIPTION
## Summary
- add streaming helpers for chunk-wise encoding and decoding
- enable `--stream` option in CLI
- update base4_direct functions to support iterable streaming
- expose streaming checkbox in GUI
- document streaming CLI usage
- test streaming round‑trip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d2f64f1c8326951a1fec0af1126a