### PR TITLE
Fix Fountain codec empty data handling

### DIFF
--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -28,6 +28,9 @@ def _require_pyfinite() -> None:  # pragma: no cover - helper
 def encode_data_fountain(data: bytes, chunk_size: int = 4) -> Tuple[bytes, Any]:
     """Encode ``data`` using a trivial Fountain scheme with one parity chunk."""
     _require_pyfinite()
+    if not data:
+        return b"", {"chunk_size": chunk_size, "orig_len": 0}
+
     F = ffield.FField(8)
     blocks = [data[i : i + chunk_size] for i in range(0, len(data), chunk_size)]
     if len(blocks[-1]) < chunk_size:

--- a/src/genecoder/plotting.py
+++ b/src/genecoder/plotting.py
@@ -6,24 +6,30 @@ rendered to in-memory buffers for display in Flet or other GUI frameworks.
 """
 import io
 import collections
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import base64
 
-matplotlib: Any
-plt: Any
-MaxNLocator: Any
-try:  # pragma: no cover - optional dependency
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     import matplotlib
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
     from matplotlib.ticker import MaxNLocator
+    import matplotlib.pyplot as plt
     _MATPLOTLIB_AVAILABLE = True
-except Exception:  # noqa: BLE001 - broader catch for optional import
-    matplotlib = None
-    plt = None
-    MaxNLocator = None
-    _MATPLOTLIB_AVAILABLE = False
+else:  # pragma: no cover - runtime optional dependency handling
+    matplotlib: Any
+    plt: Any
+    MaxNLocator: Any
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib.ticker import MaxNLocator
+        _MATPLOTLIB_AVAILABLE = True
+    except Exception:  # noqa: BLE001 - broader catch for optional import
+        matplotlib = None
+        plt = None
+        MaxNLocator = None
+        _MATPLOTLIB_AVAILABLE = False
 
 _DUMMY_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="

--- a/tests/test_fountain_codec.py
+++ b/tests/test_fountain_codec.py
@@ -9,3 +9,11 @@ def test_fountain_roundtrip():
     encoded, info = encode_data_fountain(data, chunk_size=5)
     decoded, _ = decode_data_fountain(encoded, info)
     assert decoded == data
+
+
+def test_fountain_empty_data():
+    encoded, info = encode_data_fountain(b"", chunk_size=5)
+    assert encoded == b""
+    assert info["orig_len"] == 0
+    decoded, _ = decode_data_fountain(encoded, info)
+    assert decoded == b""


### PR DESCRIPTION
## Summary
- avoid indexing into the blocks list in `encode_data_fountain` when `data` is empty
- add tests to ensure empty data is encoded/decoded without errors
- tweak plotting module imports to satisfy mypy

## Testing
- `pre-commit run --files src/genecoder/fountain_codec.py tests/test_fountain_codec.py src/genecoder/plotting.py`

------
https://chatgpt.com/codex/tasks/task_e_685578bfe4f083269693bcfcb50d8df3