### PR TITLE
Add desktop packaging and web build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,30 @@
+name: Build Packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+      - name: Build package
+        run: ./scripts/package_desktop.sh ${{ github.ref_name }}
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: GeneCoder-${{ matrix.os }}
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ pip install -r requirements.txt
 pip install .[gui]  # install GUI extras when desired
 ```
 
+Desktop packages are available on the [releases page](https://github.com/d0tTino/GeneCoder/releases).
+Download the `.msix` file for Windows or the `.dmg` for macOS and follow your
+platform's standard installation prompts.
+
+To run the web build locally install the optional `web` extras and start the
+FastAPI server:
+
+```bash
+pip install .[web]
+uvicorn web.main:app --reload
+```
+
 See [docs/installation.md](docs/installation.md) for detailed setup and testing instructions, including the [mamba-based setup](docs/installation.md#mamba-based-setup).
 
 ## OpenAI Testing Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ gui = [
     "flet>=0.28,<0.29",
     "matplotlib",
 ]
+web = [
+    "fastapi",
+    "uvicorn[standard]",
+]
 
 [project.scripts]
 genecoder = "genecoder.cli:main"

--- a/scripts/package_desktop.sh
+++ b/scripts/package_desktop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build desktop packages for GeneCoder using PyInstaller.
+# Usage: package_desktop.sh <version>
+# On macOS this creates a DMG. On Windows it creates an MSIX package.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VERSION="${1:-0.0.0}"
+DIST_DIR="$REPO_ROOT/dist"
+
+cd "$REPO_ROOT"
+mkdir -p "$DIST_DIR"
+
+pyinstaller --noconfirm src/genecoder/flet_app.py --name GeneCoder
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    hdiutil create "${DIST_DIR}/GeneCoder-${VERSION}.dmg" \
+        -fs HFS+ -srcfolder "dist/GeneCoder.app"
+elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* || "$OS" == "Windows_NT" ]]; then
+    pyinstaller msix --name GeneCoder --version "$VERSION" GeneCoder.spec
+    mv GeneCoder.msix "${DIST_DIR}/GeneCoder-${VERSION}.msix"
+fi

--- a/web/main.py
+++ b/web/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+
+app = FastAPI(title="GeneCoder Web")
+
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+index_path = static_dir / "index.html"
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> str:
+    return index_path.read_text(encoding="utf-8")

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>GeneCoder Web</title>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js"></script>
+</head>
+<body>
+    <h1>GeneCoder Web</h1>
+    <p id="status">Loading Pyodide...</p>
+    <script type="text/javascript">
+        async function main() {
+            const pyodide = await loadPyodide();
+            document.getElementById("status").textContent = "Pyodide loaded";
+        }
+        main();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add script to build MSIX and DMG with PyInstaller
- publish packages on release tags with new workflow
- enable optional `web` extras with FastAPI+uvicorn
- create minimal FastAPI+Pyodide web build
- document downloads and web server instructions in README

## Testing
- `pre-commit run --files README.md pyproject.toml scripts/package_desktop.sh .github/workflows/package.yml web/main.py web/static/index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bb0e0bd0832693e38ee71f8e8326