### PR TITLE
Add Node modules cache to Python CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -174,6 +174,11 @@ jobs:
       with:
         node-version: '20'
 
+    - uses: actions/cache@v3
+      with:
+        path: openai_testing/node_modules
+        key: node-${{ runner.os }}-${{ hashFiles('openai_testing/package-lock.json') }}
+
     - name: Install Node dependencies
       run: |
         cd openai_testing


### PR DESCRIPTION
## Summary
- cache `openai_testing/node_modules` in the CI

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536488a2ec8326925ffb964d628f36