### PR TITLE
Fix plugin registration for d2sim

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -726,41 +726,22 @@ def main(page: ft.Page) -> None:
                 dna_seq = parsed[0][1]
         helix_container.controls.clear()
         helix_container.controls.append(
-            ft.Row([
-                animate_checkbox,
-                ft.Text("Zoom:"),
-                zoom_slider,
-            ])
-        )
-        helix_container.controls.append(
-            show_helix(dna_seq, animate=animate_checkbox.value, zoom=zoom_slider.value)
+            show_helix(
+                dna_seq,
+                length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
+                colors={
+                    "A": helix_color_a.value,
+                    "C": helix_color_c.value,
+                    "G": helix_color_g.value,
+                    "T": helix_color_t.value,
+                },
+            )
         )
         page.update()
 
-    animate_checkbox.on_change = refresh_helix_view
-    zoom_slider.on_change = refresh_helix_view
-
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:
-            dna_seq = ""
-            if encode_hidden_fasta_content.value:
-                parsed = from_fasta(encode_hidden_fasta_content.value)
-                if parsed:
-                    dna_seq = parsed[0][1]
-            helix_container.controls.clear()
-            helix_container.controls.append(
-                show_helix(
-                    dna_seq,
-                    length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
-                    colors={
-                        "A": helix_color_a.value,
-                        "C": helix_color_c.value,
-                        "G": helix_color_g.value,
-                        "T": helix_color_t.value,
-                    },
-                )
-            )
-
+            refresh_helix_view()
 
         page.update()
 

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -68,6 +68,8 @@ def main(page: ft.Page) -> None:
 
     # Container used for the Helix View tab. Filled when the tab is selected.
     helix_container = ft.Column()
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.5, max=2.0, value=1.0, divisions=15, width=200)
     helix_length_input = ft.TextField(
         label="Sequence Length",
         value="50",
@@ -726,6 +728,13 @@ def main(page: ft.Page) -> None:
                 dna_seq = parsed[0][1]
         helix_container.controls.clear()
         helix_container.controls.append(
+            ft.Row([
+                animate_checkbox,
+                ft.Text("Zoom:"),
+                zoom_slider,
+            ])
+        )
+        helix_container.controls.append(
             show_helix(
                 dna_seq,
                 length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
@@ -735,9 +744,14 @@ def main(page: ft.Page) -> None:
                     "G": helix_color_g.value,
                     "T": helix_color_t.value,
                 },
+                animate=animate_checkbox.value,
+                zoom=zoom_slider.value,
             )
         )
         page.update()
+
+    animate_checkbox.on_change = refresh_helix_view
+    zoom_slider.on_change = refresh_helix_view
 
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -165,6 +165,8 @@ def _make_helix_html(
     *,
     length: int | None = None,
     colors: dict[str, int] | None = None,
+    animate: bool = True,
+    zoom: float = 1.0,
 ) -> str:
     """Return HTML for the helix viewer.
 
@@ -197,6 +199,8 @@ def _make_helix_html(
         "ORBIT_JS_URL": ORBIT_JS_URL,
         "DNA_SEQ": dna_sequence,
         "COLOR_MAP": colors_js,
+        "ANIMATE": "true" if animate else "false",
+        "ZOOM": zoom,
     }
 
 
@@ -205,6 +209,8 @@ def show_helix(
     *,
     length: int | None = None,
     colors: dict[str, int] | None = None,
+    animate: bool = True,
+    zoom: float = 1.0,
 ) -> ft.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls.
 
@@ -218,7 +224,13 @@ def show_helix(
     colors:
         Mapping of nucleotide to hex color value or string.
     """
-    helix_html = _make_helix_html(dna_sequence, length=length, colors=colors)
+    helix_html = _make_helix_html(
+        dna_sequence,
+        length=length,
+        colors=colors,
+        animate=animate,
+        zoom=zoom,
+    )
 
     data_url = "data:text/html," + quote(helix_html)
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -82,7 +82,7 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": lambda seq, _rate=0.05: seq,
+    "none": simulate_none,
 }
 
 
@@ -104,7 +104,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
 
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
@@ -116,7 +115,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in SIMULATOR_ADAPTERS:
         register_simulator(name, _wrap(name))
 
 

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -23,6 +23,6 @@ def test_fec_plugins_registered() -> None:
 
 
 def test_simulator_plugins_registered() -> None:
-    for name in ["none", "nanopore", "dnarsim", "squigulator"]:
+    for name in ["d2sim", "none", "nanopore", "dnarsim", "squigulator"]:
         assert name in SIMULATOR_REGISTRY
 


### PR DESCRIPTION
## Summary
- ensure all simulator adapters are registered, including `d2sim`
- restore helix view controls variables removed during merge
- remove unused helper for the 'none' simulator
- update helix view refresh logic to use length and color options
- test that simulator registry includes the `d2sim` adapter

## Testing
- `pre-commit run --files src/genecoder/flet_app.py tests/test_plugin_loading.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853214319788326b49e839c85901b62