### PR TITLE
Expand FEC parity check logic

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -60,7 +60,11 @@ def run_decoding_pipeline(
             )
 
     parity_errors: list[int] = []
-    should_check_parity = options.check_parity and "fec=hamming_7_4" not in header and "fec=reed_solomon" not in header
+    fec_names = [f"fec={name}" for name in FEC_REGISTRY]
+    should_check_parity = (
+        options.check_parity
+        and not any(tag in header for tag in fec_names)
+    )
 
     if options.method == "base4_direct":
         if should_check_parity and options.k_value <= 0:

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -104,19 +104,11 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
-
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
     """Register the builtin simulators."""
 
-    def _wrap(name: str) -> Callable[[str, float], str]:
-        def simulate(seq: str, error_rate: float = 0.05) -> str:
-            return simulate_reads(seq, name, error_rate)
-
-        return simulate
-
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
-        register_simulator(name, _wrap(name))
+    for name, func in SIMULATOR_ADAPTERS.items():
+        register_simulator(name, func)
 
 

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -174,6 +174,47 @@ def test_cli_roundtrip_ldpc(tmp_path: Path):
     assert output_file.read_text().startswith("ldpc test")
 
 
+def test_cli_ldpc_check_parity(tmp_path: Path):
+    pytest.importorskip("pyldpc")
+
+    input_file = tmp_path / "ldpc_parity.txt"
+    input_file.write_text("ldpc parity")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "ldpc",
+        ]
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "ldpc_parity.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--check-parity",
+        ]
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "ldpc_parity.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text().startswith("ldpc parity")
+
+
 def test_cli_roundtrip_fountain(tmp_path: Path):
     pytest.importorskip("pyfinite")
 


### PR DESCRIPTION
## Summary
- disable DNA-level parity when any registered FEC is present
- test LDPC decode with parity check
- register all simulators including d2sim

## Testing
- `ruff check src/genecoder/cli/decode.py src/genecoder/nanopore_sim.py tests/test_cli_roundtrip.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685349de6f508326b1d56aee992a48ca