### PR TITLE
Add Material theme to MkDocs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install MkDocs
-        run: pip install mkdocs
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
       - name: Build site
         run: mkdocs build --strict
       - name: Upload artifact

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,9 @@
 site_name: GeneCoder Documentation
 site_url: https://d0ttino.github.io/GeneCoder/
+theme:
+  name: material
+  palette:
+    primary: indigo
 nav:
   - Home: index.md
   - Vision & Core Concept: vision.md


### PR DESCRIPTION
## Summary
- switch docs CI to install `mkdocs-material`
- enable the Material theme in `mkdocs.yml`
- add a basic palette color

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_685194b4cbd883269571fc449998f8d2