### PR TITLE
Add CLI capsule option

### DIFF
--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -49,6 +49,7 @@ from genecoder.plotting import (
     identify_homopolymer_regions,
     generate_sequence_analysis_plot,
 )
+from genecoder.synthesis import SynthesisConstraints
 
 logger = logging.getLogger(__name__)
 
@@ -858,6 +859,11 @@ def main() -> None:
         help="Path to write a Twist/IDT order CSV with Name and Sequence columns.",
 
     )
+    encode_parser.add_argument(
+        "--capsule",
+        type=str,
+        help="Write capsule JSON with header, sequence and metadata.",
+    )
 
     # Decode command parser
     decode_parser = subparsers.add_parser(
@@ -1134,13 +1140,15 @@ def main() -> None:
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=min(8, cpu_count + 4)
             ) as executor:
-                futures = [
-                    executor.submit(process_single_decode, task[0], task[1], task[2])
+                futures_list: list[concurrent.futures.Future[None]] = [
+                    executor.submit(
+                        process_single_decode, task[0], task[1], task[2]
+                    )
                     for task in tasks
                 ]
-                for future in concurrent.futures.as_completed(futures):
+                for decode_future in concurrent.futures.as_completed(futures_list):
                     try:
-                        future.result()
+                        decode_future.result()
                     except Exception as exc:
                         logger.error(
                             f"A file decoding task generated an exception: {exc}",


### PR DESCRIPTION
## Summary
- add `--capsule` option in CLI encode parser
- fix undefined `SynthesisConstraints` by importing it
- fix mypy errors in decode thread loop

## Testing
- `pre-commit run --files src/genecoder/cli.py` *(fails: pytest error in unrelated helix view test)*
- `pytest tests/test_capsule.py tests/test_cli.py tests/test_cli_additional.py tests/test_cli_entrypoint.py tests/test_cli_helpers.py tests/test_cli_manifest.py tests/test_cli_roundtrip.py tests/test_cli_version.py` *(fails: test_cli_manifest::test_cli_writes_manifest assertion failure)*

------
https://chatgpt.com/codex/tasks/task_e_6851d08ce47c8326974fa961efd7d337