### PR TITLE
Add squigulator support in simulate_reads

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,9 +111,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
 10. **Decode using an external simulator**
 
+   The ``--simulator`` option accepts ``nanopore``, ``dnarsim`` or ``squigulator``.
+   When the specified tool is not installed, GeneCoder falls back to an internal
+   error model.
+
    ```bash
    genecoder decode --input-files encoded.fasta \
-       --output-file decoded.bin --simulator nanopore
+       --output-file decoded.bin --simulator squigulator
    ```
 
 ## Graphical User Interface (GUI)

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -801,7 +801,7 @@ def main() -> None:
         "--simulator",
         type=str,
         default="none",
-        choices=["none", "nanopore", "dnarsim"],
+        choices=["none", "nanopore", "dnarsim", "squigulator"],
         help="Apply an external simulator before decoding (default: none).",
     )
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -34,7 +34,7 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     If the requested simulator command isn't available, fall back to a simple
     substitution error model implemented in :func:`simulate_errors`.
-    ``simulator`` may be ``none``, ``nanopore`` or ``dnarsim``.
+    ``simulator`` may be ``none``, ``nanopore``, ``dnarsim`` or ``squigulator``.
     """
     if simulator == "none":
         return sequence
@@ -51,6 +51,11 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     if simulator == "dnarsim":
         if shutil.which("dnarsim"):
             return _run_external("dnarsim", sequence)
+        return simulate_errors(sequence, error_rate)
+
+    if simulator == "squigulator":
+        if shutil.which("squigulator"):
+            return _run_external("squigulator", sequence)
         return simulate_errors(sequence, error_rate)
 
     raise ValueError(f"Unknown simulator: {simulator}")

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -85,3 +85,50 @@ def test_cli_decode_with_simulator(tmp_path: Path):
     assert output_file.exists()
     assert output_file.read_text() == "nanopore test"
 
+
+def test_cli_decode_with_squigulator(tmp_path: Path):
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "sq.txt"
+    input_file.write_text("squigulator test")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "sq.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            "squigulator",
+        ],
+        env=env,
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "sq.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text() == "squigulator test"
+


### PR DESCRIPTION
## Summary
- extend nanopore simulator with `squigulator` option
- allow `--simulator squigulator` in the CLI
- document new simulator choice
- test decode pipeline with squigulator

## Testing
- `ruff check src/genecoder/nanopore_sim.py src/genecoder/cli.py tests/test_cli_roundtrip.py`
- `mypy --config-file mypy.ini src/genecoder/nanopore_sim.py src/genecoder/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850915c6b508326b39d910c856344d1