### PR TITLE
Add httpx to web extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ gui = [
 web = [
     "fastapi",
     "uvicorn[standard]",
+    "httpx",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add httpx to web extra in pyproject
- install the web extra and run web app tests

## Testing
- `pre-commit run --files pyproject.toml`
- `pip install -e .[web]`
- `pytest tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68521f4da8008326af584936cc1a4e3e