### PR TITLE
Add comment-only automerge workflow

### DIFF
--- a/.github/workflows/automerge-comments.yml
+++ b/.github/workflows/automerge-comments.yml
@@ -1,0 +1,25 @@
+name: Auto-merge comment-only PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect comment-only changes
+        id: comment_check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python scripts/only_comments_changed.py
+
+      - name: Enable auto-merge
+        if: steps.comment_check.outputs.only_comments == 'true'
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -97,3 +97,11 @@ removed from the queue and will need to be re-queued after fixes are pushed.
 Contributors do not need to take any manual steps beyond opening the pull
 request. The merge queue will handle running `python-ci` automatically and will
 merge the branch once all checks pass.
+
+## Automatic Merging for Comment-Only Changes
+
+A separate workflow (`automerge-comments.yml`) listens to pull request events. It
+runs `scripts/only_comments_changed.py` to check if the changes are restricted to
+comments or documentation. When the script reports `only_comments=true`, the
+workflow invokes `peter-evans/enable-pull-request-automerge@v2` to automatically
+enable auto-merge for the pull request.


### PR DESCRIPTION
## Summary
- enable automatic merging for comment-only PRs using `peter-evans/enable-pull-request-automerge`
- document the new workflow in `WORKFLOWS.md`

## Testing
- `pre-commit run --files .github/workflows/automerge-comments.yml WORKFLOWS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498cbcf7a48326a68921454200f432