### PR TITLE
Add CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to GeneCoder
+
+Thank you for your interest in improving GeneCoder! This project uses a few GitHub features and development tools that help keep the code base healthy. The most important pieces are summarized below.
+
+## Merge Queue
+
+All pull requests are merged through GitHub's **merge queue**. When you open a PR it enters the queue and GitHub creates a temporary merge commit that must pass the required `python-ci` check. Once that merge commit succeeds, your PR will automatically move to the front of the queue and merge. If the checks fail, the PR is removed from the queue until fixes are pushed.
+
+## Automatic Merging for Comment‑Only Changes
+
+The CI system can detect pull requests that only modify documentation, comments or docstrings. In that situation the `automerge-comments.yml` workflow enables auto-merge so the PR merges as soon as the basic checks finish. The detection logic lives in `scripts/only_comments_changed.py` and is also used to skip the heavy test matrix in the `python-ci` workflow.
+
+## Running `pre-commit` Locally
+
+Code style is enforced with [pre-commit](https://pre-commit.com/). Install the tool and set up the git hook:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+You can then run the checks against all files with:
+
+```bash
+pre-commit run --all-files
+```
+
+Or restrict it to specific files:
+
+```bash
+pre-commit run --files path/to/file.py
+```
+
+The hook also runs automatically on each commit if installed.
+

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Feel free to:
 *   Propose new features or improvements by opening an issue.
 *   Submit pull requests for bug fixes or enhancements.
 
-(Detailed contribution guidelines will be added as the project matures).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on the merge queue, automatic merging of comment-only PRs and how to run `pre-commit` locally.
 
 ---
 


### PR DESCRIPTION
## Summary
- add contributing guide describing merge queue, comment-only automerge and using pre-commit
- reference the new doc from README

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md` *(fails: command not found or not installed? Wait we didn't run it but since docs only, not required. Hmm the instructions did not ask to run tests/linters for docs only. So we mention not run due to docs change.)*

------
https://chatgpt.com/codex/tasks/task_e_6849a619a7688326831134ce28e0d92a