### PR TITLE
Fix plugin registration for d2sim

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -78,6 +78,8 @@ def main(page: ft.Page) -> None:
     helix_color_c = ft.TextField(label="C", value="#5555ff", width=100)
     helix_color_g = ft.TextField(label="G", value="#55ff55", width=100)
     helix_color_t = ft.TextField(label="T", value="#ffff55", width=100)
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.5, max=2.0, divisions=15, value=1.0, width=150)
     helix_controls = ft.Row(
         [
             helix_length_input,
@@ -85,6 +87,9 @@ def main(page: ft.Page) -> None:
             helix_color_c,
             helix_color_g,
             helix_color_t,
+            animate_checkbox,
+            ft.Text("Zoom:"),
+            zoom_slider,
         ],
         alignment=ft.MainAxisAlignment.START,
     )
@@ -726,14 +731,18 @@ def main(page: ft.Page) -> None:
                 dna_seq = parsed[0][1]
         helix_container.controls.clear()
         helix_container.controls.append(
-            ft.Row([
-                animate_checkbox,
-                ft.Text("Zoom:"),
-                zoom_slider,
-            ])
-        )
-        helix_container.controls.append(
-            show_helix(dna_seq, animate=animate_checkbox.value, zoom=zoom_slider.value)
+            show_helix(
+                dna_seq,
+                animate=animate_checkbox.value,
+                zoom=zoom_slider.value,
+                length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
+                colors={
+                    "A": helix_color_a.value,
+                    "C": helix_color_c.value,
+                    "G": helix_color_g.value,
+                    "T": helix_color_t.value,
+                },
+            )
         )
         page.update()
 
@@ -742,25 +751,7 @@ def main(page: ft.Page) -> None:
 
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:
-            dna_seq = ""
-            if encode_hidden_fasta_content.value:
-                parsed = from_fasta(encode_hidden_fasta_content.value)
-                if parsed:
-                    dna_seq = parsed[0][1]
-            helix_container.controls.clear()
-            helix_container.controls.append(
-                show_helix(
-                    dna_seq,
-                    length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
-                    colors={
-                        "A": helix_color_a.value,
-                        "C": helix_color_c.value,
-                        "G": helix_color_g.value,
-                        "T": helix_color_t.value,
-                    },
-                )
-            )
-
+            refresh_helix_view()
 
         page.update()
 

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -163,6 +163,8 @@ animate();
 def _make_helix_html(
     dna_sequence: str,
     *,
+    animate: bool = True,
+    zoom: float = 1.0,
     length: int | None = None,
     colors: dict[str, int] | None = None,
 ) -> str:
@@ -172,6 +174,10 @@ def _make_helix_html(
     ----------
     dna_sequence:
         Base sequence used for rendering.
+    animate:
+        Whether to animate rotation of the helix.
+    zoom:
+        Camera zoom level.
     length:
         Optional length of the rendered helix. The sequence is repeated as
         needed.
@@ -191,18 +197,21 @@ def _make_helix_html(
 
     colors_js = "{ " + ", ".join(f"{b}: 0x{v:06x}" for b, v in color_map.items()) + " }"
 
-
     return HELIX_TEMPLATE % {
         "THREE_JS_URL": THREE_JS_URL,
         "ORBIT_JS_URL": ORBIT_JS_URL,
         "DNA_SEQ": dna_sequence,
         "COLOR_MAP": colors_js,
+        "ANIMATE": "true" if animate else "false",
+        "ZOOM": zoom,
     }
 
 
 def show_helix(
     dna_sequence: str = "ACGT",
     *,
+    animate: bool = True,
+    zoom: float = 1.0,
     length: int | None = None,
     colors: dict[str, int] | None = None,
 ) -> ft.WebView:
@@ -212,13 +221,23 @@ def show_helix(
     ----------
     dna_sequence:
         Base sequence used for rendering.
+    animate:
+        Whether to animate rotation of the helix.
+    zoom:
+        Camera zoom level.
     length:
         Optional length of the rendered helix. The sequence is repeated as
         needed.
     colors:
         Mapping of nucleotide to hex color value or string.
     """
-    helix_html = _make_helix_html(dna_sequence, length=length, colors=colors)
+    helix_html = _make_helix_html(
+        dna_sequence,
+        animate=animate,
+        zoom=zoom,
+        length=length,
+        colors=colors,
+    )
 
     data_url = "data:text/html," + quote(helix_html)
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -82,7 +82,7 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": lambda seq, _rate=0.05: seq,
+    "none": simulate_none,
 }
 
 
@@ -104,7 +104,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
 
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
@@ -116,7 +115,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in SIMULATOR_ADAPTERS:
         register_simulator(name, _wrap(name))
 
 

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -38,8 +38,16 @@ def test_show_helix_sequence_in_html() -> None:
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
 def test_show_helix_options() -> None:
     ft, show_helix = _get_ft_and_show_helix()
-    elem = show_helix("AC", length=5, colors={"A": "#123456"})
+    elem = show_helix(
+        "AC",
+        length=5,
+        colors={"A": "#123456"},
+        animate=False,
+        zoom=1.5,
+    )
     html = unquote(elem.url.split(",", 1)[1])
     assert "ACACA" in html  # sequence repeated to length
     assert "0x123456" in html
+    assert "false" in html
+    assert "1.5" in html
 

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -23,6 +23,6 @@ def test_fec_plugins_registered() -> None:
 
 
 def test_simulator_plugins_registered() -> None:
-    for name in ["none", "nanopore", "dnarsim", "squigulator"]:
+    for name in ["d2sim", "none", "nanopore", "dnarsim", "squigulator"]:
         assert name in SIMULATOR_REGISTRY
 


### PR DESCRIPTION
## Summary
- ensure all simulator adapters are registered, including `d2sim`
- restore helix view controls variables removed during merge
- remove unused helper for the 'none' simulator
- update helix view refresh logic to use length and color options
- test that simulator registry includes the `d2sim` adapter
- restore animate checkbox & zoom slider and expand helix options

## Testing
- `pre-commit run --files src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853214319788326b49e839c85901b62