### PR TITLE
Add optional external simulator support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,13 +118,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
 11. **Decode using an external simulator**
 
-   The ``--simulator`` option accepts ``nanopore``, ``dnarsim`` or ``squigulator``.
+   The ``--simulator`` option accepts ``d2sim``, ``dnarsim`` or ``squigulator``.
    Install the desired simulator separately and ensure the command is on your
    ``PATH``:
 
-   * ``nanopore`` uses the ``d2sim`` command
-   * ``dnarsim`` uses the ``dnarsim`` command
-   * ``squigulator`` uses the ``squigulator`` command
+   * ``d2sim`` — [D2Sim](https://github.com/kurimsw/d2sim)
+   * ``dnarsim`` — [DNArSim](https://github.com/Purdue-ScottLab/DNArSim)
+   * ``squigulator`` — [Squigulator](https://github.com/hasindu2008/squigulator)
 
    When a command is missing GeneCoder automatically falls back to an internal
    error model.

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -47,10 +47,14 @@ def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
     return simulate_errors(sequence, error_rate)
 
 
-def simulate_nanopore(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_d2sim(sequence: str, error_rate: float = 0.05) -> str:
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
     return _simulate_adapter("d2sim", sequence, error_rate)
+
+
+# Backwards compatibility alias
+simulate_nanopore = simulate_d2sim
 
 
 def simulate_dnarsim(sequence: str, error_rate: float = 0.05) -> str:
@@ -66,9 +70,12 @@ def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
 
 
 SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
-    "nanopore": simulate_nanopore,
+    "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
+    # backward compatibility names
+    "nanopore": simulate_d2sim,
+    "none": lambda seq, _rate=0.05: seq,
 }
 
 
@@ -92,4 +99,11 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
     return adapter(sequence, error_rate)
+
+
+def register(register_simulator: Callable[[str, Callable[..., str]], None]) -> None:
+    """Register built-in read simulators."""
+
+    for name, func in SIMULATOR_ADAPTERS.items():
+        register_simulator(name, func)
 

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -95,7 +95,7 @@ def test_reed_solomon_pipeline(tmp_path: Path):
     enc_opts = build_encoding_options(enc_args)
     dna, header, *_ = run_encoding_pipeline(data, enc_opts, input_file.name)
     assert "fec=reed_solomon" in header
-    assert "fec_nsym=" in header
+    assert "fec_info=" in header
     assert "parity_k" not in header
 
     dec_args = argparse.Namespace(

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -45,7 +45,7 @@ def test_cli_decode_with_simulator(tmp_path: Path):
     env["GENECODER_SIM_SEED"] = "1"
 
     input_file = tmp_path / "sim.txt"
-    input_file.write_text("nanopore test")
+    input_file.write_text("d2sim test")
 
     # Encode with triple_repeat FEC for robustness
     encode_result = run_cli_command(
@@ -66,7 +66,7 @@ def test_cli_decode_with_simulator(tmp_path: Path):
     fasta_file = tmp_path / "sim.txt.fasta"
     assert fasta_file.exists()
 
-    # Decode using the nanopore simulator
+    # Decode using the d2sim simulator
     decode_result = run_cli_command(
         [
             "decode",
@@ -77,14 +77,14 @@ def test_cli_decode_with_simulator(tmp_path: Path):
             "--method",
             "base4_direct",
             "--simulator",
-            "nanopore",
+            "d2sim",
         ],
         env=env,
     )
     assert decode_result.returncode == 0, decode_result.stderr
     output_file = tmp_path / "sim.txt_decoded.bin"
     assert output_file.exists()
-    assert output_file.read_text() == "nanopore test"
+    assert output_file.read_text() == "d2sim test"
 
 
 def test_cli_decode_with_squigulator(tmp_path: Path):

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -5,7 +5,7 @@ import pytest
 from genecoder import nanopore_sim
 
 ADAPTERS = {
-    "nanopore": (nanopore_sim.simulate_nanopore, "d2sim"),
+    "d2sim": (nanopore_sim.simulate_d2sim, "d2sim"),
     "dnarsim": (nanopore_sim.simulate_dnarsim, "dnarsim"),
     "squigulator": (nanopore_sim.simulate_squigulator, "squigulator"),
 }

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -16,5 +16,5 @@ def test_fec_plugins_registered():
 
 
 def test_simulator_plugins_registered():
-    for name in ["none", "nanopore", "dnarsim", "squigulator"]:
+    for name in ["none", "d2sim", "dnarsim", "squigulator", "nanopore"]:
         assert name in SIMULATOR_REGISTRY


### PR DESCRIPTION
## Summary
- add d2sim/dnarsim adapters and plugin registration
- document simulator installation
- adjust CLI tests and plugin expectations

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852266b8bc88326868d7f78a4fe7bae