### PR TITLE
Improve capsule parsing error handling

### DIFF
--- a/src/genecoder/cache_dna.py
+++ b/src/genecoder/cache_dna.py
@@ -62,4 +62,11 @@ def read_capsule(path: str) -> Capsule:
         raise OSError(f"Could not read capsule file: {path}") from exc
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid capsule file: {path}") from exc
-    return Capsule(**data)
+
+    if not isinstance(data, dict):
+        raise ValueError("Invalid capsule file structure")
+
+    try:
+        return Capsule(**data)
+    except TypeError as exc:
+        raise ValueError("Invalid capsule file structure") from exc

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -99,6 +99,13 @@ def test_read_capsule_malformed(tmp_path: Path) -> None:
         read_capsule(str(path))
 
 
+def test_read_capsule_bad_structure(tmp_path: Path) -> None:
+    path = tmp_path / "struct.capsule"
+    path.write_text("[]")
+    with pytest.raises(ValueError, match="Invalid capsule file structure"):
+        read_capsule(str(path))
+
+
 def test_read_capsule_missing(tmp_path: Path) -> None:
     path = tmp_path / "missing.capsule"
     with pytest.raises(FileNotFoundError, match="Capsule file not found"):


### PR DESCRIPTION
## Summary
- validate that capsule JSON is a mapping before dataclass instantiation
- raise `ValueError` for bad capsule structures

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578cbbd9388326940d1f8b10e7a7c9