### PR TITLE
Ensure streaming file outputs create directories

### DIFF
--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Iterator
+import os
 
 from .encoders import encode_base4_direct, decode_base4_direct
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -22,6 +23,8 @@ def stream_encode_file(
 
     Returns the total encoded DNA length.
     """
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     def data_iter() -> Iterator[bytes]:
         with open(input_path, "rb") as f_in:
@@ -63,6 +66,8 @@ def stream_decode_file(
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
 ) -> None:
     """Decode ``input_path`` FASTA file to ``output_path`` streaming chunks."""
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     with open(input_path, "r", encoding="utf-8") as f_in:
         header_line = f_in.readline()

--- a/tests/test_streaming_directories.py
+++ b/tests/test_streaming_directories.py
@@ -1,0 +1,24 @@
+import os
+from genecoder.streaming import stream_encode_file, stream_decode_file
+
+
+def test_stream_encode_file_creates_directory(tmp_path):
+    data = os.urandom(128)
+    input_file = tmp_path / "in.bin"
+    input_file.write_bytes(data)
+    output_file = tmp_path / "non" / "existent" / "out.fasta"
+    header = "method=base4_direct input_file=in.bin"
+    stream_encode_file(str(input_file), str(output_file), header=header)
+    assert output_file.exists()
+
+
+def test_stream_decode_file_creates_directory(tmp_path):
+    data = os.urandom(128)
+    input_file = tmp_path / "in.bin"
+    encoded_file = tmp_path / "encoded.fasta"
+    input_file.write_bytes(data)
+    stream_encode_file(str(input_file), str(encoded_file), header="hdr")
+    output_file = tmp_path / "dec" / "dir" / "decoded.bin"
+    stream_decode_file(str(encoded_file), str(output_file))
+    assert output_file.exists()
+    assert output_file.read_bytes() == data


### PR DESCRIPTION
## Summary
- create the parent directory for the encoded and decoded files if needed
- test that `stream_encode_file` and `stream_decode_file` create missing directories
- refine directory creation calls

## Testing
- `pre-commit run ruff --files src/genecoder/streaming.py tests/test_streaming_directories.py`
- `pre-commit run mypy --files src/genecoder/streaming.py` *(fails: type errors in unrelated modules)*
- `pytest -q tests/test_streaming_directories.py`


------
https://chatgpt.com/codex/tasks/task_e_685349e4e5888326bfe9e1279db70207