### PR TITLE
Handle invalid integer input in GUI

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -306,16 +306,22 @@ def main(page: ft.Page) -> None:
             with open(input_path, "rb") as f_in:
                 input_data = await asyncio.to_thread(f_in.read)
 
-            options = EncodeOptions(
-                method=method_dropdown.value,
-                add_parity=parity_checkbox.value,
-                k_value=parse_int_input(k_value_input.value, 7),
-                fec_method=fec_dropdown.value,
-                window_size=parse_int_input(window_size_input.value, 50),
-                step_size=parse_int_input(step_size_input.value, 10),
-                min_homopolymer_len=parse_int_input(min_homopolymer_input.value, 4),
-                alphabet=alphabet_dropdown.value,
-            )
+            try:
+                options = EncodeOptions(
+                    method=method_dropdown.value,
+                    add_parity=parity_checkbox.value,
+                    k_value=parse_int_input(k_value_input.value, 7),
+                    fec_method=fec_dropdown.value,
+                    window_size=parse_int_input(window_size_input.value, 50),
+                    step_size=parse_int_input(step_size_input.value, 10),
+                    min_homopolymer_len=parse_int_input(min_homopolymer_input.value, 4),
+                    alphabet=alphabet_dropdown.value,
+                )
+            except ValueError as ex:
+                encode_status_text.value = f"Invalid numeric input: {ex}"
+                encode_status_text.color = ft.colors.RED_ACCENT_700
+                page.update()
+                return
 
             result = await asyncio.to_thread(perform_encoding, input_data, options)
 

--- a/src/genecoder/flet_helpers.py
+++ b/src/genecoder/flet_helpers.py
@@ -12,8 +12,7 @@ def parse_int_input(value: str | None, default: int, min_value: int = 1) -> int:
         Text from a GUI input field. ``None`` or an empty string results
         in ``default``.
     default:
-        Value returned when parsing fails or the parsed value is less than
-        ``min_value``.
+        Value returned when parsing fails or ``value`` is empty/``None``.
     min_value:
         The minimum allowed integer value. Defaults to ``1``.
 
@@ -23,10 +22,13 @@ def parse_int_input(value: str | None, default: int, min_value: int = 1) -> int:
         The parsed integer if valid and >= ``min_value``; otherwise ``default``.
     """
     try:
-        if value is not None and value != "":
-            parsed = int(value)
-        else:
-            parsed = default
+        if value is None or value == "":
+            return default
+        parsed = int(value)
     except (TypeError, ValueError):
         return default
-    return parsed if parsed >= min_value else default
+
+    if parsed < min_value:
+        raise ValueError(f"Value must be >= {min_value}")
+
+    return parsed

--- a/tests/test_flet_helpers.py
+++ b/tests/test_flet_helpers.py
@@ -1,10 +1,22 @@
+import pytest
 from genecoder.flet_helpers import parse_int_input
 
 
-def test_parse_int_input_basic():
-    assert parse_int_input("10", 5) == 10
-    assert parse_int_input("", 5) == 5
-    assert parse_int_input("abc", 5) == 5
-    assert parse_int_input("-1", 5) == 5
-    assert parse_int_input("2", 5, min_value=2) == 2
-    assert parse_int_input("1", 5, min_value=2) == 5
+@pytest.mark.parametrize(
+    "value, default, min_value, expected",
+    [
+        ("10", 5, 1, 10),
+        ("", 5, 1, 5),
+        (None, 5, 1, 5),
+        ("abc", 5, 1, 5),
+    ],
+)
+def test_parse_int_input_valid_and_invalid(value, default, min_value, expected):
+    assert parse_int_input(value, default, min_value) == expected
+
+
+def test_parse_int_input_out_of_range():
+    with pytest.raises(ValueError):
+        parse_int_input("1", 5, min_value=2)
+    with pytest.raises(ValueError):
+        parse_int_input("-1", 5)


### PR DESCRIPTION
## Summary
- raise `ValueError` when `parse_int_input` receives a number below `min_value`
- show a user-friendly message if the GUI encounters this error
- update helper tests for valid, invalid and out-of-range inputs

## Testing
- `ruff check .`
- `pytest tests/test_flet_helpers.py tests/test_flet_app_interactions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685578d90578832687be175bf3f3d842