### PR TITLE
Add animated helix visualization for encoded DNA

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -21,7 +21,6 @@ import json
 from genecoder import (
     EncodeOptions,
     perform_encoding,
-
 )
 from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
@@ -30,32 +29,39 @@ from genecoder.helix_view import show_helix
 
 
 encode_fasta_data_to_save_ref = ft.Ref[str]()
-decoded_bytes_to_save: bytes = b"" 
+decoded_bytes_to_save: bytes = b""
+
 
 def main(page: ft.Page):
     """Create the UI and register callbacks for Flet's event loop."""
     page.title = "GeneCoder"
     page.vertical_alignment = ft.MainAxisAlignment.START
     page.horizontal_alignment = ft.CrossAxisAlignment.CENTER
-    
-    selected_encode_input_file_path = ft.Ref[str]() 
-    selected_encode_input_file_path.current = "" 
 
-    selected_decode_input_file_path = ft.Ref[str]() 
+    selected_encode_input_file_path = ft.Ref[str]()
+    selected_encode_input_file_path.current = ""
+
+    selected_decode_input_file_path = ft.Ref[str]()
     selected_decode_input_file_path.current = ""
 
     # --- Analysis Tab UI Controls (defined early for access in encode_data) ---
     codeword_hist_image = ft.Image(
-        width=500, height=350, fit=ft.ImageFit.CONTAIN, 
-        tooltip="Huffman Codeword Length Histogram"
+        width=500,
+        height=350,
+        fit=ft.ImageFit.CONTAIN,
+        tooltip="Huffman Codeword Length Histogram",
     )
     nucleotide_freq_image = ft.Image(
-        width=500, height=350, fit=ft.ImageFit.CONTAIN, 
-        tooltip="Nucleotide Frequency Distribution"
+        width=500,
+        height=350,
+        fit=ft.ImageFit.CONTAIN,
+        tooltip="Nucleotide Frequency Distribution",
     )
-    sequence_analysis_plot_image = ft.Image( # New image control
-        width=600, height=400, fit=ft.ImageFit.CONTAIN,
-        tooltip="Sequence GC & Homopolymer Analysis"
+    sequence_analysis_plot_image = ft.Image(  # New image control
+        width=600,
+        height=400,
+        fit=ft.ImageFit.CONTAIN,
+        tooltip="Sequence GC & Homopolymer Analysis",
     )
     analysis_status_text = ft.Text("Encode data to view analysis plots.", italic=True)
 
@@ -83,26 +89,29 @@ def main(page: ft.Page):
 
     # --- Encode Tab UI Controls ---
     encode_selected_input_file_text = ft.Text("No file selected.", italic=True)
-    
+
     def on_encode_file_picker_result(e: ft.FilePickerResultEvent):
         if e.files and len(e.files) > 0:
             selected_encode_input_file_path.current = e.files[0].path
-            encode_selected_input_file_text.value = f"Selected: {os.path.basename(e.files[0].name)}"
+            encode_selected_input_file_text.value = (
+                f"Selected: {os.path.basename(e.files[0].name)}"
+            )
         else:
             selected_encode_input_file_path.current = ""
-            encode_selected_input_file_text.value = "File selection cancelled or failed."
+            encode_selected_input_file_text.value = (
+                "File selection cancelled or failed."
+            )
         page.update()
 
     encode_file_picker = ft.FilePicker(on_result=on_encode_file_picker_result)
-    page.overlay.append(encode_file_picker) 
+    page.overlay.append(encode_file_picker)
 
     encode_browse_button = ft.ElevatedButton(
         "Browse File",
         icon=ft.icons.FOLDER_OPEN,
         on_click=lambda _: encode_file_picker.pick_files(
-            allow_multiple=False,
-            dialog_title="Select Input File for Encoding"
-        )
+            allow_multiple=False, dialog_title="Select Input File for Encoding"
+        ),
     )
 
     method_dropdown = ft.Dropdown(
@@ -112,7 +121,7 @@ def main(page: ft.Page):
             ft.dropdown.Option("Huffman"),
             ft.dropdown.Option("GC-Balanced"),
         ],
