### PR TITLE
Fix missing any_plot computation

### DIFF
--- a/src/flet_app.py
+++ b/src/flet_app.py
@@ -283,6 +283,7 @@ def main(page: ft.Page):
             nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
             sequence_analysis_plot_image.src_base64 = result.plots.get("sequence_analysis")
 
+            any_plot = any(result.plots.values())
 
             if any_plot:
                 analysis_status_text.value = "All analysis plots generated successfully."


### PR DESCRIPTION
## Summary
- compute `any_plot` from result plots
- enable or disable analysis tab based on `any_plot`

## Testing
- `ruff check src/flet_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847713679688326b302f641ee30c075