### PR TITLE
Add encode/decode web API endpoints

### DIFF
--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -17,3 +17,26 @@ GET /static/index.html
 ```
 
 You can add your own endpoints to expose encoding and decoding features.
+
+## Example Encode/Decode Requests
+
+The server exposes `/encode` and `/decode` POST endpoints. Payloads are JSON:
+
+```json
+POST /encode
+{
+  "data": "SGVsbG8=",
+  "options": {"method": "Base-4 Direct"}
+}
+```
+
+The response contains a FASTA string that can be fed back to `/decode`:
+
+```json
+POST /decode
+{
+  "fasta_data": "<FASTA from /encode>"
+}
+```
+
+Decoded bytes are returned as a base64 string.

--- a/tests/test_web_api_encode_decode.py
+++ b/tests/test_web_api_encode_decode.py
@@ -1,0 +1,21 @@
+import base64
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+from web.main import app
+
+client = TestClient(app)
+
+
+def test_encode_decode_roundtrip() -> None:
+    payload = base64.b64encode(b"web api").decode()
+    r = client.post("/encode", json={"data": payload, "options": {"method": "Base-4 Direct"}})
+    assert r.status_code == 200
+    fasta = r.json()["fasta"]
+    r2 = client.post("/decode", json={"fasta_data": fasta})
+    assert r2.status_code == 200
+    decoded = base64.b64decode(r2.json()["decoded_bytes"])
+    assert decoded == b"web api"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -3,11 +3,10 @@ import pytest
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
-from httpx import WSGITransport
 
 from web.main import app, index_path
 
-client = TestClient(app, transport=WSGITransport(app))
+client = TestClient(app)
 
 
 def test_root_route_serves_index_html() -> None:

--- a/web/main.py
+++ b/web/main.py
@@ -2,6 +2,12 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
+from pydantic import BaseModel
+from dataclasses import asdict
+import asyncio
+import base64
+
+from genecoder import EncodeOptions, perform_encoding, perform_decoding
 
 app = FastAPI(title="GeneCoder Web")
 
@@ -13,3 +19,47 @@ index_path = static_dir / "index.html"
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]
 async def index() -> str:
     return index_path.read_text(encoding="utf-8")
+
+
+class EncodeOptionsModel(BaseModel):
+    method: str
+    add_parity: bool = False
+    k_value: int = 7
+    fec_method: str = "None"
+    gc_min: float = 0.45
+    gc_max: float = 0.55
+    max_homopolymer: int = 3
+    window_size: int = 50
+    step_size: int = 10
+    min_homopolymer_len: int = 4
+    alphabet: str = "base4"
+
+
+class EncodeRequest(BaseModel):
+    data: str
+    options: EncodeOptionsModel
+
+
+class DecodeRequest(BaseModel):
+    fasta_data: str
+    alphabet: str = "base4"
+
+
+@app.post("/encode")
+async def encode(req: EncodeRequest) -> dict:
+    data_bytes = base64.b64decode(req.data.encode("utf-8"), validate=True)
+    opts = EncodeOptions(**req.options.model_dump())
+    result = await asyncio.to_thread(perform_encoding, data_bytes, opts)
+    return asdict(result)
+
+
+@app.post("/decode")
+async def decode(req: DecodeRequest) -> dict:
+    result = await asyncio.to_thread(
+        perform_decoding, req.fasta_data, req.alphabet
+    )
+    return {
+        "decoded_bytes": base64.b64encode(result.decoded_bytes).decode("utf-8"),
+        "status_message": result.status_message,
+        "fec_info": result.fec_info,
+    }


### PR DESCRIPTION
## Summary
- add FastAPI models and endpoints for `/encode` and `/decode`
- document how to call the new endpoints
- update web integration tests
- test encode/decode roundtrip via TestClient
- use `dataclasses.asdict` when serializing encode results

## Testing
- `ruff check web/main.py`
- `pytest tests/test_web_app.py tests/test_web_api_encode_decode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6858a8ea18b08326805e400dc7f3c2c1