### PR TITLE
Fix AST parsing to not inherit future flags

### DIFF
--- a/scripts/only_comments_changed.py
+++ b/scripts/only_comments_changed.py
@@ -31,7 +31,13 @@ def _ast_without_docstrings(source: str) -> str | None:
     """Return AST dump without docstrings."""
 
     try:
-        tree = ast.parse(source)
+        tree = compile(
+            source,
+            "<string>",
+            "exec",
+            flags=ast.PyCF_ONLY_AST,
+            dont_inherit=True,
+        )
     except SyntaxError:
         return None
 

--- a/tests/test_only_comments_changed.py
+++ b/tests/test_only_comments_changed.py
@@ -1,9 +1,15 @@
+from __future__ import barry_as_FLUFL
+
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from scripts.only_comments_changed import _is_triple_quoted, only_comments_changed
+from scripts.only_comments_changed import (
+    _ast_without_docstrings,
+    _is_triple_quoted,
+    only_comments_changed,
+)
 import io
 import tokenize
 
@@ -110,3 +116,9 @@ def test_is_triple_quoted_detection() -> None:
 def test_is_triple_quoted_negative() -> None:
     tok = next(tokenize.generate_tokens(io.StringIO('"hi"').readline))
     assert not _is_triple_quoted(tok)
+
+
+def test_ast_parsing_dont_inherit() -> None:
+    """``_ast_without_docstrings`` should not inherit future flags."""
+    source = "a <> b"
+    assert _ast_without_docstrings(source) is None


### PR DESCRIPTION
## Summary
- use `compile()` with `dont_inherit=True` in `only_comments_changed`
- test the behaviour when future flags are active

## Testing
- `pre-commit run --files scripts/only_comments_changed.py tests/test_only_comments_changed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685616b1ef948326ad403cef6b92eb2d