### PR TITLE
Update manifest generation validation

### DIFF
--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -11,11 +11,17 @@ def generate_manifest(
     encoding_params: Any,
     metrics: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Return a manifest dictionary for an encoded file."""
+    """Return a manifest dictionary for an encoded file.
+
+    ``encoding_params`` may be either a dataclass instance or a mapping. Passing
+    anything else will raise :class:`ValueError`.
+    """
     if is_dataclass(encoding_params) and not isinstance(encoding_params, type):
         params = asdict(encoding_params)
-    else:
+    elif isinstance(encoding_params, Mapping):
         params = dict(encoding_params)
+    else:
+        raise ValueError("encoding_params must be a dataclass or mapping")
     return {
         "file": file_name,
         "encoding_parameters": params,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,3 +1,5 @@
+import pytest
+
 from genecoder.manifest import generate_manifest
 from genecoder.cli import EncodingOptions
 
@@ -36,3 +38,13 @@ def test_generate_manifest_from_mapping() -> None:
     assert manifest["file"] == "data.bin"
     assert manifest["encoding_parameters"]["method"] == "huffman"
     assert manifest["metrics"]["num_records"] == 1
+
+
+def test_generate_manifest_invalid_type() -> None:
+    with pytest.raises(ValueError, match="encoding_params must be a dataclass or mapping"):
+        generate_manifest("bad.txt", ["not", "mapping"], {"dna_length": 1})
+
+
+def test_generate_manifest_dataclass_type() -> None:
+    with pytest.raises(ValueError, match="encoding_params must be a dataclass or mapping"):
+        generate_manifest("bad.txt", EncodingOptions, {"dna_length": 1})


### PR DESCRIPTION
## Summary
- refine manifest generation to validate input types
- add tests for invalid parameters
- improve docstring for generate_manifest

## Testing
- `pre-commit run --files src/genecoder/manifest.py tests/test_manifest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578cbd215083268970591fc29e0919