### PR TITLE
Add helix interaction options

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -21,3 +21,14 @@ and web deployments.
 
 All required JavaScript libraries are bundled with the package so the helix
 visualization functions entirely offline.
+
+<!-- screenshot omitted in this repository because binary files are not supported -->
+
+### Usage
+
+Import `show_helix` and pass a DNA sequence. Optional `length` and `colors` arguments control the rendered sequence length and sphere colors:
+
+```python
+from genecoder.helix_view import show_helix
+webview = show_helix("ACGT", length=50, colors={"A": "#ff0000", "T": "#00ffff"})
+```

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -68,6 +68,26 @@ def main(page: ft.Page) -> None:
 
     # Container used for the Helix View tab. Filled when the tab is selected.
     helix_container = ft.Column()
+    helix_length_input = ft.TextField(
+        label="Sequence Length",
+        value="50",
+        width=150,
+        keyboard_type=ft.KeyboardType.NUMBER,
+    )
+    helix_color_a = ft.TextField(label="A", value="#ff5555", width=100)
+    helix_color_c = ft.TextField(label="C", value="#5555ff", width=100)
+    helix_color_g = ft.TextField(label="G", value="#55ff55", width=100)
+    helix_color_t = ft.TextField(label="T", value="#ffff55", width=100)
+    helix_controls = ft.Row(
+        [
+            helix_length_input,
+            helix_color_a,
+            helix_color_c,
+            helix_color_g,
+            helix_color_t,
+        ],
+        alignment=ft.MainAxisAlignment.START,
+    )
 
     window_size_input = ft.TextField(
         label="GC Window Size",
@@ -685,7 +705,12 @@ def main(page: ft.Page) -> None:
                 text="Helix View",
                 icon=ft.icons.DNA,
                 content=ft.Container(
-                    helix_container, padding=10, alignment=ft.alignment.top_left
+                    ft.Column([
+                        helix_controls,
+                        helix_container,
+                    ], spacing=10),
+                    padding=10,
+                    alignment=ft.alignment.top_left,
                 ),
             ),
         ],
@@ -700,7 +725,18 @@ def main(page: ft.Page) -> None:
                 if parsed:
                     dna_seq = parsed[0][1]
             helix_container.controls.clear()
-            helix_container.controls.append(show_helix(dna_seq))
+            helix_container.controls.append(
+                show_helix(
+                    dna_seq,
+                    length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
+                    colors={
+                        "A": helix_color_a.value,
+                        "C": helix_color_c.value,
+                        "G": helix_color_g.value,
+                        "T": helix_color_t.value,
+                    },
+                )
+            )
 
         page.update()
 

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -38,6 +38,14 @@ try:
 except FileNotFoundError:
     pass
 
+# Default colors used for nucleotide spheres in the helix view.
+DEFAULT_COLORS: dict[str, int] = {
+    "A": 0xFF5555,
+    "C": 0x5555FF,
+    "G": 0x55FF55,
+    "T": 0xFFFF55,
+}
+
 HELIX_TEMPLATE = """
 <div id='helix-container' style='position:relative;width:100%%;height:100%%'></div>
 <div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px'></div>
@@ -61,21 +69,18 @@ controls.update();
 
 const seq = '%(DNA_SEQ)s';
 const bases = [];
-const bits = [];
 for (let i = 0; i < seq.length; i++) {
-    const base = seq[i];
-    bases.push(base);
-    bits.push(base);
+    bases.push(seq[i]);
 }
 
 
-const colors = { A: 0xff5555, C: 0x5555ff, G: 0x55ff55, T: 0xffff55 };
+const colors = %(COLOR_MAP)s;
 const group = new THREE.Group();
 const radius = 0.1;
 const height = 0.4;
 for (let i = 0; i < bases.length; i++) {
     const geometry = new THREE.SphereGeometry(radius, 16, 16);
-    const material = new THREE.MeshBasicMaterial({ color: colors[bases[i]] || 0xffffff });
+    const material = new THREE.MeshPhongMaterial({ color: colors[bases[i]] || 0xffffff });
     const mesh = new THREE.Mesh(geometry, material);
     const angle = i * 0.3;
     mesh.position.set(Math.cos(angle), Math.sin(angle), i * height);
@@ -86,6 +91,7 @@ scene.add(group);
 
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
+let highlighted = null;
 function onMouseMove(event) {
     const rect = renderer.domElement.getBoundingClientRect();
     mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
@@ -97,8 +103,17 @@ function onMouseMove(event) {
         tooltip.style.left = `${event.clientX + 5}px`;
         tooltip.style.top = `${event.clientY + 5}px`;
         tooltip.textContent = hit.object.userData.info;
+        if (highlighted && highlighted !== hit.object) {
+            highlighted.material.emissive.set(0x000000);
+        }
+        highlighted = hit.object;
+        highlighted.material.emissive.set(0x333333);
     } else {
         tooltip.style.display = 'none';
+        if (highlighted) {
+            highlighted.material.emissive.set(0x000000);
+            highlighted = null;
+        }
     }
 }
 renderer.domElement.addEventListener('mousemove', onMouseMove);
@@ -111,6 +126,7 @@ window.addEventListener('resize', () => {
 
 function animate() {
     requestAnimationFrame(animate);
+    group.rotation.z += 0.01;
     controls.update();
     renderer.render(scene, camera);
 }
@@ -118,17 +134,64 @@ animate();
 </script>
 """
 
