### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Check out code

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Selecting 'Hamming(7,4)' or 'Reed-Solomon' automatically disables the `Add Parit
 
 ## Technology Stack
 
-*   **Language:** Python 3.10 or 3.11 (tested)
+*   **Language:** Python 3.10, 3.11, or 3.12 (tested)
 *   **Core Libraries (Python Standard Library):**
     *   `argparse` (for CLI argument parsing)
     *   `json` (for serializing Huffman table in FASTA headers)


### PR DESCRIPTION
## Summary
- test CI on Python 3.12
- document support for Python 3.12

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486befe1988326a3fca878541e7223