### PR TITLE
Add typing marker file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ Changelog = "https://github.com/d0tTino/GeneCoder/blob/main/CHANGELOG.md"
 where = ["src"]
 include = ["genecoder*"]
 
+[tool.setuptools.package-data]
+"genecoder" = ["py.typed"]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- include `py.typed` marker for typed package distribution
- configure setuptools to ship the marker file

## Testing
- `pre-commit run --files pyproject.toml src/genecoder/py.typed`
- `pytest -q`
- `pip install .`
- `pip show -f GeneCoder`

------
https://chatgpt.com/codex/tasks/task_e_685194b849608326b257afb3fd8db3db