### PR TITLE
Fix CLI output path handling when no directory

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -195,7 +195,7 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "wb") as f_out:
             f_out.write(final_decoded_data)
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -230,7 +230,7 @@ def process_single_encode(
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "w", encoding="utf-8") as f_out:
             f_out.write(fasta_output)
 

--- a/tests/test_cli_output_file.py
+++ b/tests/test_cli_output_file.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli_command_cwd(command_args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_path = PROJECT_ROOT / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    full_command = [sys.executable, "-m", "genecoder.cli"] + command_args
+    return subprocess.run(full_command, capture_output=True, text=True, env=env, cwd=cwd)
+
+
+def test_encode_output_file_no_directory(tmp_path: Path):
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("hello")
+
+    result = run_cli_command_cwd([
+        "encode",
+        "--input-files",
+        input_file.name,
+        "--output-file",
+        "out.fasta",
+        "--method",
+        "base4_direct",
+    ], tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "out.fasta").exists()
+
+
+def test_decode_output_file_no_directory(tmp_path: Path):
+    # first encode
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("abc")
+    encode_res = run_cli_command_cwd([
+        "encode",
+        "--input-files",
+        input_file.name,
+        "--output-file",
+        "enc.fasta",
+        "--method",
+        "base4_direct",
+    ], tmp_path)
+    assert encode_res.returncode == 0, encode_res.stderr
+
+    # now decode
+    result = run_cli_command_cwd([
+        "decode",
+        "--input-files",
+        "enc.fasta",
+        "--output-file",
+        "decoded.bin",
+        "--method",
+        "base4_direct",
+    ], tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "decoded.bin").exists()
+


### PR DESCRIPTION
## Summary
- fix `process_single_encode` and `process_single_decode` to allow output paths without directories
- add regression tests for using `--output-file` with only a filename

## Testing
- `ruff check --fix .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853fc481f5883268c6fa04c74371d26