### PR TITLE
Add mamba-based setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For full usage instructions and additional documentation see the [docs/](docs/) 
 pip install -r requirements.txt
 ```
 
-See [docs/installation.md](docs/installation.md) for detailed setup and testing instructions.
+See [docs/installation.md](docs/installation.md) for detailed setup and testing instructions, including the [mamba-based setup](docs/installation.md#mamba-based-setup).
 
 ## OpenAI Testing Environment
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,17 @@ fail due to missing packages.
 pip install -r requirements.lock
 pytest -q
 ```
+
+## Mamba-Based Setup
+
+The progress report outlines a conda workflow using `mamba` to create a dedicated development environment:
+
+```bash
+mamba create -n genecoder python=3.12 flet reedsolo matplotlib pytest ruff mypy
+mamba activate genecoder
+pip install -e .
+pre-commit install
+```
 ## Windows Quick Start
 
 Install Miniforge with `winget` and create a dedicated environment using `mamba`:


### PR DESCRIPTION
## Summary
- document the mamba workflow used in the report
- link the new section from the Quick Install instructions

## Testing
- No tests run because this change only updates documentation

------
https://chatgpt.com/codex/tasks/task_e_685089c99fc8832691ba2d3ab35bffbb