### PR TITLE
Fix pyproject to remove duplicate urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "matplotlib",
     "reedsolo",
 ]
-urls = {"Homepage" = "https://github.com/d0tTino/GeneCoder"}
 
 [project.scripts]
 genecoder = "src.cli:main"


### PR DESCRIPTION
## Summary
- remove a duplicate `urls` field from `pyproject.toml`
- verify the remaining `[project.urls]` table for `ruff`

## Testing
- `ruff check pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5a80ff048326bba1dd8cb9f69125