### PR TITLE
Add Reed-Solomon FEC mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
         *   The FASTA header will include `fec=hamming_7_4` and `fec_padding_bits=<number>`, where `fec_padding_bits` indicates the number of zero-bits added to the end of the Hamming-encoded bitstream to make its total length a multiple of 8 before byte packing.
         *   The decoder uses these header fields to correctly apply Hamming decoding to the binary data (after DNA decoding) and reports the total number of corrected errors.
         *   Note: If Hamming(7,4) FEC is selected, DNA-level parity (`--add-parity`) is currently ignored as Hamming provides stronger error correction at the binary level.
+    *   **Reed-Solomon FEC (`--fec reed_solomon`):**
+        *   Adds Reed-Solomon parity bytes to the binary data before DNA encoding (via the `reedsolo` library).
+        *   The FASTA header will include `fec=reed_solomon` and `fec_nsym=<number>` indicating the number of parity symbols used.
+        *   During decoding, the same number of symbols is read from the header to repair burst errors. The decoder reports how many symbols were corrected.
 *   **Error Detection (Parity):**
     *   Optional parity bit addition for `base4_direct` and `huffman` methods using `--add-parity` (details on rules like `GC_even_A_odd_T` can be found in `error_detection.py`). Parity info is stored in the FASTA header. This is typically used if Hamming(7,4) FEC is not active.
 *   **Decoding Engine:**
@@ -75,7 +79,7 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
     *   For `gc_balanced`: Actual GC content and max homopolymer length of the payload (pre-FEC).
 *   **Graphical User Interface (GUI):**
     *   A Flet-based GUI (`src/flet_app.py`) provides an interactive way to use most encoding/decoding features.
-*   Includes options for GC-Balanced encoding, Triple-Repeat FEC, and Hamming(7,4) FEC.
+*   Includes options for GC-Balanced encoding, Triple-Repeat FEC, Hamming(7,4) FEC, and Reed-Solomon FEC.
     *   GUI operations are now asynchronous for improved responsiveness.
     *   Displays encoding metrics and analysis plots:
         *   Huffman codeword lengths histogram.
@@ -160,7 +164,7 @@ Run the Flet application:
 ```bash
 python src/flet_app.py
 ```
-The GUI provides controls for most encoding methods and parity. Forward error correction is selectable from a dropdown offering `None`, `Triple-Repeat`, or `Hamming(7,4)`. Metric displays and analysis plots are included. GUI operations are asynchronous to keep the interface responsive. See [WORKFLOWS.md](WORKFLOWS.md) for the underlying processing steps.
+The GUI provides controls for most encoding methods and parity. Forward error correction is selectable from a dropdown offering `None`, `Triple-Repeat`, `Hamming(7,4)`, or `Reed-Solomon`. Metric displays and analysis plots are included. GUI operations are asynchronous to keep the interface responsive. See [WORKFLOWS.md](WORKFLOWS.md) for the underlying processing steps.
 
 ---
 
@@ -185,7 +189,7 @@ The GUI provides controls for most encoding methods and parity. Forward error co
 1.  **Foundation & Enhancements (Implemented):**
     *   CLI-based encoding and decoding.
     *   Encoding methods: Base-4 Direct, Huffman-4, GC-Balanced.
-    *   Error handling: Parity checks, Triple-Repeat FEC (on DNA), Hamming(7,4) FEC (on binary via CLI).
+    *   Error handling: Parity checks, Triple-Repeat FEC (on DNA), Hamming(7,4) FEC, Reed-Solomon FEC (both on binary).
     *   FASTA output with comprehensive metadata.
     *   Display of encoding metrics.
     *   Batch processing for CLI.

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,3 +2,4 @@ flet==0.28.3
 matplotlib==3.10.3
 pytest==8.3.5
 pytest-cov==6.1.1
+reedsolo==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 # Packages used for running the test suite
 pytest
 pytest-cov
+reedsolo

--- a/src/cli.py
+++ b/src/cli.py
@@ -31,6 +31,7 @@ from genecoder.hamming_codec import (
     encode_data_with_hamming,
     decode_data_with_hamming,
 )  # Binary-level FEC
