### PR TITLE
Add concurrency controls and register d2sim

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,10 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
 
+concurrency: # Cancel stale docs runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
 
-concurrency: # Cancel stale docs runs
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
 
+# Cancel any stale docs builds if new commits arrive
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
 
-# Cancel any stale docs builds if new commits arrive
+# Cancel stale docs builds if a newer run starts
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -89,6 +89,9 @@ def main(page: ft.Page) -> None:
         alignment=ft.MainAxisAlignment.START,
     )
 
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.1, max=2.0, divisions=19, value=1.0, width=150)
+
 
     window_size_input = ft.TextField(
         label="GC Window Size",

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -82,7 +82,7 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": lambda seq, _rate=0.05: seq,
+    "none": simulate_none,
 }
 
 
@@ -104,7 +104,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
 
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
@@ -116,7 +115,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in ("none", "nanopore", "d2sim", "dnarsim", "squigulator"):
         register_simulator(name, _wrap(name))
 
 


### PR DESCRIPTION
## Summary
- cancel stale docs workflows via `concurrency` group
- register the `d2sim` simulator so CLI tests pass
- define missing controls in the Flet UI

## Testing
- `pre-commit run --files .github/workflows/docs.yml src/genecoder/nanopore_sim.py src/genecoder/flet_app.py`
- `pre-commit run --files .github/workflows/docs.yml`


------
https://chatgpt.com/codex/tasks/task_e_6852d1717d1c83268658c20a46e8eb48