-        value="Base-4 Direct"
+        value="Base-4 Direct",
     )
 
     alphabet_dropdown = ft.Dropdown(
@@ -126,11 +135,11 @@ def main(page: ft.Page):
     )
 
     k_value_input = ft.TextField(
-        label="k-value (for parity)", 
-        value="7", 
-        width=150, 
-        disabled=True, 
-        keyboard_type=ft.KeyboardType.NUMBER
+        label="k-value (for parity)",
+        value="7",
+        width=150,
+        disabled=True,
+        keyboard_type=ft.KeyboardType.NUMBER,
     )
 
     def _toggle_k_value(e: ft.ControlEvent) -> None:
@@ -138,9 +147,7 @@ def main(page: ft.Page):
         page.update()
 
     parity_checkbox = ft.Checkbox(
-        label="Add Parity",
-        value=False,
-        on_change=_toggle_k_value
+        label="Add Parity", value=False, on_change=_toggle_k_value
     )
 
     def on_fec_change(e: ft.ControlEvent):
@@ -155,8 +162,6 @@ def main(page: ft.Page):
             k_value_input.disabled = not parity_checkbox.value
         page.update()
 
-
-
     fec_dropdown = ft.Dropdown(
         label="FEC Method",
         options=[
@@ -166,10 +171,9 @@ def main(page: ft.Page):
             ft.dropdown.Option("Reed-Solomon"),
         ],
         value="None",
-        on_change=on_fec_change
-
+        on_change=on_fec_change,
     )
-    
+
     encode_button = ft.ElevatedButton("Encode")
 
     encode_status_text = ft.Text("", selectable=True)
@@ -179,21 +183,21 @@ def main(page: ft.Page):
     encode_bits_per_nt_text = ft.Text("Bits per nucleotide: - bits/nt")
     encode_actual_gc_text = ft.Text("Actual GC content (payload): -")
     encode_actual_homopolymer_text = ft.Text("Actual max homopolymer (payload): -")
-    encode_progress_ring = ft.ProgressRing(visible=False, width=20, height=20) # Progress indicator
-    
+    encode_progress_ring = ft.ProgressRing(
+        visible=False, width=20, height=20
+    )  # Progress indicator
+
     encode_dna_snippet_text = ft.TextField(
         label="DNA Snippet (first 200 chars)",
-        read_only=True, 
-        multiline=True, 
+        read_only=True,
+        multiline=True,
         max_lines=3,
         value="",
-        width=500 
+        width=500,
     )
 
     encode_save_button = ft.ElevatedButton(
-        "Save Encoded FASTA...",
-        icon=ft.icons.SAVE,
-        visible=False
+        "Save Encoded FASTA...", icon=ft.icons.SAVE, visible=False
     )
 
     encode_manifest_save_button = ft.ElevatedButton(
@@ -202,29 +206,32 @@ def main(page: ft.Page):
         visible=False,
     )
 
-    encode_hidden_fasta_content = ft.Text(ref=encode_fasta_data_to_save_ref, visible=False, value="")
+    encode_hidden_fasta_content = ft.Text(
+        ref=encode_fasta_data_to_save_ref, visible=False, value=""
+    )
     encode_manifest_to_save_ref = ft.Ref[str]()
     encode_hidden_manifest_content = ft.Text(
         ref=encode_manifest_to_save_ref,
         visible=False,
         value="",
     )
+    encode_hidden_sequence = ft.Text(visible=False, value="")
 
     # --- Main App Structure (Tabs) defined here so encode_data can access app_tabs.tabs[2] ---
     # This is a forward declaration of sorts for app_tabs, its full definition with content is later.
