### PR TITLE
Add Flet-related tests

### DIFF
--- a/tests/test_flet_app_startup.py
+++ b/tests/test_flet_app_startup.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+ft = pytest.importorskip("flet")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_flet_app_main_starts(tmp_path: Path):
+    script = textwrap.dedent(
+        """
+        import flet as ft
+        from genecoder.flet_app import main
+        ft.app(target=main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+        """
+    )
+    script_file = tmp_path / "run_app.py"
+    script_file.write_text(script)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = subprocess.Popen([sys.executable, str(script_file)], env=env)
+    time.sleep(2)
+    assert proc.poll() is None
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,0 +1,15 @@
+import pytest
+
+ft = pytest.importorskip("flet")
+if not hasattr(ft, "HtmlElement"):
+    pytest.skip("Flet HtmlElement not available", allow_module_level=True)
+
+from genecoder.helix_view import show_helix
+
+
+def test_show_helix_basic():
+    elem = show_helix()
+    assert isinstance(elem, ft.HtmlElement)
+    assert elem.width == 600
+    assert elem.height == 400
+    assert "helix-container" in elem.content


### PR DESCRIPTION
## Summary
- add tests for helix_view.show_helix
- exercise flet_app.main startup

## Testing
- `pytest -q`
- `pytest --cov=genecoder -q`

------
https://chatgpt.com/codex/tasks/task_e_685089caa0f8832698a5c177b129be73