### PR TITLE
Support plugins.py modules

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -68,6 +68,8 @@ def main(page: ft.Page) -> None:
 
     # Container used for the Helix View tab. Filled when the tab is selected.
     helix_container = ft.Column()
+    animate_checkbox = ft.Checkbox(label="Animate", value=True)
+    zoom_slider = ft.Slider(min=0.5, max=2.0, value=1.0, divisions=15, width=200)
     helix_length_input = ft.TextField(
         label="Sequence Length",
         value="50",
@@ -742,24 +744,7 @@ def main(page: ft.Page) -> None:
 
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:
-            dna_seq = ""
-            if encode_hidden_fasta_content.value:
-                parsed = from_fasta(encode_hidden_fasta_content.value)
-                if parsed:
-                    dna_seq = parsed[0][1]
-            helix_container.controls.clear()
-            helix_container.controls.append(
-                show_helix(
-                    dna_seq,
-                    length=parse_int_input(helix_length_input.value, len(dna_seq) or 1),
-                    colors={
-                        "A": helix_color_a.value,
-                        "C": helix_color_c.value,
-                        "G": helix_color_g.value,
-                        "T": helix_color_t.value,
-                    },
-                )
-            )
+            refresh_helix_view()
 
 
         page.update()

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -82,7 +82,7 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
     "squigulator": simulate_squigulator,
     # backward compatibility names
     "nanopore": simulate_d2sim,
-    "none": lambda seq, _rate=0.05: seq,
+    "none": simulate_none,
 }
 
 
@@ -104,7 +104,6 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     return adapter(sequence, error_rate)
 
-from typing import Any
 
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
@@ -116,7 +115,7 @@ def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> N
 
         return simulate
 
-    for name in ("none", "nanopore", "dnarsim", "squigulator"):
+    for name in ("none", "nanopore", "dnarsim", "squigulator", "d2sim"):
         register_simulator(name, _wrap(name))
 
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -51,19 +51,31 @@ def load_plugins() -> None:
     except ModuleNotFoundError:
         plugins = None
     if plugins is not None:
-        for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):
-            module = importlib.import_module(f"plugins.{module_name}")
-            register = getattr(module, "register", None)
-            if callable(register):
-                register(register_codec)
-            register_f = getattr(module, "register_fec", None)
-            if callable(register_f):
-                register_f(register_fec)
-            register_s = getattr(module, "register_simulator", None)
-            if callable(register_s):
-                register_s(register_simulator)
+        if hasattr(plugins, "__path__"):
+            for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):
+                module = importlib.import_module(f"plugins.{module_name}")
+                register = getattr(module, "register", None)
+                if callable(register):
+                    register(register_codec)
+                register_f = getattr(module, "register_fec", None)
+                if callable(register_f):
+                    register_f(register_fec)
+                register_s = getattr(module, "register_simulator", None)
+                if callable(register_s):
+                    register_s(register_simulator)
+        register = getattr(plugins, "register", None)
+        if callable(register):
+            register(register_codec)
+        register_f = getattr(plugins, "register_fec", None)
+        if callable(register_f):
+            register_f(register_fec)
+        register_s = getattr(plugins, "register_simulator", None)
+        if callable(register_s):
+            register_s(register_simulator)
 
     # Load built-in back-ends directly when running from source
+    from plugins import reverse_codec as _reverse
+    _reverse.register(register_codec)
     from . import reed_solomon_codec as _rs
     _rs.register(register_fec)
     from . import ldpc_codec as _ldpc

--- a/tests/test_plugin_file_module.py
+++ b/tests/test_plugin_file_module.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import pytest
+
+from genecoder import plugins
+
+
+def test_plugins_py_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mod = tmp_path / "plugins.py"
+    mod.write_text("x = 1\n")
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("plugins", None)
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    plugins.load_plugins()
+    assert "reverse" in plugins.CODEC_REGISTRY
+    assert "reed_solomon" in plugins.FEC_REGISTRY
+    assert "ldpc" in plugins.FEC_REGISTRY
+    assert "fountain" in plugins.FEC_REGISTRY


### PR DESCRIPTION
## Summary
- handle plugins module without `__path__`
- ensure builtin plugins still load when `plugins.py` file is present
- register builtin reverse codec directly
- expose helix animation controls and update simulator registry

## Testing
- `pre-commit run --files src/genecoder/plugins.py src/genecoder/flet_app.py src/genecoder/nanopore_sim.py tests/test_plugin_file_module.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853442d0028832693b7394809370a80