### PR TITLE
Add constraint checks for inverted sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - CLI/GUI option ``--alphabet`` supporting ``base4``, ``base5`` and ``base6``.
 - Fixed plugin registration during package installation.
 - Pinned dependencies to stable versions.
+- ``encode_gc_balanced`` now validates the inverted sequence and logs a warning
+  if it still violates GC content or homopolymer limits.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -16,7 +16,11 @@ required.
 """
 
 from typing import Optional, Tuple, cast
+import logging
+
 from .utils import check_homopolymer_length, get_max_homopolymer_length
+
+logger = logging.getLogger(__name__)
 
 def calculate_gc_content(dna_sequence: str) -> float:
     """Calculates the GC content of a DNA sequence.
@@ -41,8 +45,10 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
     Encoding Strategy:
     - Encodes data using `encode_base4_direct`.
     - If constraints (GC content, homopolymer length) are met, returns the sequence prefixed with "0".
-    - If constraints are violated, inverts data bits, re-encodes, and returns prefixed with "1".
-      (Assumes the alternative sequence is better without re-checking constraints).
+    - If constraints are violated, inverts data bits and re-encodes.
+      The alternative sequence is also checked against the constraints. If it
+      still violates them, the sequence is returned prefixed with "1" and a
+      warning is logged.
 
 
     Args:
@@ -68,19 +74,26 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
         # Prefix with ``"0"`` to indicate that the sequence is the direct
         # encoding of ``data`` without any modifications.
         return "0" + initial_sequence
