### PR TITLE
Add channel noise simulator

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --stream --method base4_direct
    ```
 
+9. **Decode with simulated channel errors**
+
+   ```bash
+   python src/cli.py decode --input-files encoded.fasta \
+       --output-file decoded.bin --simulate-errors 0.02
+   ```
+
 ## Graphical User Interface (GUI)
 
 Launch the Flet application:

--- a/src/cli.py
+++ b/src/cli.py
@@ -518,6 +518,16 @@ def process_single_decode(
                 )
                 sys.exit(1)
 
+        if args.simulate_errors > 0.0:
+            from genecoder.channel_sim import simulate_errors
+
+            sequence_from_fasta = simulate_errors(
+                sequence_from_fasta, args.simulate_errors
+            )
+            print(
+                f"Applied simulated errors (p={args.simulate_errors}) before decoding."
+            )
+
         options = build_decoding_options(args)
         final_decoded_data = run_decoding_pipeline(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
@@ -749,6 +759,12 @@ def main() -> None:
         "--stream",
         action="store_true",
         help="Stream decode large files (base4_direct only).",
+    )
+    decode_parser.add_argument(
+        "--simulate-errors",
+        type=float,
+        default=0.0,
+        help="Probability of random substitution errors applied before decoding.",
     )
 
     # Analyze command parser

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -1,0 +1,25 @@
+"""Simple channel error simulator for DNA sequences."""
+from __future__ import annotations
+
+import random
+
+NUCLEOTIDES = ["A", "T", "C", "G"]
+
+
+def simulate_errors(seq: str, p_error: float) -> str:
+    """Introduce random substitution errors into *seq* with probability ``p_error``.
+
+    Each nucleotide has an independent chance ``p_error`` of being replaced by a
+    different random nucleotide.  ``p_error`` should be between 0.0 and 1.0.
+    """
+    if not 0.0 <= p_error <= 1.0:
+        raise ValueError("p_error must be between 0 and 1")
+
+    result = []
+    for nt in seq:
+        if random.random() < p_error:
+            choices = [n for n in NUCLEOTIDES if n != nt]
+            result.append(random.choice(choices))
+        else:
+            result.append(nt)
+    return "".join(result)

--- a/tests/test_channel_sim.py
+++ b/tests/test_channel_sim.py
@@ -1,0 +1,20 @@
+import random
+from genecoder.channel_sim import simulate_errors
+from genecoder.encoders import encode_base4_direct, decode_base4_direct
+from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat
+
+
+def test_simulate_errors_deterministic():
+    random.seed(0)
+    assert simulate_errors("AAAA", 1.0) == "CGCC"
+
+
+def test_decode_recovery_with_triple_repeat():
+    random.seed(42)
+    data = b"hello"
+    dna = encode_base4_direct(data)
+    dna_tr = encode_triple_repeat(dna)
+    corrupted = simulate_errors(dna_tr, 0.05)
+    corrected, _, _ = decode_triple_repeat(corrupted)
+    recovered, _ = decode_base4_direct(corrected)
+    assert recovered == data


### PR DESCRIPTION
## Summary
- implement `simulate_errors` in new `genecoder.channel_sim` module
- add CLI option `--simulate-errors` to apply noise during decoding
- cover new functionality with unit tests
- update usage docs with example

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb41a9bcc8326848ab5fb817c59fb