### PR TITLE
Fix helix view template escaping

### DIFF
--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -44,6 +44,7 @@ from genecoder.error_detection import (
     PARITY_RULE_GC_EVEN_A_ODD_T,
 )  # Import parity constant
 from genecoder.error_simulation import introduce_errors
+from genecoder.synthesis import SynthesisConstraints
 from genecoder.plotting import (
     calculate_windowed_gc_content,
     identify_homopolymer_regions,
@@ -99,7 +100,7 @@ class EncodingOptions:
     gc_min: float
     gc_max: float
     max_homopolymer: int
-    alphabet: str
+    alphabet: str = "base4"
 
 
 @dataclass
@@ -570,12 +571,13 @@ def process_single_encode(
             )
         logger.info("----------------------")
         logger.info(f"Successfully encoded '{input_file_path}' to '{output_file_path}'.")
-        return os.path.basename(input_file_path), final_encoded_dna_sequence
 
         manifest = generate_manifest(os.path.basename(input_file_path), options, metrics)
         manifest_path = os.path.splitext(output_file_path)[0] + ".manifest.json"
         with open(manifest_path, "w", encoding="utf-8") as mf:
             json.dump(manifest, mf, indent=2)
+
+        return os.path.basename(input_file_path), final_encoded_dna_sequence
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")
@@ -856,6 +858,12 @@ def main() -> None:
         "--export-csv",
         type=str,
         help="Path to write a Twist/IDT order CSV with Name and Sequence columns.",
+
+    )
+    encode_parser.add_argument(
+        "--capsule",
+        type=str,
+        help="Path to write a capsule file capturing the FASTA header, sequence, and metadata.",
 
     )
 

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -32,7 +32,7 @@ except FileNotFoundError:
     pass
 
 HELIX_TEMPLATE = """
-<div id='helix-container' style='position:relative;width:100%;height:100%'></div>
+<div id='helix-container' style='position:relative;width:100%%;height:100%%'></div>
 <div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px'></div>
 <script type='module'>
 import * as THREE from '%(THREE_JS_URL)s';


### PR DESCRIPTION
## Summary
- escape percent signs in `HELIX_TEMPLATE` to avoid runtime formatting errors
- import `SynthesisConstraints` to satisfy ruff checks
- write encode manifest before returning and support `--capsule` argument

## Testing
- `ruff check src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d08c4ff48326ad1a0c87ba873800