### PR TITLE
Add MkDocs API docs and tutorials

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'src/**'
+      - 'web/**'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'src/**'
+      - 'web/**'
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: genecoder

--- a/docs/cli_tutorial.md
+++ b/docs/cli_tutorial.md
@@ -1,0 +1,19 @@
+# CLI Tutorial
+
+This tutorial walks through basic command-line usage of GeneCoder.
+
+## Encoding a file
+
+```bash
+pip install genecoder[cli]
+
+genecoder encode --input-files example.txt --output-file example.fasta --method base4_direct
+```
+
+## Decoding a file
+
+```bash
+genecoder decode --input-files example.fasta --output-file decoded.txt --method base4_direct
+```
+
+See `genecoder --help` for all available options.

--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -1,0 +1,17 @@
+# GUI Tutorial
+
+This tutorial shows how to launch the Flet-based graphical interface.
+
+## Installation
+
+```bash
+pip install genecoder[gui]
+```
+
+## Running the application
+
+```bash
+python -m genecoder.flet_app
+```
+
+The GUI provides tabs for encoding, decoding and visualizing DNA sequences.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material
 mkdocs-pdf-export-plugin
+mkdocstrings[python]

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -1,0 +1,19 @@
+# Web API Tutorial
+
+GeneCoder includes a minimal FastAPI server for web access.
+
+## Starting the server
+
+```bash
+uvicorn web.main:app --reload
+```
+
+Open <http://127.0.0.1:8000> to view the landing page.
+
+## Calling the API
+
+```
+GET /static/index.html
+```
+
+You can add your own endpoints to expose encoding and decoding features.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,9 @@ theme:
   name: material
   palette:
     primary: indigo
+plugins:
+  - search
+  - mkdocstrings
 nav:
   - Home: index.md
   - Getting Started:
@@ -19,6 +22,10 @@ nav:
       - Development Vision: DEVELOPMENT_VISION.md
   - Integrations:
       - n8n Overview: n8n_overview.md
+  - Tutorials:
+      - CLI Tutorial: cli_tutorial.md
+      - GUI Tutorial: gui_tutorial.md
+      - Web API Tutorial: web_api_tutorial.md
   - Archived:
       - Full Development Vision: archived/DEVELOPMENT_VISION.md
   - Technology Stack: technology_stack.md
@@ -26,4 +33,6 @@ nav:
   - Development Vision: DEVELOPMENT_VISION.md
 
   - Plugin System: plugins.md
+
+  - API Reference: api_reference.md
 


### PR DESCRIPTION
## Summary
- generate API reference with mkdocstrings
- document CLI, GUI and web API usage
- include mkdocstrings in docs requirements
- trigger docs workflow on src/web changes

## Testing
- `pre-commit run --files mkdocs.yml docs/api_reference.md docs/cli_tutorial.md docs/gui_tutorial.md docs/web_api_tutorial.md docs/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68581453a21c8326aca80c6955f2ec97