### PR TITLE
Enable mypy strict checking

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -128,7 +128,7 @@ jobs:
         pip install mypy
 
     - name: Run mypy
-      run: mypy --config-file mypy.ini src
+      run: mypy --config-file mypy.ini src --show-error-codes --no-error-summary
 
   build:
     needs: [changes, check-comments, lint, mypy]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 python_version = 3.10
 ignore_missing_imports = true
-strict = false
+strict = true
 explicit_package_bases = true

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -17,7 +17,10 @@ load_plugins()
 __all__ = [*sorted(_LAZY_ATTRS), "__version__", "CODEC_REGISTRY", "load_plugins"]
 
 
-def __getattr__(name: str):
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
     if name in _LAZY_ATTRS:
         from .app_helpers import (
             EncodeOptions,

--- a/src/genecoder/cli.py
+++ b/src/genecoder/cli.py
@@ -50,7 +50,6 @@ from genecoder.plotting import (
     identify_homopolymer_regions,
     generate_sequence_analysis_plot,
 )
-from genecoder.synthesis import SynthesisConstraints
 
 logger = logging.getLogger(__name__)
 
@@ -373,7 +372,7 @@ def run_decoding_pipeline(
             f"Warning for {input_file_name}: DNA-level parity errors in data blocks: {parity_errors}",
         )
 
-    final_data = binary_data
+    final_data: bytes = binary_data
     if "fec=hamming_7_4" in header:
         logger.info(f"Hamming(7,4) FEC detected in header for {input_file_name}.")
         fec_padding_bits_match = re.search(r"fec_padding_bits=(\d+)", header)

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -32,7 +32,7 @@ from genecoder.helix_view import show_helix
 encode_fasta_data_to_save_ref = ft.Ref[str]()
 decoded_bytes_to_save: bytes = b"" 
 
-def main(page: ft.Page):
+def main(page: ft.Page) -> None:
     """Create the UI and register callbacks for Flet's event loop."""
     page.title = "GeneCoder"
     page.vertical_alignment = ft.MainAxisAlignment.START
@@ -84,7 +84,7 @@ def main(page: ft.Page):
     # --- Encode Tab UI Controls ---
     encode_selected_input_file_text = ft.Text("No file selected.", italic=True)
     
-    def on_encode_file_picker_result(e: ft.FilePickerResultEvent):
+    def on_encode_file_picker_result(e: ft.FilePickerResultEvent) -> None:
         if e.files and len(e.files) > 0:
             selected_encode_input_file_path.current = e.files[0].path
             encode_selected_input_file_text.value = f"Selected: {os.path.basename(e.files[0].name)}"
@@ -143,7 +143,7 @@ def main(page: ft.Page):
         on_change=_toggle_k_value
     )
 
-    def on_fec_change(e: ft.ControlEvent):
+    def on_fec_change(e: ft.ControlEvent) -> None:
         """Toggle parity checkbox based on selected FEC."""
         selected = e.control.value
         if selected in ("Hamming(7,4)", "Reed-Solomon"):
@@ -215,7 +215,7 @@ def main(page: ft.Page):
     app_tabs = ft.Tabs() 
 
     # --- Encode Event Handlers ---
