### PR TITLE
Improve flet_app exception handling

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -16,6 +16,7 @@ import flet as ft
 import os
 import asyncio  # For asynchronous operations
 import json
+import logging
 from typing import Optional
 
 # Project module imports
@@ -28,6 +29,9 @@ from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix
 from genecoder.formats import from_fasta
+
+
+logger = logging.getLogger(__name__)
 
 
 encode_fasta_data_to_save_ref: ft.Ref[Optional[str]] = ft.Ref[Optional[str]]()
@@ -326,7 +330,13 @@ def main(page: ft.Page) -> None:
                 page.update()
                 return
 
-            result = await asyncio.to_thread(perform_encoding, input_data, options)
+            try:
+                result = await asyncio.to_thread(perform_encoding, input_data, options)
+            except ValueError as ex:
+                encode_status_text.value = f"Error: {ex}"
+                encode_status_text.color = ft.colors.RED_ACCENT_700
+                page.update()
+                return
 
             encode_hidden_fasta_content.value = result.fasta
             encode_hidden_sequence.value = result.encoded_dna
@@ -397,9 +407,14 @@ def main(page: ft.Page) -> None:
         except FileNotFoundError:
             encode_status_text.value = f"Error: Input file '{input_path}' not found."
             encode_status_text.color = ft.colors.RED_ACCENT_700
-        except Exception as ex:
-            encode_status_text.value = f"An error occurred during encoding: {ex}"
+        except OSError as ex:
+            encode_status_text.value = f"I/O error during encoding: {ex}"
             encode_status_text.color = ft.colors.RED_ACCENT_700
+        except Exception as ex:
+            logger.exception("Unexpected error during encoding")
+            encode_status_text.value = f"An unexpected error occurred: {ex}"
+            encode_status_text.color = ft.colors.RED_ACCENT_700
+            raise
         finally:
             # Re-enable buttons and hide progress
             encode_button.disabled = False
@@ -419,9 +434,14 @@ def main(page: ft.Page) -> None:
                     f"Encoded file saved successfully to: {e.path}"
                 )
                 encode_status_text.color = ft.colors.GREEN_700
-            except Exception as ex:
+            except OSError as ex:
                 encode_status_text.value = f"Error saving file: {ex}"
                 encode_status_text.color = ft.colors.RED_ACCENT_700
+            except Exception as ex:
+                logger.exception("Unexpected error while saving encoded FASTA")
+                encode_status_text.value = f"Unexpected error saving file: {ex}"
+                encode_status_text.color = ft.colors.RED_ACCENT_700
+                raise
         else:
             encode_status_text.value = "Save operation cancelled by user."
             encode_status_text.color = ft.colors.AMBER_ACCENT_700
@@ -445,9 +465,14 @@ def main(page: ft.Page) -> None:
                     f_out.write(encode_hidden_manifest_content.value)
                 encode_status_text.value = f"Manifest saved successfully to: {e.path}"
                 encode_status_text.color = ft.colors.GREEN_700
-            except Exception as ex:
+            except OSError as ex:
                 encode_status_text.value = f"Error saving manifest: {ex}"
                 encode_status_text.color = ft.colors.RED_ACCENT_700
+            except Exception as ex:
+                logger.exception("Unexpected error while saving manifest")
+                encode_status_text.value = f"Unexpected error saving manifest: {ex}"
+                encode_status_text.color = ft.colors.RED_ACCENT_700
+                raise
         else:
             encode_status_text.value = "Save operation cancelled by user."
             encode_status_text.color = ft.colors.AMBER_ACCENT_700
@@ -553,11 +578,16 @@ def main(page: ft.Page) -> None:
                 result = await asyncio.to_thread(
                     perform_decoding, file_content_str, decode_alphabet_dropdown.value
                 )
-            except Exception as ex:
+            except ValueError as ex:
                 decode_status_text.value = f"Error: {ex}"
                 decode_status_text.color = ft.colors.RED_ACCENT_700
                 page.update()
                 return
+            except Exception as ex:
+                logger.exception("Unexpected error during decoding")
+                decode_status_text.value = f"Unexpected error: {ex}"
+                decode_status_text.color = ft.colors.RED_ACCENT_700
+                raise
 
             decoded_bytes_to_save = result.decoded_bytes
             decode_status_text.value = result.status_message
@@ -572,9 +602,14 @@ def main(page: ft.Page) -> None:
         except FileNotFoundError:
             decode_status_text.value = f"Error: Input file '{input_path}' not found."
             decode_status_text.color = ft.colors.RED_ACCENT_700
