### PR TITLE
Add FEC parity toggle in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ python src/flet_app.py
 ```
 The GUI provides controls for most encoding methods and parity. Forward error correction is selectable from a dropdown offering `None`, `Triple-Repeat`, `Hamming(7,4)`, or `Reed-Solomon`. Metric displays and analysis plots are included. GUI operations are asynchronous to keep the interface responsive. See [WORKFLOWS.md](WORKFLOWS.md) for the underlying processing steps.
 
+Selecting 'Hamming(7,4)' or 'Reed-Solomon' automatically disables the `Add Parity` checkbox. It becomes available again when `None` or `Triple-Repeat` is chosen.
 ---
 
 ## Technology Stack

--- a/src/flet_app.py
+++ b/src/flet_app.py
@@ -135,6 +135,19 @@ def main(page: ft.Page):
         on_change=lambda e: setattr(k_value_input, 'disabled', not e.control.value) or page.update()
     )
 
+    def on_fec_change(e: ft.ControlEvent):
+        """Toggle parity checkbox based on selected FEC."""
+        selected = e.control.value
+        if selected in ("Hamming(7,4)", "Reed-Solomon"):
+            parity_checkbox.value = False
+            parity_checkbox.disabled = True
+            k_value_input.disabled = True
+        else:
+            parity_checkbox.disabled = False
+            k_value_input.disabled = not parity_checkbox.value
+        page.update()
+
+
 
     fec_dropdown = ft.Dropdown(
         label="FEC Method",
@@ -143,7 +156,8 @@ def main(page: ft.Page):
             ft.dropdown.Option("Triple-Repeat"),
             ft.dropdown.Option("Hamming(7,4)")
         ],
-        value="None"
+        value="None",
+        on_change=on_fec_change
 
     )
     


### PR DESCRIPTION
## Summary
- disable parity checkbox when selecting Hamming or Reed-Solomon FEC in the Flet app
- update README with instructions for this behaviour

## Testing
- `ruff check src/flet_app.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684764094f9c832682ead7eb15a5daa3