### PR TITLE
Add httpx dependency

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -5,3 +5,4 @@ pytest-cov==6.2.1
 reedsolo==1.7.0
 pyfinite==1.9.1
 pyldpc==0.7.9
+httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 reedsolo
 pyfinite
 pyldpc
+httpx

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -8,14 +8,14 @@ _HAS_PYLDPC = False
 
 if TYPE_CHECKING:
     import numpy as np
-    from pyldpc import make_ldpc, encode, decode
+    from pyldpc import make_ldpc, decode, utils
 else:
     try:  # pragma: no cover - optional dependency
         import numpy as np
-        from pyldpc import make_ldpc, encode, decode
+        from pyldpc import make_ldpc, decode, utils
         _HAS_PYLDPC = True
     except Exception:  # pragma: no cover - missing optional dependency
-        make_ldpc = encode = decode = None  # type: ignore
+        make_ldpc = decode = utils = None  # type: ignore
         np = None  # type: ignore
         _HAS_PYLDPC = False
 
@@ -47,8 +47,9 @@ def encode_data_ldpc(data: bytes) -> Tuple[bytes, Any]:
     n_bits = len(data) * 8
     H, G = make_ldpc(n_bits, d_v=2, d_c=4, systematic=True)
     bits = np.unpackbits(np.frombuffer(data, dtype=np.uint8))
-    codeword = encode(G, bits, snr=2)
-    return np.packbits(codeword).tobytes(), {"H": H, "n_bits": n_bits}
+    message = np.pad(bits, (0, G.shape[1] - bits.size), "constant")[: G.shape[1]]
+    codeword = utils.binaryproduct(G, message).astype(np.uint8)
+    return np.packbits(codeword).tobytes(), {"H": H, "n_bits": bits.size}
 
 
 def decode_data_ldpc(encoded: bytes, info: Any) -> Tuple[bytes, int]:

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -93,3 +93,19 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
+
+from typing import Any
+
+
+def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+    """Register the builtin simulators."""
+
+    def _wrap(name: str) -> Callable[[str, float], str]:
+        def simulate(seq: str, error_rate: float = 0.05) -> str:
+            return simulate_reads(seq, name, error_rate)
+
+        return simulate
+
+    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+        register_simulator(name, _wrap(name))
+


### PR DESCRIPTION
## Summary
- include `httpx` in requirements
- implement plugin registration for built-in simulators
- refine LDPC encoding logic
- correct lockfile

## Testing
- `ruff check src/genecoder/ldpc_codec.py src/genecoder/nanopore_sim.py`
- `mypy src/genecoder/ldpc_codec.py src/genecoder/nanopore_sim.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68522665925c8326be02187911a8ab8a