### PR TITLE
Add concurrency and refine docs workflow

### DIFF
--- a/.github/workflows/automerge-comments.yml
+++ b/.github/workflows/automerge-comments.yml
@@ -3,8 +3,10 @@ name: Auto-merge comment-only PRs
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-permissions:
-  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,11 +3,18 @@ name: Deploy Docs
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   package:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ make openai-testing
 
 See [openai_testing/README.md](openai_testing/README.md) for full details.
 
+## Continuous Integration
+
+GitHub Actions run linting and tests whenever source code changes. Documentation
+or comment-only updates skip the heavy jobs, keeping CI usage efficient.
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -133,3 +133,11 @@ token has rights to modify the pull request. As a result, pull requests
 containing only documentation or comment updates merge automatically once the
 standard checks succeed.
 
+## CI Optimizations
+
+Workflows now include a `concurrency` block so that only the newest run for a
+branch executes. The documentation deployment workflow triggers only when
+`docs/` or `mkdocs.yml` changes, and the packaging workflow behaves similarly
+for version tags. These adjustments keep CI usage minimal while still running
+tests and linters for real code changes.
+

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -105,6 +105,15 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     return adapter(sequence, error_rate)
 
 
+def _wrap(name: str) -> Callable[[str, float], str]:
+    """Return a simulator function bound to ``name``."""
+
+    def simulate(seq: str, error_rate: float = 0.05) -> str:
+        return simulate_reads(seq, name, error_rate)
+
+    return simulate
+
+
 
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
     """Register the builtin simulators."""


### PR DESCRIPTION
## Summary
- add concurrency to docs, automerge and package workflows
- limit docs workflow to documentation files on push
- document CI optimizations in README and WORKFLOWS docs
- fix simulator registration helper

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py .github/workflows/automerge-comments.yml .github/workflows/docs.yml .github/workflows/package.yml .github/workflows/python-ci.yml WORKFLOWS.md README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68534eff7044832692906bbe4ba7644e