### PR TITLE
Improve coverage for error handling paths

### DIFF
--- a/src/genecoder/plotting.py
+++ b/src/genecoder/plotting.py
@@ -6,7 +6,7 @@ rendered to in-memory buffers for display in Flet or other GUI frameworks.
 """
 import io
 import collections
-from typing import Dict, List, TYPE_CHECKING
+from typing import Any, Dict, List
 
 import base64
 

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -138,3 +138,14 @@ def test_hamming_missing_padding_bits():
 def test_decoding_no_fasta_records():
     with pytest.raises(ValueError, match="No valid FASTA records found"):
         perform_decoding("")
+
+
+def test_perform_encoding_unknown_method():
+    with pytest.raises(ValueError, match="Unknown method"):  # type: ignore[call-arg]
+        perform_encoding(b"data", EncodeOptions(method="bogus"))
+
+
+def test_perform_decoding_unknown_method():
+    fasta = ">method=bogus\nACGT\n"
+    with pytest.raises(ValueError, match="decoding method"):
+        perform_decoding(fasta)

--- a/tests/test_cache_dna.py
+++ b/tests/test_cache_dna.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from genecoder.cache_dna import write_capsule
+
+
+def test_write_capsule(tmp_path: Path) -> None:
+    path = tmp_path / "capsules" / "capsule.capsule"
+    metadata = {"foo": "bar"}
+    write_capsule("ACGT", "header", metadata, str(path))
+
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["version"] == 1
+    assert data["header"] == "header"
+    assert data["sequence"] == "ACGT"
+    assert data["metadata"] == metadata
+    assert "created" in data

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -143,3 +143,7 @@ def test_simulate_reads_preserves_global_rng(monkeypatch):
     assert before == expected_first
     assert after == expected_second
 
+
+def test_simulate_reads_unknown_simulator():
+    with pytest.raises(ValueError, match="Unknown simulator"):
+        nanopore_sim.simulate_reads("ACGT", "bogus")


### PR DESCRIPTION
## Summary
- add unit test for `write_capsule`
- test `simulate_reads` with an unknown simulator
- check error messages for invalid encode/decode methods
- fix missing `Any` import in plotting module

## Testing
- `ruff check tests/test_cache_dna.py tests/test_nanopore_sim.py tests/test_app_helpers.py src/genecoder/plotting.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685593568a98832692aa01c723dff3fe