### PR TITLE
Add manifest generation and saving

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,6 +120,22 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file decoded.bin --simulator squigulator
    ```
 
+### Manifest files
+
+Each encoded file produces a companion JSON manifest capturing the encoding
+parameters and basic metrics. The manifest is saved alongside the FASTA output
+using the `.manifest.json` extension.
+
+Example snippet:
+
+```json
+{
+  "file": "example.txt",
+  "encoding_parameters": {"method": "base4_direct"},
+  "metrics": {"dna_length": 42}
+}
+```
+
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -18,6 +18,7 @@ import random
 import re  # For parsing header parameters
 import concurrent.futures
 from dataclasses import dataclass
+from genecoder.manifest import generate_manifest
 from genecoder.encoders import (
     encode_base4_direct,
     decode_base4_direct,
@@ -450,6 +451,13 @@ def process_single_encode(
             else 0.0
         )
 
+        metrics = {
+            "original_size": original_size_bytes,
+            "dna_length": final_encoded_length_nucleotides,
+            "compression_ratio": compression_ratio,
+            "bits_per_nt": bits_per_nucleotide,
+        }
+
         logger.info(f"\n--- Encoding Metrics for {input_file_path} ---")
         logger.info(f"Original file size: {original_size_bytes} bytes")
         if args.fec == "hamming_7_4":
@@ -478,8 +486,17 @@ def process_single_encode(
             logger.info(
                 f"Actual max homopolymer length (gc_balanced payload, pre-DNA FEC): {get_max_homopolymer_length(gc_balanced_payload_dna)}"
             )
+            metrics["actual_gc"] = calculate_gc_content(gc_balanced_payload_dna)
+            metrics["max_homopolymer"] = get_max_homopolymer_length(
+                gc_balanced_payload_dna
+            )
         logger.info("----------------------")
         logger.info(f"Successfully encoded '{input_file_path}' to '{output_file_path}'.")
+
+        manifest = generate_manifest(os.path.basename(input_file_path), options, metrics)
+        manifest_path = os.path.splitext(output_file_path)[0] + ".manifest.json"
+        with open(manifest_path, "w", encoding="utf-8") as mf:
+            json.dump(manifest, mf, indent=2)
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -15,6 +15,7 @@ responsive.
 import flet as ft
 import os
 import asyncio  # For asynchronous operations
+import json
 
 # Project module imports
 from genecoder import (
@@ -22,6 +23,7 @@ from genecoder import (
     perform_encoding,
 
 )
+from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix
@@ -179,12 +181,24 @@ def main(page: ft.Page):
     )
 
     encode_save_button = ft.ElevatedButton(
-        "Save Encoded FASTA...", 
+        "Save Encoded FASTA...",
         icon=ft.icons.SAVE,
-        visible=False 
+        visible=False
     )
-    
+
+    encode_manifest_save_button = ft.ElevatedButton(
+        "Save Manifest...",
+        icon=ft.icons.SAVE,
+        visible=False,
+    )
+
     encode_hidden_fasta_content = ft.Text(ref=encode_fasta_data_to_save_ref, visible=False, value="")
+    encode_manifest_to_save_ref = ft.Ref[str]()
+    encode_hidden_manifest_content = ft.Text(
+        ref=encode_manifest_to_save_ref,
+        visible=False,
+        value="",
+    )
 
     # --- Main App Structure (Tabs) defined here so encode_data can access app_tabs.tabs[2] ---
     # This is a forward declaration of sorts for app_tabs, its full definition with content is later.
@@ -226,7 +240,9 @@ def main(page: ft.Page):
         encode_actual_homopolymer_text.value = "Actual max homopolymer (payload): -"
         encode_dna_snippet_text.value = ""
         encode_save_button.visible = False
+        encode_manifest_save_button.visible = False
         encode_hidden_fasta_content.value = ""
+        encode_hidden_manifest_content.value = ""
         
         codeword_hist_image.src_base64 = None
         nucleotide_freq_image.src_base64 = None
@@ -263,6 +279,11 @@ def main(page: ft.Page):
             encode_hidden_fasta_content.value = result.fasta
             encode_dna_snippet_text.value = result.encoded_dna[:200]
             encode_save_button.visible = True
+            manifest = generate_manifest(
+                os.path.basename(input_path), options, result.metrics
+            )
+            encode_hidden_manifest_content.value = json.dumps(manifest, indent=2)
+            encode_manifest_save_button.visible = True
 
             metrics = result.metrics
             encode_orig_size_text.value = f"Original size: {metrics['original_size']} bytes"
@@ -351,6 +372,32 @@ def main(page: ft.Page):
         dialog_title="Save Encoded FASTA File",
         file_name="encoded_output.fasta",
         allowed_extensions=["fasta", "fa"]
+    )
+
+    async def on_manifest_save_file_result(e: ft.FilePickerResultEvent) -> None:
+        if e.path:
+            try:
+                with open(e.path, "w", encoding="utf-8") as f_out:
+                    f_out.write(encode_hidden_manifest_content.value)
+                encode_status_text.value = f"Manifest saved successfully to: {e.path}"
+                encode_status_text.color = ft.colors.GREEN_700
+            except Exception as ex:
+                encode_status_text.value = f"Error saving manifest: {ex}"
+                encode_status_text.color = ft.colors.RED_ACCENT_700
+        else:
+            encode_status_text.value = "Save operation cancelled by user."
+            encode_status_text.color = ft.colors.AMBER_ACCENT_700
+        page.update()
+
+    manifest_file_picker = ft.FilePicker(on_result=on_manifest_save_file_result)
+    page.overlay.append(manifest_file_picker)
+
+    encode_manifest_save_button.on_click = (
+        lambda _: manifest_file_picker.save_file(
+            dialog_title="Save Manifest File",
+            file_name="encoded_output.manifest.json",
+            allowed_extensions=["json"],
+        )
     )
 
 
@@ -536,8 +583,10 @@ def main(page: ft.Page):
                             ft.Text("Output Preview:", weight=ft.FontWeight.BOLD),
                             encode_dna_snippet_text,
                             encode_save_button,
+                            encode_manifest_save_button,
                             encode_status_text,
                             encode_hidden_fasta_content,
+                            encode_hidden_manifest_content,
                         ],
                         spacing=15, scroll=ft.ScrollMode.AUTO
                     ), padding=10, alignment=ft.alignment.TOP_LEFT

--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Utilities for creating encode manifests."""
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+
+def generate_manifest(
+    file_name: str,
+    encoding_params: Any,
+    metrics: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a manifest dictionary for an encoded file."""
+    if is_dataclass(encoding_params) and not isinstance(encoding_params, type):
+        params = asdict(encoding_params)
+    else:
+        params = dict(encoding_params)
+    return {
+        "file": file_name,
+        "encoding_parameters": params,
+        "metrics": dict(metrics),
+    }

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_cli_writes_manifest(tmp_path: Path) -> None:
+    input_file = tmp_path / "data.txt"
+    input_file.write_text("hi")
+    result = run_cli_command([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+    ])
+    assert result.returncode == 0, result.stderr
+    manifest = tmp_path / "data.txt.manifest.json"
+    assert manifest.exists()
+    data = json.loads(manifest.read_text())
+    assert data["file"] == "data.txt"
+    assert data["encoding_parameters"]["method"] == "base4_direct"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,20 @@
+from genecoder.manifest import generate_manifest
+from genecoder.cli import EncodingOptions
+
+
+def test_generate_manifest_basic() -> None:
+    opts = EncodingOptions(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule="PR",
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+    )
+    metrics = {"dna_length": 10}
+    manifest = generate_manifest("file.txt", opts, metrics)
+    assert manifest["file"] == "file.txt"
+    assert manifest["encoding_parameters"]["method"] == "base4_direct"
+    assert manifest["metrics"]["dna_length"] == 10


### PR DESCRIPTION
## Summary
- generate manifest dictionaries with parameters and metrics
- save manifest JSON in CLI encode workflow
- allow saving the manifest via Flet GUI
- test manifest creation and CLI integration
- document manifest file format

## Testing
- `pre-commit run --files docs/usage.md src/genecoder/cli.py src/genecoder/flet_app.py src/genecoder/manifest.py tests/test_cli_manifest.py tests/test_manifest.py`

------
https://chatgpt.com/codex/tasks/task_e_6851bb03416083268eddf2b65380bf02