### PR TITLE
Handle invalid capsule JSON

### DIFF
--- a/src/genecoder/cache_dna.py
+++ b/src/genecoder/cache_dna.py
@@ -54,5 +54,8 @@ def write_capsule(sequence: str, header: str, metadata: Dict[str, Any], path: st
 def read_capsule(path: str) -> Capsule:
     """Load a capsule from ``path``."""
     with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid capsule file: {path}") from exc
     return Capsule(**data)

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 from tests.test_cli import run_cli_command
+from genecoder.cache_dna import read_capsule
+import pytest
 
 
 def test_encode_capsule_contents(tmp_path: Path) -> None:
@@ -88,3 +90,10 @@ def test_encode_capsule_nested_directory(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert capsule_path.exists(), "Capsule path was not created in nested dir"
+
+
+def test_read_capsule_malformed(tmp_path: Path) -> None:
+    path = tmp_path / "bad.capsule"
+    path.write_text("{ invalid json ]")
+    with pytest.raises(ValueError, match="Invalid capsule file"):
+        read_capsule(str(path))


### PR DESCRIPTION
## Summary
- wrap capsule reading with JSONDecodeError handling
- test error raised for malformed capsule files

## Testing
- `ruff check tests/test_capsule.py src/genecoder/cache_dna.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685378b834e08326ba9253aa691a2a32