### PR TITLE
Update Flet dependency range

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ pytest -q
 The progress report outlines a conda workflow using `mamba` to create a dedicated development environment:
 
 ```bash
-mamba create -n genecoder python=3.12 flet=0.28.* reedsolo matplotlib pytest ruff mypy
+mamba create -n genecoder python=3.12 flet>=0.28,<0.29 reedsolo matplotlib pytest ruff mypy
 mamba activate genecoder
 pip install -e .
 pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,14 @@ license = { text = "MIT" }
 requires-python = ">=3.10"
 keywords = ["DNA", "storage", "encoding", "simulation"]
 dependencies = [
-    "flet~=0.28",
+    "flet>=0.28,<0.29",
     "matplotlib",
     "reedsolo",
 ]
 
 [project.optional-dependencies]
 gui = [
-    "flet~=0.28",
+    "flet>=0.28,<0.29",
     "matplotlib",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flet~=0.28
+flet>=0.28,<0.29
 matplotlib
 
 # Packages used for running the test suite

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import flet as ft
+from urllib.parse import quote
 
 HELIX_HTML = """
 <div id='helix-container' style='width:100%; height:100%;'></div>
@@ -35,6 +36,7 @@ animate();
 </script>
 """
 
-def show_helix() -> ft.HtmlElement:
-    """Return an ``HtmlElement`` displaying a basic DNA helix scene."""
-    return ft.HtmlElement(content=HELIX_HTML, width=600, height=400)
+def show_helix() -> ft.WebView:
+    """Return a ``WebView`` displaying a basic DNA helix scene."""
+    data_url = "data:text/html," + quote(HELIX_HTML)
+    return ft.WebView(url=data_url, width=600, height=400)

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -24,7 +24,7 @@ def test_cli_version(tmp_path: Path):
     genecoder_path = venv_dir / bin_dir / "genecoder"
 
     subprocess.run([str(pip_path), "install", "-U", "pip", "setuptools", "wheel"], check=True)
-    subprocess.run([str(pip_path), "install", "matplotlib", "flet~=0.28", "reedsolo"], check=True)
+    subprocess.run([str(pip_path), "install", "matplotlib", "flet>=0.28,<0.29", "reedsolo"], check=True)
 
     subprocess.run([
         str(pip_path),

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,4 +1,3 @@
-import pytest
 
 
 
@@ -6,7 +5,7 @@ def test_show_helix_basic():
     from genecoder.helix_view import show_helix
 
     elem = show_helix()
-    assert isinstance(elem, ft.HtmlElement)
+    assert elem.__class__.__name__ == "WebView"
     assert elem.width == 600
     assert elem.height == 400
-    assert "helix-container" in elem.content
+    assert elem.url.startswith("data:text/html,")


### PR DESCRIPTION
## Summary
- tighten Flet version to >=0.28,<0.29
- adjust install docs
- switch helix demo to WebView for latest Flet
- keep CLI tests aligned
- adapt GUI test for WebView

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851680e853083268f7a2c54fd51a7a1