### PR TITLE
Add direct _D2SIM.run test

### DIFF
--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 import random
 from typing import Callable, Any
 
-from .nanopore_sim import _simulate_adapter
+from .nanopore_sim import _simulate_adapter, _run_external
+
+
+class _D2SIM:
+    """Internal helper to invoke the :mod:`d2sim` binary."""
+
+    command = "d2sim"
+
+    @staticmethod
+    def run(sequence: str) -> str:
+        """Run ``d2sim`` on ``sequence`` via :func:`_run_external`."""
+
+        return _run_external(_D2SIM.command, sequence)
 
 
 def simulate_d2sim(

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -100,3 +100,17 @@ def test_command_not_found_warning(monkeypatch, caplog):
         rec.levelno == logging.WARNING and "not found" in rec.message
         for rec in caplog.records
     )
+
+
+def test_d2sim_class_run(monkeypatch):
+    called = []
+
+    def fake_run_external(cmd, seq):
+        called.append((cmd, seq))
+        return "ok"
+
+    monkeypatch.setattr(d2sim_adapter, "_run_external", fake_run_external)
+
+    result = d2sim_adapter._D2SIM.run("ACGT")
+    assert result == "ok"
+    assert called == [("d2sim", "ACGT")]


### PR DESCRIPTION
## Summary
- add `_D2SIM` helper class for running the `d2sim` binary
- test direct call of `_D2SIM.run` with a mocked `_run_external`

## Testing
- `pre-commit run --files src/genecoder/d2sim_adapter.py tests/test_d2sim_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_685609d39054832693049e9cf33fa285