### PR TITLE
Fix Huffman parameter validation

### DIFF
--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -131,10 +131,10 @@ def perform_encoding(data: bytes, options: EncodeOptions) -> EncodeResult:
         header_parts.extend(
             [f"parity_k={options.k_value}", f"parity_rule={PARITY_RULE_GC_EVEN_A_ODD_T}"]
         )
+    params = None
     if method == "Huffman" and huffman_table:
         serializable = {str(k): v for k, v in huffman_table.items()}
         params = {"table": serializable, "padding": num_padding_bits}
-        header_parts.append(f"huffman_params={json.dumps(params)}")
     elif method == "GC-Balanced":
         header_parts.extend([
             f"gc_min={options.gc_min}",
@@ -149,6 +149,9 @@ def perform_encoding(data: bytes, options: EncodeOptions) -> EncodeResult:
     elif options.fec_method == "Reed-Solomon":
         header_parts.append("fec=reed_solomon")
         header_parts.append(f"fec_nsym={rs_nsym}")
+
+    if params is not None:
+        header_parts.append(f"huffman_params={json.dumps(params)}")
 
     fasta_header = " ".join(header_parts)
     fasta_str = to_fasta(final_dna, fasta_header, 80)
@@ -234,9 +237,12 @@ def perform_decoding(fasta_data: str, alphabet: str = "base4") -> DecodeResult:
         json_field = header.split("huffman_params=", 1)[1]
         decoder = json.JSONDecoder()
         try:
-            params, _ = decoder.raw_decode(json_field)
+            params, idx = decoder.raw_decode(json_field)
         except json.JSONDecodeError as exc:
             raise ValueError("Invalid Huffman parameters") from exc
+
+        if json_field[idx:].strip():
+            raise ValueError("Invalid Huffman parameters")
 
         table_str = params.get("table")
         num_padding_bits = params.get("padding")

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -58,6 +58,16 @@ def test_decoding_invalid_huffman_json():
         perform_decoding(fasta)
 
 
+def test_decoding_huffman_extra_text_after_json():
+    fasta = (
+        ">method=huffman input_file=x "
+        "huffman_params={\"table\":{\"65\":\"0\"},\"padding\":0} extratext\n"
+        "AAAA\n"
+    )
+    with pytest.raises(ValueError):
+        perform_decoding(fasta)
+
+
 def test_decoding_missing_rs_nsym():
     if not _HAS_REEDSOLO:
         pytest.skip("reedsolo not installed")


### PR DESCRIPTION
## Summary
- ensure Huffman JSON has no trailing text
- append `huffman_params` after FEC header fields
- test decoding a header with extra text

## Testing
- `pre-commit run --files src/genecoder/app_helpers.py tests/test_app_helpers.py`
- `pytest -k huffman_extra_text_after_json -q`

------
https://chatgpt.com/codex/tasks/task_e_68578cc0378483269498d5d9091e6e82