### PR TITLE
Enhance helix view with interactive nucleotides

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,8 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 
 ## Helix View
 
-The GUI now includes a **Helix View** tab powered by a small Three.js scene. Select the tab to load a rotating DNA helix rendered inside the application. This is implemented using an `HtmlElement` so it works in both desktop and web deployments. The screenshot is omitted in this repository.
-
-To view the helix, open the *Helix View* tab in the GUI. The visualization loads on demand and does not block other tabs.
+The GUI now includes a **Helix View** tab powered by a Three.js scene. The
+visualization renders each nucleotide as a colored sphere with hover tooltips
+showing the original byte information.  Orbit controls allow zooming and
+rotating the helix.  The scene is loaded on demand so it works in both desktop
+and web deployments.

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -18,30 +18,82 @@ if not hasattr(ft, "HtmlElement"):
     ft.HtmlElement = _HtmlElement  # type: ignore[attr-defined]
 
 HELIX_HTML = """
-<div id='helix-container' style='width:100%; height:100%;'></div>
+<div id='helix-container' style='position:relative;width:100%;height:100%'></div>
+<div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px'></div>
 <script type='module'>
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js';
+
 const container = document.getElementById('helix-container');
+const tooltip = document.getElementById('tooltip');
+
 const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(container.clientWidth, container.clientHeight);
 container.appendChild(renderer.domElement);
 
-const points = [];
-for (let i = 0; i < 50; i++) {
-    const t = i * 0.2;
-    points.push(new THREE.Vector3(Math.cos(t), Math.sin(t), i * 0.1));
-}
-const geometry = new THREE.BufferGeometry().setFromPoints(points);
-const material = new THREE.LineBasicMaterial({ color: 0x0077ff });
-const helix = new THREE.Line(geometry, material);
-scene.add(helix);
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+camera.position.set(2, 2, 5);
+controls.update();
 
-camera.position.z = 5;
+const text = 'GeneCoder';
+const bytes = new TextEncoder().encode(text);
+const bases = [];
+const bits = [];
+for (const byte of bytes) {
+    for (let shift = 6; shift >= 0; shift -= 2) {
+        const val = (byte >> shift) & 3;
+        const base = ['A', 'C', 'G', 'T'][val];
+        bases.push(base);
+        bits.push(`${byte.toString(16).padStart(2,'0')}[${val.toString(2).padStart(2,'0')}]`);
+    }
+}
+
+const colors = { A: 0xff5555, C: 0x5555ff, G: 0x55ff55, T: 0xffff55 };
+const group = new THREE.Group();
+const radius = 0.1;
+const height = 0.4;
+for (let i = 0; i < bases.length; i++) {
+    const geometry = new THREE.SphereGeometry(radius, 16, 16);
+    const material = new THREE.MeshBasicMaterial({ color: colors[bases[i]] });
+    const mesh = new THREE.Mesh(geometry, material);
+    const angle = i * 0.3;
+    mesh.position.set(Math.cos(angle), Math.sin(angle), i * height);
+    mesh.userData = { info: bits[i] };
+    group.add(mesh);
+}
+scene.add(group);
+
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+function onMouseMove(event) {
+    const rect = renderer.domElement.getBoundingClientRect();
+    mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera(mouse, camera);
+    const hit = raycaster.intersectObjects(group.children)[0];
+    if (hit) {
+        tooltip.style.display = 'block';
+        tooltip.style.left = `${event.clientX + 5}px`;
+        tooltip.style.top = `${event.clientY + 5}px`;
+        tooltip.textContent = hit.object.userData.info;
+    } else {
+        tooltip.style.display = 'none';
+    }
+}
+renderer.domElement.addEventListener('mousemove', onMouseMove);
+
+window.addEventListener('resize', () => {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+});
+
 function animate() {
     requestAnimationFrame(animate);
-    helix.rotation.z += 0.01;
+    controls.update();
     renderer.render(scene, camera);
 }
 animate();
@@ -49,6 +101,6 @@ animate();
 """
 
 def show_helix() -> ft.WebView:
-    """Return a ``WebView`` displaying a basic DNA helix scene."""
+    """Return a ``WebView`` displaying a DNA helix scene with controls."""
     data_url = "data:text/html," + quote(HELIX_HTML)
     return ft.WebView(url=data_url, width=600, height=400)


### PR DESCRIPTION
## Summary
- render nucleotides as colored spheres in the helix view
- add hover tooltips with byte information
- enable zoom and rotation controls via OrbitControls
- document the richer helix scene

## Testing
- `ruff check --fix src/genecoder/helix_view.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685194c985688326b7f958517a80401e