### PR TITLE
Add concurrency group to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,6 +12,11 @@ on:
       - 'docs/**'
       - '**/*.md'
 
+# Ensure only a single workflow run per PR or branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- abort previous Python CI workflow runs when new commits arrive
- note concurrency behavior in GitHub Actions config

## Testing
- `pre-commit run --show-diff-on-failure --color=always`
- `ruff check . --output-format=github`
- `pytest --cov=src --cov-config=.coveragerc -vv`

------
https://chatgpt.com/codex/tasks/task_e_68498cbb96248326ad19ce84f53f9f21