### PR TITLE
Update CI workflow for web extras

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -164,6 +164,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.lock
 
+    - name: Install web extras
+      if: runner.os == 'Windows'
+      run: |
+        pip install '.[web]'
+
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -93,3 +93,20 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
+
+def _simulate_none(sequence: str, error_rate: float = 0.05) -> str:
+    """Return ``sequence`` unchanged."""
+
+    return sequence
+
+
+def register(
+    register_simulator: Callable[[str, Callable[[str, float], str]], None]
+) -> None:
+    """Register built-in read simulators."""
+
+    register_simulator("none", _simulate_none)
+    register_simulator("nanopore", simulate_nanopore)
+    register_simulator("dnarsim", simulate_dnarsim)
+    register_simulator("squigulator", simulate_squigulator)
+


### PR DESCRIPTION
## Summary
- install `.[web]` extras when running tests on Windows
- register builtin nanopore simulators

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml src/genecoder/nanopore_sim.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685225e43d248326812729eab20e01de