### PR TITLE
Improve CI path filtering and linting job

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,6 +35,7 @@ jobs:
               - 'pyproject.toml'
               - 'requirements.lock'
               - '.github/workflows/**'
+              - 'scripts/**'
 
   check-comments:
     runs-on: ubuntu-latest
@@ -51,8 +52,57 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: python scripts/only_comments_changed.py
 
-  build:
+  lint:
     needs: [changes, check-comments]
+    if: needs.changes.outputs.src == 'true' && needs['check-comments'].outputs.only_comments != 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-${{ runner.os }}-${{ hashFiles('requirements.lock') }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.lock
+
+    - name: Restore pre-commit cache
+      id: precommit-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cache/pre-commit
+          .ruff_cache
+        key: pre-commit-3.11-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          pre-commit-3.11-
+
+    - name: Run pre-commit
+      uses: pre-commit/action@v3
+      env:
+        PRE_COMMIT_HOME: ~/.cache/pre-commit
+
+    - name: Save pre-commit cache
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cache/pre-commit
+          .ruff_cache
+        key: pre-commit-3.11-${{ hashFiles('.pre-commit-config.yaml') }}
+
+  build:
+    needs: [changes, check-comments, lint]
     if: needs.changes.outputs.src == 'true' && needs['check-comments'].outputs.only_comments != 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -81,34 +131,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.lock
-        pip install ruff
 
-    - name: Restore pre-commit cache
-      if: needs['check-comments'].outputs.only_comments != 'true'
-      id: precommit-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.cache/pre-commit
-          .ruff_cache
-        key: pre-commit-${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: |
-          pre-commit-${{ matrix.python-version }}-
-
-    - name: Run pre-commit
-      if: needs['check-comments'].outputs.only_comments != 'true'
-      uses: pre-commit/action@v3
-      env:
-        PRE_COMMIT_HOME: ~/.cache/pre-commit
-
-    - name: Save pre-commit cache
-      if: needs['check-comments'].outputs.only_comments != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: |
-          ~/.cache/pre-commit
-          .ruff_cache
-        key: pre-commit-${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
 
     - name: Run unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,12 @@ pre-commit run --files path/to/file.py
 
 The hook also runs automatically on each commit if installed.
 
+## Running the Test Suite
+
+Unit tests use `pytest`. Install the pinned dependencies and run:
+
+```bash
+pip install -r requirements.lock
+pytest -q
+```
+

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ pip install -r requirements.txt
 # For exact versions used in CI, see requirements.lock
 ```
 
+### Running Tests
+
+Install the dependencies and execute the test suite with `pytest`:
+
+```bash
+pip install -r requirements.lock
+pytest -q
+```
+
 
 ## Usage
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -98,18 +98,26 @@ Contributors do not need to take any manual steps beyond opening the pull
 request. The merge queue will handle running `python-ci` automatically and will
 merge the branch once all checks pass.
 
+### `changes` Job
+
+The workflow begins with a **`changes`** job that uses
+`dorny/paths-filter` to check whether source files were modified. It looks at
+`src/`, `tests/`, configuration files, workflow definitions and the `scripts/`
+directory. If no files in those paths changed, the heavy test matrix is
+skipped.
+
 ### `check-comments` Job
 
 The `python-ci` workflow contains a **`check-comments`** job that runs
 `scripts/only_comments_changed.py` to detect pull requests that exclusively
 touch comments, docstrings or documentation files. When the script outputs
-`only_comments=true`, the workflow skips the `build` job entirely so the full
-test matrix does not run. This short‑circuits CI for documentation‑only updates
-and significantly reduces build time.
+`only_comments=true`, the workflow skips the `lint` and `build` jobs entirely so
+the full test matrix does not run. This short‑circuits CI for
+documentation‑only updates and significantly reduces build time.
 
-Within the `build` job, code style checks are executed via `pre-commit`, which
-invokes `ruff`. The previous dedicated "Lint with ruff" step has been removed
-because ruff now runs automatically through the pre‑commit hook.
+Code style checks are handled in a dedicated **`lint`** job that runs
+`pre-commit` with Python 3.11. The `build` matrix depends on this job so
+linting only executes once per change.
 
 
 ## Automatic Merging for Comment-Only Changes


### PR DESCRIPTION
## Summary
- run CI when `scripts/` changes by extending path filter
- add a dedicated `lint` job to run pre-commit once
- remove redundant pre-commit steps from the build matrix
- document the `changes` and `lint` jobs in `WORKFLOWS.md`
- add instructions for running the test suite

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md .github/workflows/python-ci.yml WORKFLOWS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0f061bfc8326aaa84f47adace21d