### PR TITLE
Add FEC and simulator plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ See [CITATION.cff](CITATION.cff) for citation information.
 ### Plugins
 
 GeneCoder can be extended through plugins discovered via the
-`genecoder.plugins` entry point. See [docs/plugins.md](docs/plugins.md) for
-details on writing and registering new codecs or viewers.
+`genecoder.plugins`, `genecoder.fec` and `genecoder.simulators` entry points.
+See [docs/plugins.md](docs/plugins.md) for details on writing and registering
+new codecs, FEC back-ends or simulators.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,9 +1,10 @@
 # Plugin System
 
 GeneCoder discovers additional functionality using Python entry points. Any
-package can expose a `genecoder.plugins` entry point that points to a module with
-a `register` function. The function receives a `register_codec` callable used to
-add new codecs to the registry.
+package can expose entry points under `genecoder.plugins`, `genecoder.fec` or
+`genecoder.simulators` that point to modules with a `register` function. The
+function receives a callback used to add the implementation to the appropriate
+registry.
 
 Example `pyproject.toml` snippet:
 
@@ -24,6 +25,29 @@ def register(register_codec):
         ...
     register_codec("mycodec", encode, decode)
 ```
+
+To add a custom FEC implementation you would use the `genecoder.fec` group and
+call the provided `register_fec` callback:
+
+```toml
+[project.entry-points."genecoder.fec"]
+myfec = "my_package.my_fec"
+```
+
+```python
+# my_package/my_fec.py
+
+def register(register_fec):
+    def encode(data: bytes):
+        ...
+    def decode(encoded: bytes, info):
+        ...
+register_fec("myfec", encode, decode)
+```
+
+Simulator plugins follow the same pattern using the `genecoder.simulators`
+group with a `register_simulator` callback that receives a function taking a
+DNA sequence and returning a mutated version.
 
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,9 +118,10 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
 11. **Decode using an external simulator**
 
-   The ``--simulator`` option accepts ``nanopore``, ``dnarsim`` or ``squigulator``.
-   When the specified tool is not installed, GeneCoder falls back to an internal
-   error model.
+   The ``--simulator`` option lists all registered simulators. GeneCoder ships
+   with wrappers for ``nanopore``, ``dnarsim`` and ``squigulator`` which are
+   loaded via the plugin system. When a tool is not installed, GeneCoder falls
+   back to an internal error model.
 
    ```bash
    genecoder decode --input-files encoded.fasta \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,14 @@ genecoder = "genecoder.cli.cli:main"
 [project.entry-points."genecoder.plugins"]
 reverse = "plugins.reverse_codec"
 
+[project.entry-points."genecoder.fec"]
+reed_solomon = "genecoder.reed_solomon_codec"
+ldpc = "genecoder.ldpc_codec"
+fountain = "genecoder.fountain_codec"
+
+[project.entry-points."genecoder.simulators"]
+nanopore = "genecoder.nanopore_sim"
+
 [project.urls]
 Homepage = "https://github.com/d0tTino/GeneCoder"
 Changelog = "https://github.com/d0tTino/GeneCoder/blob/main/CHANGELOG.md"

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -10,11 +10,23 @@ _LAZY_ATTRS = {
     "perform_decoding",
 }
 
-from .plugins import CODEC_REGISTRY, load_plugins
+from .plugins import (
+    CODEC_REGISTRY,
+    FEC_REGISTRY,
+    SIMULATOR_REGISTRY,
+    load_plugins,
+)
 
 load_plugins()
 
-__all__ = [*sorted(_LAZY_ATTRS), "__version__", "CODEC_REGISTRY", "load_plugins"]
+__all__ = [
+    *sorted(_LAZY_ATTRS),
+    "__version__",
+    "CODEC_REGISTRY",
+    "FEC_REGISTRY",
+    "SIMULATOR_REGISTRY",
+    "load_plugins",
+]
 
 
 from typing import Any

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
 from genecoder.hamming_codec import decode_data_with_hamming
-from genecoder.reed_solomon_codec import decode_data_rs
+from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -105,13 +105,19 @@ def run_decoding_pipeline(
             raise ValueError("'fec_padding_bits' missing in header for Hamming(7,4) FEC.")
         fec_padding_bits = int(fec_padding_bits_match.group(1))
         final_data, _ = decode_data_with_hamming(binary_data, fec_padding_bits)
-    if "fec=reed_solomon" in header:
-        logger.info(f"Reed-Solomon FEC detected in header for {input_file_name}.")
-        nsym_match = re.search(r"fec_nsym=(\d+)", header)
-        if not nsym_match:
-            raise ValueError("'fec_nsym' missing in header for Reed-Solomon FEC.")
-        nsym = int(nsym_match.group(1))
-        final_data, _ = decode_data_rs(final_data, nsym)
+    else:
+        fec_match = re.search(r"fec=([\w_]+)", header)
+        if fec_match:
+            fec_name = fec_match.group(1)
+            if fec_name in FEC_REGISTRY:
+                info_match = re.search(r"fec_info=([^ ]+)", header)
+                info = None
+                if info_match:
+                    import base64
+                    import pickle
+
+                    info = pickle.loads(base64.b64decode(info_match.group(1)))
+                final_data, _ = FEC_REGISTRY[fec_name]["decode"](final_data, info)
     return final_data
 
 
@@ -162,10 +168,9 @@ def process_single_decode(
                 )
                 raise SystemExit(1)
 
-        if args.simulator != "none":
-            from genecoder.nanopore_sim import simulate_reads
-
-            sequence_from_fasta = simulate_reads(sequence_from_fasta, args.simulator)
+        if args.simulator in SIMULATOR_REGISTRY:
+            simulate_func = SIMULATOR_REGISTRY[args.simulator]
+            sequence_from_fasta = simulate_func(sequence_from_fasta)
             logger.info(
                 f"Applied {args.simulator} simulator before decoding."
             )
@@ -263,11 +268,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         default=0.0,
         help="Probability of random substitution errors applied before decoding.",
     )
