### PR TITLE
Handle output file without directory

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -195,7 +195,7 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "wb") as f_out:
             f_out.write(final_decoded_data)
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -230,7 +230,7 @@ def process_single_encode(
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "w", encoding="utf-8") as f_out:
             f_out.write(fasta_output)
 

--- a/tests/test_cli_output_file_no_dir.py
+++ b/tests/test_cli_output_file_no_dir.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.test_cli import PROJECT_ROOT
+from src.genecoder.encoders import encode_base4_direct
+from src.genecoder.formats import to_fasta
+
+
+def _run_cli(command_args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_path = PROJECT_ROOT / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    cmd = [sys.executable, "-m", "genecoder.cli"] + command_args
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)
+
+
+def test_encode_output_file_no_directory(tmp_path: Path) -> None:
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("hello")
+    result = _run_cli([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-file",
+        "out.fasta",
+        "--method",
+        "base4_direct",
+    ], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "out.fasta").exists()
+
+
+def test_decode_output_file_no_directory(tmp_path: Path) -> None:
+    data = b"decode-test"
+    dna = encode_base4_direct(data)
+    fasta = to_fasta(dna, "method=base4_direct input_file=in.bin")
+    fasta_file = tmp_path / "seq.fasta"
+    fasta_file.write_text(fasta)
+    result = _run_cli([
+        "decode",
+        "--input-files",
+        str(fasta_file),
+        "--output-file",
+        "out.bin",
+        "--method",
+        "base4_direct",
+    ], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    out_path = tmp_path / "out.bin"
+    assert out_path.exists()
+    assert out_path.read_bytes() == data


### PR DESCRIPTION
## Summary
- allow encoding and decoding CLI to create output files in CWD
- test encoding and decoding when `--output-file` omits a directory

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853789e84a08326825036d6c85bc301