### PR TITLE
Add BaseChannel protocol and update simulators

### DIFF
--- a/src/genecoder/channels/base.py
+++ b/src/genecoder/channels/base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["BaseChannel"]
+
+
+@runtime_checkable
+class BaseChannel(Protocol):
+    """Protocol for DNA read simulators."""
+
+    def simulate(self, sequence: str) -> str:
+        """Return a possibly corrupted version of ``sequence``."""
+        ...

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -189,8 +189,8 @@ def process_single_decode(
             raise SystemExit(1)
 
         if args.simulator != "none":
-            simulate_func = SIMULATOR_REGISTRY[args.simulator]
-            sequence_from_fasta = simulate_func(sequence_from_fasta)
+            channel = SIMULATOR_REGISTRY[args.simulator]
+            sequence_from_fasta = channel.simulate(sequence_from_fasta)
             logger.info(
                 f"Applied {args.simulator} simulator before decoding."
             )

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import random
-from typing import Callable, Any
+from typing import Callable
+
+from .channels.base import BaseChannel
 
 from .nanopore_sim import _simulate_adapter, _run_external
 
@@ -29,7 +31,17 @@ def simulate_d2sim(
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
 
-def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+class D2SimChannel(BaseChannel):
+    """Channel wrapper for the optional ``d2sim`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_d2sim(sequence, error_rate=self.error_rate)
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
     """Register the ``d2sim`` simulator."""
 
-    register_simulator("d2sim", simulate_d2sim)
+    register_simulator("d2sim", D2SimChannel())

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -8,7 +8,9 @@ import subprocess
 import tempfile
 from pathlib import Path
 import logging
-from typing import Any, Callable, Sequence
+from typing import Callable, Sequence
+
+from .channels.base import BaseChannel
 
 logger = logging.getLogger(__name__)
 
@@ -159,20 +161,22 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     return adapter(sequence, error_rate, rng)
 
 
-def _wrap(name: str) -> Callable[[str, float], str]:
-    """Return a simulator function bound to ``name``."""
+class _Channel(BaseChannel):
+    """Adapter implementing :class:`BaseChannel` for built-in simulators."""
 
-    def simulate(seq: str, error_rate: float = 0.05) -> str:
-        return simulate_reads(seq, name, error_rate)
+    def __init__(self, name: str, error_rate: float = 0.05) -> None:
+        self.name = name
+        self.error_rate = error_rate
 
-    return simulate
+    def simulate(self, sequence: str) -> str:
+        return simulate_reads(sequence, self.name, self.error_rate)
 
 
 
-def register(register_simulator: Callable[[str, Callable[..., Any]], None]) -> None:
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
     """Register the builtin simulators."""
 
     for name in SIMULATOR_ADAPTERS:
-        register_simulator(name, _wrap(name))
+        register_simulator(name, _Channel(name))
 
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, Any
+
+from .channels.base import BaseChannel
 from importlib.metadata import entry_points
 import importlib
 import logging
@@ -10,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-SIMULATOR_REGISTRY: Dict[str, Callable[..., Any]] = {}
+SIMULATOR_REGISTRY: Dict[str, BaseChannel] = {}
 
 
 def register_codec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
@@ -23,9 +25,9 @@ def register_fec(name: str, encode: Callable[..., Any], decode: Callable[..., An
     FEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
 
-def register_simulator(name: str, simulate: Callable[..., Any]) -> None:
+def register_simulator(name: str, channel: BaseChannel) -> None:
     """Register a read simulator under ``name``."""
-    SIMULATOR_REGISTRY[name] = simulate
+    SIMULATOR_REGISTRY[name] = channel
 
 
 def load_plugins() -> None:
@@ -111,6 +113,5 @@ def load_plugins() -> None:
     if hasattr(_nano, "register"):
         _nano.register(register_simulator)
     else:
-        for name, func in _nano.SIMULATOR_ADAPTERS.items():
-            register_simulator(name, func)
-        register_simulator("none", lambda seq, error_rate=0.05: seq)
+        for name in _nano.SIMULATOR_ADAPTERS:
+            register_simulator(name, _nano._Channel(name))

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -114,3 +114,14 @@ def test_d2sim_class_run(monkeypatch):
     result = d2sim_adapter._D2SIM.run("ACGT")
     assert result == "ok"
     assert called == [("d2sim", "ACGT")]
+
+
+def test_channel_object(monkeypatch):
+    from genecoder.channels.base import BaseChannel
+
+    registry: dict[str, BaseChannel] = {}
+
+    d2sim_adapter.register(lambda name, ch: registry.setdefault(name, ch))
+
+    assert "d2sim" in registry
+    assert isinstance(registry["d2sim"], BaseChannel)

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -149,3 +149,14 @@ def test_simulate_reads_preserves_global_rng(monkeypatch):
 def test_simulate_reads_unknown_simulator():
     with pytest.raises(ValueError, match="Unknown simulator"):
         nanopore_sim.simulate_reads("ACGT", "bogus")
+
+
+def test_register_returns_channels():
+    from genecoder.channels.base import BaseChannel
+
+    registry: dict[str, BaseChannel] = {}
+
+    nanopore_sim.register(lambda name, chan: registry.setdefault(name, chan))
+
+    assert registry
+    assert all(isinstance(chan, BaseChannel) for chan in registry.values())

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -25,5 +25,8 @@ def test_fec_plugins_registered() -> None:
 
 
 def test_simulator_plugins_registered() -> None:
+    from genecoder.channels.base import BaseChannel
+
     assert isinstance(SIMULATOR_REGISTRY, dict)
+    assert all(isinstance(ch, BaseChannel) for ch in SIMULATOR_REGISTRY.values())
 


### PR DESCRIPTION
## Summary
- add `BaseChannel` protocol
- implement protocol in `nanopore_sim` and `d2sim_adapter`
- update plugin registry and CLI to work with channel objects
- add tests asserting simulators implement the protocol

## Testing
- `pre-commit run --files src/genecoder/channels/base.py src/genecoder/nanopore_sim.py src/genecoder/d2sim_adapter.py src/genecoder/plugins.py src/genecoder/cli/decode.py tests/test_plugin_loading.py tests/test_nanopore_sim.py tests/test_d2sim_adapter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685814400d18832692bf88bf408f86ad