### PR TITLE
Pin flet version in pyproject

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 Clone the repository and install dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs flet>=0.28,<0.29
 # For exact versions used in CI, see requirements.lock
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,10 @@ readme = "README.md"
 license = { text = "MIT" }
 keywords = ["DNA", "storage", "encoding", "simulation"]
 dependencies = [
-    "flet",
+    "flet>=0.28,<0.29",
     "matplotlib",
     "reedsolo",
 ]
-urls = {"Homepage" = "https://github.com/d0tTino/GeneCoder"}
-
 [project.scripts]
 genecoder = "src.cli:main"
 


### PR DESCRIPTION
## Summary
- pin `flet` to `>=0.28,<0.29` in `pyproject.toml`
- document the version constraint in installation docs
- cleanup duplicate `project.urls` key

## Testing
- `pre-commit run --files pyproject.toml docs/installation.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5a817e0c8326b782af607bbd6491