### PR TITLE
Skip CI on comment-only changes

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,30 +16,42 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Detect comment-only changes
+      id: comment_check
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: python scripts/only_comments_changed.py
+
     - name: Install dependencies
+      if: steps.comment_check.outputs.only_comments != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install ruff # For linting
 
     - name: Lint with ruff
+      if: steps.comment_check.outputs.only_comments != 'true'
       run: |
         ruff check . --output-format=github
         # The --output-format=github will show annotations directly in PRs
 
     - name: Run unit tests
+      if: steps.comment_check.outputs.only_comments != 'true'
       run: |
         python -m pip install pytest pytest-cov
         pytest --cov=src --cov-config=.coveragerc -vv
         coverage xml
 
     - name: Upload coverage to Codecov
+      if: steps.comment_check.outputs.only_comments != 'true'
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml

--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Check if Python code changes are limited to comments or documentation."""
+import os
+import subprocess
+
+
+def run(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def is_comment_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith("#"):
+        return True
+    if '"""' in stripped or "'''" in stripped:
+        return True
+    return False
+
+
+def only_comments_changed(base_ref: str) -> bool:
+    # List python files changed compared to base_ref
+    files = run(["git", "diff", "--name-only", base_ref, "--", "*.py"]).splitlines()
+    if not files:
+        return True
+    diff = run(["git", "diff", base_ref, "--unified=0", "--", *files])
+    for line in diff.splitlines():
+        if not line.startswith(("+", "-")):
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        content = line[1:]
+        if not is_comment_line(content):
+            return False
+    return True
+
+
+def main() -> int:
+    base_ref = os.environ.get("BASE_SHA", "origin/main")
+    only_comments = only_comments_changed(base_ref)
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as fh:
+            fh.write(f"only_comments={str(only_comments).lower()}\n")
+    else:
+        print(f"only_comments={str(only_comments).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- detect comment-only diffs using `scripts/only_comments_changed.py`
- run the detection before the build in GitHub Actions
- skip install, lint, tests, and coverage steps when there are no code changes

## Testing
- `ruff check scripts/only_comments_changed.py`
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68486bf14c8c8326b164f202041957c9