### PR TITLE
Include error rate when invoking d2sim

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ from .channel_sim import simulate_errors
 from .formats import from_fasta, to_fasta
 
 
-def _run_external(command: str, sequence: str) -> str:
+def _run_external(command: Sequence[str] | str, sequence: str) -> str:
     """Run an external simulator command on ``sequence``.
 
     The command must accept an input FASTA file and output FASTA to a
@@ -26,7 +26,8 @@ def _run_external(command: str, sequence: str) -> str:
         input_path = Path(tmpdir) / "input.fasta"
         output_path = Path(tmpdir) / "output.fasta"
         input_path.write_text(to_fasta(sequence, "seq"))
-        subprocess.run([command, str(input_path), str(output_path)], check=True)
+        cmd_list = [command] if isinstance(command, str) else list(command)
+        subprocess.run(cmd_list + [str(input_path), str(output_path)], check=True)
         records = from_fasta(output_path.read_text())
         if not records:
             raise RuntimeError(f"{command} produced no FASTA output")
@@ -40,7 +41,10 @@ def _simulate_adapter(
     """Return ``sequence`` processed by an external ``command`` if available."""
     if shutil.which(command):
         try:
-            return _run_external(command, sequence)
+            cmd_list = [command]
+            if command == "d2sim":
+                cmd_list += ["-e", str(error_rate)]
+            return _run_external(cmd_list, sequence)
         except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
             logger.warning(
                 "%s failed with return code %s; falling back to simple error model",

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -24,7 +24,7 @@ def test_run_external(monkeypatch):
     result = d2sim_adapter.simulate_d2sim("ACGT")
     assert result == "external"
     assert which_called == ["d2sim"]
-    assert run_called == [("d2sim", "ACGT")]
+    assert run_called == [(["d2sim", "-e", "0.05"], "ACGT")]
 
 
 def test_fall_back(monkeypatch):
@@ -72,7 +72,7 @@ def test_external_error(monkeypatch, caplog):
 
     assert result == "fallback"
     assert which_called == ["d2sim"]
-    assert run_called == [("d2sim", "ACGT")]
+    assert run_called == [(["d2sim", "-e", "0.2"], "ACGT")]
     assert errors_called and isinstance(errors_called[0][2], random.Random)
     assert any("falling back" in rec.message for rec in caplog.records)
 

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -32,7 +32,8 @@ def test_adapters_run_external(monkeypatch, name):
     result = func("ACGT")
     assert result == "external"
     assert which_called == [cmd]
-    assert run_called == [(cmd, "ACGT")]
+    expected = ([cmd, "-e", "0.05"], "ACGT") if cmd == "d2sim" else ([cmd], "ACGT")
+    assert run_called == [expected]
 
 
 @pytest.mark.parametrize("name", ADAPTERS.keys())
@@ -81,7 +82,8 @@ def test_adapters_external_error(monkeypatch, caplog, name):
 
     assert result == "fallback"
     assert which_called == [cmd]
-    assert run_called == [(cmd, "ACGT")]
+    expected = ([cmd, "-e", "0.2"], "ACGT") if cmd == "d2sim" else ([cmd], "ACGT")
+    assert run_called == [expected]
     assert errors_called and isinstance(errors_called[0][2], random.Random)
     assert any("falling back" in rec.message for rec in caplog.records)
 


### PR DESCRIPTION
## Summary
- let `_run_external` accept a command list
- forward `error_rate` to d2sim via `-e` option in `_simulate_adapter`
- adjust tests for the new parameter forwarding

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685609d4127883268f0f1dc0c6e995e1