### PR TITLE
Fix FEC CLI choices

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -375,7 +375,7 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         choices=[PARITY_RULE_GC_EVEN_A_ODD_T],
         help="Parity rule to use (default: GC_even_A_odd_T).",
     )
-    fec_choices = [None, "triple_repeat", "hamming_7_4", *sorted(FEC_REGISTRY.keys())]
+    fec_choices = sorted({"triple_repeat", "hamming_7_4", *FEC_REGISTRY.keys()})
     parser.add_argument(
         "--fec",
         type=str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,3 +351,24 @@ def test_simulate_errors_command(temp_dir: Path, small_fasta_file: Path):
     new_seq = from_fasta(out_file.read_text())[0][1]
     assert new_seq != original_seq
 
+
+def test_invalid_fec_none_choice(temp_dir: Path):
+    """Passing '--fec None' should result in an argparse error."""
+    input_file = temp_dir / "invalid.txt"
+    input_file.write_text("invalid fec")
+
+    cmd_args = [
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-dir",
+        str(temp_dir),
+        "--method",
+        "base4_direct",
+        "--fec",
+        "None",
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+


### PR DESCRIPTION
## Summary
- disallow `None` in FEC choices
- add CLI test for invalid `--fec None`
- sort the choices list so built-in and plugin methods appear alphabetically

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578cbf4fac832698aa89bb72e2669b