### PR TITLE
Add d2sim simulator adapter

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,9 +122,15 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    Install the desired simulator separately and ensure the command is on your
    ``PATH``:
 
-   * ``d2sim`` — [D2Sim](https://github.com/kurimsw/d2sim)
+   * ``d2sim`` — [D2Sim](https://github.com/kurimsw/d2sim). Follow the
+     instructions in the repository to build the binary and place ``d2sim`` on
+     your ``PATH``.
    * ``dnarsim`` — [DNArSim](https://github.com/Purdue-ScottLab/DNArSim)
    * ``squigulator`` — [Squigulator](https://github.com/hasindu2008/squigulator)
+
+   The ``d2sim`` adapter is bundled with GeneCoder and is registered
+   automatically. Once the ``d2sim`` command is available you can invoke it with
+   ``--simulator d2sim``.
 
    When a command is missing GeneCoder automatically falls back to an internal
    error model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ fountain = "genecoder.fountain_codec"
 
 [project.entry-points."genecoder.simulators"]
 nanopore = "genecoder.nanopore_sim"
+d2sim = "genecoder.d2sim_adapter"
 
 [project.urls]
 Homepage = "https://github.com/d0tTino/GeneCoder"

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -1,0 +1,23 @@
+"""Adapter for the optional ``d2sim`` read simulator."""
+from __future__ import annotations
+
+import random
+from typing import Callable, Any
+
+from .nanopore_sim import _simulate_adapter
+
+
+def simulate_d2sim(
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+) -> str:
+    """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
+
+    return _simulate_adapter("d2sim", sequence, error_rate, rng)
+
+
+def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+    """Register the ``d2sim`` simulator."""
+
+    register_simulator("d2sim", simulate_d2sim)

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -1,0 +1,102 @@
+import logging
+import random
+import subprocess
+
+from genecoder import d2sim_adapter, nanopore_sim
+
+
+
+def test_run_external(monkeypatch):
+    which_called = []
+    run_called = []
+
+    def fake_which(target):
+        which_called.append(target)
+        return "/usr/bin/" + target
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        return "external"
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+
+    result = d2sim_adapter.simulate_d2sim("ACGT")
+    assert result == "external"
+    assert which_called == ["d2sim"]
+    assert run_called == [("d2sim", "ACGT")]
+
+
+def test_fall_back(monkeypatch):
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(
+        nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None
+    )
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+
+    result = d2sim_adapter.simulate_d2sim("ACGT", error_rate=0.1)
+    assert result == "fallback"
+    assert which_called == ["d2sim"]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+
+
+def test_external_error(monkeypatch, caplog):
+    which_called = []
+    run_called = []
+    errors_called = []
+
+    monkeypatch.setattr(
+        nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t
+    )
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = d2sim_adapter.simulate_d2sim("ACGT", error_rate=0.2)
+
+    assert result == "fallback"
+    assert which_called == ["d2sim"]
+    assert run_called == [("d2sim", "ACGT")]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any("falling back" in rec.message for rec in caplog.records)
+
+
+def test_command_not_found_warning(monkeypatch, caplog):
+    errors_called = []
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: None)
+
+    def boom(*_):
+        raise AssertionError("_run_external should not be called")
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", boom)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = d2sim_adapter.simulate_d2sim("ACGT")
+
+    assert result == "fallback"
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any(
+        rec.levelno == logging.WARNING and "not found" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add `d2sim_adapter` module exposing a `simulate_d2sim` function
- register adapter via `genecoder.simulators` entry point
- document how to install and use `d2sim` in the usage guide
- include unit tests for the adapter

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ee227ce08326a85ef5898797d4d1