### PR TITLE
Add synthesis validation and CSV export

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
+* **CSV export for synthesis** with length and homopolymer validation. The analysis command warns when sequences violate these constraints.
 
 ## Helix View
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,6 +120,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file decoded.bin --simulator squigulator
    ```
 
+11. **Export sequences for synthesis**
+
+   ```bash
+   genecoder encode --input-files design.txt \
+       --output-dir encoded/ --export-csv order.csv
+   ```
+
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -13,6 +13,7 @@ import logging
 
 from genecoder import __version__
 import json
+import csv
 import os
 import random
 import re  # For parsing header parameters
@@ -26,6 +27,7 @@ from genecoder.encoders import (
     calculate_gc_content,
 )
 from genecoder.utils import get_max_homopolymer_length
+from genecoder.synthesis import SynthesisConstraints
 from genecoder.encoders import (
     encode_triple_repeat,
     decode_triple_repeat,
@@ -365,7 +367,7 @@ def run_decoding_pipeline(
 # --- Helper function for single file encoding ---
 def process_single_encode(
     input_file_path: str, output_file_path: str, args: argparse.Namespace
-) -> None:
+) -> tuple[str, str] | None:
     """Encodes a single file based on provided arguments."""
     logger.info(
         f"\nProcessing encode for input: {input_file_path} -> output: {output_file_path}"
@@ -412,7 +414,7 @@ def process_single_encode(
             logger.info(
                 f"Successfully encoded '{input_file_path}' to '{output_file_path}' using streaming."
             )
-            return
+            return os.path.basename(input_file_path), ""  # streamed DNA not collected
 
         with open(input_file_path, "rb") as f_in:
             original_input_data = f_in.read()  # Store original for metrics
@@ -480,6 +482,7 @@ def process_single_encode(
             )
         logger.info("----------------------")
         logger.info(f"Successfully encoded '{input_file_path}' to '{output_file_path}'.")
+        return os.path.basename(input_file_path), final_encoded_dna_sequence
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")
@@ -489,6 +492,7 @@ def process_single_encode(
         logger.error(
             f"Error for {input_file_path}: Unexpected error during encoding: {e}",
         )
+    return None
 
 
 # --- Helper function for single file decoding ---
@@ -616,6 +620,16 @@ def process_single_analyze(input_file_path: str, args: argparse.Namespace) -> No
         logger.info(f"Sequence length: {len(sequence)} nucleotides")
         logger.info(f"GC content: {gc_content:.2%}")
         logger.info(f"Max homopolymer length: {max_hp}")
+
+        constraints = SynthesisConstraints()
+        if len(sequence) < constraints.min_length or len(sequence) > constraints.max_length:
+            logger.warning(
+                f"Warning for {input_file_path}: Sequence length {len(sequence)} is outside the synthesis range {constraints.min_length}-{constraints.max_length}."
+            )
+        if max_hp > constraints.max_homopolymer:
+            logger.warning(
+                f"Warning for {input_file_path}: Maximum homopolymer {max_hp} exceeds allowed {constraints.max_homopolymer}."
+            )
         if gc_values:
             logger.info(
                 f"Windowed GC stats (window={args.window_size}, step={args.step}): "
@@ -737,6 +751,11 @@ def main() -> None:
         "--stream",
         action="store_true",
         help="Stream encode large files (base4_direct only).",
+    )
+    encode_parser.add_argument(
+        "--export-csv",
+        type=str,
+        help="Path to write a Twist/IDT order CSV with Name and Sequence columns.",
     )
 
     # Decode command parser
@@ -901,6 +920,7 @@ def main() -> None:
             )
 
         tasks = []
+        csv_rows: list[tuple[str, str]] = []
         for input_file_path in args.input_files:
             output_file_path = ""
             if (
@@ -931,13 +951,15 @@ def main() -> None:
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=min(8, cpu_count + 4)
             ) as executor:
-                futures = [
-                    executor.submit(process_single_encode, task[0], task[1], task[2])
-                    for task in tasks
-                ]
+                futures = {
+                    executor.submit(process_single_encode, t[0], t[1], t[2]): t[0]
+                    for t in tasks
+                }
                 for future in concurrent.futures.as_completed(futures):
                     try:
-                        future.result()  # To raise exceptions if any occurred in the thread
+                        res = future.result()
+                        if args.export_csv and res:
+                            csv_rows.append(res)
                     except Exception as exc:
                         logger.error(
                             f"A file processing task generated an exception: {exc}",
@@ -945,7 +967,17 @@ def main() -> None:
             logger.info("\nBatch encoding finished.")
         else:  # Single file
             if tasks:
-                process_single_encode(tasks[0][0], tasks[0][1], tasks[0][2])
+                res = process_single_encode(tasks[0][0], tasks[0][1], tasks[0][2])
+                if args.export_csv and res:
+                    csv_rows.append(res)
+
+        if args.export_csv and csv_rows:
+            os.makedirs(os.path.dirname(args.export_csv) or ".", exist_ok=True)
+            with open(args.export_csv, "w", newline="", encoding="utf-8") as csv_f:
+                writer = csv.writer(csv_f)
+                writer.writerow(["Name", "Sequence"])
+                writer.writerows(csv_rows)
+            logger.info(f"CSV order file written to {args.export_csv}")
 
     elif args.command == "decode":
         if num_input_files > 1 and not args.output_dir:

--- a/src/genecoder/synthesis.py
+++ b/src/genecoder/synthesis.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Helpers for DNA synthesis constraints."""
+
+from dataclasses import dataclass
+
+from .utils import get_max_homopolymer_length
+
+
+@dataclass
+class SynthesisConstraints:
+    """Simple synthesis constraints."""
+
+    min_length: int = 25
+    max_length: int = 300
+    max_homopolymer: int = 4
+
+
+def validate_sequence(seq: str, constraints: SynthesisConstraints | None = None) -> bool:
+    """Return ``True`` if ``seq`` satisfies ``constraints``."""
+
+    if constraints is None:
+        constraints = SynthesisConstraints()
+
+    length = len(seq)
+    if length < constraints.min_length or length > constraints.max_length:
+        return False
+    if get_max_homopolymer_length(seq) > constraints.max_homopolymer:
+        return False
+    return True

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from genecoder.synthesis import SynthesisConstraints, validate_sequence
+from genecoder.formats import to_fasta
+
+
+import os
+import subprocess
+import sys
+from pathlib import Path as SysPath
+
+PROJECT_ROOT = SysPath(__file__).parent.parent
+
+
+def run_cli_command(command_args: list[str], env=None) -> subprocess.CompletedProcess:
+    if env is None:
+        env = os.environ.copy()
+        src_path = PROJECT_ROOT / "src"
+        env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    full_command = [sys.executable, "-m", "genecoder.cli"] + command_args
+    return subprocess.run(full_command, capture_output=True, text=True, env=env, cwd=PROJECT_ROOT)
+
+
+def test_validate_sequence_pass():
+    constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
+    assert validate_sequence("ACGTAC", constraints)
+
+
+def test_validate_sequence_fail_length():
+    constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
+    assert not validate_sequence("AC", constraints)
+
+
+def test_validate_sequence_fail_homopolymer():
+    constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
+    assert not validate_sequence("AAACCC", constraints)
+
+
+def test_export_csv_and_analysis_warnings(tmp_path: Path):
+    # Create input files
+    f1 = tmp_path / "a.txt"
+    f1.write_text("hello")
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    csv_file = tmp_path / "order.csv"
+
+    cmd = [
+        "encode",
+        "--input-files",
+        str(f1),
+        "--output-dir",
+        str(outdir),
+        "--method",
+        "base4_direct",
+        "--export-csv",
+        str(csv_file),
+    ]
+    result = run_cli_command(cmd)
+    assert result.returncode == 0
+    assert csv_file.exists()
+    content = csv_file.read_text()
+    assert "Name,Sequence" in content
+
+    # Create fasta with long homopolymer
+    seq = "A" * 10
+    fasta = outdir / "bad.fasta"
+    fasta.write_text(to_fasta(seq, "seq1"))
+
+    cmd = ["analyze", "--input-files", str(fasta)]
+    result = run_cli_command(cmd)
+    assert result.returncode == 0
+    assert "homopolymer" in result.stderr


### PR DESCRIPTION
## Summary
- add `synthesis` module with simple length/homopolymer validator
- update CLI to export sequences to a CSV order file
- warn during analysis when synthesis constraints are violated
- document the new feature
- test validator, CSV export and warnings

## Testing
- `ruff check src/genecoder/synthesis.py src/genecoder/cli.py tests/test_synthesis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bb0730c48326b48afc7db2b0fdff