-    else:
-        # The sequence violates the constraints.  As a simple remediation the
-        # bits of ``data`` are inverted using XOR with ``0xFF`` (bitwise NOT for
-        # each byte) and that modified payload is encoded instead.
-        modified_data = bytes(b ^ 0xFF for b in data)
-        alternative_sequence = cast(
-            str, encode_base4_direct(modified_data, add_parity=False)
+
+    # The sequence violates the constraints. As a simple remediation the
+    # bits of ``data`` are inverted using XOR with ``0xFF`` (bitwise NOT for
+    # each byte) and that modified payload is encoded instead.
+    modified_data = bytes(b ^ 0xFF for b in data)
+    alternative_sequence = cast(
+        str, encode_base4_direct(modified_data, add_parity=False)
+    )
+
+    alt_gc_ok = target_gc_min <= calculate_gc_content(alternative_sequence) <= target_gc_max
+    alt_homopolymer_ok = not check_homopolymer_length(alternative_sequence, max_homopolymer)
+    if not (alt_gc_ok and alt_homopolymer_ok):
+        logger.warning(
+            "Inverted sequence violates GC content or homopolymer constraints"
         )
 
-        # ``"1"`` is prepended so the decoder knows to invert the bits again.
-        # A more sophisticated implementation could attempt multiple
-        # alternatives before falling back to this simple inversion.
-        return "1" + alternative_sequence
+    # ``"1"`` is prepended so the decoder knows to invert the bits again.
+    # A more sophisticated implementation could attempt multiple
+    # alternatives before falling back to this simple inversion.
+    return "1" + alternative_sequence
 
 def decode_gc_balanced(
     dna_sequence: str,

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pytest
 import re
+import logging
 from unittest.mock import patch, call  # call is needed for checking multiple calls to a mock
 
 from genecoder.encoders import encode_base4_direct  # noqa: E402
@@ -234,7 +235,7 @@ def test_encode_gc_balanced_initial_ok_alternative_not_used(mock_encode_base4):
 
 # Test for encode_gc_balanced when initial fails GC, alternative is used
 @patch('genecoder.encoders.encode_base4_direct')
-def test_encode_gc_balanced_initial_fails_gc_alternative_used(mock_encode_base4):
+def test_encode_gc_balanced_initial_fails_gc_alternative_used(mock_encode_base4, caplog):
     dummy_data = b"data"
     inverted_dummy_data = bytes(b ^ 0xFF for b in dummy_data)
     # Initial sequence: GC=0.0 (fails 0.4-0.6), max_hp=8
@@ -244,16 +245,20 @@ def test_encode_gc_balanced_initial_fails_gc_alternative_used(mock_encode_base4)
 
     mock_encode_base4.side_effect = [initial_seq, alternative_seq]
     
-    result = encode_gc_balanced(dummy_data, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3)
+    with caplog.at_level(logging.WARNING):
+        result = encode_gc_balanced(
+            dummy_data, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3
+        )
     
     assert result == "1" + alternative_seq
     assert mock_encode_base4.call_count == 2
     mock_encode_base4.assert_any_call(dummy_data, add_parity=False)
     mock_encode_base4.assert_any_call(inverted_dummy_data, add_parity=False)
+    assert not caplog.records
 
 # Test for encode_gc_balanced when initial fails homopolymer, alternative is used
 @patch('genecoder.encoders.encode_base4_direct')
-def test_encode_gc_balanced_initial_fails_homopolymer_alternative_used(mock_encode_base4):
+def test_encode_gc_balanced_initial_fails_homopolymer_alternative_used(mock_encode_base4, caplog):
     dummy_data = b"data"
     inverted_dummy_data = bytes(b ^ 0xFF for b in dummy_data)
     # Initial sequence: GC=0.5 (ok), max_hp=4 (fails max_homopolymer=3)
@@ -263,13 +268,17 @@ def test_encode_gc_balanced_initial_fails_homopolymer_alternative_used(mock_enco
 
 
     mock_encode_base4.side_effect = [initial_seq, alternative_seq]
-    
-    result = encode_gc_balanced(dummy_data, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3)
+
+    with caplog.at_level(logging.WARNING):
+        result = encode_gc_balanced(
+            dummy_data, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3
+        )
     
     assert result == "1" + alternative_seq
     assert mock_encode_base4.call_count == 2
     mock_encode_base4.assert_any_call(dummy_data, add_parity=False)
     mock_encode_base4.assert_any_call(inverted_dummy_data, add_parity=False)
+    assert not caplog.records
 
 # Test encode_gc_balanced with empty data
 def test_encode_gc_balanced_empty_data():
@@ -310,7 +319,7 @@ def test_get_max_homopolymer_length_single_char():
 # The function should still return the alternative sequence rather than erroring
 # even if it doesn't meet the GC or homopolymer limits.
 @patch('genecoder.encoders.encode_base4_direct')
-def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4):
+def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4, caplog):
 
     dummy_data = b"test"
     inverted_dummy_data = bytes(b ^ 0xFF for b in dummy_data)
@@ -324,7 +333,8 @@ def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4):
     target_gc_max = 0.6
     max_homopolymer = 3
 
-    result = encode_gc_balanced(dummy_data, target_gc_min, target_gc_max, max_homopolymer)
+    with caplog.at_level(logging.WARNING):
+        result = encode_gc_balanced(dummy_data, target_gc_min, target_gc_max, max_homopolymer)
 
     assert result.startswith("1")  # current logic always picks alternative if initial fails
     assert result[1:] == alternative_sequence
@@ -335,6 +345,7 @@ def test_encode_gc_balanced_both_fail_picks_alternative(mock_encode_base4):
         call(dummy_data, add_parity=False),
         call(inverted_dummy_data, add_parity=False)
     ])
+    assert any("Inverted sequence violates" in rec.message for rec in caplog.records)
 
 # Test decode_gc_balanced with optional arguments passed (though not used by current logic)
 def test_decode_gc_balanced_with_optional_args():


### PR DESCRIPTION
## Summary
- ensure `encode_gc_balanced` validates GC content and homopolymers for the inverted sequence
- warn when the inverted sequence still fails
- test warning behaviour and confirm no warnings when constraints are met
- document new behaviour in the changelog

## Testing
- `ruff check src/genecoder/gc_constrained_encoder.py tests/test_gc_constrained_encoder.py`
- `pytest -q tests/test_gc_constrained_encoder.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685578c4d7c88326bda0d55628ffbbc0