### PR TITLE
Fix helix view pytest import

### DIFF
--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,8 +1,13 @@
+import pytest
+
+ft = pytest.importorskip("flet")
+if not hasattr(ft, "HtmlElement"):
+    pytest.skip("Flet HtmlElement not available", allow_module_level=True)
+
+from genecoder.helix_view import show_helix
+
+
 def _get_ft_and_show_helix():
-    ft = pytest.importorskip("flet")
-    if not hasattr(ft, "HtmlElement"):
-        pytest.skip("Flet HtmlElement not available")
-    from genecoder.helix_view import show_helix
     return ft, show_helix
 
 


### PR DESCRIPTION
## Summary
- import pytest at module level in tests/test_helix_view.py
- move `pytest.importorskip` call to module scope and import `show_helix` afterwards

## Testing
- `ruff check tests/test_helix_view.py`
- `pytest tests/test_helix_view.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68518c45ba588326bc37b8f6d698fe67