### PR TITLE
Support custom alphabets for streaming

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -141,6 +141,7 @@ def process_single_decode(
                 check_parity=args.check_parity,
                 k_value=args.k_value,
                 parity_rule=args.parity_rule,
+                alphabet=args.alphabet,
             )
             logger.info(
                 f"Successfully decoded '{input_file_path}' to '{output_file_path}' using streaming."

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -183,6 +183,7 @@ def process_single_encode(
                 add_parity=args.add_parity,
                 k_value=args.k_value,
                 parity_rule=args.parity_rule,
+                alphabet=args.alphabet,
             )
 
             original_size_bytes = os.path.getsize(input_file_path)

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -7,6 +7,7 @@ import os
 
 from .encoders import encode_base4_direct, decode_base4_direct
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from .utils import get_alphabet_maps
 
 
 def stream_encode_file(
@@ -18,6 +19,7 @@ def stream_encode_file(
     add_parity: bool = False,
     k_value: int = 7,
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
+    alphabet: str = "base4",
 ) -> int:
     """Encode ``input_path`` to ``output_path`` streaming chunks.
 
@@ -34,6 +36,8 @@ def stream_encode_file(
                     break
                 yield chunk
 
+    encode_map, _ = get_alphabet_maps(alphabet)
+
     total_len = 0
     line_width = 80
     buffer = ""
@@ -44,6 +48,7 @@ def stream_encode_file(
             add_parity=add_parity,
             k_value=k_value,
             parity_rule=parity_rule,
+            encode_map=encode_map,
             stream=True,
         ):
             total_len += len(dna_chunk)
@@ -64,10 +69,13 @@ def stream_decode_file(
     check_parity: bool = False,
     k_value: int = 7,
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
+    alphabet: str = "base4",
 ) -> None:
     """Decode ``input_path`` FASTA file to ``output_path`` streaming chunks."""
 
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    _, decode_map = get_alphabet_maps(alphabet)
 
     with open(input_path, "r", encoding="utf-8") as f_in:
         header_line = f_in.readline()
@@ -93,6 +101,7 @@ def stream_decode_file(
                 check_parity=check_parity,
                 k_value=k_value,
                 parity_rule=parity_rule,
+                decode_map=decode_map,
                 stream=True,
             ):
                 f_out.write(bytes(decoded_chunk))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,9 +1,16 @@
 import os
+import pytest
 
-from genecoder.streaming import stream_encode_file, stream_decode_file, encode_base4_direct, decode_base4_direct
+from genecoder.streaming import (
+    stream_encode_file,
+    stream_decode_file,
+    encode_base4_direct,
+    decode_base4_direct,
+)
 
 
-def test_stream_round_trip(tmp_path, monkeypatch):
+@pytest.mark.parametrize("alphabet", ["base4", "base5"])
+def test_stream_round_trip(tmp_path, monkeypatch, alphabet):
     data = os.urandom(1_500_000)
     input_file = tmp_path / "input.bin"
     encoded_file = tmp_path / "encoded.fasta"
@@ -20,7 +27,7 @@ def test_stream_round_trip(tmp_path, monkeypatch):
     monkeypatch.setattr("genecoder.streaming.encode_base4_direct", mock_encode)
 
     header = "method=base4_direct input_file=test.bin"
-    stream_encode_file(str(input_file), str(encoded_file), header=header)
+    stream_encode_file(str(input_file), str(encoded_file), header=header, alphabet=alphabet)
     assert True in enc_calls
 
     dec_calls = []
@@ -32,7 +39,7 @@ def test_stream_round_trip(tmp_path, monkeypatch):
 
     monkeypatch.setattr("genecoder.streaming.decode_base4_direct", mock_decode)
 
-    stream_decode_file(str(encoded_file), str(decoded_file))
+    stream_decode_file(str(encoded_file), str(decoded_file), alphabet=alphabet)
     assert True in dec_calls
 
     assert decoded_file.read_bytes() == data


### PR DESCRIPTION
## Summary
- allow `stream_encode_file` and `stream_decode_file` to specify an alphabet
- forward alphabet option from CLI encode/decode commands to streaming helpers
- test streaming round trip with `base4` and `base5`

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853705b4c888326a417bfc8673c5100