### PR TITLE
Handle missing reedsolo gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
         *   The decoder uses these header fields to correctly apply Hamming decoding to the binary data (after DNA decoding) and reports the total number of corrected errors.
         *   Note: If Hamming(7,4) FEC is selected, DNA-level parity (`--add-parity`) is currently ignored as Hamming provides stronger error correction at the binary level.
     *   **Reed-Solomon FEC (`--fec reed_solomon`):**
-        *   Adds Reed-Solomon parity bytes to the binary data before DNA encoding (via the `reedsolo` library).
+        *   Adds Reed-Solomon parity bytes to the binary data before DNA encoding.
+        *   Requires the optional `reedsolo` library (`pip install reedsolo`).
         *   The FASTA header will include `fec=reed_solomon` and `fec_nsym=<number>` indicating the number of parity symbols used.
         *   During decoding, the same number of symbols is read from the header to repair burst errors. The decoder reports how many symbols were corrected.
 *   **Error Detection (Parity):**

--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -16,6 +16,7 @@ from .hamming_codec import encode_data_with_hamming, decode_data_with_hamming
 from .huffman_coding import encode_huffman, decode_huffman
 from .formats import to_fasta, from_fasta
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from .reed_solomon_codec import encode_data_rs, decode_data_rs
 from .plotting import (
     prepare_huffman_codeword_length_data,
     generate_codeword_length_histogram,

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -9,7 +9,24 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from reedsolo import RSCodec, ReedSolomonError
+try:  # pragma: no cover - optional dependency
+    from reedsolo import RSCodec, ReedSolomonError
+    _HAS_REEDSOLO = True
+except ImportError:  # pragma: no cover - missing optional dependency
+    RSCodec = None
+
+    class ReedSolomonError(Exception):
+        """Placeholder used when :mod:`reedsolo` is unavailable."""
+
+    _HAS_REEDSOLO = False
+
+
+def _require_reedsolo() -> None:  # pragma: no cover - helper
+    """Ensure the :mod:`reedsolo` package is installed."""
+    if not _HAS_REEDSOLO:
+        raise ImportError(
+            "reedsolo is required for Reed-Solomon encoding. Install it via 'pip install reedsolo'."
+        )
 
 
 def encode_data_rs(data: bytes, nsym: int = 10) -> Tuple[bytes, int]:
@@ -28,6 +45,7 @@ def encode_data_rs(data: bytes, nsym: int = 10) -> Tuple[bytes, int]:
         ``(encoded_bytes, nsym)`` where ``encoded_bytes`` is the encoded output
         including parity symbols.
     """
+    _require_reedsolo()
     rs = RSCodec(nsym)
     encoded = rs.encode(data)
     return bytes(encoded), nsym
@@ -54,6 +72,7 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
     ValueError
         If decoding fails due to too many errors.
     """
+    _require_reedsolo()
     rs = RSCodec(nsym)
     try:
         decoded, _full, err_pos = rs.decode(encoded)

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from typing import Iterable, Iterator
+from typing import Iterator
 
 from .encoders import encode_base4_direct, decode_base4_direct
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,6 +1,4 @@
 import os
-from pathlib import Path
-import tempfile
 
 from genecoder.streaming import stream_encode_file, stream_decode_file, encode_base4_direct, decode_base4_direct
 


### PR DESCRIPTION
## Summary
- add optional import for `reedsolo` in Reed-Solomon codec
- raise a helpful error only when encoding/decoding is attempted without the dependency
- note that `reedsolo` is optional in README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844f72875088326bae2ae82d3bd0fe0