### PR TITLE
Add additional simulator and streaming tests

### DIFF
--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -1,0 +1,41 @@
+import random
+import pytest
+
+from genecoder import nanopore_sim
+from genecoder.channel_sim import simulate_errors
+
+
+def test_simulate_errors_preserves_global_rng():
+    rng = random.Random(123)
+    expected_first = rng.random()
+    expected_second = rng.random()
+    random.seed(123)
+    before = random.random()
+    simulate_errors("AAAA", 0.1)
+    after = random.random()
+    assert before == expected_first
+    assert after == expected_second
+
+
+@pytest.mark.parametrize("prob", [-0.1, 1.1])
+def test_simulate_errors_invalid_probability(prob):
+    with pytest.raises(ValueError):
+        simulate_errors("A", prob)
+
+
+def test_simulate_reads_fallback(monkeypatch):
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None)
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+
+    result = nanopore_sim.simulate_reads("ACGT", "d2sim", error_rate=0.1)
+    assert result == "fallback"
+    assert which_called == ["d2sim"]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)

--- a/tests/test_streaming_additional.py
+++ b/tests/test_streaming_additional.py
@@ -26,3 +26,15 @@ def test_stream_decode_invalid_header(tmp_path):
     with pytest.raises(ValueError):
         stream_decode_file(str(bad_file), str(out_file))
 
+
+def test_stream_roundtrip_large(tmp_path):
+    data = os.urandom(5_000_000)
+    input_file = tmp_path / "input.bin"
+    encoded_file = tmp_path / "encoded.fasta"
+    decoded_file = tmp_path / "decoded.bin"
+    input_file.write_bytes(data)
+    header = "method=base4_direct input_file=input.bin"
+    stream_encode_file(str(input_file), str(encoded_file), header=header)
+    stream_decode_file(str(encoded_file), str(decoded_file))
+    assert decoded_file.read_bytes() == data
+


### PR DESCRIPTION
## Summary
- add missing RNG, invalid parameter and fallback tests in `tests/test_simulators_additional.py`
- add large file streaming roundtrip test

## Testing
- `pre-commit run --files tests/test_simulators_additional.py tests/test_streaming_additional.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685814547d588326a58763df162216a7