### PR TITLE
Add project metadata for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,19 @@ line-length = 88
   [tool.ruff.lint]
   extend-select = []
 
+[project]
+name = "GeneCoder"
+version = "0.1.0"
+description = "Simulated DNA data encoding & decoding toolkit"
+authors = [{ name = "GeneCoder Team" }]
+readme = "README.md"
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- include PEP 621 `[project]` table in `pyproject.toml`
- configure `setuptools` to build packages from `src`

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q`
- `python -m build`
- `pip install .`

------
https://chatgpt.com/codex/tasks/task_e_684b2d2dc2088326884c681211500a04