### PR TITLE
Add capsule caching support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
+* **Capsule export** to cache encoded DNA and metadata via ``--capsule``.
 
 ## Helix View
 

--- a/src/genecoder/cache_dna.py
+++ b/src/genecoder/cache_dna.py
@@ -1,0 +1,56 @@
+"""Utilities for storing encoded DNA sequences in capsule files.
+
+A capsule is a JSON document capturing the FASTA header, the sequence and
+metadata describing the encoding process.  It allows GeneCoder to quickly
+replay or inspect previous encodings.
+
+The JSON structure follows this specification::
+
+    {
+        "version": 1,
+        "header": "<fasta header>",
+        "sequence": "<dna sequence>",
+        "metadata": { ... },
+        "created": "<ISO timestamp>"
+    }
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+import json
+from typing import Any, Dict
+
+
+@dataclass
+class Capsule:
+    """Represents the contents of a capsule."""
+
+    header: str
+    sequence: str
+    metadata: Dict[str, Any]
+    created: str
+    version: int = 1
+
+
+__all__ = ["Capsule", "write_capsule", "read_capsule"]
+
+
+def write_capsule(sequence: str, header: str, metadata: Dict[str, Any], path: str) -> None:
+    """Write ``sequence`` and ``metadata`` to ``path`` as a capsule."""
+    capsule = Capsule(
+        header=header,
+        sequence=sequence,
+        metadata=metadata,
+        created=datetime.utcnow().isoformat(),
+    )
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(asdict(capsule), f, indent=2)
+
+
+def read_capsule(path: str) -> Capsule:
+    """Load a capsule from ``path``."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return Capsule(**data)

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -434,6 +434,22 @@ def process_single_encode(
         with open(output_file_path, "w", encoding="utf-8") as f_out:
             f_out.write(fasta_output)
 
+        if getattr(args, "capsule", None):
+            from genecoder.cache_dna import write_capsule
+
+            metadata = {
+                "input_file": os.path.basename(input_file_path),
+                "method": args.method,
+                "fec": args.fec,
+            }
+            write_capsule(
+                final_encoded_dna_sequence,
+                fasta_header,
+                metadata,
+                args.capsule,
+            )
+            logger.info(f"Capsule written to {args.capsule}")
+
         # Metrics based on original_input_data and final_encoded_dna_sequence
         original_size_bytes = len(original_input_data)
         final_encoded_length_nucleotides = len(final_encoded_dna_sequence)
@@ -738,6 +754,11 @@ def main() -> None:
         action="store_true",
         help="Stream encode large files (base4_direct only).",
     )
+    encode_parser.add_argument(
+        "--capsule",
+        type=str,
+        help="Path to write a capsule with encoded DNA and metadata.",
+    )
 
     # Decode command parser
     decode_parser = subparsers.add_parser(
@@ -899,6 +920,11 @@ def main() -> None:
             logger.warning(
                 "Warning: Both --output-file and --output-dir provided for single input. Using --output-file.",
             )
+        if args.capsule and num_input_files != 1:
+            logger.error(
+                "Error: --capsule can only be used with a single input file.",
+            )
+            sys.exit(1)
 
         tasks = []
         for input_file_path in args.input_files:

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+
+def test_encode_capsule_contents(tmp_path: Path) -> None:
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("capsule test")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    capsule_path = tmp_path / "seq.capsule"
+
+    result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(output_dir),
+            "--method",
+            "base4_direct",
+            "--capsule",
+            str(capsule_path),
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert capsule_path.exists()
+
+    data = json.loads(capsule_path.read_text())
+    assert data["version"] == 1
+    assert "method=base4_direct" in data["header"]
+    assert data["metadata"]["input_file"] == "msg.txt"
+    assert data["metadata"]["method"] == "base4_direct"
+    assert isinstance(data["sequence"], str) and data["sequence"]
+
+
+def test_encode_capsule_multiple_inputs_error(tmp_path: Path) -> None:
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.txt"
+    f1.write_text("a")
+    f2.write_text("b")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    capsule_path = tmp_path / "multi.capsule"
+
+    result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(f1),
+            str(f2),
+            "--output-dir",
+            str(out_dir),
+            "--method",
+            "base4_direct",
+            "--capsule",
+            str(capsule_path),
+        ]
+    )
+    assert result.returncode != 0
+    assert "--capsule can only be used" in result.stderr


### PR DESCRIPTION
## Summary
- implement capsule caching utilities
- support `--capsule` option in CLI
- document capsule feature
- test capsule creation and metadata

## Testing
- `ruff check src/genecoder/cache_dna.py src/genecoder/cli.py tests/test_capsule.py docs/features.md`
- `mypy --config-file mypy.ini src/genecoder/cache_dna.py src/genecoder/cli.py`
- `pytest -q tests/test_capsule.py`

------
https://chatgpt.com/codex/tasks/task_e_6851bb08caa48326a80c59becc4a2df1