### PR TITLE
Fix plugin registration for d2sim

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -68,6 +68,8 @@ def main(page: ft.Page) -> None:
 
     # Container used for the Helix View tab. Filled when the tab is selected.
     helix_container = ft.Column()
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.5, max=2.0, value=1.0, divisions=15, width=200)
     helix_length_input = ft.TextField(
         label="Sequence Length",
         value="50",

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -76,17 +76,13 @@ def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
     return sequence
 
 
-def _simulate_none(seq: str, _rate: float = 0.05) -> str:
-    return seq
-
-
 SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": _simulate_none,
+    "none": simulate_none,
 }
 
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -76,13 +76,17 @@ def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
     return sequence
 
 
+def _simulate_none(seq: str, _rate: float = 0.05) -> str:
+    return seq
+
+
 SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": lambda seq, _rate=0.05: seq,
+    "none": _simulate_none,
 }
 
 
@@ -104,7 +108,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
 
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
@@ -116,7 +119,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in SIMULATOR_ADAPTERS:
         register_simulator(name, _wrap(name))
 
 


### PR DESCRIPTION
## Summary
- ensure all simulator adapters are registered, including `d2sim`
- restore helix view controls variables removed during merge

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py src/genecoder/flet_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853214319788326b49e839c85901b62