### PR TITLE
Fix nanopore simulator registration

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -166,10 +166,7 @@ def _wrap(name: str) -> Callable[[str, float], str]:
 def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
     """Register the builtin simulators."""
 
-    for name, func in SIMULATOR_ADAPTERS.items():
-        register_simulator(name, func)
-
-    for name in ("none", "nanopore", "dnarsim", "squigulator", "d2sim"):
+    for name in SIMULATOR_ADAPTERS:
         register_simulator(name, _wrap(name))
 
 


### PR DESCRIPTION
## Summary
- simplify nanopore simulator registration
- register simulators once using `_wrap`

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_6854a32a92b4832688b5084f8d695862