### PR TITLE
Enable pip caching in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,6 +54,13 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: python scripts/only_comments_changed.py
 
+    - name: Cache pip
+      if: steps.comment_check.outputs.only_comments != 'true'
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+
 
     - name: Install dependencies
       if: steps.comment_check.outputs.only_comments != 'true'


### PR DESCRIPTION
## Summary
- cache pip packages to speed up CI runs

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849858848e08326aa48064a13737cd1