### PR TITLE
Enable MkDocs PDF build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install MkDocs Material
-        run: pip install mkdocs-material
+      - name: Install documentation requirements
+        run: pip install -r docs/requirements.txt
       - name: Build site
         run: mkdocs build --strict
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-pdf
+          path: site/pdf/combined.pdf
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,3 +79,14 @@ Or export the variable directly:
 export OPENAI_API_KEY=sk-yourkey
 ```
 
+## Building the Documentation
+
+Install the documentation dependencies and generate the static site:
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs build
+```
+
+The combined PDF will be available at `site/pdf/combined.pdf`.
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material
+mkdocs-pdf-export-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,12 +6,19 @@ theme:
     primary: indigo
 nav:
   - Home: index.md
-  - Vision & Core Concept: vision.md
-  - Implemented Features: features.md
-  - Installation: installation.md
-  - Usage:
+  - Getting Started:
+      - Installation: installation.md
       - Usage Guide: usage.md
+  - Project Overview:
+      - Vision & Core Concept: vision.md
+      - Implemented Features: features.md
+      - Technology Stack: technology_stack.md
+  - Development:
+      - Development Roadmap: development_roadmap.md
+      - Development Vision: DEVELOPMENT_VISION.md
+  - Integrations:
       - n8n Overview: n8n_overview.md
-  - Technology Stack: technology_stack.md
-  - Development Roadmap: development_roadmap.md
-  - Development Vision: DEVELOPMENT_VISION.md
+plugins:
+  - search
+  - pdf-export:
+      combined: true


### PR DESCRIPTION
## Summary
- add docs-specific requirements
- reorganize documentation into chapters and enable PDF export
- build documentation and attach generated PDF in CI
- explain how to build the docs

## Testing
- `pip download mkdocs-pdf-export-plugin==0.5.10 -d /tmp`

------
https://chatgpt.com/codex/tasks/task_e_6851bb1871f88326aa327887a8570232