### PR TITLE
Add sequence control to helix view

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -27,6 +27,7 @@ from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix
+from genecoder.formats import from_fasta
 
 
 encode_fasta_data_to_save_ref = ft.Ref[str]()
@@ -638,8 +639,13 @@ def main(page: ft.Page):
 
     def on_tab_change(e: ft.ControlEvent):
         if app_tabs.selected_index == 3:
+            dna_seq = ""
+            if encode_hidden_fasta_content.value:
+                parsed = from_fasta(encode_hidden_fasta_content.value)
+                if parsed:
+                    dna_seq = parsed[0][1]
             helix_container.controls.clear()
-            helix_container.controls.append(show_helix())
+            helix_container.controls.append(show_helix(dna_seq))
         page.update()
 
     app_tabs.on_change = on_tab_change

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -52,17 +52,13 @@ controls.enableDamping = true;
 camera.position.set(2, 2, 5);
 controls.update();
 
-const text = 'GeneCoder';
-const bytes = new TextEncoder().encode(text);
+const seq = '%(DNA_SEQ)s';
 const bases = [];
 const bits = [];
-for (const byte of bytes) {
-    for (let shift = 6; shift >= 0; shift -= 2) {
-        const val = (byte >> shift) & 3;
-        const base = ['A', 'C', 'G', 'T'][val];
-        bases.push(base);
-        bits.push(`${byte.toString(16).padStart(2,'0')}[${val.toString(2).padStart(2,'0')}]`);
-    }
+for (let i = 0; i < seq.length; i++) {
+    const base = seq[i];
+    bases.push(base);
+    bits.push(base);
 }
 
 const colors = { A: 0xff5555, C: 0x5555ff, G: 0x55ff55, T: 0xffff55 };
@@ -114,12 +110,16 @@ animate();
 </script>
 """
 
-HELIX_HTML = HELIX_TEMPLATE % {
-    "THREE_JS_URL": THREE_JS_URL,
-    "ORBIT_JS_URL": ORBIT_JS_URL,
-}
+def _make_helix_html(dna_sequence: str) -> str:
+    return HELIX_TEMPLATE % {
+        "THREE_JS_URL": THREE_JS_URL,
+        "ORBIT_JS_URL": ORBIT_JS_URL,
+        "DNA_SEQ": dna_sequence,
+    }
 
-def show_helix() -> ft.WebView:
+
+def show_helix(dna_sequence: str = "ACGT") -> ft.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls."""
-    data_url = "data:text/html," + quote(HELIX_HTML)
+    helix_html = _make_helix_html(dna_sequence)
+    data_url = "data:text/html," + quote(helix_html)
     return ft.WebView(url=data_url, width=600, height=400)

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -23,3 +23,12 @@ def test_show_helix_basic():
     html = unquote(elem.url.split(",", 1)[1])
     assert "cdn.jsdelivr" not in html
     assert "data:application/javascript;base64" in html
+
+
+@pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
+def test_show_helix_sequence_in_html():
+    ft, show_helix = _get_ft_and_show_helix()
+    seq = "AACCGGTT"
+    elem = show_helix(seq)
+    html = unquote(elem.url.split(",", 1)[1])
+    assert seq in html


### PR DESCRIPTION
## Summary
- allow a DNA sequence to be passed to the helix WebView
- show encoded DNA from the Encode tab when opening the Helix View
- test that the helix HTML includes the provided sequence

## Testing
- `pre-commit run --files src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py`

------
https://chatgpt.com/codex/tasks/task_e_6851fe4b4ac4832684b034e48f5d367c