### PR TITLE
Improve run helper failure reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "matplotlib",
     "reedsolo",
 ]
-urls = {"Homepage" = "https://github.com/d0tTino/GeneCoder"}
 
 [project.scripts]
 genecoder = "src.cli:main"

--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -7,12 +7,27 @@ import io
 import os
 import subprocess
 import re
+import sys
 import tokenize
 
 
-def run(cmd):
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    return result.stdout
+def run(cmd: list[str]) -> str:
+    """Run ``cmd`` and return stdout.
+
+    Failures are reported so CI doesn't silently continue when git commands fail.
+    """
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Command {cmd} failed with exit code {exc.returncode}\n{exc.stderr}",
+            file=sys.stderr,
+        )
+        raise
 
 
 _TRIPLE_QUOTE_RE = re.compile(r"^[uUbBfFrR]*(['\"]{3})")


### PR DESCRIPTION
## Summary
- report git command failures in `only_comments_changed.py`
- fix duplicate `urls` entry in `pyproject.toml`

## Testing
- `pre-commit run --files scripts/only_comments_changed.py pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b5a8368388326adb572a7dc3b8649