### PR TITLE
Fix CI dependencies install

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,7 +33,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - 'requirements.txt'
+              - 'requirements.lock'
               - '.github/workflows/**'
 
   check-comments:
@@ -77,13 +77,13 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: pip-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+        key: pip-${{ runner.os }}-${{ hashFiles('requirements.lock') }}
 
     - name: Install dependencies
       if: needs['check-comments'].outputs.only_comments != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.lock
         pip install ruff
 
     - uses: pre-commit/action@v3


### PR DESCRIPTION
## Summary
- in python-ci, install from the locked requirement file

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a06cacbc8832689f7c1d72821717b