### PR TITLE
Fix nested capsule directories

### DIFF
--- a/src/genecoder/cache_dna.py
+++ b/src/genecoder/cache_dna.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict
 from datetime import datetime
 import json
+import os
 from typing import Any, Dict
 
 
@@ -45,6 +46,7 @@ def write_capsule(sequence: str, header: str, metadata: Dict[str, Any], path: st
         metadata=metadata,
         created=datetime.utcnow().isoformat(),
     )
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         json.dump(asdict(capsule), f, indent=2)
 

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -61,3 +61,30 @@ def test_encode_capsule_multiple_inputs_error(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "--capsule can only be used" in result.stderr
+
+
+def test_encode_capsule_nested_directory(tmp_path: Path) -> None:
+    """Capsule path should be created if it is in a nested directory."""
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("capsule test")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    capsule_path = tmp_path / "capsules" / "nested" / "seq.capsule"
+
+    result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(output_dir),
+            "--method",
+            "base4_direct",
+            "--capsule",
+            str(capsule_path),
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert capsule_path.exists(), "Capsule path was not created in nested dir"


### PR DESCRIPTION
## Summary
- create parent folders before writing capsule file
- test encoding a capsule to a nested path

## Testing
- `pre-commit run --files src/genecoder/cache_dna.py tests/test_capsule.py`
- `pytest tests/test_capsule.py::test_encode_capsule_nested_directory -vv`

------
https://chatgpt.com/codex/tasks/task_e_6853705c0074832682e0b59c80ece2a6