### PR TITLE
Add probability validation to introduce_errors

### DIFF
--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -34,11 +34,24 @@ def introduce_errors(
     rng:
         Optional :class:`random.Random` instance for deterministic behaviour.
 
+    Raises
+    ------
+    ValueError
+        If any of ``substitution_prob``, ``insertion_prob`` or ``deletion_prob``
+        is outside the range [0.0, 1.0].
+
     Returns
     -------
     str
         The mutated DNA sequence.
     """
+    if not 0.0 <= substitution_prob <= 1.0:
+        raise ValueError("substitution_prob must be between 0 and 1")
+    if not 0.0 <= insertion_prob <= 1.0:
+        raise ValueError("insertion_prob must be between 0 and 1")
+    if not 0.0 <= deletion_prob <= 1.0:
+        raise ValueError("deletion_prob must be between 0 and 1")
+
     if rng is None:
         rng = random.Random()
 

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -1,4 +1,5 @@
 import random
+import pytest
 from genecoder.error_simulation import introduce_errors
 
 
@@ -66,3 +67,20 @@ def test_introduce_errors_combined_operations():
 
 def test_introduce_errors_empty_sequence():
     assert introduce_errors("", substitution_prob=1.0, insertion_prob=1.0, deletion_prob=1.0, rng=random.Random(0)) == ""
+
+
+@pytest.mark.parametrize(
+    "kw,value",
+    [
+        ("substitution_prob", -0.1),
+        ("substitution_prob", 1.1),
+        ("insertion_prob", -0.1),
+        ("insertion_prob", 1.1),
+        ("deletion_prob", -0.1),
+        ("deletion_prob", 1.1),
+    ],
+)
+def test_introduce_errors_invalid_probabilities(kw: str, value: float) -> None:
+    kwargs = {kw: value, "rng": random.Random(0)}
+    with pytest.raises(ValueError):
+        introduce_errors("A", **kwargs)


### PR DESCRIPTION
## Summary
- validate all probability arguments in `introduce_errors`
- document new ValueError behaviour
- test invalid probability values

## Testing
- `ruff check --fix src/genecoder/error_simulation.py tests/test_error_simulation.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853705c91388326a68adf4775f397f8