### PR TITLE
Add deterministic seed docs and test

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,6 +116,9 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file decoded.bin --simulate-errors 0.02
    ```
 
+   Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
+   simulated substitutions deterministic across runs.
+
 11. **Decode using an external simulator**
 
    The ``--simulator`` option accepts ``d2sim``, ``dnarsim`` or ``squigulator``.

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -10,6 +10,9 @@ uvicorn web.main:app --reload
 
 Open <http://127.0.0.1:8000> to view the landing page.
 
+Set the `GENECODER_SIM_SEED` environment variable to an integer to get
+reproducible results when API endpoints invoke error simulations.
+
 ## Calling the API
 
 ```

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -286,7 +286,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--simulate-errors",
         type=float,
         default=0.0,
-        help="Probability of random substitution errors applied before decoding.",
+        help=(
+            "Probability of random substitution errors applied before decoding. "
+            "Set the GENECODER_SIM_SEED environment variable to an integer to "
+            "seed the random generator."
+        ),
     )
     sim_choices = list(sorted(SIMULATOR_REGISTRY.keys())) or ["none"]
     parser.add_argument(

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -254,3 +254,55 @@ def test_cli_roundtrip_fountain(tmp_path: Path):
     assert output_file.exists()
     assert output_file.read_text() == "fountain test"
 
+
+def test_decode_sim_errors_deterministic(tmp_path: Path):
+    input_file = tmp_path / "seed.txt"
+    input_file.write_text("deterministic")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+        ]
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "seed.txt.fasta"
+    assert fasta_file.exists()
+
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "7"
+
+    out_dir1 = tmp_path / "d1"
+    out_dir2 = tmp_path / "d2"
+    out_dir1.mkdir()
+    out_dir2.mkdir()
+
+    decode_args = [
+        "decode",
+        "--input-files",
+        str(fasta_file),
+        "--output-dir",
+        str(out_dir1),
+        "--method",
+        "base4_direct",
+        "--simulate-errors",
+        "0.2",
+    ]
+    decode_result1 = run_cli_command(decode_args, env=env)
+    assert decode_result1.returncode == 0, decode_result1.stderr
+
+    decode_args[4] = str(out_dir2)  # update output-dir for second run
+    decode_result2 = run_cli_command(decode_args, env=env)
+    assert decode_result2.returncode == 0, decode_result2.stderr
+
+    output_file1 = out_dir1 / "seed.txt_decoded.bin"
+    output_file2 = out_dir2 / "seed.txt_decoded.bin"
+    assert output_file1.read_bytes() == output_file2.read_bytes()
+


### PR DESCRIPTION
## Summary
- document `GENECODER_SIM_SEED` in CLI docs
- mention environment variable in web API tutorial
- show env var in `--simulate-errors` help text
- add test to verify deterministic behavior with seeding

## Testing
- `pre-commit run --files docs/usage.md docs/web_api_tutorial.md src/genecoder/cli/decode.py tests/test_cli_roundtrip.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a8e377b083269a1465969c8fb3dc