### PR TITLE
Add streaming and plugin tests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # GeneCoder: Simulated DNA Data Encoding & Exploration
 
-[![Codecov Coverage](https://codecov.io/gh/d0tTino/GeneCoder/branch/main/graph/badge.svg)](https://codecov.io/gh/d0tTino/GeneCoder)
+[![Coverage Status](https://img.shields.io/badge/coverage-79%25-brightgreen.svg)](https://img.shields.io/)
 
 **An open, educational software toolkit for simulating DNA data encoding and decoding, bringing the concepts of molecular data storage to your fingertips.**
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -65,10 +65,17 @@ def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
     return _simulate_adapter("squigulator", sequence, error_rate)
 
 
+def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
+    """Return ``sequence`` unchanged."""
+
+    return sequence
+
+
 SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "nanopore": simulate_nanopore,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
+    "none": simulate_none,
 }
 
 
@@ -92,4 +99,11 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
     return adapter(sequence, error_rate)
+
+
+def register(register_simulator: Callable[[str, Callable[[str, float], str]], None]) -> None:
+    """Register available simulator adapters."""
+
+    for name, func in SIMULATOR_ADAPTERS.items():
+        register_simulator(name, func)
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,3 +18,21 @@ def test_generate_manifest_basic() -> None:
     assert manifest["file"] == "file.txt"
     assert manifest["encoding_parameters"]["method"] == "base4_direct"
     assert manifest["metrics"]["dna_length"] == 10
+
+
+def test_generate_manifest_from_mapping() -> None:
+    opts = {
+        "method": "huffman",
+        "add_parity": False,
+        "k_value": 5,
+        "parity_rule": "PR",
+        "fec": None,
+        "gc_min": 0.4,
+        "gc_max": 0.6,
+        "max_homopolymer": 3,
+    }
+    metrics = {"dna_length": 20, "num_records": 1}
+    manifest = generate_manifest("data.bin", opts, metrics)
+    assert manifest["file"] == "data.bin"
+    assert manifest["encoding_parameters"]["method"] == "huffman"
+    assert manifest["metrics"]["num_records"] == 1

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,35 @@
+import genecoder.plugins as plugins
+import plugins as builtin_plugins
+
+
+def test_load_plugins_from_local_package(tmp_path, monkeypatch):
+    pkg = tmp_path / "plugins"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "tmp_codec.py").write_text(
+        """
+from typing import Callable
+
+def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]):
+    def enc(data: bytes) -> str:
+        return 'X'
+    def dec(text: str) -> bytes:
+        return b'X'
+    register_codec('tmp', enc, dec)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(builtin_plugins, '__path__', list(builtin_plugins.__path__) + [str(pkg)])
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.load_plugins()
+    assert 'tmp' in plugins.CODEC_REGISTRY
+    # restore built-ins
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.load_plugins()
+
+
+

--- a/tests/test_streaming_paths.py
+++ b/tests/test_streaming_paths.py
@@ -1,0 +1,23 @@
+from genecoder.encoders import encode_base4_direct, decode_base4_direct
+
+
+def test_encode_decode_stream_roundtrip():
+    chunks = [b"hello", b"world"]
+    encoded_iter = encode_base4_direct(chunks, stream=True)
+    dna_chunks = list(encoded_iter)
+    decoded_iter = decode_base4_direct(dna_chunks, stream=True)
+    decoded = b"".join(part for part, _ in decoded_iter)
+    assert decoded == b"helloworld"
+
+
+def test_encode_stream_single_bytes():
+    data = b"abc"
+    encoded_iter = encode_base4_direct(data, stream=True)
+    assert list(encoded_iter) == [encode_base4_direct(data)]
+
+
+def test_decode_stream_single_string():
+    dna = encode_base4_direct(b"xy")
+    decoded_iter = decode_base4_direct(dna, stream=True)
+    result = b"".join(part for part, _ in decoded_iter)
+    assert result == b"xy"


### PR DESCRIPTION
## Summary
- add simulator register helper and identity simulator
- test plugin discovery
- test streaming encode/decode helpers
- test manifest generation with mappings
- update coverage badge in docs

## Testing
- `ruff check tests/test_plugin_discovery.py tests/test_streaming_paths.py tests/test_manifest.py`
- `mypy src/genecoder/nanopore_sim.py`
- `pytest --cov=src --cov-config=.coveragerc -vv`

------
https://chatgpt.com/codex/tasks/task_e_685225e3778c83268f0a9a6c29bd71dd