### PR TITLE
Add decoder simulator validation

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -174,7 +174,13 @@ def process_single_decode(
                 )
                 raise SystemExit(1)
 
-        if args.simulator in SIMULATOR_REGISTRY:
+        if args.simulator not in SIMULATOR_REGISTRY:
+            logger.error(
+                f"Error for {input_file_path}: Unknown simulator '{args.simulator}'."
+            )
+            raise SystemExit(1)
+
+        if args.simulator != "none":
             simulate_func = SIMULATOR_REGISTRY[args.simulator]
             sequence_from_fasta = simulate_func(sequence_from_fasta)
             logger.info(

--- a/tests/test_cli_output_paths.py
+++ b/tests/test_cli_output_paths.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from pathlib import Path
+import pytest
 
 from genecoder.cli.encode import process_single_encode
 from genecoder.cli.decode import process_single_decode
@@ -65,4 +66,18 @@ def test_process_single_decode_no_directory(tmp_path: Path) -> None:
     finally:
         os.chdir(cwd)
     assert (tmp_path / "decoded.bin").read_text() == "world"
+
+
+def test_process_single_decode_unknown_simulator(tmp_path: Path) -> None:
+    infile = tmp_path / "data.bin"
+    infile.write_text("abc")
+    enc_args = _encode_args()
+    fasta = tmp_path / "enc.fasta"
+    process_single_encode(str(infile), str(fasta), enc_args)
+
+    dec_args = _decode_args()
+    dec_args.simulator = "bogus"
+    with pytest.raises(SystemExit) as exc:
+        process_single_decode(str(fasta), str(tmp_path / "out.bin"), dec_args)
+    assert exc.value.code != 0
 


### PR DESCRIPTION
## Summary
- abort decode if simulator argument isn't registered
- test process_single_decode error path for unknown simulator

## Testing
- `pre-commit run --files src/genecoder/cli/decode.py tests/test_cli_output_paths.py`

------
https://chatgpt.com/codex/tasks/task_e_68578cc79e248326863fbff6235bae7c