-    async def encode_data(e):
+    async def encode_data(e: ft.ControlEvent) -> None:
         """
         Handles the encoding process when the 'Encode' button is clicked.
         
@@ -361,7 +361,7 @@ def main(page: ft.Page):
 
     encode_button.on_click = encode_data
 
-    async def on_encode_save_file_result(e: ft.FilePickerResultEvent): # Made async for consistency, though not strictly needed here
+    async def on_encode_save_file_result(e: ft.FilePickerResultEvent) -> None:  # Made async for consistency, though not strictly needed here
         if e.path:
             try:
                 with open(e.path, "w", encoding="utf-8") as f_out:
@@ -437,7 +437,7 @@ def main(page: ft.Page):
         value="base4",
     )
 
-    async def on_decode_file_picker_result(e: ft.FilePickerResultEvent): # Made async
+    async def on_decode_file_picker_result(e: ft.FilePickerResultEvent) -> None:  # Made async
         if e.files and len(e.files) > 0:
             selected_decode_input_file_path.current = e.files[0].path
             decode_selected_input_file_text.value = f"Selected: {os.path.basename(e.files[0].name)}"
@@ -461,7 +461,7 @@ def main(page: ft.Page):
         )
     )
 
-    async def decode_file_data(e):
+    async def decode_file_data(e: ft.ControlEvent) -> None:
         """Decode an input FASTA file using :func:`perform_decoding`."""
         global decoded_bytes_to_save
 
@@ -518,7 +518,7 @@ def main(page: ft.Page):
 
     decode_button.on_click = decode_file_data
 
-    async def on_save_decoded_file_result(e: ft.FilePickerResultEvent):  # Made async
+    async def on_save_decoded_file_result(e: ft.FilePickerResultEvent) -> None:  # Made async
         if e.path:
             try:
                 with open(e.path, "wb") as f_out: 
@@ -636,7 +636,7 @@ def main(page: ft.Page):
         expand=True
     )
 
-    def on_tab_change(e: ft.ControlEvent):
+    def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:
             helix_container.controls.clear()
             helix_container.controls.append(show_helix())

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -17,7 +17,7 @@ if not hasattr(ft, "HtmlElement"):
             self.width = width
             self.height = height
 
-    ft.HtmlElement = _HtmlElement  # type: ignore[attr-defined]
+    ft.HtmlElement = _HtmlElement
 
 THREE_JS_URL = ""
 ORBIT_JS_URL = ""

--- a/src/genecoder/huffman_coding.py
+++ b/src/genecoder/huffman_coding.py
@@ -11,7 +11,7 @@ This module provides functions to:
 """
 import collections
 import heapq
