### PR TITLE
Fix web test client for HTTPX update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ matplotlib = "*"
 [tool.poetry.group.web.dependencies]
 fastapi = "*"
 uvicorn = { version = "*", extras = ["standard"] }
-httpx = "*"
+httpx = "<0.28"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/requirements.lock
+++ b/requirements.lock
@@ -5,4 +5,4 @@ pytest-cov==6.2.1
 reedsolo==1.7.0
 pyfinite==1.9.1
 pyldpc==0.7.9
-httpx==0.28.1
+httpx==0.27.0

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -3,10 +3,11 @@ import pytest
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
+from httpx import WSGITransport
 
 from web.main import app, index_path
 
-client = TestClient(app)
+client = TestClient(app, transport=WSGITransport(app))
 
 
 def test_root_route_serves_index_html() -> None:


### PR DESCRIPTION
## Summary
- pin httpx below 0.28
- adapt FastAPI web test to use `WSGITransport`

## Testing
- `pre-commit run --files pyproject.toml requirements.lock tests/test_web_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858143778fc832687a80127440e9121