### PR TITLE
Update changelog and release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - Continuous improvements to CI workflows and build configuration.
 - Added packaging metadata for PyPI distribution.
 - CLI/GUI option ``--alphabet`` supporting ``base4``, ``base5`` and ``base6``.
+- Fixed plugin registration during package installation.
+- Pinned dependencies to stable versions.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,26 @@ pytest -q
 All code changes must pass `pre-commit` and the test suite. These checks are not
 required for documentation-only pull requests.
 
+## Making a Release
+
+Follow these steps to publish a new version:
+
+1. Update `CHANGELOG.md` with a new version heading and notes.
+2. Bump the version in `pyproject.toml` and `CITATION.cff`.
+3. Commit the changes and create an annotated tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push --tags
+   ```
+
+4. Build and upload the package to PyPI:
+
+   ```bash
+   python -m pip install build twine
+   python -m build
+   twine upload dist/*
+   ```
+
+5. Create a GitHub release pointing at the same tag.
+


### PR DESCRIPTION
## Summary
- document plugin registration fix and dependency pins under the Unreleased section
- describe how to make a release in `CONTRIBUTING.md`

## Testing
- `pre-commit` *(skipped: documentation only)*
- `pytest -q` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_68522685870083268419032a43982d57