-    app_tabs = ft.Tabs() 
+    app_tabs = ft.Tabs()
 
     # --- Encode Event Handlers ---
     async def encode_data(e):
         """
         Handles the encoding process when the 'Encode' button is clicked.
-        
+
         This asynchronous function performs the following steps:
         1. Disables UI controls (buttons, progress ring) to prevent concurrent operations.
         2. Resets UI elements (status texts, image displays).
         3. Validates user inputs (file selection, parity k-value).
         4. Reads input file data asynchronously.
-        5. Applies the selected encoding method (Base-4 Direct, Huffman, GC-Balanced) 
+        5. Applies the selected encoding method (Base-4 Direct, Huffman, GC-Balanced)
            asynchronously using `asyncio.to_thread`.
         6. Optionally applies Triple-Repeat, Hamming(7,4), or Reed-Solomon FEC if selected,
            also asynchronously.
@@ -240,7 +247,7 @@ def main(page: ft.Page):
         encode_button.disabled = True
         encode_browse_button.disabled = True
         encode_progress_ring.visible = True
-        
+
         encode_status_text.value = "Processing..."
         encode_orig_size_text.value = "Original size: - bytes"
         encode_dna_len_text.value = "Encoded DNA length: - nucleotides"
@@ -253,14 +260,14 @@ def main(page: ft.Page):
         encode_manifest_save_button.visible = False
         encode_hidden_fasta_content.value = ""
         encode_hidden_manifest_content.value = ""
-        
+
         codeword_hist_image.src_base64 = None
         nucleotide_freq_image.src_base64 = None
-        sequence_analysis_plot_image.src_base64 = None # Clear new plot
+        sequence_analysis_plot_image.src_base64 = None  # Clear new plot
         analysis_status_text.value = "Encode data to view analysis plots."
-        if len(app_tabs.tabs) > 2: 
+        if len(app_tabs.tabs) > 2:
             app_tabs.tabs[2].disabled = True
-        
+
         page.update()
 
         try:
@@ -288,6 +295,7 @@ def main(page: ft.Page):
             result = await asyncio.to_thread(perform_encoding, input_data, options)
 
             encode_hidden_fasta_content.value = result.fasta
+            encode_hidden_sequence.value = result.encoded_dna
             encode_dna_snippet_text.value = result.encoded_dna[:200]
             encode_save_button.visible = True
             manifest = generate_manifest(
@@ -297,11 +305,15 @@ def main(page: ft.Page):
             encode_manifest_save_button.visible = True
 
             metrics = result.metrics
-            encode_orig_size_text.value = f"Original size: {metrics['original_size']} bytes"
+            encode_orig_size_text.value = (
+                f"Original size: {metrics['original_size']} bytes"
+            )
             encode_dna_len_text.value = (
                 f"Encoded DNA length: {metrics['dna_length']} nucleotides"
             )
-            encode_comp_ratio_text.value = f"Compression ratio: {metrics['compression_ratio']:.2f}"
+            encode_comp_ratio_text.value = (
+                f"Compression ratio: {metrics['compression_ratio']:.2f}"
+            )
             encode_bits_per_nt_text.value = (
                 f"Bits per nucleotide: {metrics['bits_per_nt']:.2f} bits/nt"
             )
@@ -310,40 +322,42 @@ def main(page: ft.Page):
                 encode_actual_gc_text.value = (
                     f"Actual GC content (payload, pre-FEC): {metrics['actual_gc']:.2%}"
                 )
-                encode_actual_homopolymer_text.value = (
-                    f"Actual max homopolymer (payload, pre-FEC): {metrics['max_homopolymer']}"
-
-                )
+                encode_actual_homopolymer_text.value = f"Actual max homopolymer (payload, pre-FEC): {metrics['max_homopolymer']}"
             else:
                 encode_actual_gc_text.value = "Actual GC content (payload): N/A"
-                encode_actual_homopolymer_text.value = "Actual max homopolymer (payload): N/A"
+                encode_actual_homopolymer_text.value = (
+                    "Actual max homopolymer (payload): N/A"
+                )
 
             codeword_hist_image.src_base64 = result.plots.get("codeword_hist")
             nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
-            sequence_analysis_plot_image.src_base64 = result.plots.get("sequence_analysis")
+            sequence_analysis_plot_image.src_base64 = result.plots.get(
+                "sequence_analysis"
+            )
 
             # Compute after populating result.plots so checks use a stable value
             any_plot = any(result.plots.values())
 
             if any_plot:
-                analysis_status_text.value = "All analysis plots generated successfully."
+                analysis_status_text.value = (
+                    "All analysis plots generated successfully."
+                )
                 analysis_status_text.color = ft.colors.GREEN_700
             else:
-                analysis_status_text.value = (
-                    "No analysis plots applicable or generated for the selected options."
-                )
+                analysis_status_text.value = "No analysis plots applicable or generated for the selected options."
                 analysis_status_text.color = ft.colors.ORANGE_ACCENT_700
             if len(app_tabs.tabs) > 2:
                 app_tabs.tabs[2].disabled = not any_plot
 
             info_msgs = list(result.info_messages)
             if options.method == "GC-Balanced" and options.add_parity:
-                info_msgs.insert(0, "Info: 'Add Parity' not directly used by GC-Balanced.")
+                info_msgs.insert(
+                    0, "Info: 'Add Parity' not directly used by GC-Balanced."
+                )
             status_prefix = " ".join(info_msgs)
             encode_status_text.value = (
-                (status_prefix + " " if status_prefix else "")
-                + "Encoding successful! Click 'Save Encoded FASTA...' to save."
-            )
+                status_prefix + " " if status_prefix else ""
+            ) + "Encoding successful! Click 'Save Encoded FASTA...' to save."
             encode_status_text.color = ft.colors.GREEN_700
 
         except FileNotFoundError:
@@ -361,12 +375,16 @@ def main(page: ft.Page):
 
     encode_button.on_click = encode_data
 
-    async def on_encode_save_file_result(e: ft.FilePickerResultEvent): # Made async for consistency, though not strictly needed here
+    async def on_encode_save_file_result(
+        e: ft.FilePickerResultEvent,
+    ):  # Made async for consistency, though not strictly needed here
         if e.path:
             try:
                 with open(e.path, "w", encoding="utf-8") as f_out:
-                    f_out.write(encode_hidden_fasta_content.value) 
-                encode_status_text.value = f"Encoded file saved successfully to: {e.path}"
+                    f_out.write(encode_hidden_fasta_content.value)
+                encode_status_text.value = (
+                    f"Encoded file saved successfully to: {e.path}"
+                )
                 encode_status_text.color = ft.colors.GREEN_700
             except Exception as ex:
                 encode_status_text.value = f"Error saving file: {ex}"
@@ -382,7 +400,7 @@ def main(page: ft.Page):
     encode_save_button.on_click = lambda _: encode_save_file_picker.save_file(
         dialog_title="Save Encoded FASTA File",
         file_name="encoded_output.fasta",
-        allowed_extensions=["fasta", "fa"]
+        allowed_extensions=["fasta", "fa"],
     )
 
     async def on_manifest_save_file_result(e: ft.FilePickerResultEvent) -> None:
@@ -403,25 +421,26 @@ def main(page: ft.Page):
     manifest_file_picker = ft.FilePicker(on_result=on_manifest_save_file_result)
     page.overlay.append(manifest_file_picker)
 
-    encode_manifest_save_button.on_click = (
-        lambda _: manifest_file_picker.save_file(
-            dialog_title="Save Manifest File",
-            file_name="encoded_output.manifest.json",
-            allowed_extensions=["json"],
-        )
+    encode_manifest_save_button.on_click = lambda _: manifest_file_picker.save_file(
+        dialog_title="Save Manifest File",
+        file_name="encoded_output.manifest.json",
+        allowed_extensions=["json"],
     )
-
 
     # --- Decode Tab UI Controls & Logic ---
     decode_selected_input_file_text = ft.Text("No FASTA file selected.", italic=True)
-    decode_status_text = ft.Text("", selectable=True) # Main status for decoding results
-    decode_fec_info_text = ft.Text("", selectable=True, color=ft.colors.BLUE_GREY_500) # Displays FEC correction/error counts
-    decode_progress_ring = ft.ProgressRing(visible=False, width=20, height=20) # Progress indicator
+    decode_status_text = ft.Text(
+        "", selectable=True
+    )  # Main status for decoding results
+    decode_fec_info_text = ft.Text(
+        "", selectable=True, color=ft.colors.BLUE_GREY_500
+    )  # Displays FEC correction/error counts
+    decode_progress_ring = ft.ProgressRing(
+        visible=False, width=20, height=20
+    )  # Progress indicator
 
     decode_save_button = ft.ElevatedButton(
-        "Save Decoded File...",
-        icon=ft.icons.SAVE,
-        visible=False
+        "Save Decoded File...", icon=ft.icons.SAVE, visible=False
     )
 
     decode_button = ft.ElevatedButton("Decode")
@@ -437,14 +456,18 @@ def main(page: ft.Page):
         value="base4",
     )
 
-    async def on_decode_file_picker_result(e: ft.FilePickerResultEvent): # Made async
+    async def on_decode_file_picker_result(e: ft.FilePickerResultEvent):  # Made async
         if e.files and len(e.files) > 0:
             selected_decode_input_file_path.current = e.files[0].path
-            decode_selected_input_file_text.value = f"Selected: {os.path.basename(e.files[0].name)}"
+            decode_selected_input_file_text.value = (
+                f"Selected: {os.path.basename(e.files[0].name)}"
+            )
         else:
             selected_decode_input_file_path.current = ""
-            decode_selected_input_file_text.value = "File selection cancelled or failed."
-        decode_status_text.value = "" 
+            decode_selected_input_file_text.value = (
+                "File selection cancelled or failed."
+            )
+        decode_status_text.value = ""
         decode_save_button.visible = False
         page.update()
 
@@ -457,8 +480,8 @@ def main(page: ft.Page):
         on_click=lambda _: decode_file_picker.pick_files(
             allow_multiple=False,
             dialog_title="Select FASTA File for Decoding",
-            allowed_extensions=["fasta", "fa", "txt"] 
-        )
+            allowed_extensions=["fasta", "fa", "txt"],
+        ),
     )
 
     async def decode_file_data(e):
@@ -476,7 +499,9 @@ def main(page: ft.Page):
         try:
             input_path = selected_decode_input_file_path.current
             if not input_path:
-                decode_status_text.value = "Error: Please select an input FASTA file first."
+                decode_status_text.value = (
+                    "Error: Please select an input FASTA file first."
+                )
                 decode_status_text.color = ft.colors.RED_ACCENT_700
                 page.update()
                 return
@@ -521,9 +546,11 @@ def main(page: ft.Page):
     async def on_save_decoded_file_result(e: ft.FilePickerResultEvent):  # Made async
         if e.path:
             try:
-                with open(e.path, "wb") as f_out: 
+                with open(e.path, "wb") as f_out:
                     f_out.write(decoded_bytes_to_save)
-                decode_status_text.value = f"Decoded file saved successfully to {e.path}"
+                decode_status_text.value = (
+                    f"Decoded file saved successfully to {e.path}"
+                )
             except Exception as ex:
                 decode_status_text.value = f"Error saving decoded file: {ex}"
         else:
@@ -534,14 +561,16 @@ def main(page: ft.Page):
     page.overlay.append(save_decoded_file_picker)
 
     decode_save_button.on_click = lambda _: save_decoded_file_picker.save_file(
-        dialog_title="Save Decoded File",
-        file_name="decoded_output.bin" 
+        dialog_title="Save Decoded File", file_name="decoded_output.bin"
     )
 
     decode_tab_content_column = ft.Column(
         controls=[
-            ft.Row([decode_browse_button, decode_selected_input_file_text], alignment=ft.MainAxisAlignment.START),
-            ft.Row([decode_button, decode_progress_ring]), # Added progress ring
+            ft.Row(
+                [decode_browse_button, decode_selected_input_file_text],
+                alignment=ft.MainAxisAlignment.START,
+            ),
+            ft.Row([decode_button, decode_progress_ring]),  # Added progress ring
             decode_alphabet_dropdown,
             decode_stream_checkbox,
             ft.Divider(),
@@ -562,21 +591,29 @@ def main(page: ft.Page):
             ft.Text("Huffman Codeword Length Histogram:", weight=ft.FontWeight.BOLD),
             codeword_hist_image,
             ft.Divider(),
-            ft.Text("Nucleotide Frequency Distribution (Encoded Sequence):", weight=ft.FontWeight.BOLD),
+            ft.Text(
+                "Nucleotide Frequency Distribution (Encoded Sequence):",
+                weight=ft.FontWeight.BOLD,
+            ),
             nucleotide_freq_image,
-            ft.Divider(), # New divider
-            ft.Text("Sequence GC & Homopolymer Analysis:", weight=ft.FontWeight.BOLD), # New title
-            ft.Row([
-                window_size_input,
-                step_size_input,
-                min_homopolymer_input,
-            ], alignment=ft.MainAxisAlignment.START),
-            sequence_analysis_plot_image, # New plot image
+            ft.Divider(),  # New divider
+            ft.Text(
+                "Sequence GC & Homopolymer Analysis:", weight=ft.FontWeight.BOLD
+            ),  # New title
+            ft.Row(
+                [
+                    window_size_input,
+                    step_size_input,
+                    min_homopolymer_input,
+                ],
+                alignment=ft.MainAxisAlignment.START,
+            ),
+            sequence_analysis_plot_image,  # New plot image
         ],
         spacing=10,
         scroll=ft.ScrollMode.AUTO,
     )
-    
+
     # --- Main App Structure (Tabs) ---
     # Ensure app_tabs is defined before encode_data tries to access it
     app_tabs = ft.Tabs(
@@ -589,13 +626,16 @@ def main(page: ft.Page):
                 content=ft.Container(
                     ft.Column(
                         controls=[
-                            ft.Row([encode_browse_button, encode_selected_input_file_text]),
+                            ft.Row(
+                                [encode_browse_button, encode_selected_input_file_text]
+                            ),
                             method_dropdown,
                             alphabet_dropdown,
                             ft.Row([parity_checkbox, k_value_input]),
                             fec_dropdown,
-
-                            ft.Row([encode_button, encode_progress_ring]), # Added progress ring
+                            ft.Row(
+                                [encode_button, encode_progress_ring]
+                            ),  # Added progress ring
                             ft.Divider(),
                             ft.Text("Metrics:", weight=ft.FontWeight.BOLD),
                             encode_orig_size_text,
@@ -611,35 +651,49 @@ def main(page: ft.Page):
                             encode_status_text,
                             encode_hidden_fasta_content,
                             encode_hidden_manifest_content,
+                            encode_hidden_sequence,
                         ],
-                        spacing=15, scroll=ft.ScrollMode.AUTO
-                    ), padding=10, alignment=ft.alignment.TOP_LEFT
-                )
+                        spacing=15,
+                        scroll=ft.ScrollMode.AUTO,
+                    ),
+                    padding=10,
+                    alignment=ft.alignment.TOP_LEFT,
+                ),
             ),
             ft.Tab(
                 text="Decode",
                 icon=ft.icons.UNARCHIVE_OUTLINED,
-                content=ft.Container(decode_tab_content_column, padding=10, alignment=ft.alignment.top_left)
+                content=ft.Container(
+                    decode_tab_content_column,
+                    padding=10,
+                    alignment=ft.alignment.top_left,
+                ),
             ),
             ft.Tab(
                 text="Analysis",
                 icon=ft.icons.ANALYTICS_OUTLINED,
-                content=ft.Container(analysis_tab_content_column, padding=10, alignment=ft.alignment.top_left),
-                disabled=True # Initially disabled until data is encoded
+                content=ft.Container(
+                    analysis_tab_content_column,
+                    padding=10,
+                    alignment=ft.alignment.top_left,
+                ),
+                disabled=True,  # Initially disabled until data is encoded
             ),
             ft.Tab(
                 text="Helix View",
                 icon=ft.icons.DNA,
-                content=ft.Container(helix_container, padding=10, alignment=ft.alignment.top_left)
-            )
+                content=ft.Container(
+                    helix_container, padding=10, alignment=ft.alignment.top_left
+                ),
+            ),
         ],
-        expand=True
+        expand=True,
     )
 
     def on_tab_change(e: ft.ControlEvent):
         if app_tabs.selected_index == 3:
             helix_container.controls.clear()
-            helix_container.controls.append(show_helix())
+            helix_container.controls.append(show_helix(encode_hidden_sequence.value))
         page.update()
 
     app_tabs.on_change = on_tab_change

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -9,6 +9,7 @@ import pkgutil
 
 # Flet <0.29 removed ``HtmlElement``. Provide a minimal fallback for tests.
 if not hasattr(ft, "HtmlElement"):
+
     class _HtmlElement:
         """Lightweight stand-in for :class:`flet.HtmlElement`."""
 
@@ -25,9 +26,15 @@ try:
     three_data = pkgutil.get_data("genecoder", "static/three.min.js")
     orbit_data = pkgutil.get_data("genecoder", "static/OrbitControls.min.js")
     if three_data:
-        THREE_JS_URL = "data:application/javascript;base64," + base64.b64encode(three_data).decode()
+        THREE_JS_URL = (
+            "data:application/javascript;base64,"
+            + base64.b64encode(three_data).decode()
+        )
     if orbit_data:
-        ORBIT_JS_URL = "data:application/javascript;base64," + base64.b64encode(orbit_data).decode()
+        ORBIT_JS_URL = (
+            "data:application/javascript;base64,"
+            + base64.b64encode(orbit_data).decode()
+        )
 except FileNotFoundError:
     pass
 
@@ -52,18 +59,8 @@ controls.enableDamping = true;
 camera.position.set(2, 2, 5);
 controls.update();
 
-const text = 'GeneCoder';
-const bytes = new TextEncoder().encode(text);
-const bases = [];
-const bits = [];
-for (const byte of bytes) {
-    for (let shift = 6; shift >= 0; shift -= 2) {
-        const val = (byte >> shift) & 3;
-        const base = ['A', 'C', 'G', 'T'][val];
-        bases.push(base);
-        bits.push(`${byte.toString(16).padStart(2,'0')}[${val.toString(2).padStart(2,'0')}]`);
-    }
-}
+const sequence = '%(SEQUENCE)s';
+const bases = Array.from(sequence);
 
 const colors = { A: 0xff5555, C: 0x5555ff, G: 0x55ff55, T: 0xffff55 };
 const group = new THREE.Group();
@@ -71,11 +68,11 @@ const radius = 0.1;
 const height = 0.4;
 for (let i = 0; i < bases.length; i++) {
     const geometry = new THREE.SphereGeometry(radius, 16, 16);
-    const material = new THREE.MeshBasicMaterial({ color: colors[bases[i]] });
+    const material = new THREE.MeshBasicMaterial({ color: colors[bases[i]] || 0xffffff });
     const mesh = new THREE.Mesh(geometry, material);
     const angle = i * 0.3;
     mesh.position.set(Math.cos(angle), Math.sin(angle), i * height);
-    mesh.userData = { info: bits[i] };
+    mesh.userData = { info: `${bases[i]} (${i})` };
     group.add(mesh);
 }
 scene.add(group);
@@ -114,12 +111,13 @@ animate();
 </script>
 """
 
