### PR TITLE
Add simulator registration function

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -65,6 +65,11 @@ def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
     return _simulate_adapter("squigulator", sequence, error_rate)
 
 
+def _simulate_none(sequence: str, _error_rate: float | None = None) -> str:
+    """Return ``sequence`` unchanged."""
+    return sequence
+
+
 SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "nanopore": simulate_nanopore,
     "dnarsim": simulate_dnarsim,
@@ -92,4 +97,12 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
     return adapter(sequence, error_rate)
+
+
+def register(register_simulator: Callable[[str, Callable[[str, float], str]], None]) -> None:
+    """Register this module's read simulators."""
+    register_simulator("none", _simulate_none)
+    register_simulator("nanopore", simulate_nanopore)
+    register_simulator("dnarsim", simulate_dnarsim)
+    register_simulator("squigulator", simulate_squigulator)
 


### PR DESCRIPTION
## Summary
- implement `register` in `nanopore_sim` to hook nanopore simulators into the plugin system
- include a `none` simulator for identity behavior

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522664b47483268f739d651a4d3dca