### PR TITLE
Fix automerge checkout

### DIFF
--- a/.github/workflows/automerge-comments.yml
+++ b/.github/workflows/automerge-comments.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: MERGE

--- a/.github/workflows/automerge-comments.yml
+++ b/.github/workflows/automerge-comments.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Detect comment-only changes
         id: comment_check

--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -120,6 +120,8 @@ def only_comments_changed(base_ref: str) -> bool:
 
 
 def main() -> int:
+    # BASE_SHA holds the commit hash for the PR base. Compare HEAD to this
+    # reference so we only analyze the pull request diff.
     base_ref = os.environ.get("BASE_SHA", "origin/main")
     only_comments = only_comments_changed(base_ref)
     output_path = os.environ.get("GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary
- ensure the automerge workflow checks out the pull request HEAD
- verify comment-only check uses BASE_SHA for comparison

## Testing
- `ruff check scripts/only_comments_changed.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535c079c08832686dd23500d8a5df2