### PR TITLE
Pin Flet 0.28.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The current version of GeneCoder, built around a Command-Line Interface (CLI), d
 Clone the repository and install the required packages:
 
 ```bash
-pip install -r requirements.txt
-# For exact versions used in CI, see requirements.lock
+pip install -r requirements.txt  # installs flet>=0.28,<0.29
+# For the exact versions used in CI (flet 0.28.x), see requirements.lock
 ```
 
 ### Running Tests

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,5 +1,5 @@
 flet==0.28.3
 matplotlib==3.10.3
-pytest==8.3.5
-pytest-cov==6.1.1
+pytest==8.4.0
+pytest-cov==6.2.1
 reedsolo==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flet
+flet>=0.28,<0.29
 matplotlib
 
 # Packages used for running the test suite


### PR DESCRIPTION
## Summary
- pin Flet to the 0.28 series
- regenerate lock file
- mention pinned Flet version in install instructions

## Testing
- `pre-commit run --files requirements.txt requirements.lock README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5722e90483269ef98df2273fc6aa