### PR TITLE
Add probability sum validation

### DIFF
--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -38,7 +38,7 @@ def introduce_errors(
     ------
     ValueError
         If any of ``substitution_prob``, ``insertion_prob`` or ``deletion_prob``
-        is outside the range [0.0, 1.0].
+        is outside the range [0.0, 1.0] or if their sum exceeds 1.0.
 
     Returns
     -------
@@ -51,6 +51,8 @@ def introduce_errors(
         raise ValueError("insertion_prob must be between 0 and 1")
     if not 0.0 <= deletion_prob <= 1.0:
         raise ValueError("deletion_prob must be between 0 and 1")
+    if substitution_prob + insertion_prob + deletion_prob > 1.0:
+        raise ValueError("sum of error probabilities must not exceed 1")
 
     if rng is None:
         rng = random.Random()

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -57,16 +57,25 @@ def test_introduce_errors_combined_operations():
     rng = random.Random(1)
     result = introduce_errors(
         "AT",
-        substitution_prob=0.5,
-        insertion_prob=0.5,
-        deletion_prob=0.5,
+        substitution_prob=0.3,
+        insertion_prob=0.3,
+        deletion_prob=0.3,
         rng=rng,
     )
     assert result == "TG"
 
 
 def test_introduce_errors_empty_sequence():
-    assert introduce_errors("", substitution_prob=1.0, insertion_prob=1.0, deletion_prob=1.0, rng=random.Random(0)) == ""
+    assert (
+        introduce_errors(
+            "",
+            substitution_prob=1.0,
+            insertion_prob=0.0,
+            deletion_prob=0.0,
+            rng=random.Random(0),
+        )
+        == ""
+    )
 
 
 @pytest.mark.parametrize(
@@ -84,3 +93,14 @@ def test_introduce_errors_invalid_probabilities(kw: str, value: float) -> None:
     kwargs = {kw: value, "rng": random.Random(0)}
     with pytest.raises(ValueError):
         introduce_errors("A", **kwargs)
+
+
+def test_introduce_errors_probability_sum_exceeds_one() -> None:
+    with pytest.raises(ValueError):
+        introduce_errors(
+            "A",
+            substitution_prob=0.6,
+            insertion_prob=0.3,
+            deletion_prob=0.2,
+            rng=random.Random(0),
+        )


### PR DESCRIPTION
## Summary
- validate total error probability in `introduce_errors`
- update tests for new validation rule

## Testing
- `ruff check --fix src/genecoder/error_simulation.py tests/test_error_simulation.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d0d2d4308326a3bd078041addf9d