-def _make_helix_html(dna_sequence: str) -> str:
+def _make_helix_html(
+    dna_sequence: str,
+    *,
+    length: int | None = None,
+    colors: dict[str, int] | None = None,
+) -> str:
+    """Return HTML for the helix viewer.
+
+    Parameters
+    ----------
+    dna_sequence:
+        Base sequence used for rendering.
+    length:
+        Optional length of the rendered helix. The sequence is repeated as
+        needed.
+    colors:
+        Optional mapping of nucleotide to hex color value or string.
+    """
+    if length is not None:
+        repeats = (length + len(dna_sequence) - 1) // len(dna_sequence)
+        dna_sequence = (dna_sequence * repeats)[:length]
+
+    color_map = DEFAULT_COLORS.copy()
+    if colors:
+        for base, col in colors.items():
+            if isinstance(col, str):
+                col = int(col.lstrip("#").removeprefix("0x"), 16)
+            color_map[base.upper()] = col
+
+    colors_js = "{ " + ", ".join(f"{b}: 0x{v:06x}" for b, v in color_map.items()) + " }"
+
     return HELIX_TEMPLATE % {
         "THREE_JS_URL": THREE_JS_URL,
         "ORBIT_JS_URL": ORBIT_JS_URL,
         "DNA_SEQ": dna_sequence,
+        "COLOR_MAP": colors_js,
     }
 
 
-def show_helix(dna_sequence: str = "ACGT") -> ft.WebView:
-    """Return a ``WebView`` displaying a DNA helix scene with controls."""
-    helix_html = _make_helix_html(dna_sequence)
+def show_helix(
+    dna_sequence: str = "ACGT",
+    *,
+    length: int | None = None,
+    colors: dict[str, int] | None = None,
+) -> ft.WebView:
+    """Return a ``WebView`` displaying a DNA helix scene with controls.
+
+    Parameters
+    ----------
+    dna_sequence:
+        Base sequence used for rendering.
+    length:
+        Optional length of the rendered helix. The sequence is repeated as
+        needed.
+    colors:
+        Mapping of nucleotide to hex color value or string.
+    """
+    helix_html = _make_helix_html(dna_sequence, length=length, colors=colors)
     data_url = "data:text/html," + quote(helix_html)
 
     return ft.WebView(url=data_url, width=600, height=400)

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -5,12 +5,15 @@ ft = pytest.importorskip("flet")
 from genecoder.helix_view import show_helix
 
 
-def _get_ft_and_show_helix():
+from typing import Any, Callable
+
+
+def _get_ft_and_show_helix() -> tuple[Any, Callable[..., Any]]:
     return ft, show_helix
 
 
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
-def test_show_helix_basic():
+def test_show_helix_basic() -> None:
     ft, show_helix = _get_ft_and_show_helix()
 
     elem = show_helix("ACGT")
@@ -24,10 +27,19 @@ def test_show_helix_basic():
 
 
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
-def test_show_helix_sequence_in_html():
+def test_show_helix_sequence_in_html() -> None:
     ft, show_helix = _get_ft_and_show_helix()
     seq = "AACCGGTT"
     elem = show_helix(seq)
     html = unquote(elem.url.split(",", 1)[1])
     assert seq in html
+
+
+@pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
+def test_show_helix_options() -> None:
+    ft, show_helix = _get_ft_and_show_helix()
+    elem = show_helix("AC", length=5, colors={"A": "#123456"})
+    html = unquote(elem.url.split(",", 1)[1])
+    assert "ACACA" in html  # sequence repeated to length
+    assert "0x123456" in html
 


### PR DESCRIPTION
## Summary
- animate helix rotation with hover highlighting
- allow sequence length and colors to be customized from `show_helix`
- add GUI inputs for helix length and colors
- update feature docs; remove unsupported screenshot

## Testing
- `ruff check src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py`
- `PYTHONPATH=src mypy --config-file mypy.ini -m genecoder.helix_view -m genecoder.flet_app -m tests.test_helix_view`
- `pytest -q tests/test_helix_view.py`

------
https://chatgpt.com/codex/tasks/task_e_68522670c2e88326851ec94c861d4e83