### PR TITLE
Add nanopore simulator wrapper

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,6 +109,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file decoded.bin --simulate-errors 0.02
    ```
 
+10. **Decode using an external simulator**
+
+   ```bash
+   genecoder decode --input-files encoded.fasta \
+       --output-file decoded.bin --simulator nanopore
+   ```
+
 ## Graphical User Interface (GUI)
 
 Launch the Flet application:

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -541,6 +541,16 @@ def process_single_decode(
                 )
                 sys.exit(1)
 
+        if args.simulator != "none":
+            from genecoder.nanopore_sim import simulate_reads
+
+            sequence_from_fasta = simulate_reads(
+                sequence_from_fasta, args.simulator
+            )
+            logger.info(
+                f"Applied {args.simulator} simulator before decoding."
+            )
+
         if args.simulate_errors > 0.0:
             from genecoder.channel_sim import simulate_errors
 
@@ -786,6 +796,13 @@ def main() -> None:
         type=float,
         default=0.0,
         help="Probability of random substitution errors applied before decoding.",
+    )
+    decode_parser.add_argument(
+        "--simulator",
+        type=str,
+        default="none",
+        choices=["none", "nanopore", "dnarsim"],
+        help="Apply an external simulator before decoding (default: none).",
     )
 
     # Analyze command parser

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -1,0 +1,56 @@
+"""Wrapper for optional nanopore read simulators."""
+from __future__ import annotations
+
+import os
+import random
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .channel_sim import simulate_errors
+from .formats import from_fasta, to_fasta
+
+
+def _run_external(command: str, sequence: str) -> str:
+    """Run an external simulator command on ``sequence``.
+
+    The command must accept an input FASTA file and output FASTA to a
+    second file: ``command <in> <out>``.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = Path(tmpdir) / "input.fasta"
+        output_path = Path(tmpdir) / "output.fasta"
+        input_path.write_text(to_fasta(sequence, "seq"))
+        subprocess.run([command, str(input_path), str(output_path)], check=True)
+        records = from_fasta(output_path.read_text())
+        if not records:
+            raise RuntimeError(f"{command} produced no FASTA output")
+        return records[0][1]
+
+
+def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
+    """Return ``sequence`` corrupted using the chosen simulator.
+
+    If the requested simulator command isn't available, fall back to a simple
+    substitution error model implemented in :func:`simulate_errors`.
+    ``simulator`` may be ``none``, ``nanopore`` or ``dnarsim``.
+    """
+    if simulator == "none":
+        return sequence
+
+    seed_env = os.getenv("GENECODER_SIM_SEED")
+    if seed_env is not None:
+        random.seed(int(seed_env))
+
+    if simulator == "nanopore":
+        if shutil.which("d2sim"):
+            return _run_external("d2sim", sequence)
+        return simulate_errors(sequence, error_rate)
+
+    if simulator == "dnarsim":
+        if shutil.which("dnarsim"):
+            return _run_external("dnarsim", sequence)
+        return simulate_errors(sequence, error_rate)
+
+    raise ValueError(f"Unknown simulator: {simulator}")

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 from tests.test_cli import run_cli_command
 
 
@@ -34,4 +35,53 @@ def test_cli_encode_decode_roundtrip(tmp_path: Path):
     output_file = tmp_path / "round.txt_decoded.bin"
     assert output_file.exists()
     assert output_file.read_text() == "cli round trip"
+
+
+def test_cli_decode_with_simulator(tmp_path: Path):
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "sim.txt"
+    input_file.write_text("nanopore test")
+
+    # Encode with triple_repeat FEC for robustness
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "sim.txt.fasta"
+    assert fasta_file.exists()
+
+    # Decode using the nanopore simulator
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            "nanopore",
+        ],
+        env=env,
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "sim.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text() == "nanopore test"
 


### PR DESCRIPTION
## Summary
- add new `nanopore_sim` module that can call D2Sim or DNArSim
- expose `--simulator` flag on the CLI
- document using external simulators in usage docs
- test decode pipeline with simulator noise

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py src/genecoder/cli.py docs/usage.md tests/test_cli_roundtrip.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089cb35dc83269889c1b1bd91b915