### PR TITLE
Validate FASTA characters

### DIFF
--- a/src/genecoder/formats.py
+++ b/src/genecoder/formats.py
@@ -5,7 +5,13 @@ sequences, where nucleotides or amino acids are represented using single-letter
 codes. A sequence in FASTA format consists of a single-line description (header),
 followed by lines of sequence data.
 """
-from typing import List, Tuple # For type hints
+from typing import List, Tuple  # For type hints
+
+# The set of valid characters for FASTA sequence lines.
+# Valid characters are the uppercase ASCII letters ``A``-``Z``, the digits
+# ``0``-``9``, the gap characters ``-`` and ``*``, and the slash ``/``.
+# Lowercase characters are considered invalid and will trigger a ``ValueError``.
+FASTA_ALLOWED_CHARS: set[str] = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-*/")
 
 def to_fasta(dna_sequence: str, header: str, line_width: int = 60) -> str:
     """Formats a DNA sequence into a FASTA formatted string.
@@ -76,7 +82,7 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
 
     lines = fasta_content.splitlines()
 
-    for line_text in lines: # Renamed 'line' to 'line_text' for clarity
+    for line_number, line_text in enumerate(lines, start=1):
         stripped_line = line_text.strip()
         if not stripped_line: # Skip empty or whitespace-only lines
             continue
@@ -88,10 +94,12 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
             
             current_header = stripped_line[1:].strip() # Store header without ">"
             current_sequence_parts = [] # Reset for the new sequence
-        elif current_header is not None: 
+        elif current_header is not None:
             # This is a sequence line for the current active header.
             # Remove all whitespace (leading, trailing, and internal) from the sequence line.
             processed_sequence_line = "".join(stripped_line.split())
+            if not set(processed_sequence_line).issubset(FASTA_ALLOWED_CHARS):
+                raise ValueError(f"Invalid characters on line {line_number}.")
             current_sequence_parts.append(processed_sequence_line)
         # else: If line_text does not start with ">" and no current_header is active,
         #       it's considered content outside a valid FASTA record (e.g., text

--- a/src/genecoder/plotting.py
+++ b/src/genecoder/plotting.py
@@ -6,24 +6,28 @@ rendered to in-memory buffers for display in Flet or other GUI frameworks.
 """
 import io
 import collections
-from typing import Any, Dict, List
+from typing import Dict, List, TYPE_CHECKING
 
 import base64
 
-matplotlib: Any
-plt: Any
-MaxNLocator: Any
-try:  # pragma: no cover - optional dependency
+_MATPLOTLIB_AVAILABLE: bool = False
+
+if TYPE_CHECKING:
     import matplotlib
-    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from matplotlib.ticker import MaxNLocator
-    _MATPLOTLIB_AVAILABLE = True
-except Exception:  # noqa: BLE001 - broader catch for optional import
-    matplotlib = None
-    plt = None
-    MaxNLocator = None
-    _MATPLOTLIB_AVAILABLE = False
+else:
+    try:  # pragma: no cover - optional dependency
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib.ticker import MaxNLocator
+        _MATPLOTLIB_AVAILABLE = True
+    except Exception:  # noqa: BLE001 - broader catch for optional import
+        matplotlib = None  # type: ignore
+        plt = None  # type: ignore
+        MaxNLocator = None  # type: ignore
+        _MATPLOTLIB_AVAILABLE = False
 
 _DUMMY_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -158,3 +158,15 @@ def test_from_fasta_header_with_various_chars():
     content = f">{header}\nATGC"
     expected = [(header, "ATGC")]
     assert from_fasta(content) == expected
+
+
+def test_from_fasta_valid_extended_iupac_characters():
+    content = ">seq_valid\nACGTNRYKMSWBDHV\n"
+    expected = [("seq_valid", "ACGTNRYKMSWBDHV")]
+    assert from_fasta(content) == expected
+
+
+def test_from_fasta_invalid_character_error_line_number():
+    content = ">seq_invalid\nACGT\naXYZ\n"
+    with pytest.raises(ValueError, match="line 3"):
+        from_fasta(content)


### PR DESCRIPTION
## Summary
- validate FASTA lines against allowed characters (now includes `/`)
- refactor optional matplotlib import handling for mypy

## Testing
- `ruff check src/genecoder/formats.py tests/test_formats.py src/genecoder/plotting.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685578d177788326881525698989ac82