### PR TITLE
Improve error handling and local RNG

### DIFF
--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import random
 
+from typing import Optional
+
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
 
-def simulate_errors(seq: str, p_error: float) -> str:
+def simulate_errors(seq: str, p_error: float, rng: Optional[random.Random] = None) -> str:
     """Introduce random substitution errors into *seq* with probability ``p_error``.
 
     Each nucleotide has an independent chance ``p_error`` of being replaced by a
@@ -15,11 +17,14 @@ def simulate_errors(seq: str, p_error: float) -> str:
     if not 0.0 <= p_error <= 1.0:
         raise ValueError("p_error must be between 0 and 1")
 
+    if rng is None:
+        rng = random.Random()
+
     result = []
     for nt in seq:
-        if random.random() < p_error:
+        if rng.random() < p_error:
             choices = [n for n in NUCLEOTIDES if n != nt]
-            result.append(random.choice(choices))
+            result.append(rng.choice(choices))
         else:
             result.append(nt)
     return "".join(result)

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -6,6 +6,7 @@ import argparse
 import concurrent.futures
 import logging
 import os
+import random
 import re
 from dataclasses import dataclass
 
@@ -183,8 +184,10 @@ def process_single_decode(
         if args.simulate_errors > 0.0:
             from genecoder.channel_sim import simulate_errors
 
+            seed_env = os.getenv("GENECODER_SIM_SEED")
+            rng = random.Random(int(seed_env)) if seed_env is not None else random.Random()
             sequence_from_fasta = simulate_errors(
-                sequence_from_fasta, args.simulate_errors
+                sequence_from_fasta, args.simulate_errors, rng=rng
             )
             logger.info(
                 f"Applied simulated errors (p={args.simulate_errors}) before decoding."
@@ -195,7 +198,7 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "wb") as f_out:
             f_out.write(final_decoded_data)
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -230,7 +230,7 @@ def process_single_encode(
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
 
-        os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+        os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "w", encoding="utf-8") as f_out:
             f_out.write(fasta_output)
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -33,7 +33,9 @@ def _run_external(command: str, sequence: str) -> str:
         return records[0][1]
 
 
-def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
+def _simulate_adapter(
+    command: str, sequence: str, error_rate: float, rng: random.Random
+) -> str:
     """Return ``sequence`` processed by an external ``command`` if available."""
     if shutil.which(command):
         try:
@@ -44,39 +46,45 @@ def _simulate_adapter(command: str, sequence: str, error_rate: float) -> str:
                 command,
                 exc.returncode,
             )
-    return simulate_errors(sequence, error_rate)
+    return simulate_errors(sequence, error_rate, rng=rng)
 
 
-def simulate_d2sim(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_d2sim(sequence: str, error_rate: float = 0.05, rng: random.Random | None = None) -> str:
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("d2sim", sequence, error_rate)
+    if rng is None:
+        rng = random.Random()
+    return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
 
 # Backwards compatibility alias
 simulate_nanopore = simulate_d2sim
 
 
-def simulate_dnarsim(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_dnarsim(sequence: str, error_rate: float = 0.05, rng: random.Random | None = None) -> str:
     """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("dnarsim", sequence, error_rate)
