### PR TITLE
Enforce required manifest fields

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,18 @@
+# Manifest Format
+
+Each encoded file generates a JSON manifest describing the encoding process.
+The manifest has three top-level keys:
+
+```json
+{
+  "file": "<input file name>",
+  "encoding_parameters": {
+    "method": "<encoding method>"
+  },
+  "metrics": {}
+}
+```
+
+`encoding_parameters` must at least contain a `method` field identifying the
+encoder used. Additional keys mirror the options supplied on the CLI or GUI.
+If required keys are missing an error will be raised when creating the manifest.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,6 +157,8 @@ Example snippet:
 }
 ```
 
+See [Manifest Format](manifest.md) for the full structure and required keys.
+
 
 
 ### Capsule output

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - Getting Started:
       - Installation: installation.md
       - Usage Guide: usage.md
+      - Manifest Format: manifest.md
   - Project Overview:
       - Vision & Core Concept: vision.md
       - Implemented Features: features.md

--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any, Mapping
 
+REQUIRED_ENCODING_KEYS: set[str] = {"method"}
+
 
 def generate_manifest(
     file_name: str,
@@ -16,6 +18,13 @@ def generate_manifest(
         params = asdict(encoding_params)
     else:
         params = dict(encoding_params)
+
+    missing = REQUIRED_ENCODING_KEYS - params.keys()
+    if missing:
+        raise ValueError(
+            f"Missing required encoding parameters: {', '.join(sorted(missing))}"
+        )
+
     return {
         "file": file_name,
         "encoding_parameters": params,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+
+import pytest
+
 from genecoder.manifest import generate_manifest
 from genecoder.cli import EncodingOptions
 
@@ -36,3 +40,18 @@ def test_generate_manifest_from_mapping() -> None:
     assert manifest["file"] == "data.bin"
     assert manifest["encoding_parameters"]["method"] == "huffman"
     assert manifest["metrics"]["num_records"] == 1
+
+
+def test_generate_manifest_missing_method_mapping() -> None:
+    opts = {"add_parity": False}
+    with pytest.raises(ValueError):
+        generate_manifest("file.txt", opts, {})
+
+
+def test_generate_manifest_missing_method_dataclass() -> None:
+    @dataclass
+    class BadOpts:
+        add_parity: bool
+
+    with pytest.raises(ValueError):
+        generate_manifest("file.txt", BadOpts(False), {})


### PR DESCRIPTION
## Summary
- ensure `generate_manifest` requires required encoding keys
- document manifest format and reference docs in usage guide
- integrate manifest doc in MkDocs navigation
- reject missing `method` via tests

## Testing
- `poetry run pre-commit run --files src/genecoder/manifest.py tests/test_manifest.py mkdocs.yml docs/usage.md docs/manifest.md`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578ccbe4288326912800c0d5fd4b24