+    sim_choices = list(sorted(SIMULATOR_REGISTRY.keys())) or ["none"]
     parser.add_argument(
         "--simulator",
         type=str,
         default="none",
-        choices=["none", "nanopore", "dnarsim", "squigulator"],
+        choices=sim_choices,
         help="Apply an external simulator before decoding (default: none).",
     )
     parser.set_defaults(func=_handle_command)

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -18,7 +18,7 @@ from genecoder.encoders import (
     encode_triple_repeat,
 )
 from genecoder.hamming_codec import encode_data_with_hamming
-from genecoder.reed_solomon_codec import encode_data_rs
+from genecoder.plugins import FEC_REGISTRY
 from genecoder.formats import to_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -73,21 +73,27 @@ def run_encoding_pipeline(
         logger.info(
             f"Applied Hamming(7,4) FEC to {input_file_name}. Original binary size: {len(data)}, Hamming encoded binary size: {len(current_input)} (padding bits: {fec_padding_bits})."
         )
-    elif options.fec == "reed_solomon":
+    elif options.fec and options.fec in FEC_REGISTRY:
         if options.add_parity:
             logger.warning(
-                f"Warning for {input_file_name}: --add-parity is ignored when Reed-Solomon FEC is applied to binary data."
+                f"Warning for {input_file_name}: --add-parity is ignored when {options.fec} FEC is applied to binary data."
             )
-        current_input, rs_nsym = encode_data_rs(data)
-        header_parts.append("fec=reed_solomon")
-        header_parts.append(f"fec_nsym={rs_nsym}")
+        enc = FEC_REGISTRY[options.fec]
+        current_input, info = enc["encode"](data)
+        header_parts.append(f"fec={options.fec}")
+        if info is not None:
+            import base64
+            import pickle
+
+            encoded_info = base64.b64encode(pickle.dumps(info)).decode()
+            header_parts.append(f"fec_info={encoded_info}")
         logger.info(
-            f"Applied Reed-Solomon FEC to {input_file_name}. Original binary size: {len(data)}, RS encoded binary size: {len(current_input)} (nsym={rs_nsym})."
+            f"Applied {options.fec} FEC to {input_file_name}. Original binary size: {len(data)}, encoded size: {len(current_input)}."
         )
     raw_dna = ""
-    should_add_parity = options.add_parity and options.fec not in (
-        "hamming_7_4",
-        "reed_solomon",
+    disabled_fec = {"hamming_7_4", *FEC_REGISTRY.keys()}
+    should_add_parity = options.add_parity and (
+        options.fec is None or options.fec not in disabled_fec
     )
 
     if options.method == "base4_direct":
@@ -360,11 +366,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         choices=[PARITY_RULE_GC_EVEN_A_ODD_T],
         help="Parity rule to use (default: GC_even_A_odd_T).",
     )
+    fec_choices = [None, "triple_repeat", "hamming_7_4", *sorted(FEC_REGISTRY.keys())]
     parser.add_argument(
         "--fec",
         type=str,
         default=None,
-        choices=[None, "triple_repeat", "hamming_7_4", "reed_solomon"],
+        choices=fec_choices,
         help="Forward Error Correction method to apply.",
     )
     parser.add_argument(

--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -51,3 +51,11 @@ def decode_data_fountain(encoded: bytes, info: Any) -> Tuple[bytes, int]:
     ]
     data = b"".join(blocks)[:orig_len]
     return data, 0
+
+
+from typing import Callable
+
+
+def register(register_fec: Callable[[str, Callable[[bytes], tuple[bytes, Any]], Callable[[bytes, Any], tuple[bytes, int]]], None]) -> None:
+    """Register this module's FEC backend."""
+    register_fec("fountain", encode_data_fountain, decode_data_fountain)

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -62,3 +62,11 @@ def decode_data_ldpc(encoded: bytes, info: Any) -> Tuple[bytes, int]:
     data_bits = decoded[:n_bits]
     corrections = int((bits[:n_bits] != data_bits).sum())
     return np.packbits(data_bits).tobytes(), corrections
+
+
+from typing import Callable
+
+
+def register(register_fec: Callable[[str, Callable[[bytes], tuple[bytes, Any]], Callable[[bytes, Any], tuple[bytes, int]]], None]) -> None:
+    """Register this module's FEC backend."""
+    register_fec("ldpc", encode_data_ldpc, decode_data_ldpc)

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -83,3 +83,19 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
         return simulate_errors(sequence, error_rate)
 
     raise ValueError(f"Unknown simulator: {simulator}")
+
+
+from typing import Callable, Any
+
+
+def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+    """Register the builtin simulators."""
+
+    def _wrap(name: str) -> Callable[[str, float], str]:
+        def simulate(seq: str, error_rate: float = 0.05) -> str:
+            return simulate_reads(seq, name, error_rate)
+
+        return simulate
+
+    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+        register_simulator(name, _wrap(name))

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -6,6 +6,8 @@ import importlib
 import pkgutil
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
+FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
+SIMULATOR_REGISTRY: Dict[str, Callable[..., Any]] = {}
 
 
 def register_codec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
@@ -13,21 +15,60 @@ def register_codec(name: str, encode: Callable[..., Any], decode: Callable[..., 
     CODEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
 
+def register_fec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
+    """Register a FEC backend under ``name``."""
+    FEC_REGISTRY[name] = {"encode": encode, "decode": decode}
+
+
+def register_simulator(name: str, simulate: Callable[..., Any]) -> None:
+    """Register a read simulator under ``name``."""
+    SIMULATOR_REGISTRY[name] = simulate
+
+
 def load_plugins() -> None:
-    """Load plugins defined via ``genecoder.plugins`` entry points."""
+    """Load plugins defined via GeneCoder entry points."""
     for ep in entry_points(group="genecoder.plugins"):
         plugin = ep.load()
         register = getattr(plugin, "register", None)
         if callable(register):
             register(register_codec)
 
+    for ep in entry_points(group="genecoder.fec"):
+        plugin = ep.load()
+        register = getattr(plugin, "register", None)
+        if callable(register):
+            register(register_fec)
+
+    for ep in entry_points(group="genecoder.simulators"):
+        plugin = ep.load()
+        register = getattr(plugin, "register", None)
+        if callable(register):
+            register(register_simulator)
+
     # Also load plugins from a local ``plugins`` package if present
     try:
         import plugins
     except ModuleNotFoundError:
-        return
-    for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):
-        module = importlib.import_module(f"plugins.{module_name}")
-        register = getattr(module, "register", None)
-        if callable(register):
-            register(register_codec)
+        plugins = None
+    if plugins is not None:
+        for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):
+            module = importlib.import_module(f"plugins.{module_name}")
+            register = getattr(module, "register", None)
+            if callable(register):
+                register(register_codec)
+            register_f = getattr(module, "register_fec", None)
+            if callable(register_f):
+                register_f(register_fec)
+            register_s = getattr(module, "register_simulator", None)
+            if callable(register_s):
+                register_s(register_simulator)
+
+    # Load built-in back-ends directly when running from source
+    from . import reed_solomon_codec as _rs
+    _rs.register(register_fec)
+    from . import ldpc_codec as _ldpc
+    _ldpc.register(register_fec)
+    from . import fountain_codec as _fountain
+    _fountain.register(register_fec)
+    from . import nanopore_sim as _nano
+    _nano.register(register_simulator)

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -84,3 +84,11 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
     except ReedSolomonError as exc:  # pragma: no cover - error path
         raise ValueError(f"Reed-Solomon decode failed: {exc}") from exc
     return bytes(decoded), len(err_pos)
+
+
+from typing import Callable, Any
+
+
+def register(register_fec: Callable[[str, Callable[[bytes], tuple[bytes, Any]], Callable[[bytes, Any], tuple[bytes, int]]], None]) -> None:
+    """Register this module's FEC backend."""
+    register_fec("reed_solomon", encode_data_rs, decode_data_rs)

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -1,4 +1,4 @@
-from genecoder import CODEC_REGISTRY
+from genecoder import CODEC_REGISTRY, FEC_REGISTRY, SIMULATOR_REGISTRY
 
 
 def test_reverse_codec_plugin_loaded():
@@ -7,3 +7,14 @@ def test_reverse_codec_plugin_loaded():
     encoded = codec["encode"](b"abc")
     assert encoded == "cba"
     assert codec["decode"](encoded) == b"abc"
+
+
+def test_fec_plugins_registered():
+    assert "reed_solomon" in FEC_REGISTRY
+    assert "ldpc" in FEC_REGISTRY
+    assert "fountain" in FEC_REGISTRY
+
+
+def test_simulator_plugins_registered():
+    for name in ["none", "nanopore", "dnarsim", "squigulator"]:
+        assert name in SIMULATOR_REGISTRY


### PR DESCRIPTION
## Summary
- add `genecoder.fec` and `genecoder.simulators` entry points
- register built‑in Reed-Solomon, LDPC, Fountain and nanopore simulators as plug-ins
- update CLI to use dynamic FEC and simulator choices
- document how to create new plug-ins
- test that plug-ins are registered

## Testing
- `ruff check src tests`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521f594e7c83268c8030a7cdd8686b