### PR TITLE
Handle docstrings in only_comments_changed

### DIFF
--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import os
 import subprocess
+import re
 import tokenize
 
 
@@ -12,16 +13,35 @@ def run(cmd):
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return result.stdout
 
+DOCSTRING_RE = re.compile(r"^[rRuUbBfF]*('{3}|\"{3})")
+
+
+def _is_triple_quoted(token: tokenize.TokenInfo) -> bool:
+    """Return True if ``token`` represents a triple quoted string."""
+
+    return bool(DOCSTRING_RE.match(token.string))
+
+
 def _tokens_without_comments(source: str) -> list[tuple[int, str]] | None:
-    """Return tokens excluding comments and NL tokens."""
+    """Return tokens excluding comments, NL tokens and docstrings."""
 
     try:
         tokens = tokenize.generate_tokens(io.StringIO(source).readline)
-        return [
-            (tok.type, tok.string)
-            for tok in tokens
-            if tok.type not in (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING)
-        ]
+        result: list[tuple[int, str]] = []
+        prev_type = None
+        for tok in tokens:
+            if tok.type in (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING):
+                continue
+            if (
+                tok.type == tokenize.STRING
+                and _is_triple_quoted(tok)
+                and (prev_type == tokenize.INDENT or not result)
+            ):
+                prev_type = tok.type
+                continue
+            result.append((tok.type, tok.string))
+            prev_type = tok.type
+        return result
     except tokenize.TokenError:
         return None
 

--- a/tests/test_only_comments_changed.py
+++ b/tests/test_only_comments_changed.py
@@ -54,3 +54,36 @@ def test_other_file_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     git(repo, "add", "config.yml")
     monkeypatch.chdir(repo)
     assert not only_comments_changed("HEAD")
+
+
+def test_module_docstring_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "file.py").write_text('"""hi"""\nprint("hi")\n')
+    git(repo, "add", "file.py")
+    git(repo, "commit", "-m", "add docstring")
+    (repo / "file.py").write_text('"""bye"""\nprint("hi")\n')
+    git(repo, "add", "file.py")
+    monkeypatch.chdir(repo)
+    assert only_comments_changed("HEAD")
+
+
+def test_function_docstring_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "file.py").write_text('def f():\n    """hi"""\n    pass\n')
+    git(repo, "add", "file.py")
+    git(repo, "commit", "-m", "add func doc")
+    (repo / "file.py").write_text('def f():\n    """bye"""\n    pass\n')
+    git(repo, "add", "file.py")
+    monkeypatch.chdir(repo)
+    assert only_comments_changed("HEAD")
+
+
+def test_triple_quoted_string_not_docstring(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = setup_repo(tmp_path)
+    (repo / "file.py").write_text('data = """hi"""\nprint(data)\n')
+    git(repo, "add", "file.py")
+    git(repo, "commit", "-m", "init triple string")
+    (repo / "file.py").write_text('data = """bye"""\nprint(data)\n')
+    git(repo, "add", "file.py")
+    monkeypatch.chdir(repo)
+    assert not only_comments_changed("HEAD")


### PR DESCRIPTION
## Summary
- treat docstrings as comments in only_comments_changed check
- test docstring scenarios

## Testing
- `pre-commit run --files scripts/only_comments_changed.py tests/test_only_comments_changed.py`
- `pytest -q tests/test_only_comments_changed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499a3ee1b48326bf82794838a70832