### PR TITLE
Add Windows quick start

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,3 +22,19 @@ Install locked dependencies and run the test suite:
 pip install -r requirements.lock
 pytest -q
 ```
+## Windows Quick Start
+
+Install [Miniforge](https://github.com/conda-forge/miniforge), then use `mamba` to create and activate a dedicated environment:
+
+```bash
+mamba create -n genecoder python=3.10
+conda activate genecoder
+```
+
+Finally, install the dependencies and the project in editable mode:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+```
+


### PR DESCRIPTION
## Summary
- document a Windows quick start for creating the environment with `mamba`
- reference Miniforge as the distribution to install

## Testing
- Documentation-only changes, so tests and linters were skipped

------
https://chatgpt.com/codex/tasks/task_e_684cb41d22208326968c965827d75a25