### PR TITLE
Improve CI by caching pip

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,6 +54,12 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: python scripts/only_comments_changed.py
 
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
     - name: Install dependencies
       if: steps.comment_check.outputs.only_comments != 'true'
       run: |


### PR DESCRIPTION
## Summary
- cache pip dependencies in CI

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498cbad4a48326b60bf58e0e80cb64