### PR TITLE
Add tests for CLI round-trip and edge cases

### DIFF
--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+
+def test_cli_encode_decode_roundtrip(tmp_path: Path):
+    input_file = tmp_path / "round.txt"
+    input_file.write_text("cli round trip")
+
+    # Encode
+    encode_result = run_cli_command([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+    ])
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "round.txt.fasta"
+    assert fasta_file.exists()
+
+    # Decode
+    decode_result = run_cli_command([
+        "decode",
+        "--input-files",
+        str(fasta_file),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+    ])
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "round.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text() == "cli round trip"
+

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -403,3 +403,14 @@ def test_decode_gc_balanced_homopolymer_constraint_violation():
 # It's ignored for the GC count (numerator) but not for the length (denominator).
 # This seems fine.
 
+
+
+@patch("genecoder.encoders.encode_base4_direct")
+def test_encode_gc_balanced_boundary_gc(mock_encode_base4):
+    data = b"xx"
+    seq = "ATGC"
+    mock_encode_base4.return_value = seq
+    result = encode_gc_balanced(data, target_gc_min=0.5, target_gc_max=0.5, max_homopolymer=1)
+    assert result == "0" + seq
+    mock_encode_base4.assert_called_once_with(data, add_parity=False)
+

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -202,3 +202,13 @@ def test_generate_sequence_analysis_plot_empty():
     assert isinstance(buf, io.BytesIO)
     assert buf.getvalue().startswith(b"\x89PNG\r\n\x1a\n")
     buf.close()
+
+
+def test_generate_sequence_analysis_plot_negative_length():
+    gc_data = ([0, 1], [0.5, 0.5])
+    homos = [(0, 0, "A")]
+    buf = generate_sequence_analysis_plot(gc_data, homos, sequence_length=-5)
+    assert isinstance(buf, io.BytesIO)
+    assert buf.getvalue().startswith(b"\x89PNG\r\n\x1a\n")
+    buf.close()
+


### PR DESCRIPTION
## Summary
- ensure plotting handles negative sequence lengths
- test gc_constrained_encoder at GC boundary
- cover CLI encode/decode round-trip scenario

## Testing
- `pytest --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_684cb419dad48326be9d314cfae1ecc8