### PR TITLE
Add pip editable install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Install optional extras for the GUI or web API with:
 poetry install --with gui,web --no-interaction
 ```
 
+Alternatively, use `pip` with **Python 3.10+** to install the project in
+editable mode:
+
+```bash
+python -m pip install -e .[gui,web]
+```
+
 Desktop packages are available on the [releases page](https://github.com/d0tTino/GeneCoder/releases).
 Download the `.msix` file for Windows or the `.dmg` for macOS and follow your
 platform's standard installation prompts.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,15 @@ Install optional extras with the `--with` flag:
 poetry install --with gui,web --no-interaction
 ```
 
+## Editable install with pip
+
+If you prefer `pip`, ensure you are using **Python 3.10+** and install the
+repository in editable mode so changes take effect immediately:
+
+```bash
+python -m pip install -e .[gui,web]
+```
+
 ## Development Setup
 
 Install the project in editable mode so local changes are picked up immediately:


### PR DESCRIPTION
## Summary
- document how to install in editable mode using pip
- update README quick start with the pip command

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_685603066e808326839b9d8f697c6d11