+    if rng is None:
+        rng = random.Random()
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng)
 
 
-def simulate_squigulator(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_squigulator(sequence: str, error_rate: float = 0.05, rng: random.Random | None = None) -> str:
     """Use ``squigulator`` if available, else fall back to :func:`simulate_errors`."""
 
-    return _simulate_adapter("squigulator", sequence, error_rate)
+    if rng is None:
+        rng = random.Random()
+    return _simulate_adapter("squigulator", sequence, error_rate, rng)
 
 
-def simulate_none(sequence: str, error_rate: float = 0.0) -> str:
+def simulate_none(sequence: str, error_rate: float = 0.0, rng: random.Random | None = None) -> str:
 
     """Return ``sequence`` unchanged."""
 
     return sequence
 
 
-SIMULATOR_ADAPTERS: dict[str, Callable[[str, float], str]] = {
+SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random], str]] = {
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
@@ -94,15 +102,14 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     """
 
     seed_env = os.getenv("GENECODER_SIM_SEED")
-    if seed_env is not None:
-        random.seed(int(seed_env))
+    rng = random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
     try:
         adapter = SIMULATOR_ADAPTERS[simulator]
     except KeyError as exc:
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
-    return adapter(sequence, error_rate)
+    return adapter(sequence, error_rate, rng)
 
 
 def _wrap(name: str) -> Callable[[str, float], str]:

--- a/tests/test_channel_sim.py
+++ b/tests/test_channel_sim.py
@@ -5,16 +5,16 @@ from genecoder.error_correction import encode_triple_repeat, decode_triple_repea
 
 
 def test_simulate_errors_deterministic():
-    random.seed(0)
-    assert simulate_errors("AAAA", 1.0) == "CGCC"
+    rng = random.Random(0)
+    assert simulate_errors("AAAA", 1.0, rng=rng) == "CGCC"
 
 
 def test_decode_recovery_with_triple_repeat():
-    random.seed(42)
+    rng = random.Random(42)
     data = b"hello"
     dna = encode_base4_direct(data)
     dna_tr = encode_triple_repeat(dna)
-    corrupted = simulate_errors(dna_tr, 0.05)
+    corrupted = simulate_errors(dna_tr, 0.05, rng=rng)
     corrected, _, _ = decode_triple_repeat(corrupted)
     recovered, _ = decode_base4_direct(corrected)
     assert recovered == data

--- a/tests/test_cli_output_paths.py
+++ b/tests/test_cli_output_paths.py
@@ -1,0 +1,68 @@
+import argparse
+import os
+from pathlib import Path
+
+from genecoder.cli.encode import process_single_encode
+from genecoder.cli.decode import process_single_decode
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+
+
+def _encode_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+        alphabet="base4",
+        stream=False,
+        capsule=None,
+        export_csv=None,
+    )
+
+
+def _decode_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        method="base4_direct",
+        check_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        alphabet="base4",
+        stream=False,
+        simulate_errors=0.0,
+        simulator="none",
+    )
+
+
+def test_process_single_encode_no_directory(tmp_path: Path) -> None:
+    infile = tmp_path / "input.bin"
+    infile.write_text("hello")
+    args = _encode_args()
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        process_single_encode(str(infile), "out.fasta", args)
+    finally:
+        os.chdir(cwd)
+    assert (tmp_path / "out.fasta").exists()
+
+
+def test_process_single_decode_no_directory(tmp_path: Path) -> None:
+    infile = tmp_path / "data.bin"
+    infile.write_text("world")
+    enc_args = _encode_args()
+    fasta = tmp_path / "encoded.fasta"
+    process_single_encode(str(infile), str(fasta), enc_args)
+
+    dec_args = _decode_args()
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        process_single_decode(str(fasta), "decoded.bin", dec_args)
+    finally:
+        os.chdir(cwd)
+    assert (tmp_path / "decoded.bin").read_text() == "world"
+

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import subprocess
 import pytest
 
@@ -41,7 +42,11 @@ def test_adapters_fall_back(monkeypatch, name):
     errors_called = []
 
     monkeypatch.setattr(nanopore_sim.shutil, "which", lambda target: which_called.append(target) or None)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda seq, rate: errors_called.append((seq, rate)) or "fallback")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate)) or "fallback",
+    )
     monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
 
     result = func("ACGT", error_rate=0.1)
@@ -64,7 +69,7 @@ def test_adapters_external_error(monkeypatch, caplog, name):
         raise subprocess.CalledProcessError(1, command)
 
     monkeypatch.setattr(nanopore_sim, "_run_external", fake_run_external)
-    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda s, r: errors_called.append((s, r)) or "fallback")
+    monkeypatch.setattr(nanopore_sim, "simulate_errors", lambda s, r, rng=None: errors_called.append((s, r)) or "fallback")
 
     with caplog.at_level(logging.WARNING):
         result = func("ACGT", error_rate=0.2)
@@ -78,10 +83,27 @@ def test_adapters_external_error(monkeypatch, caplog, name):
 
 def test_simulate_reads_dispatch(monkeypatch):
     called = []
-    def fake_adapter(seq: str, rate: float = 0.05) -> str:
-        called.append((seq, rate))
+    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
+        called.append((seq, rate, isinstance(rng, random.Random)))
         return "ok"
 
     monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
     assert nanopore_sim.simulate_reads("AAAA", "dummy") == "ok"
-    assert called == [("AAAA", 0.05)]
+    assert called == [("AAAA", 0.05, True)]
+
+
+def test_simulate_reads_preserves_global_rng(monkeypatch):
+    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
+        return seq
+
+    monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
+
+    rng = random.Random(123)
+    expected_first = rng.random()
+    expected_second = rng.random()
+    random.seed(123)
+    before = random.random()
+    nanopore_sim.simulate_reads("ACGT", "dummy")
+    after = random.random()
+    assert before == expected_first
+    assert after == expected_second


### PR DESCRIPTION
## Summary
- revert logging changes to start from clean dev branch
- use optional RNG argument for channel simulator and nanopore simulators
- create output paths safely when no directory provided
- add tests for RNG isolation and path handling

## Testing
- `pre-commit run --files src/genecoder/channel_sim.py src/genecoder/cli/decode.py src/genecoder/cli/encode.py src/genecoder/nanopore_sim.py tests/test_channel_sim.py tests/test_nanopore_sim.py tests/test_cli_output_paths.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853768608e08326819cd1639c422171