### PR TITLE
Use local RNG in nanopore simulator

### DIFF
--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -2,11 +2,21 @@
 from __future__ import annotations
 
 import random
+from typing import Protocol
+
+
+__all__ = ["simulate_errors", "RandomLike"]
+
+
+class RandomLike(Protocol):
+    def random(self) -> float: ...
+
+    def choice(self, seq: list[str]) -> str: ...
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
 
-def simulate_errors(seq: str, p_error: float) -> str:
+def simulate_errors(seq: str, p_error: float, rng: RandomLike = random) -> str:
     """Introduce random substitution errors into *seq* with probability ``p_error``.
 
     Each nucleotide has an independent chance ``p_error`` of being replaced by a
@@ -15,11 +25,12 @@ def simulate_errors(seq: str, p_error: float) -> str:
     if not 0.0 <= p_error <= 1.0:
         raise ValueError("p_error must be between 0 and 1")
 
+
     result = []
     for nt in seq:
-        if random.random() < p_error:
+        if rng.random() < p_error:
             choices = [n for n in NUCLEOTIDES if n != nt]
-            result.append(random.choice(choices))
+            result.append(rng.choice(choices))
         else:
             result.append(nt)
     return "".join(result)

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import random
+from random import Random
 import shutil
 import subprocess
 import tempfile
@@ -12,7 +13,7 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
-from .channel_sim import simulate_errors
+from .channel_sim import RandomLike, simulate_errors
 from .formats import from_fasta, to_fasta
 
 
@@ -33,7 +34,7 @@ def _run_external(command: str, sequence: str) -> str:
         return records[0][1]
 
 
-def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
+def _simulate_adapter(command: str, sequence: str, error_rate: float, rng: RandomLike) -> str:
     """Return ``sequence`` processed by an external ``command`` if available."""
     if shutil.which(command):
         try:
@@ -44,39 +45,39 @@ def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
                 command,
                 exc.returncode,
             )
-    return simulate_errors(sequence, error_rate)
+    return simulate_errors(sequence, error_rate, rng)
 
 
-def simulate_d2sim(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_d2sim(sequence: str, error_rate: float = 0.05, rng: RandomLike | None = None) -> str:
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("d2sim", sequence, error_rate)
+    return _simulate_adapter("d2sim", sequence, error_rate, rng or random)
 
 
 # Backwards compatibility alias
 simulate_nanopore = simulate_d2sim
 
 
-def simulate_dnarsim(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_dnarsim(sequence: str, error_rate: float = 0.05, rng: RandomLike | None = None) -> str:
     """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("dnarsim", sequence, error_rate)
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng or random)
 
 
-def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_squigulator(sequence: str, error_rate: float = 0.05, rng: RandomLike | None = None) -> str:
     """Use ``squigulator`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("squigulator", sequence, error_rate)
+    return _simulate_adapter("squigulator", sequence, error_rate, rng or random)
 
 
-def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
+def simulate_none(sequence: str, error_rate: float = 0.0, rng: RandomLike | None = None) -> str:
 
     """Return ``sequence`` unchanged."""
 
     return sequence
 
 
-SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
+SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, RandomLike], str]] = {
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
@@ -94,15 +95,14 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     """
 
     seed_env = os.getenv("GENECODER_SIM_SEED")
-    if seed_env is not None:
-        random.seed(int(seed_env))
+    rng = Random(int(seed_env)) if seed_env is not None else Random()
 
     try:
         adapter = SIMULATOR_ADAPTERS[simulator]
     except KeyError as exc:
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
-    return adapter(sequence, error_rate)
+    return adapter(sequence, error_rate, rng)
 
 
 def _wrap(name: str) -> Callable[[str, float], str]:

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import random
 import pytest
 
 from genecoder import nanopore_sim
@@ -41,7 +42,11 @@ def test_adapters_fall_back(monkeypatch, name):
     errors_called = []
 
     monkeypatch.setattr(nanopore_sim.shutil, "which", lambda target: which_called.append(target) or None)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda seq, rate: errors_called.append((seq, rate)) or "fallback")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate)) or "fallback",
+    )
     monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
 
     result = func("ACGT", error_rate=0.1)
@@ -64,7 +69,11 @@ def test_adapters_external_error(monkeypatch, caplog, name):
         raise subprocess.CalledProcessError(1, command)
 
     monkeypatch.setattr(nanopore_sim, "_run_external", fake_run_external)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda s, r: errors_called.append((s, r)) or "fallback")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r)) or "fallback",
+    )
 
     with caplog.at_level(logging.WARNING):
         result = func("ACGT", error_rate=0.2)
@@ -78,10 +87,23 @@ def test_adapters_external_error(monkeypatch, caplog, name):
 
 def test_simulate_reads_dispatch(monkeypatch):
     called = []
-    def fake_adapter(seq: str, rate: float = 0.05) -> str:
-        called.append((seq, rate))
+    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
+        called.append((seq, rate, rng))
         return "ok"
 
     monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
     assert nanopore_sim.simulate_reads("AAAA", "dummy") == "ok"
-    assert called == [("AAAA", 0.05)]
+    assert len(called) == 1
+    assert called[0][0] == "AAAA"
+    assert called[0][1] == 0.05
+    assert called[0][2] is not None
+
+
+def test_simulate_reads_no_global_random(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    random.seed(123)
+    expected = [random.random(), random.random()]
+    random.seed(123)
+    nanopore_sim.simulate_reads("ACGT", "none")
+    result = [random.random(), random.random()]
+    assert result == expected


### PR DESCRIPTION
## Summary
- refactor channel simulator to support custom RNG
- keep nanopore simulator from altering global RNG state
- update tests for new RNG behavior

## Testing
- `pre-commit run --files src/genecoder/channel_sim.py src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685378ad2c4483268c3d9b89f9fadcf7