-from typing import Dict, Tuple, List, Union # For type hints
+from typing import Dict, Tuple, List, Union
 from .utils import DNA_ENCODE_MAP, DNA_DECODE_MAP
 from genecoder.error_detection import (
     add_parity_to_sequence, 
@@ -20,11 +20,11 @@ from genecoder.error_detection import (
 )
 
 # Type alias for Huffman tree nodes used internally
-HuffmanNode = Union[int, List[Union[int, 'HuffmanNode', List['HuffmanNode']]]] # type: ignore
+HuffmanNode = Union[int, List[Union[int, 'HuffmanNode', List['HuffmanNode']]]]
 
 # --- Helper Functions ---
 
-def _calculate_frequencies(data: bytes) -> collections.Counter:
+def _calculate_frequencies(data: bytes) -> collections.Counter[int]:
     """Calculates the frequency of each byte in the input data.
 
     Args:
@@ -38,7 +38,9 @@ def _calculate_frequencies(data: bytes) -> collections.Counter:
         return collections.Counter()
     return collections.Counter(data)
 
-def _build_huffman_tree_and_codes(frequencies: collections.Counter) -> Dict[int, str]:
+def _build_huffman_tree_and_codes(
+    frequencies: collections.Counter[int],
+) -> Dict[int, str]:
     """Builds a Huffman tree from byte frequencies and generates Huffman codes.
 
     Args:
@@ -72,10 +74,10 @@ def _build_huffman_tree_and_codes(frequencies: collections.Counter) -> Dict[int,
     # Edge case: If there's only one unique byte in the input data.
     # The Huffman code for this single byte is defined as '0'.
     if len(heap) == 1:
-        _freq, _uid, byte_val = heap[0]
-        # Ensure byte_val is an int, as expected by type hints, not a list.
-        if isinstance(byte_val, int):
-            return {byte_val: '0'}
+        _freq, _uid, single_node = heap[0]
+        # Ensure ``single_node`` is an int, as expected by type hints, not a list.
+        if isinstance(single_node, int):
+            return {single_node: "0"}
         else:
             # This case should ideally not be reached if frequencies are from bytes.
             # However, for robustness, handle potential malformed heap item.

--- a/src/genecoder/plotting.py
+++ b/src/genecoder/plotting.py
@@ -6,14 +6,17 @@ rendered to in-memory buffers for display in Flet or other GUI frameworks.
 """
 import io
 import collections
-from typing import Dict, List  # For older Python; can be dict, list for 3.9+
+from typing import Dict, List
 
 import matplotlib
 matplotlib.use('Agg') # Set Matplotlib backend to Agg for headless environments
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
 
 
-def prepare_huffman_codeword_length_data(huffman_table: Dict[int, str]) -> collections.Counter:
+def prepare_huffman_codeword_length_data(
+    huffman_table: Dict[int, str],
+) -> collections.Counter[int]:
     """Prepares data for a Huffman codeword length histogram.
 
     Calculates the length of each codeword in the provided Huffman table and
@@ -36,7 +39,9 @@ def prepare_huffman_codeword_length_data(huffman_table: Dict[int, str]) -> colle
     return length_counts
 
 
-def generate_codeword_length_histogram(length_counts: collections.Counter) -> io.BytesIO:
+def generate_codeword_length_histogram(
+    length_counts: collections.Counter[int],
+) -> io.BytesIO:
     """Generates a histogram of Huffman codeword lengths as a PNG image in a BytesIO buffer.
 
     Args:
@@ -77,7 +82,7 @@ def generate_codeword_length_histogram(length_counts: collections.Counter) -> io
             pass 
         
         # Ensure y-axis ticks are integers if counts are always integers
-        ax.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
 
     plt.tight_layout()  # Adjust layout to prevent labels from being cut off
@@ -92,7 +97,7 @@ def generate_codeword_length_histogram(length_counts: collections.Counter) -> io
     return buf
 
 
-def prepare_nucleotide_frequency_data(dna_sequence: str) -> collections.Counter:
+def prepare_nucleotide_frequency_data(dna_sequence: str) -> collections.Counter[str]:
     """Prepares data for a nucleotide frequency plot.
 
     Counts occurrences of 'A', 'T', 'C', 'G' in the DNA sequence.
@@ -118,7 +123,9 @@ def prepare_nucleotide_frequency_data(dna_sequence: str) -> collections.Counter:
     return nucleotide_counts
 
 
-def generate_nucleotide_frequency_plot(nucleotide_counts: collections.Counter) -> io.BytesIO:
+def generate_nucleotide_frequency_plot(
+    nucleotide_counts: collections.Counter[str],
+) -> io.BytesIO:
     """Generates a bar plot of nucleotide frequencies as a PNG image in a BytesIO buffer.
 
     Args:
@@ -145,7 +152,7 @@ def generate_nucleotide_frequency_plot(nucleotide_counts: collections.Counter) -
     ax.set_xlabel("Nucleotide")
     ax.set_ylabel("Frequency (Count)")
     ax.set_title("Nucleotide Frequency Distribution")
-    ax.yaxis.set_major_locator(plt.MaxNLocator(integer=True)) # Ensure y-axis has integer ticks
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))  # Ensure y-axis has integer ticks
 
     plt.tight_layout()
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -23,7 +23,7 @@ def load_plugins() -> None:
 
     # Also load plugins from a local ``plugins`` package if present
     try:
-        import plugins  # type: ignore
+        import plugins
     except ModuleNotFoundError:
         return
     for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):

--- a/src/plugins/reverse_codec.py
+++ b/src/plugins/reverse_codec.py
@@ -3,7 +3,9 @@
 from typing import Callable
 
 
-def register(register_codec: Callable[[str, Callable, Callable], None]) -> None:
+def register(
+    register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]
+) -> None:
     """Register the reverse codec."""
 
     def encode_reverse(data: bytes) -> str:


### PR DESCRIPTION
## Summary
- enforce `strict = true` in mypy configuration
- fix strict-mode type errors across the codebase
- tighten mypy invocation in CI to surface codes

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml mypy.ini src/genecoder/huffman_coding.py src/genecoder/cli.py src/genecoder/flet_app.py src/plugins/reverse_codec.py src/genecoder/plugins.py src/genecoder/helix_view.py src/genecoder/plotting.py src/genecoder/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fe532f0c83268f272aa804203b97