### PR TITLE
Implement triple quote detection

### DIFF
--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -14,6 +14,15 @@ def run(cmd):
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return result.stdout
 
+
+_TRIPLE_QUOTE_RE = re.compile(r"^[uUbBfFrR]*(['\"]{3})")
+
+
+def _is_triple_quoted(tok: tokenize.TokenInfo) -> bool:
+    """Return True if ``tok.string`` uses triple quotes."""
+
+    return bool(_TRIPLE_QUOTE_RE.match(tok.string))
+
 def _ast_without_docstrings(source: str) -> str | None:
     """Return AST dump without docstrings."""
 

--- a/tests/test_only_comments_changed.py
+++ b/tests/test_only_comments_changed.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import pytest
 
-from scripts.only_comments_changed import only_comments_changed
+from scripts.only_comments_changed import _is_triple_quoted, only_comments_changed
+import io
+import tokenize
 
 
 def git(cwd: Path, *args: str) -> None:
@@ -98,3 +100,13 @@ def test_triple_quoted_string_not_docstring(tmp_path: Path, monkeypatch: pytest.
     git(repo, "add", "file.py")
     monkeypatch.chdir(repo)
     assert not only_comments_changed("HEAD")
+
+
+def test_is_triple_quoted_detection() -> None:
+    tok = next(tokenize.generate_tokens(io.StringIO('"""hi"""').readline))
+    assert _is_triple_quoted(tok)
+
+
+def test_is_triple_quoted_negative() -> None:
+    tok = next(tokenize.generate_tokens(io.StringIO('"hi"').readline))
+    assert not _is_triple_quoted(tok)


### PR DESCRIPTION
## Summary
- detect triple-quoted strings in `scripts/only_comments_changed.py`
- test `_is_triple_quoted` detection

## Testing
- `ruff check scripts/only_comments_changed.py tests/test_only_comments_changed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a61594cc8326bf2656544ff6c757