### PR TITLE
Handle nanopore simulator failures

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -7,6 +7,9 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 from .channel_sim import simulate_errors
 from .formats import from_fasta, to_fasta
@@ -45,17 +48,38 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     if simulator == "nanopore":
         if shutil.which("d2sim"):
-            return _run_external("d2sim", sequence)
+            try:
+                return _run_external("d2sim", sequence)
+            except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+                logger.warning(
+                    "d2sim failed with return code %s; falling back to simple error model",
+                    exc.returncode,
+                )
+                return simulate_errors(sequence, error_rate)
         return simulate_errors(sequence, error_rate)
 
     if simulator == "dnarsim":
         if shutil.which("dnarsim"):
-            return _run_external("dnarsim", sequence)
+            try:
+                return _run_external("dnarsim", sequence)
+            except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+                logger.warning(
+                    "dnarsim failed with return code %s; falling back to simple error model",
+                    exc.returncode,
+                )
+                return simulate_errors(sequence, error_rate)
         return simulate_errors(sequence, error_rate)
 
     if simulator == "squigulator":
         if shutil.which("squigulator"):
-            return _run_external("squigulator", sequence)
+            try:
+                return _run_external("squigulator", sequence)
+            except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+                logger.warning(
+                    "squigulator failed with return code %s; falling back to simple error model",
+                    exc.returncode,
+                )
+                return simulate_errors(sequence, error_rate)
         return simulate_errors(sequence, error_rate)
 
     raise ValueError(f"Unknown simulator: {simulator}")

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -1,3 +1,5 @@
+import logging
+import subprocess
 import pytest
 
 from genecoder import nanopore_sim
@@ -75,3 +77,36 @@ def test_simulate_reads_none(monkeypatch):
     result = nanopore_sim.simulate_reads("ACGT", "none")
     assert result == "ACGT"
     assert call_count == []
+
+
+@pytest.mark.parametrize("simulator", SIMULATORS.keys())
+def test_simulate_reads_external_error(monkeypatch, caplog, simulator):
+    cmd = SIMULATORS[simulator]
+    which_called: list[str] = []
+    external_called: list[tuple[str, str]] = []
+    errors_called: list[tuple[str, float]] = []
+
+    def fake_which(name: str) -> str:
+        which_called.append(name)
+        return "/usr/bin/" + name
+
+    def fake_external(command: str, seq: str) -> str:
+        external_called.append((command, seq))
+        raise subprocess.CalledProcessError(1, command)
+
+    def fake_errors(seq: str, rate: float) -> str:
+        errors_called.append((seq, rate))
+        return "fallback"
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_external)
+    monkeypatch.setattr(nanopore_sim, "simulate_errors", fake_errors)
+
+    with caplog.at_level(logging.WARNING):
+        result = nanopore_sim.simulate_reads("ACGT", simulator, error_rate=0.2)
+
+    assert result == "fallback"
+    assert which_called == [cmd]
+    assert external_called == [(cmd, "ACGT")]
+    assert errors_called == [("ACGT", 0.2)]
+    assert any("falling back" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add warning logging in `simulate_reads`
- use fallback errors when simulators exit with non-zero status
- test fallback when external simulator fails

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_6851fe41b8148326aef6ebec44f64e51