+from genecoder.reed_solomon_codec import encode_data_rs, decode_data_rs
 from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman, decode_huffman
 from genecoder.error_detection import (
@@ -115,9 +116,21 @@ def run_encoding_pipeline(
         print(
             f"Applied Hamming(7,4) FEC to {input_file_name}. Original binary size: {len(data)}, Hamming encoded binary size: {len(current_input)} (padding bits: {fec_padding_bits})."
         )
+    elif options.fec == "reed_solomon":
+        if options.add_parity:
+            print(
+                f"Warning for {input_file_name}: --add-parity is ignored when Reed-Solomon FEC is applied to binary data.",
+                file=sys.stderr,
+            )
+        current_input, rs_nsym = encode_data_rs(data)
+        header_parts.append("fec=reed_solomon")
+        header_parts.append(f"fec_nsym={rs_nsym}")
+        print(
+            f"Applied Reed-Solomon FEC to {input_file_name}. Original binary size: {len(data)}, RS encoded binary size: {len(current_input)} (nsym={rs_nsym})."
+        )
 
     raw_dna = ""
-    should_add_parity = options.add_parity and options.fec != "hamming_7_4"
+    should_add_parity = options.add_parity and options.fec not in ("hamming_7_4", "reed_solomon")
 
     if options.method == "base4_direct":
         if should_add_parity and options.k_value <= 0:
@@ -177,7 +190,7 @@ def run_encoding_pipeline(
         print(
             f"Applied Triple-Repeat FEC to {input_file_name}. DNA length before: {len(raw_dna)}, after: {len(final_dna)}."
         )
-    elif options.fec is not None and options.fec != "hamming_7_4":
+    elif options.fec is not None and options.fec not in ("hamming_7_4", "reed_solomon"):
         print(
             f"Warning for {input_file_name}: Unknown FEC method '{options.fec}'. No DNA-level FEC applied.",
             file=sys.stderr,
@@ -211,7 +224,7 @@ def run_decoding_pipeline(
             )
 
     parity_errors: list[int] = []
-    should_check_parity = options.check_parity and "fec=hamming_7_4" not in header
+    should_check_parity = options.check_parity and "fec=hamming_7_4" not in header and "fec=reed_solomon" not in header
 
     if options.method == "base4_direct":
         if should_check_parity and options.k_value <= 0:
@@ -298,6 +311,22 @@ def run_decoding_pipeline(
         except ValueError as ve:
             print(
                 f"Error during Hamming(7,4) FEC decoding for {input_file_name}: {ve}. Output may be incorrect.",
+                file=sys.stderr,
+            )
+    if "fec=reed_solomon" in header:
+        print(f"Reed-Solomon FEC detected in header for {input_file_name}.")
+        nsym_match = re.search(r"fec_nsym=(\d+)", header)
+        if not nsym_match:
+            raise ValueError("'fec_nsym' missing in header for Reed-Solomon FEC.")
+        nsym = int(nsym_match.group(1))
+        try:
+            final_data, corrected_rs = decode_data_rs(final_data, nsym)
+            print(
+                f"Reed-Solomon FEC decoding for {input_file_name}: {corrected_rs} corrections."
+            )
+        except ValueError as ve:
+            print(
+                f"Error during Reed-Solomon FEC decoding for {input_file_name}: {ve}. Output may be incorrect.",
                 file=sys.stderr,
             )
 
@@ -581,8 +610,8 @@ def main() -> None:
         "--fec",
         type=str,
         default=None,
-        choices=[None, "triple_repeat", "hamming_7_4"],  # Added hamming_7_4
-        help="Forward Error Correction method to apply. Optional. (Note: hamming_7_4 is applied to binary data before DNA encoding; triple_repeat is applied to DNA sequence after encoding).",
+        choices=[None, "triple_repeat", "hamming_7_4", "reed_solomon"],  # Added hamming_7_4 and reed_solomon
+        help="Forward Error Correction method to apply. Optional. (Note: hamming_7_4 and reed_solomon are applied to binary data before DNA encoding; triple_repeat is applied to DNA sequence after encoding).",
     )
     encode_parser.add_argument(
         "--gc-min",

--- a/src/flet_app.py
+++ b/src/flet_app.py
@@ -121,7 +121,7 @@ def main(page: ft.Page):
 
     def on_fec_change(e: ft.ControlEvent):
         """Handle FEC selection updates."""
-        if e.control.value == "Hamming(7,4)":
+        if e.control.value in ("Hamming(7,4)", "Reed-Solomon"):
             parity_checkbox.value = False
             parity_checkbox.disabled = True
             k_value_input.disabled = True
@@ -135,14 +135,15 @@ def main(page: ft.Page):
         options=[
             ft.dropdown.Option("None"),
             ft.dropdown.Option("Triple-Repeat"),
-            ft.dropdown.Option("Hamming(7,4)")
+            ft.dropdown.Option("Hamming(7,4)"),
+            ft.dropdown.Option("Reed-Solomon")
         ],
         value="None",
         on_change=on_fec_change
     )
 
     fec_info_text = ft.Text(
-        "Parity automatically disabled when Hamming FEC selected.",
+        "Parity automatically disabled when Hamming or Reed-Solomon FEC selected.",
         size=12,
         color=ft.colors.BLUE_GREY_400,
         italic=True,

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -1,0 +1,62 @@
+"""Reed--Solomon encoding and decoding utilities using ``reedsolo``.
+
+This module provides minimal wrappers around the :mod:`reedsolo` library to
+encode and decode byte strings with Reed--Solomon error correction. Only the
+number of parity symbols (``nsym``) is currently exposed as a parameter.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from reedsolo import RSCodec, ReedSolomonError
+
+
+def encode_data_rs(data: bytes, nsym: int = 10) -> Tuple[bytes, int]:
+    """Encode ``data`` with Reed--Solomon FEC.
+
+    Parameters
+    ----------
+    data:
+        Byte string to encode.
+    nsym:
+        Number of parity symbols to append. Defaults to ``10``.
+
+    Returns
+    -------
+    tuple
+        ``(encoded_bytes, nsym)`` where ``encoded_bytes`` is the encoded output
+        including parity symbols.
+    """
+    rs = RSCodec(nsym)
+    encoded = rs.encode(data)
+    return bytes(encoded), nsym
+
+
+def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
+    """Decode Reed--Solomon encoded ``encoded`` bytes.
+
+    Parameters
+    ----------
+    encoded:
+        Encoded data including parity symbols.
+    nsym:
+        Number of parity symbols that were used during encoding.
+
+    Returns
+    -------
+    tuple
+        ``(decoded_bytes, corrections)`` where ``corrections`` is the number of
+        symbols corrected during decoding.
+
+    Raises
+    ------
+    ValueError
+        If decoding fails due to too many errors.
+    """
+    rs = RSCodec(nsym)
+    try:
+        decoded, _full, err_pos = rs.decode(encoded)
+    except ReedSolomonError as exc:  # pragma: no cover - error path
+        raise ValueError(f"Reed-Solomon decode failed: {exc}") from exc
+    return bytes(decoded), len(err_pos)

--- a/tests/test_reed_solomon_codec.py
+++ b/tests/test_reed_solomon_codec.py
@@ -1,0 +1,32 @@
+import pytest
+
+from genecoder.reed_solomon_codec import encode_data_rs, decode_data_rs
+
+
+def test_rs_roundtrip_no_errors():
+    data = b"Hello RS"
+    encoded, nsym = encode_data_rs(data, nsym=10)
+    decoded, corrected = decode_data_rs(encoded, nsym)
+    assert decoded == data
+    assert corrected == 0
+
+
+def test_rs_corrects_burst_errors():
+    data = b"0123456789ABCDEF"
+    encoded, nsym = encode_data_rs(data, nsym=10)
+    corrupted = bytearray(encoded)
+    for i in range(4):
+        corrupted[i] ^= 0xFF
+    decoded, corrected = decode_data_rs(bytes(corrupted), nsym)
+    assert decoded == data
+    assert corrected == 4
+
+
+def test_rs_too_many_errors():
+    data = b"0123456789ABCDEF"
+    encoded, nsym = encode_data_rs(data, nsym=10)
+    corrupted = bytearray(encoded)
+    for i in range(6):
+        corrupted[i] ^= 0xFF
+    with pytest.raises(ValueError):
+        decode_data_rs(bytes(corrupted), nsym)


### PR DESCRIPTION
## Summary
- implement Reed-Solomon encode/decode helpers
- support `reed_solomon` FEC in CLI, GUI and helpers
- document new FEC in README
- add tests for Reed-Solomon burst error correction
- update requirements

## Testing
- `python -m pip install -r requirements.txt`
- `pip install reedsolo==1.7.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d2f714b08326bb5c583989d55da3