### PR TITLE
Add pre-commit run to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,13 +54,17 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: python scripts/only_comments_changed.py
 
-
     - name: Install dependencies
       if: steps.comment_check.outputs.only_comments != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ruff # For linting
+        pip install ruff pre-commit # For linting and pre-commit
+
+    - name: Run pre-commit
+      if: steps.comment_check.outputs.only_comments != 'true'
+      run: |
+        pre-commit run --show-diff-on-failure --color=always
 
     - name: Lint with ruff
       if: steps.comment_check.outputs.only_comments != 'true'


### PR DESCRIPTION
## Summary
- run `pre-commit` in the CI workflow after installing dependencies
- install `pre-commit` alongside lint dependencies

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849858b0bf88326aa7cf36ffbe1313c