### PR TITLE
Fix helix view test import order

### DIFF
--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,13 +1,16 @@
 import pytest
 
-ft = pytest.importorskip("flet")
-if not hasattr(ft, "HtmlElement"):
-    pytest.skip("Flet HtmlElement not available", allow_module_level=True)
 
-from genecoder.helix_view import show_helix
+def _get_ft_and_show_helix():
+    ft = pytest.importorskip("flet")
+    if not hasattr(ft, "HtmlElement"):
+        pytest.skip("Flet HtmlElement not available")
+    from genecoder.helix_view import show_helix
+    return ft, show_helix
 
 
 def test_show_helix_basic():
+    ft, show_helix = _get_ft_and_show_helix()
     elem = show_helix()
     assert isinstance(elem, ft.HtmlElement)
     assert elem.width == 600


### PR DESCRIPTION
## Summary
- move skip logic into helper so imports happen first
- call helper from test

## Testing
- `ruff check tests/test_helix_view.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850915748908326b3933dd72a25ce1d