### PR TITLE
Fix helix view test import order

### DIFF
--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -1,9 +1,6 @@
 import pytest
 
 ft = pytest.importorskip("flet")
-if not hasattr(ft, "HtmlElement"):
-    pytest.skip("Flet HtmlElement not available", allow_module_level=True)
-
 from genecoder.helix_view import show_helix
 
 


### PR DESCRIPTION
## Summary
- remove module skip when `HtmlElement` is missing
- import `show_helix` before checking for fallback
- keep existing `WebView` assertions intact

## Testing
- `pre-commit run --files tests/test_helix_view.py src/genecoder/helix_view.py`

------
https://chatgpt.com/codex/tasks/task_e_6851baffafd08326b7ac16aecf10f3bc