### PR TITLE
Add coverage tests for CLI and streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "matplotlib",
     "reedsolo",
 ]
-urls = {"Homepage" = "https://github.com/d0tTino/GeneCoder"}
 
 [project.scripts]
 genecoder = "src.cli:main"

--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -10,9 +10,13 @@ import re
 import tokenize
 
 
-def run(cmd):
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    return result.stdout
+def run(cmd: list[str]) -> str:
+    """Return stdout from ``cmd`` or an empty string on failure."""
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        return result.stdout
+    return ""
 
 
 _TRIPLE_QUOTE_RE = re.compile(r"^[uUbBfFrR]*(['\"]{3})")

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,0 +1,58 @@
+import argparse
+from src.cli import (
+    build_encoding_options,
+    build_decoding_options,
+    run_encoding_pipeline,
+    run_decoding_pipeline,
+)
+
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+
+
+def test_encoding_decoding_triple_repeat(tmp_path):
+    data = b"hello world"
+    enc_args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec="triple_repeat",
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+    )
+    enc_opts = build_encoding_options(enc_args)
+    dna, header, raw_dna, *_ = run_encoding_pipeline(data, enc_opts, "in.bin")
+    assert "fec=triple_repeat" in header
+    assert len(dna) == len(raw_dna) * 3
+
+    dec_args = argparse.Namespace(
+        method="base4_direct",
+        check_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+    )
+    dec_opts = build_decoding_options(dec_args)
+    out_bytes = run_decoding_pipeline(dna, header, dec_opts, "in.bin")
+    assert out_bytes == data
+
+
+def test_run_encoding_unknown_fec_warning(capsys):
+    data = b"abc"
+    enc_args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec="bogus",
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+    )
+    enc_opts = build_encoding_options(enc_args)
+    dna, header, *_ = run_encoding_pipeline(data, enc_opts, "x.bin")
+    captured = capsys.readouterr()
+    assert "Unknown FEC method 'bogus'" in captured.err
+    assert "fec=bogus" not in header
+    assert dna
+

--- a/tests/test_streaming_additional.py
+++ b/tests/test_streaming_additional.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from genecoder.streaming import stream_encode_file, stream_decode_file
+
+
+def test_stream_encode_line_width(tmp_path):
+    data = os.urandom(300)
+    input_file = tmp_path / "in.bin"
+    output_file = tmp_path / "out.fasta"
+    input_file.write_bytes(data)
+
+    header = "method=base4_direct input_file=in.bin"
+    total_len = stream_encode_file(str(input_file), str(output_file), header=header, chunk_size=50)
+    lines = output_file.read_text().splitlines()
+    assert lines[0] == f">{header}"
+    dna = "".join(lines[1:])
+    assert len(dna) == total_len
+    for line in lines[1:]:
+        assert len(line) <= 80
+
+
+def test_stream_decode_invalid_header(tmp_path):
+    bad_file = tmp_path / "bad.fasta"
+    bad_file.write_text("invalid\nACGT")
+    out_file = tmp_path / "out.bin"
+    with pytest.raises(ValueError):
+        stream_decode_file(str(bad_file), str(out_file))
+


### PR DESCRIPTION
## Summary
- fix duplicate 'urls' field in `pyproject.toml`
- add CLI pipeline coverage tests
- add streaming helper tests for line width and invalid FASTA

## Testing
- `ruff check .`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5a82af0483268e81861fa6089f88