-HELIX_HTML = HELIX_TEMPLATE % {
-    "THREE_JS_URL": THREE_JS_URL,
-    "ORBIT_JS_URL": ORBIT_JS_URL,
-}
 
-def show_helix() -> ft.WebView:
+def show_helix(sequence: str) -> ft.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls."""
-    data_url = "data:text/html," + quote(HELIX_HTML)
+    html = HELIX_TEMPLATE % {
+        "THREE_JS_URL": THREE_JS_URL,
+        "ORBIT_JS_URL": ORBIT_JS_URL,
+        "SEQUENCE": sequence,
+    }
+    data_url = "data:text/html," + quote(html)
     return ft.WebView(url=data_url, width=600, height=400)

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -9,13 +9,11 @@ def _get_ft_and_show_helix():
     return ft, show_helix
 
 
-
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
 def test_show_helix_basic():
     ft, show_helix = _get_ft_and_show_helix()
 
-
-    elem = show_helix()
+    elem = show_helix("ACGT")
     assert elem.__class__.__name__ == "WebView"
     assert elem.width == 600
     assert elem.height == 400
@@ -23,3 +21,4 @@ def test_show_helix_basic():
     html = unquote(elem.url.split(",", 1)[1])
     assert "cdn.jsdelivr" not in html
     assert "data:application/javascript;base64" in html
+    assert "ACGT" in html


### PR DESCRIPTION
## Summary
- color spheres in `show_helix` based on sequence
- allow passing an encoded sequence to the helix viewer
- wire encoded DNA into Flet helix view
- test helix viewer with a small sequence

## Testing
- `ruff format src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py`
- `ruff check src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fe77b54c8326af7e836fa16233ca