### PR TITLE
Fix plugin registration and update tests

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -93,3 +93,19 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
+
+from typing import Any
+
+
+def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+    """Register the builtin simulators."""
+
+    def _wrap(name: str) -> Callable[[str, float], str]:
+        def simulate(seq: str, error_rate: float = 0.05) -> str:
+            return simulate_reads(seq, name, error_rate)
+
+        return simulate
+
+    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+        register_simulator(name, _wrap(name))
+

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -95,7 +95,7 @@ def test_reed_solomon_pipeline(tmp_path: Path):
     enc_opts = build_encoding_options(enc_args)
     dna, header, *_ = run_encoding_pipeline(data, enc_opts, input_file.name)
     assert "fec=reed_solomon" in header
-    assert "fec_nsym=" in header
+    assert "fec_info=" in header
     assert "parity_k" not in header
 
     dec_args = argparse.Namespace(


### PR DESCRIPTION
## Summary
- add simulator `register` function to fix plugin loading
- update CLI helper test expectations for FEC info

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py tests/test_plugin_loading.py tests/test_cli_helpers.py`
- `pytest --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_68522674d3fc83269376b5686bf46c69