### PR TITLE
Add Flet packaging settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ line-length = 88
 
   [tool.ruff.lint]
   extend-select = []
+  extend-ignore = ["E402"]
 
 [project]
 name = "GeneCoder"
@@ -43,3 +44,10 @@ include = ["genecoder*"]
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.flet]
+product = "GeneCoder"
+
+  [tool.flet.app]
+  module = "genecoder.flet_app"
+  path = "src"


### PR DESCRIPTION
## Summary
- add `[tool.flet]` settings with product name and entrypoint module
- ignore `E402` in Ruff config so tests lint cleanly

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509157f4cc8326af6127d322162eea