### PR TITLE
Improve logging and GC constraint checks

### DIFF
--- a/src/genecoder/cache_dna.py
+++ b/src/genecoder/cache_dna.py
@@ -53,9 +53,13 @@ def write_capsule(sequence: str, header: str, metadata: Dict[str, Any], path: st
 
 def read_capsule(path: str) -> Capsule:
     """Load a capsule from ``path``."""
-    with open(path, "r", encoding="utf-8") as f:
-        try:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Invalid capsule file: {path}") from exc
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Capsule file not found: {path}") from exc
+    except OSError as exc:
+        raise OSError(f"Could not read capsule file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid capsule file: {path}") from exc
     return Capsule(**data)

--- a/src/genecoder/cli/analyze.py
+++ b/src/genecoder/cli/analyze.py
@@ -84,9 +84,9 @@ def process_single_analyze(input_file_path: str, args: argparse.Namespace) -> No
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")
-    except Exception as e:
-        logger.error(
-            f"Error for {input_file_path}: Unexpected error during analysis: {e}"
+    except Exception:
+        logger.exception(
+            "Error for %s: Unexpected error during analysis", input_file_path
         )
 
 

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -96,8 +96,8 @@ def _handle_sim_errors(args: argparse.Namespace) -> None:
     except FileNotFoundError:
         logger.error(f"Error: Input file {args.input_file} not found.")
         raise SystemExit(1)
-    except Exception as e:
-        logger.error(f"Error during simulate-errors: {e}")
+    except Exception:
+        logger.exception("Error during simulate-errors")
         raise SystemExit(1)
 
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -205,9 +205,9 @@ def process_single_decode(
         logger.error(f"Error for {input_file_path}: Input file not found.")
     except IOError as e:
         logger.error(f"Error for {input_file_path}: I/O error: {e}")
-    except Exception as e:
-        logger.error(
-            f"Error for {input_file_path}: Unexpected error during decoding: {e}"
+    except Exception:
+        logger.exception(
+            "Error for %s: Unexpected error during decoding", input_file_path
         )
 
 
@@ -331,8 +331,8 @@ def _handle_command(args: argparse.Namespace) -> None:
             for decode_future in concurrent.futures.as_completed(futures_list):
                 try:
                     decode_future.result()
-                except Exception as exc:
-                    logger.error(f"A file decoding task generated an exception: {exc}")
+                except Exception:
+                    logger.exception("A file decoding task generated an exception")
         logger.info("\nBatch decoding finished.")
     else:
         if tasks:

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -316,9 +316,9 @@ def process_single_encode(
         logger.error(f"Error for {input_file_path}: Input file not found.")
     except IOError as e:
         logger.error(f"Error for {input_file_path}: I/O error: {e}")
-    except Exception as e:
-        logger.error(
-            f"Error for {input_file_path}: Unexpected error during encoding: {e}"
+    except Exception:
+        logger.exception(
+            "Error for %s: Unexpected error during encoding", input_file_path
         )
     return None
 
@@ -457,8 +457,8 @@ def _handle_command(args: argparse.Namespace) -> None:
                     res = future.result()
                     if args.export_csv and res:
                         csv_rows.append(res)
-                except Exception as exc:
-                    logger.error(f"A file processing task generated an exception: {exc}")
+                except Exception:
+                    logger.exception("A file processing task generated an exception")
         logger.info("\nBatch encoding finished.")
     else:
         if tasks:

--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -42,7 +42,8 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
     - Encodes data using `encode_base4_direct`.
     - If constraints (GC content, homopolymer length) are met, returns the sequence prefixed with "0".
     - If constraints are violated, inverts data bits, re-encodes, and returns prefixed with "1".
-      (Assumes the alternative sequence is better without re-checking constraints).
+      The alternative sequence is validated as well and a :class:`ValueError` is raised
+      if it still fails the constraints.
 
     Args:
         data: The binary data to encode.
@@ -72,7 +73,15 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
         # bits of ``data`` are inverted using XOR with ``0xFF`` (bitwise NOT for
         # each byte) and that modified payload is encoded instead.
         modified_data = bytes(b ^ 0xFF for b in data)
-        alternative_sequence = cast(str, encode_base4_direct(modified_data, add_parity=False))
+        alternative_sequence = cast(
+            str, encode_base4_direct(modified_data, add_parity=False)
+        )
+        alt_gc_ok = target_gc_min <= calculate_gc_content(alternative_sequence) <= target_gc_max
+        alt_hp_ok = not check_homopolymer_length(alternative_sequence, max_homopolymer)
+        if not (alt_gc_ok and alt_hp_ok):
+            raise ValueError(
+                "Unable to encode data within GC/homopolymer constraints after bit inversion."
+            )
         # ``"1"`` is prepended so the decoder knows to invert the bits again.
         # A more sophisticated implementation could attempt multiple
         # alternatives before falling back to this simple inversion.

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -97,3 +97,9 @@ def test_read_capsule_malformed(tmp_path: Path) -> None:
     path.write_text("{ invalid json ]")
     with pytest.raises(ValueError, match="Invalid capsule file"):
         read_capsule(str(path))
+
+
+def test_read_capsule_missing(tmp_path: Path) -> None:
+    path = tmp_path / "missing.capsule"
+    with pytest.raises(FileNotFoundError, match="Capsule file not found"):
+        read_capsule(str(path))

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -304,9 +304,9 @@ def test_get_max_homopolymer_length_single_char():
     assert get_max_homopolymer_length("A") == 1
     assert get_max_homopolymer_length("G") == 1
 
-# Test encode_gc_balanced where both initial and alternative might fail (current logic picks alternative)
+# Test encode_gc_balanced where both initial and alternative fail constraints
 @patch('genecoder.encoders.encode_base4_direct')
-def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4):
+def test_encode_gc_balanced_both_fail_raises_error(mock_encode_base4):
     dummy_data = b"test"
     inverted_dummy_data = bytes(b ^ 0xFF for b in dummy_data)
     
@@ -319,10 +319,9 @@ def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4):
     target_gc_max = 0.6
     max_homopolymer = 3
 
-    result = encode_gc_balanced(dummy_data, target_gc_min, target_gc_max, max_homopolymer)
+    with pytest.raises(ValueError, match="Unable to encode data"):
+        encode_gc_balanced(dummy_data, target_gc_min, target_gc_max, max_homopolymer)
 
-    assert result.startswith("1") # Current logic always picks alternative if initial fails
-    assert result[1:] == alternative_sequence
     assert mock_encode_base4.call_count == 2
     mock_encode_base4.assert_has_calls([
         call(dummy_data, add_parity=False),


### PR DESCRIPTION
## Summary
- enhance CLI error logging using `logger.exception`
- validate GC/homopolymer constraints after bit inversion
- improve error handling in capsule reader
- adjust tests for new behaviour and add missing-file test

## Testing
- `ruff check src/genecoder/cli/analyze.py src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/cli/cli.py src/genecoder/gc_constrained_encoder.py src/genecoder/cache_dna.py tests/test_capsule.py tests/test_gc_constrained_encoder.py`
- `mypy --config-file mypy.ini src/genecoder`
- `pytest -q tests/test_gc_constrained_encoder.py::test_encode_gc_balanced_both_fail_raises_error tests/test_capsule.py::test_read_capsule_missing`

------
https://chatgpt.com/codex/tasks/task_e_6853768608e08326819cd1639c422171