### PR TITLE
Add pip cache to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ hashFiles('docs/requirements.txt') }}
       - name: Install documentation requirements
         run: pip install -r docs/requirements.txt
       - name: Build site

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -47,9 +47,9 @@ def _simulate_adapter(
                 command,
                 exc.returncode,
             )
-    # use a deterministic local RNG for external simulators but fall back to
-    # the default randomness when falling back to :func:`simulate_errors`
-    return simulate_errors(sequence, error_rate, rng=None)
+    # use a deterministic local RNG for external simulators and preserve this
+    # randomness source when falling back to :func:`simulate_errors`
+    return simulate_errors(sequence, error_rate, rng=rng)
 
 
 def simulate_d2sim(
@@ -60,6 +60,9 @@ def simulate_d2sim(
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
 
+
+    if rng is None:
+        rng = random.Random()
 
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
@@ -78,6 +81,9 @@ def simulate_dnarsim(
     """
 
 
+    if rng is None:
+        rng = random.Random()
+
     return _simulate_adapter("dnarsim", sequence, error_rate, rng)
 
 
@@ -90,6 +96,9 @@ def simulate_squigulator(
     ``rng`` provides the randomness source for the fallback simulator.
     """
 
+
+    if rng is None:
+        rng = random.Random()
 
     return _simulate_adapter("squigulator", sequence, error_rate, rng)
 


### PR DESCRIPTION
## Summary
- add a cache step for pip in the documentation deployment workflow
- ensure nanopore simulator fallbacks use a local RNG

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py .github/workflows/docs.yml`
- `pytest -k nanopore_sim -vv`

------
https://chatgpt.com/codex/tasks/task_e_68548c8e9a7883269bf23d396dbb1c3e