### PR TITLE
Add CLI version flag

### DIFF
--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -7,7 +7,6 @@ import io
 import os
 import subprocess
 import re
-import sys
 import tokenize
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -9,6 +9,8 @@ and Huffman coding.
 
 import argparse
 import sys
+
+from genecoder import __version__
 import json
 import os
 import random
@@ -611,6 +613,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="GeneCoder: Encode and decode data into simulated DNA sequences."
     )
+    parser.add_argument("--version", action="version", version=f"GeneCoder {__version__}")
     subparsers = parser.add_subparsers(
         dest="command",
         help="Available commands. Use `<command> -h` for more details.",

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -21,10 +21,13 @@ from .app_helpers import (
     perform_decoding,
 )
 
+__version__ = "0.1.0"
+
 __all__ = [
     "EncodeOptions",
     "EncodeResult",
     "DecodeResult",
     "perform_encoding",
     "perform_decoding",
+    "__version__",
 ]

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -7,6 +7,7 @@ from src.cli import (
 )
 
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from tests.test_cli import run_cli_command
 
 
 def test_encoding_decoding_triple_repeat(tmp_path):
@@ -55,4 +56,10 @@ def test_run_encoding_unknown_fec_warning(capsys):
     assert "Unknown FEC method 'bogus'" in captured.err
     assert "fec=bogus" not in header
     assert dna
+
+
+def test_genecoder_cli_version():
+    result = run_cli_command(["--version"])
+    assert result.returncode == 0
+    assert "0.1.0" in result.stdout
 


### PR DESCRIPTION
## Summary
- expose package `__version__`
- support `--version` flag in CLI
- test `genecoder --version`
- fix unused import picked up by lint

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b72d4131c8326a81826b4ec46ff2a