### PR TITLE
Remove redundant ruff lint step

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -87,12 +87,6 @@ jobs:
     - uses: pre-commit/action@v3
       if: needs['check-comments'].outputs.only_comments != 'true'
 
-    - name: Lint with ruff
-      if: needs['check-comments'].outputs.only_comments != 'true'
-      run: |
-        ruff check . --output-format=github
-        # The --output-format=github will show annotations directly in PRs
-
     - name: Run unit tests
       if: needs['check-comments'].outputs.only_comments != 'true'
       run: |

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -107,6 +107,10 @@ touch comments, docstrings or documentation files. When the script outputs
 test matrix does not run. This short‑circuits CI for documentation‑only updates
 and significantly reduces build time.
 
+Within the `build` job, code style checks are executed via `pre-commit`, which
+invokes `ruff`. The previous dedicated "Lint with ruff" step has been removed
+because ruff now runs automatically through the pre‑commit hook.
+
 
 ## Automatic Merging for Comment-Only Changes
 


### PR DESCRIPTION
## Summary
- drop explicit `Lint with ruff` step in `python-ci`
- document that ruff runs via pre-commit

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml WORKFLOWS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a61769dc832685926eea8a31f29a