### PR TITLE
Improve pre-commit caching

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -86,8 +86,21 @@ jobs:
         pip install -r requirements.txt
         pip install ruff
 
+    - name: Cache pre-commit
+      if: needs['check-comments'].outputs.only_comments != 'true'
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/pre-commit
+          .ruff_cache
+        key: pre-commit-${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          pre-commit-${{ matrix.python-version }}-
+
     - uses: pre-commit/action@v3
       if: needs['check-comments'].outputs.only_comments != 'true'
+      env:
+        PRE_COMMIT_HOME: ~/.cache/pre-commit
 
     - name: Run unit tests
       if: needs['check-comments'].outputs.only_comments != 'true'


### PR DESCRIPTION
## Summary
- cache `~/.cache/pre-commit` and `.ruff_cache` in GitHub Actions
- preserve caches between runs and point pre-commit to the cache

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0972f5fc8326bff847ee9bcab748