### PR TITLE
Update automerge workflow runner

### DIFF
--- a/.github/workflows/automerge-comments.yml
+++ b/.github/workflows/automerge-comments.yml
@@ -3,6 +3,11 @@ name: Auto-merge comment-only PRs
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.py'
+      - '**/*.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +20,7 @@ permissions:
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- use self-hosted runner for comment-only PRs
- restrict triggers to documentation and Python files

## Testing
- `pre-commit run --files .github/workflows/automerge-comments.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685492a147308326a0bd1e478dae4aaf