### PR TITLE
Fix helix view test import order

### DIFF
--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,9 +1,16 @@
 import pytest
 
 
+def _get_ft_and_show_helix():
+    ft = pytest.importorskip("flet")
+    if not hasattr(ft, "HtmlElement"):
+        pytest.skip("Flet HtmlElement not available")
+    from genecoder.helix_view import show_helix
+    return ft, show_helix
+
 
 def test_show_helix_basic():
-    from genecoder.helix_view import show_helix
+    ft, show_helix = _get_ft_and_show_helix()
 
     elem = show_helix()
     assert isinstance(elem, ft.HtmlElement)


### PR DESCRIPTION
## Summary
- wrap `flet` import and skip logic in helper
- use that helper in the helix view test

## Testing
- `ruff check tests/test_helix_view.py`
- `pytest tests/test_helix_view.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851680bfcdc8326a222124af4ae20bd