### PR TITLE
Add malformed input test for parity verification

### DIFF
--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -99,7 +99,10 @@ def test_strip_verify_empty_sequence():
 
 
 def test_strip_verify_malformed_length():
-    pass
+    assert strip_and_verify_parity("ATGCAT", 3, PARITY_RULE_GC_EVEN_A_ODD_T) == (
+        "ATGA",
+        [0],
+    )
 
 
 def test_strip_verify_invalid_k():


### PR DESCRIPTION
## Summary
- add missing assertions in `test_strip_verify_malformed_length`

## Testing
- `pre-commit run --files tests/test_error_detection.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685194b13f8c8326af4e3e1ebe01a125