### PR TITLE
Improve comment detection script and CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,18 +49,20 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - name: Detect comment-only changes
       id: comment_check
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: python scripts/only_comments_changed.py
 
+    - name: Set up Python
+      if: steps.comment_check.outputs.only_comments != 'true'
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Cache pip
+      if: steps.comment_check.outputs.only_comments != 'true'
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
@@ -71,12 +73,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ruff pre-commit # For linting and pre-commit
+        pip install ruff
 
-    - name: Run pre-commit
+    - uses: pre-commit/action@v3
       if: steps.comment_check.outputs.only_comments != 'true'
-      run: |
-        pre-commit run --show-diff-on-failure --color=always
 
     - name: Lint with ruff
       if: steps.comment_check.outputs.only_comments != 'true'

--- a/tests/test_only_comments_changed.py
+++ b/tests/test_only_comments_changed.py
@@ -1,0 +1,56 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.only_comments_changed import only_comments_changed
+
+
+def git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def setup_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    (repo / "file.py").write_text("print('hi')\n")
+    git(repo, "add", "file.py")
+    git(repo, "commit", "-m", "init")
+    return repo
+
+
+def test_python_comment_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "file.py").write_text("print('hi')\n# comment\n")
+    git(repo, "add", "file.py")
+    monkeypatch.chdir(repo)
+    assert only_comments_changed("HEAD")
+
+
+def test_docs_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    docs = repo / "docs"
+    docs.mkdir()
+    (docs / "index.md").write_text("# docs\n")
+    git(repo, "add", "docs/index.md")
+    monkeypatch.chdir(repo)
+    assert only_comments_changed("HEAD")
+
+
+def test_python_code_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "file.py").write_text("print('bye')\n")
+    git(repo, "add", "file.py")
+    monkeypatch.chdir(repo)
+    assert not only_comments_changed("HEAD")
+
+
+def test_other_file_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "config.yml").write_text("a: 1\n")
+    git(repo, "add", "config.yml")
+    monkeypatch.chdir(repo)
+    assert not only_comments_changed("HEAD")


### PR DESCRIPTION
## Summary
- detect docs-only changes in `only_comments_changed.py`
- run comment detection earlier in CI and skip heavy steps
- cache pre-commit and use its action
- add tests for comment detection behavior

## Testing
- `pre-commit run --files scripts/only_comments_changed.py tests/test_only_comments_changed.py .github/workflows/python-ci.yml`
- `ruff check scripts/only_comments_changed.py tests/test_only_comments_changed.py`
- `pytest tests/test_only_comments_changed.py`

------
https://chatgpt.com/codex/tasks/task_e_68498e7864b08326a843f5e759999c37