### PR TITLE
Use dedicated RNG in nanopore simulator

### DIFF
--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -6,20 +6,26 @@ import random
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
 
-def simulate_errors(seq: str, p_error: float) -> str:
+def simulate_errors(
+    seq: str, p_error: float, rng: random.Random | None = None
+) -> str:
     """Introduce random substitution errors into *seq* with probability ``p_error``.
 
     Each nucleotide has an independent chance ``p_error`` of being replaced by a
     different random nucleotide.  ``p_error`` should be between 0.0 and 1.0.
+    If ``rng`` is given, it will be used for randomness instead of the module
+    :mod:`random` generator.
     """
     if not 0.0 <= p_error <= 1.0:
         raise ValueError("p_error must be between 0 and 1")
 
+    rand = rng or random
+
     result = []
     for nt in seq:
-        if random.random() < p_error:
+        if rand.random() < p_error:
             choices = [n for n in NUCLEOTIDES if n != nt]
-            result.append(random.choice(choices))
+            result.append(rand.choice(choices))
         else:
             result.append(nt)
     return "".join(result)

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -33,7 +33,9 @@ def _run_external(command: str, sequence: str) -> str:
         return records[0][1]
 
 
-def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
+def _simulate_adapter(
+    command: str, sequence: str, error_rate: float, rng: random.Random | None
+) -> str:
     """Return ``sequence`` processed by an external ``command`` if available."""
     if shutil.which(command):
         try:
@@ -44,39 +46,61 @@ def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
                 command,
                 exc.returncode,
             )
-    return simulate_errors(sequence, error_rate)
+    return simulate_errors(sequence, error_rate, rng=rng)
 
 
-def simulate_d2sim(sequence: str, error_rate: float = 0.05) -> str:
-    """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
+def simulate_d2sim(
+    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+) -> str:
+    """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`.
 
-    return _simulate_adapter("d2sim", sequence, error_rate)
+    The optional ``rng`` parameter allows callers to supply a randomness source
+    for the fallback path.
+    """
+
+    return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
 
 # Backwards compatibility alias
 simulate_nanopore = simulate_d2sim
 
 
-def simulate_dnarsim(sequence: str, error_rate: float = 0.05) -> str:
-    """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`."""
+def simulate_dnarsim(
+    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+) -> str:
+    """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`.
 
-    return _simulate_adapter("dnarsim", sequence, error_rate)
+    ``rng`` is forwarded to :func:`simulate_errors` if the external command is
+    unavailable.
+    """
+
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng)
 
 
-def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
-    """Use ``squigulator`` if available, else fall back to :func:`simulate_errors`."""
+def simulate_squigulator(
+    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+) -> str:
+    """Use ``squigulator`` if available, else fall back to :func:`simulate_errors`.
 
-    return _simulate_adapter("squigulator", sequence, error_rate)
+    ``rng`` provides the randomness source for the fallback simulator.
+    """
+
+    return _simulate_adapter("squigulator", sequence, error_rate, rng)
 
 
-def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
+def simulate_none(
+    sequence: str, error_rate: float = 0.0, rng: random.Random | None = None
+) -> str:
 
-    """Return ``sequence`` unchanged."""
+    """Return ``sequence`` unchanged.
+
+    The ``rng`` parameter is accepted for API compatibility but ignored.
+    """
 
     return sequence
 
 
-SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
+SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]] = {
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
@@ -89,20 +113,22 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
 def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
     """Return ``sequence`` corrupted using the chosen simulator.
 
-    If the requested simulator command isn't available, fall back to a simple
-    substitution error model implemented in :func:`simulate_errors`.
+    A per-call :class:`~random.Random` instance is used so calls do not affect
+    the global RNG.  If the ``GENECODER_SIM_SEED`` environment variable is set,
+    it will be used to seed this local RNG.  If the requested simulator command
+    isn't available, fall back to a simple substitution error model implemented
+    in :func:`simulate_errors`.
     """
 
     seed_env = os.getenv("GENECODER_SIM_SEED")
-    if seed_env is not None:
-        random.seed(int(seed_env))
+    rng = random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
     try:
         adapter = SIMULATOR_ADAPTERS[simulator]
     except KeyError as exc:
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
-    return adapter(sequence, error_rate)
+    return adapter(sequence, error_rate, rng)
 
 
 def _wrap(name: str) -> Callable[[str, float], str]:

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import random
 import pytest
 
 from genecoder import nanopore_sim
@@ -41,13 +42,17 @@ def test_adapters_fall_back(monkeypatch, name):
     errors_called = []
 
     monkeypatch.setattr(nanopore_sim.shutil, "which", lambda target: which_called.append(target) or None)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda seq, rate: errors_called.append((seq, rate)) or "fallback")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
     monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
 
     result = func("ACGT", error_rate=0.1)
     assert result == "fallback"
     assert which_called == [cmd]
-    assert errors_called == [("ACGT", 0.1)]
+    assert errors_called == [("ACGT", 0.1, None)]
 
 
 @pytest.mark.parametrize("name", ADAPTERS.keys())
@@ -64,7 +69,11 @@ def test_adapters_external_error(monkeypatch, caplog, name):
         raise subprocess.CalledProcessError(1, command)
 
     monkeypatch.setattr(nanopore_sim, "_run_external", fake_run_external)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda s, r: errors_called.append((s, r)) or "fallback")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+    )
 
     with caplog.at_level(logging.WARNING):
         result = func("ACGT", error_rate=0.2)
@@ -72,16 +81,36 @@ def test_adapters_external_error(monkeypatch, caplog, name):
     assert result == "fallback"
     assert which_called == [cmd]
     assert run_called == [(cmd, "ACGT")]
-    assert errors_called == [("ACGT", 0.2)]
+    assert errors_called == [("ACGT", 0.2, None)]
     assert any("falling back" in rec.message for rec in caplog.records)
 
 
 def test_simulate_reads_dispatch(monkeypatch):
     called = []
-    def fake_adapter(seq: str, rate: float = 0.05) -> str:
-        called.append((seq, rate))
+    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
+        called.append((seq, rate, rng))
         return "ok"
 
     monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
     assert nanopore_sim.simulate_reads("AAAA", "dummy") == "ok"
-    assert called == [("AAAA", 0.05)]
+    assert len(called) == 1
+    assert called[0][0] == "AAAA"
+    assert called[0][1] == 0.05
+    assert isinstance(called[0][2], random.Random)
+
+
+def test_simulate_reads_does_not_affect_global_rng(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "5")
+    random.seed(123)
+    random.random()
+    # Reset and reproduce expected second value without calling simulate_reads
+    random.seed(123)
+    _ = random.random()
+    expected_second = random.random()
+
+    random.seed(123)
+    _ = random.random()
+    nanopore_sim.simulate_reads("AAAA", "none")
+    after = random.random()
+
+    assert after == expected_second


### PR DESCRIPTION
## Summary
- use optional RNG in `simulate_errors`
- thread RNG through nanopore simulator helpers
- avoid seeding global RNG in `simulate_reads`
- document RNG handling in simulators
- test that `simulate_reads` leaves global RNG untouched

## Testing
- `ruff check src/genecoder/channel_sim.py src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853fc497a948326ae362a9d14b0bd8c