### PR TITLE
Add httpx skip to web app tests

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,6 +1,7 @@
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 from web.main import app, index_path


### PR DESCRIPTION
## Summary
- prevent test failures when `httpx` isn't installed by using `pytest.importorskip`

## Testing
- `ruff check tests/test_web_app.py`
- `mypy --config-file mypy.ini src`
- `pytest tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6854a330538483268e58f7dfb5c51db5