### PR TITLE
Handle missing external simulators

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -47,6 +47,8 @@ def _simulate_adapter(
                 command,
                 exc.returncode,
             )
+    else:
+        logger.warning("%s not found; falling back to simple error model", command)
     # use a deterministic local RNG for external simulators and forward it when
     # falling back to :func:`simulate_errors` so calls remain reproducible
     if rng is None:

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -86,6 +86,35 @@ def test_adapters_external_error(monkeypatch, caplog, name):
     assert any("falling back" in rec.message for rec in caplog.records)
 
 
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_adapters_command_not_found_warning(monkeypatch, caplog, name):
+    func, cmd = ADAPTERS[name]
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda target: None)
+
+    def boom(*_):
+        raise AssertionError("_run_external should not be called")
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", boom)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng))
+        or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT")
+
+    assert result == "fallback"
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any(
+        rec.levelno == logging.WARNING and "not found" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_simulate_reads_dispatch(monkeypatch):
     called = []
     def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:


### PR DESCRIPTION
## Summary
- log when an external simulator command isn't found
- add unit test for missing command warnings
- ensure warning level is correct in tests

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685578cb668883268210bd6371fc934b