### PR TITLE
Refine exception handling

### DIFF
--- a/src/genecoder/cli/analyze.py
+++ b/src/genecoder/cli/analyze.py
@@ -84,10 +84,8 @@ def process_single_analyze(input_file_path: str, args: argparse.Namespace) -> No
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")
-    except Exception:
-        logger.exception(
-            "Error for %s: Unexpected error during analysis", input_file_path
-        )
+    except (OSError, ValueError) as exc:
+        logger.error("Error for %s: %s", input_file_path, exc)
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -96,8 +96,8 @@ def _handle_sim_errors(args: argparse.Namespace) -> None:
     except FileNotFoundError:
         logger.error(f"Error: Input file {args.input_file} not found.")
         raise SystemExit(1)
-    except Exception:
-        logger.exception("Error during simulate-errors")
+    except ValueError as exc:
+        logger.error("Error during simulate-errors: %s", exc)
         raise SystemExit(1)
 
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -208,10 +208,8 @@ def process_single_decode(
         logger.error(f"Error for {input_file_path}: Input file not found.")
     except IOError as e:
         logger.error(f"Error for {input_file_path}: I/O error: {e}")
-    except Exception:
-        logger.exception(
-            "Error for %s: Unexpected error during decoding", input_file_path
-        )
+    except ValueError as exc:
+        logger.error("Error for %s: %s", input_file_path, exc)
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/src/genecoder/plotting.py
+++ b/src/genecoder/plotting.py
@@ -10,14 +10,19 @@ from typing import Any, Dict, List
 
 import base64
 
+# "matplotlib" is optional, so import it under an alias to avoid mypy
+# redefinition errors when the import succeeds.
 matplotlib: Any
 plt: Any
 MaxNLocator: Any
 try:  # pragma: no cover - optional dependency
-    import matplotlib
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-    from matplotlib.ticker import MaxNLocator
+    import matplotlib as _mpl
+    _mpl.use("Agg")
+    import matplotlib.pyplot as _plt
+    from matplotlib.ticker import MaxNLocator as _MaxNLocator
+    matplotlib = _mpl
+    plt = _plt
+    MaxNLocator = _MaxNLocator
     _MATPLOTLIB_AVAILABLE = True
 except Exception:  # noqa: BLE001 - broader catch for optional import
     matplotlib = None

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -1,0 +1,81 @@
+import argparse
+from pathlib import Path
+import pytest
+
+from genecoder.cli.analyze import process_single_analyze
+from genecoder.cli.decode import process_single_decode
+from genecoder.cli.cli import _handle_sim_errors
+from genecoder.formats import to_fasta
+
+
+def _decode_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        method="base4_direct",
+        check_parity=False,
+        k_value=7,
+        parity_rule="gc_even_a_odd_t",
+        alphabet="base4",
+        stream=False,
+        simulate_errors=0.0,
+        simulator="none",
+    )
+
+
+def _analyze_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        window_size=4,
+        step=2,
+        min_homopolymer=3,
+        plot_dir=None,
+    )
+
+
+def _sim_args(input_file: Path, output_file: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        input_file=str(input_file),
+        output_file=str(output_file),
+        sub_prob=0.1,
+        ins_prob=0.0,
+        del_prob=0.0,
+        seed=None,
+    )
+
+
+def test_process_single_decode_unexpected_error(monkeypatch, tmp_path: Path) -> None:
+    fasta_file = tmp_path / "x.fasta"
+    fasta_file.write_text(to_fasta("ATGC", "seq1 method=base4_direct"))
+    args = _decode_args()
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("genecoder.cli.decode.run_decoding_pipeline", boom)
+    with pytest.raises(RuntimeError):
+        process_single_decode(str(fasta_file), str(tmp_path / "out.bin"), args)
+
+
+def test_process_single_analyze_unexpected_error(monkeypatch, tmp_path: Path) -> None:
+    fasta_file = tmp_path / "a.fasta"
+    fasta_file.write_text(to_fasta("ATGC", "seq1"))
+    args = _analyze_args()
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("genecoder.cli.analyze.calculate_gc_content", boom)
+    with pytest.raises(RuntimeError):
+        process_single_analyze(str(fasta_file), args)
+
+
+def test_handle_sim_errors_unexpected_error(monkeypatch, tmp_path: Path) -> None:
+    inp = tmp_path / "i.fasta"
+    inp.write_text(to_fasta("ATGC", "seq1"))
+    out = tmp_path / "o.fasta"
+    args = _sim_args(inp, out)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("genecoder.error_simulation.introduce_errors", boom)
+    with pytest.raises(RuntimeError):
+        _handle_sim_errors(args)


### PR DESCRIPTION
## Summary
- narrow broad `except Exception` handlers in CLI helpers
- catch specific errors when simulating CLI errors
- test that unexpected exceptions propagate from CLI helpers
- fix optional matplotlib import to prevent mypy redefinition warnings

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src/genecoder/cli/analyze.py src/genecoder/cli/decode.py src/genecoder/cli/cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685578c807d48326956c74b188a276f1