### PR TITLE
Add optional GUI extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For full usage instructions and additional documentation see the [docs/](docs/) 
 
 ```bash
 pip install -r requirements.txt
+pip install .[gui]  # install GUI extras when desired
 ```
 
 See [docs/installation.md](docs/installation.md) for detailed setup and testing instructions.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,9 @@
 GeneCoder requires Python 3.10 or higher. Clone the repository and install dependencies:
 
 ```bash
-pip install -r requirements.txt  # installs flet>=0.28,<0.29
+pip install -r requirements.txt
+# For the optional GUI, install the `gui` extras:
+pip install .[gui]
 # For exact versions used in CI, see requirements.lock
 ```
 
@@ -11,7 +13,7 @@ For development, install the project in editable mode. This lets you run the CLI
 as `genecoder` and immediately pick up local changes:
 
 ```bash
-pip install -e .
+pip install -e .[gui]
 ```
 
 ## Running Tests
@@ -30,9 +32,9 @@ Install Miniforge with `winget` and create a dedicated environment using `mamba`
 
 ```powershell
 winget install conda-forge.miniforge
-mamba create -n genecoder python=3.12 flet reedsolo matplotlib pytest ruff mypy
+mamba create -n genecoder python=3.12 reedsolo pytest ruff mypy
 mamba activate genecoder
-pip install -e .
+pip install -e .[gui]
 pre-commit install
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
     "reedsolo",
 ]
 
+[project.optional-dependencies]
+gui = [
+    "flet>=0.28,<0.29",
+    "matplotlib",
+]
+
 [project.scripts]
 genecoder = "genecoder.cli:main"
 


### PR DESCRIPTION
## Summary
- document optional GUI install path
- add `gui` extra in `pyproject.toml`

## Testing
- `pre-commit run --files pyproject.toml docs/installation.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089ca212c83269af0da221d952915