### PR TITLE
Add FASTA lowercase validation

### DIFF
--- a/src/genecoder/formats.py
+++ b/src/genecoder/formats.py
@@ -75,6 +75,10 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
         >>> fasta_data = ">seq1 description1\\nAT GC\\nCGTA\\n>seq2\\nTT TT\\nAAAA"
         >>> from_fasta(fasta_data)
         [('seq1 description1', 'ATGCCGTA'), ('seq2', 'TTTTAAAA')]
+
+    Raises:
+        ValueError: If any sequence line contains lowercase letters or
+            characters not present in :data:`FASTA_ALLOWED_CHARS`.
     """
     records: List[Tuple[str, str]] = []
     current_header: str | None = None
@@ -98,7 +102,10 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
             # This is a sequence line for the current active header.
             # Remove all whitespace (leading, trailing, and internal) from the sequence line.
             processed_sequence_line = "".join(stripped_line.split())
-            if not set(processed_sequence_line).issubset(FASTA_ALLOWED_CHARS):
+            if (
+                any(ch.islower() for ch in processed_sequence_line)
+                or not set(processed_sequence_line).issubset(FASTA_ALLOWED_CHARS)
+            ):
                 raise ValueError(f"Invalid characters on line {line_number}.")
             current_sequence_parts.append(processed_sequence_line)
         # else: If line_text does not start with ">" and no current_header is active,

--- a/tests/test_fasta_validation.py
+++ b/tests/test_fasta_validation.py
@@ -1,0 +1,8 @@
+import pytest
+from genecoder.formats import from_fasta
+
+
+def test_from_fasta_lowercase_error_line_number():
+    content = ">seqX\nACGT\natgc\n"
+    with pytest.raises(ValueError, match="line 3"):
+        from_fasta(content)


### PR DESCRIPTION
## Summary
- check for lowercase characters when parsing FASTA
- raise ValueError with line numbers when invalid lines are found
- test parsing errors on lowercase FASTA lines

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578ccca1348326aadcaee0523c0e12