### PR TITLE
Add LDPC and fountain FEC CLI roundtrip tests

### DIFF
--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import pytest
 from tests.test_cli import run_cli_command
 
 
@@ -131,4 +132,84 @@ def test_cli_decode_with_squigulator(tmp_path: Path):
     output_file = tmp_path / "sq.txt_decoded.bin"
     assert output_file.exists()
     assert output_file.read_text() == "squigulator test"
+
+
+def test_cli_roundtrip_ldpc(tmp_path: Path):
+    pytest.importorskip("pyldpc")
+
+    input_file = tmp_path / "ldpc.txt"
+    input_file.write_text("ldpc test")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "ldpc",
+        ]
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "ldpc.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+        ]
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "ldpc.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text().startswith("ldpc test")
+
+
+def test_cli_roundtrip_fountain(tmp_path: Path):
+    pytest.importorskip("pyfinite")
+
+    input_file = tmp_path / "fountain.txt"
+    input_file.write_text("fountain test")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "fountain",
+        ]
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "fountain.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+        ]
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "fountain.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text() == "fountain test"
 


### PR DESCRIPTION
## Summary
- add tests covering CLI encode/decode with `--fec ldpc` and `--fec fountain`
- skip these tests if optional deps are missing

## Testing
- `ruff check tests/test_cli_roundtrip.py`
- `mypy src`
- `pytest -q tests/test_cli_roundtrip.py`

------
https://chatgpt.com/codex/tasks/task_e_6851fe42a51c8326bff77ecc48b5ef06