### PR TITLE
Narrow exception handling in process_single_encode

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -327,6 +327,7 @@ def process_single_encode(
         logger.exception(
             "Error for %s: Unexpected error during encoding", input_file_path
         )
+        raise
     return None
 
 


### PR DESCRIPTION
## Summary
- re-raise unexpected exceptions in `process_single_encode`

## Testing
- `pre-commit run --files src/genecoder/cli/encode.py`
- `pytest -q`
- `mypy --config-file mypy.ini src`

------
https://chatgpt.com/codex/tasks/task_e_6855d0d3d1ec8326be23bf0ff7209158