-        except Exception as ex:
-            decode_status_text.value = f"An critical error occurred: {ex}"
+        except OSError as ex:
+            decode_status_text.value = f"I/O error: {ex}"
             decode_status_text.color = ft.colors.RED_ACCENT_700
+        except Exception as ex:
+            logger.exception("Unexpected error during decode_file_data")
+            decode_status_text.value = f"Critical error: {ex}"
+            decode_status_text.color = ft.colors.RED_ACCENT_700
+            raise
         finally:
             decode_progress_ring.visible = False
             decode_button.disabled = False
@@ -591,8 +626,13 @@ def main(page: ft.Page) -> None:
                 decode_status_text.value = (
                     f"Decoded file saved successfully to {e.path}"
                 )
-            except Exception as ex:
+            except OSError as ex:
                 decode_status_text.value = f"Error saving decoded file: {ex}"
+            except Exception as ex:
+                logger.exception("Unexpected error while saving decoded file")
+                decode_status_text.value = f"Unexpected error saving decoded file: {ex}"
+                decode_status_text.color = ft.colors.RED_ACCENT_700
+                raise
         else:
             decode_status_text.value = "Save decoded file cancelled."
         page.update()

--- a/tests/test_flet_app_interactions.py
+++ b/tests/test_flet_app_interactions.py
@@ -94,3 +94,91 @@ def test_encode_decode_buttons(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     dec_vars["selected_decode_input_file_path"].current = str(fasta_out)
     asyncio.run(decode_cb(None))
     assert "successful" in dec_vars["decode_status_text"].value.lower()
+
+
+def test_encode_unexpected_error_propagates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(flet_app, "perform_encoding", boom)
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    encode_cb = captured["encode"].on_click
+    enc_vars = {n: c.cell_contents for n, c in zip(encode_cb.__code__.co_freevars, encode_cb.__closure__)}
+
+    input_path = tmp_path / "data.bin"
+    input_path.write_bytes(b"abc")
+    enc_vars["selected_encode_input_file_path"].current = str(input_path)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(encode_cb(None))
+
+
+def test_decode_unexpected_error_propagates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(flet_app, "perform_decoding", boom)
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    decode_cb = captured["decode"].on_click
+    dec_vars = {n: c.cell_contents for n, c in zip(decode_cb.__code__.co_freevars, decode_cb.__closure__)}
+
+    fasta_in = tmp_path / "data.fasta"
+    fasta_in.write_text(">seq1\nATGC")
+    dec_vars["selected_decode_input_file_path"].current = str(fasta_in)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(decode_cb(None))
+
+
+def test_encode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    def bad(*_a, **_k):
+        raise ValueError("bad input")
+
+    monkeypatch.setattr(flet_app, "perform_encoding", bad)
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    encode_cb = captured["encode"].on_click
+    enc_vars = {n: c.cell_contents for n, c in zip(encode_cb.__code__.co_freevars, encode_cb.__closure__)}
+
+    input_path = tmp_path / "data.bin"
+    input_path.write_bytes(b"abc")
+    enc_vars["selected_encode_input_file_path"].current = str(input_path)
+
+    asyncio.run(encode_cb(None))
+    assert "bad input" in enc_vars["encode_status_text"].value
+
+
+def test_decode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    def bad(*_a, **_k):
+        raise ValueError("bad fasta")
+
+    monkeypatch.setattr(flet_app, "perform_decoding", bad)
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    decode_cb = captured["decode"].on_click
+    dec_vars = {n: c.cell_contents for n, c in zip(decode_cb.__code__.co_freevars, decode_cb.__closure__)}
+
+    fasta_in = tmp_path / "data.fasta"
+    fasta_in.write_text(">seq1\nATGC")
+    dec_vars["selected_decode_input_file_path"].current = str(fasta_in)
+
+    asyncio.run(decode_cb(None))
+    assert "bad fasta" in dec_vars["decode_status_text"].value


### PR DESCRIPTION
## Summary
- refine error handling in `flet_app`
- capture unexpected errors in save operations and during decode
- propagate `ValueError` from encoding and decoding callbacks
- add tests covering ValueError handling paths

## Testing
- `poetry run pre-commit run --files src/genecoder/flet_app.py tests/test_flet_app_interactions.py`
- `poetry run pytest -q tests/test_flet_app_interactions.py`


------
https://chatgpt.com/codex/tasks/task_e_68578cc8ead88326af89adc1374f064c