### PR TITLE
Update package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,16 +14,23 @@ concurrency:
 
 jobs:
   package:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ${{ matrix.os }}]
     timeout-minutes: 45
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows, macos]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-${{ hashFiles('requirements.lock') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -15,8 +15,6 @@ class RandomLike(Protocol):
 
 from typing import Optional
 
-from typing import Optional
-
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -47,9 +47,10 @@ def _simulate_adapter(
                 command,
                 exc.returncode,
             )
-    # use a deterministic local RNG for external simulators but fall back to
-    # the default randomness when falling back to :func:`simulate_errors`
-    return simulate_errors(sequence, error_rate, rng=None)
+    # fall back to :func:`simulate_errors` using a deterministic RNG when one is
+    # not provided so tests can verify the value passed through
+    fallback_rng = rng or random.Random()
+    return simulate_errors(sequence, error_rate, rng=fallback_rng)
 
 
 def simulate_d2sim(


### PR DESCRIPTION
## Summary
- use OS-specific labels for self-hosted runners
- cache pip deps in the package workflow
- fix duplicate import in `channel_sim`
- forward RNG to fallback simulator for deterministic tests

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68548c8878988326869351511fc28f51