### PR TITLE
Handle empty input for gc_balanced encoder

### DIFF
--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -55,6 +55,9 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
     """
     from .encoders import encode_base4_direct  # Local import to avoid circular dependency
 
+    if not data:
+        return "0"
+
     initial_sequence = cast(str, encode_base4_direct(data, add_parity=False))
 
     gc_content_ok = target_gc_min <= calculate_gc_content(initial_sequence) <= target_gc_max
@@ -107,8 +110,11 @@ def decode_gc_balanced(
     # They are included for future extensibility, e.g., to verify if the decoded sequence
     # would have met these constraints if they were re-calculated on the payload.
 
-    if not dna_sequence or len(dna_sequence) < 1: # Sequence must have at least signal bit
+    if not dna_sequence or len(dna_sequence) < 1:  # Sequence must have at least signal bit
         raise ValueError("Input DNA sequence is too short to decode (missing signal bit).")
+
+    if dna_sequence == "0":
+        return b""
 
     from .encoders import decode_base4_direct  # Local import to avoid circular dependency
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -104,8 +104,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
-
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
     """Register the builtin simulators."""
@@ -116,7 +114,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in ("d2sim", "nanopore", "dnarsim", "squigulator", "none"):
         register_simulator(name, _wrap(name))
 
 

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -179,7 +179,6 @@ def test_decode_gc_balanced_with_inversion():
 
 @pytest.mark.parametrize("invalid_sequence, error_message_match", [
     ("", "Input DNA sequence is too short to decode (missing signal bit)."),
-    ("0", "Input DNA sequence is too short (only signal bit found, no payload)."),
     ("1", "Input DNA sequence is too short (only signal bit found, no payload)."),
     ("2ATGC", "Invalid signal bit: '2'. Expected '0' or '1'."),
     ("AATGC", "Invalid signal bit: 'A'. Expected '0' or '1'."), # Another invalid signal bit
@@ -270,10 +269,14 @@ def test_encode_gc_balanced_initial_fails_homopolymer_alternative_used(mock_enco
     mock_encode_base4.assert_any_call(dummy_data, add_parity=False)
     mock_encode_base4.assert_any_call(inverted_dummy_data, add_parity=False)
 
-# Test decode_gc_balanced with empty payload (after signal bit)
+# Test encode_gc_balanced with empty data
+def test_encode_gc_balanced_empty_data():
+    result = encode_gc_balanced(b"", target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3)
+    assert result == "0"
+
+# Test decode_gc_balanced with empty payload (signal bit only)
 def test_decode_gc_balanced_empty_payload():
-    with pytest.raises(ValueError, match="Input DNA sequence is too short \(only signal bit found, no payload\)\."):
-        decode_gc_balanced("0")
+    assert decode_gc_balanced("0") == b""
     with pytest.raises(ValueError, match="Input DNA sequence is too short \(only signal bit found, no payload\)\."):
         decode_gc_balanced("1")
 


### PR DESCRIPTION
## Summary
- handle empty byte strings in `encode_gc_balanced`
- support decoding the signal bit only
- expose `d2sim` simulator name in registry
- add tests for empty data roundtrip via `gc_balanced`

## Testing
- `ruff check src/genecoder/nanopore_sim.py src/genecoder/gc_constrained_encoder.py tests/test_gc_constrained_encoder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685349e6c09c8326b3f8543cd4f36fa3