### PR TITLE
Add helix animation controls

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,3 +191,7 @@ python -m genecoder.flet_app
 ```
 
 The GUI exposes encoding options, error correction choices and displays metrics and analysis plots.
+
+The **Helix View** tab now features an animated 3D helix complete with nucleotide
+tooltips and simple overlays illustrating GC content and homopolymer regions.
+Toggle the *Animate* checkbox or adjust the *Zoom* slider to explore the visualization.

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -68,6 +68,8 @@ def main(page: ft.Page) -> None:
 
     # Container used for the Helix View tab. Filled when the tab is selected.
     helix_container = ft.Column()
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.5, max=2.0, value=1.0, divisions=15, width=200)
 
     window_size_input = ft.TextField(
         label="GC Window Size",
@@ -692,15 +694,31 @@ def main(page: ft.Page) -> None:
         expand=True,
     )
 
+    def refresh_helix_view(_: ft.ControlEvent | None = None) -> None:
+        dna_seq = ""
+        if encode_hidden_fasta_content.value:
+            parsed = from_fasta(encode_hidden_fasta_content.value)
+            if parsed:
+                dna_seq = parsed[0][1]
+        helix_container.controls.clear()
+        helix_container.controls.append(
+            ft.Row([
+                animate_checkbox,
+                ft.Text("Zoom:"),
+                zoom_slider,
+            ])
+        )
+        helix_container.controls.append(
+            show_helix(dna_seq, animate=animate_checkbox.value, zoom=zoom_slider.value)
+        )
+        page.update()
+
+    animate_checkbox.on_change = refresh_helix_view
+    zoom_slider.on_change = refresh_helix_view
+
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:
-            dna_seq = ""
-            if encode_hidden_fasta_content.value:
-                parsed = from_fasta(encode_hidden_fasta_content.value)
-                if parsed:
-                    dna_seq = parsed[0][1]
-            helix_container.controls.clear()
-            helix_container.controls.append(show_helix(dna_seq))
+            refresh_helix_view()
 
         page.update()
 

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -40,32 +40,35 @@ except FileNotFoundError:
 
 HELIX_TEMPLATE = """
 <div id='helix-container' style='position:relative;width:100%%;height:100%%'></div>
-<div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px'></div>
+<div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px;pointer-events:none'></div>
+<canvas id='metrics-overlay' style='position:absolute;top:0;left:0;pointer-events:none;opacity:0.6'></canvas>
 <script type='module'>
 import * as THREE from '%(THREE_JS_URL)s';
 import { OrbitControls } from '%(ORBIT_JS_URL)s';
 
 const container = document.getElementById('helix-container');
 const tooltip = document.getElementById('tooltip');
+const metricsCanvas = document.getElementById('metrics-overlay');
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
+camera.position.set(2 * %(ZOOM)s, 2 * %(ZOOM)s, 5 * %(ZOOM)s);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(container.clientWidth, container.clientHeight);
 container.appendChild(renderer.domElement);
+metricsCanvas.width = container.clientWidth;
+metricsCanvas.height = 30;
 
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
-camera.position.set(2, 2, 5);
 controls.update();
 
 const seq = '%(DNA_SEQ)s';
+const animateHelix = %(ANIMATE)s;
 const bases = [];
-const bits = [];
 for (let i = 0; i < seq.length; i++) {
     const base = seq[i];
     bases.push(base);
-    bits.push(base);
 }
 
 
@@ -83,6 +86,23 @@ for (let i = 0; i < bases.length; i++) {
     group.add(mesh);
 }
 scene.add(group);
+
+const ctx = metricsCanvas.getContext('2d');
+const barWidth = metricsCanvas.width / bases.length;
+const runs = new Array(bases.length).fill(1);
+for (let i = 0; i < bases.length; i++) {
+    if (i > 0 && bases[i] === bases[i - 1]) {
+        runs[i] = runs[i - 1] + 1;
+    }
+    const gcColor = bases[i] === 'G' || bases[i] === 'C' ? '#88f' : '#ddd';
+    ctx.fillStyle = gcColor;
+    ctx.fillRect(i * barWidth, 0, barWidth, 14);
+}
+for (let i = 0; i < bases.length; i++) {
+    const intensity = Math.min(runs[i] / 6, 1);
+    ctx.fillStyle = `rgba(255,0,0,${intensity})`;
+    ctx.fillRect(i * barWidth, 16, barWidth, 14);
+}
 
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
@@ -107,10 +127,20 @@ window.addEventListener('resize', () => {
     camera.aspect = container.clientWidth / container.clientHeight;
     camera.updateProjectionMatrix();
     renderer.setSize(container.clientWidth, container.clientHeight);
+    metricsCanvas.width = container.clientWidth;
 });
 
+let offset = 0;
 function animate() {
     requestAnimationFrame(animate);
+    if (animateHelix) {
+        offset += 0.05;
+        for (let i = 0; i < group.children.length; i++) {
+            const mesh = group.children[i];
+            const angle = i * 0.3 + offset;
+            mesh.position.set(Math.cos(angle), Math.sin(angle), i * height);
+        }
+    }
     controls.update();
     renderer.render(scene, camera);
 }
@@ -118,17 +148,19 @@ animate();
 </script>
 """
 
-def _make_helix_html(dna_sequence: str) -> str:
+def _make_helix_html(dna_sequence: str, animate: bool, zoom: float) -> str:
     return HELIX_TEMPLATE % {
         "THREE_JS_URL": THREE_JS_URL,
         "ORBIT_JS_URL": ORBIT_JS_URL,
         "DNA_SEQ": dna_sequence,
+        "ANIMATE": "true" if animate else "false",
+        "ZOOM": zoom,
     }
 
 
-def show_helix(dna_sequence: str = "ACGT") -> ft.WebView:
+def show_helix(dna_sequence: str = "ACGT", *, animate: bool = True, zoom: float = 1.0) -> ft.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls."""
-    helix_html = _make_helix_html(dna_sequence)
+    helix_html = _make_helix_html(dna_sequence, animate, zoom)
     data_url = "data:text/html," + quote(helix_html)
 
     return ft.WebView(url=data_url, width=600, height=400)

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 import logging
-from typing import Callable
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -92,4 +92,16 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
     return adapter(sequence, error_rate)
+
+def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+    """Register the builtin simulators."""
+
+    def _wrap(name: str) -> Callable[[str, float], str]:
+        def simulate(seq: str, error_rate: float = 0.05) -> str:
+            return simulate_reads(seq, name, error_rate)
+
+        return simulate
+
+    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+        register_simulator(name, _wrap(name))
 


### PR DESCRIPTION
## Summary
- animate helix winding in `helix_view`
- show GC/homopolymer overlays and tooltips
- allow toggling animation & zoom from GUI
- register builtin simulators
- document new Helix tab features
- drop binary screenshot, remove unused variable
- fix leftover import in nanopore simulator

## Testing
- `pre-commit run --files docs/usage.md src/genecoder/helix_view.py src/genecoder/flet_app.py src/genecoder/nanopore_sim.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685225d3e32c83269cc2a49f3427e79c