### PR TITLE
Add DNAformer FEC plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,6 +83,19 @@ genecoder --version
 poetry run pytest -q
 ```
 
+## DNAformer Plugin
+
+Install the optional DNAformer model separately. The plugin requires
+`dnaformer` and `torch` which are not installed with the base
+dependencies:
+
+```bash
+pip install dnaformer torch
+```
+
+Once installed, GeneCoder will automatically register the codec when
+imported.
+
 ## Configuring the OpenAI API Key
 
 The OpenAI testing agent requires an API key. Set the `OPENAI_API_KEY`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ldpc = "genecoder.ldpc_codec"
 fountain = "genecoder.fountain_codec"
 bch = "genecoder.bch_codec"
 raptorq = "genecoder.raptorq_codec"
+dnaformer = "genecoder.dnaformer_codec"
 
 [tool.poetry.plugins."genecoder.simulators"]
 nanopore = "genecoder.nanopore_sim"

--- a/src/genecoder/dnaformer_codec.py
+++ b/src/genecoder/dnaformer_codec.py
@@ -1,0 +1,51 @@
+"""DNAformer error correction codec using optional :mod:`dnaformer`."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple, TYPE_CHECKING
+
+_HAS_DNAFORMER = False
+
+if TYPE_CHECKING:
+    import dnaformer
+else:  # pragma: no cover - optional dependency
+    try:
+        import dnaformer  # type: ignore
+        _HAS_DNAFORMER = True
+    except Exception:  # pragma: no cover - missing optional dependency
+        dnaformer = None  # type: ignore
+        _HAS_DNAFORMER = False
+
+
+def _require_dnaformer() -> None:  # pragma: no cover - helper
+    """Ensure :mod:`dnaformer` is installed."""
+    if not _HAS_DNAFORMER:
+        raise ImportError(
+            "dnaformer is required for DNAformer encoding. Install it via 'pip install dnaformer'."
+        )
+
+
+def encode_data_dnaformer(data: bytes, model_name: str = "dnaformer-small") -> Tuple[bytes, Any]:
+    """Encode ``data`` using the DNAformer model."""
+    _require_dnaformer()
+    assert dnaformer is not None
+    model = dnaformer.DNAformer(model_name)
+    encoded = model.encode(data)
+    return encoded, {"model_name": model_name}
+
+
+def decode_data_dnaformer(encoded: bytes, info: Any) -> Tuple[bytes, int]:
+    """Decode DNAformer encoded ``encoded`` bytes using ``info`` from encoding."""
+    _require_dnaformer()
+    assert dnaformer is not None
+    model = dnaformer.DNAformer(info["model_name"])
+    decoded = model.decode(encoded)
+    return decoded, 0
+
+
+from typing import Callable
+
+
+def register(register_fec: Callable[[str, Callable[[bytes], Tuple[bytes, Any]], Callable[[bytes, Any], Tuple[bytes, int]]], None]) -> None:
+    """Register this module's FEC backend."""
+    register_fec("dnaformer", encode_data_dnaformer, decode_data_dnaformer)

--- a/tests/test_dnaformer_codec.py
+++ b/tests/test_dnaformer_codec.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytest.importorskip("dnaformer")
+
+from genecoder.dnaformer_codec import encode_data_dnaformer, decode_data_dnaformer
+
+
+def test_dnaformer_roundtrip() -> None:
+    data = b"dnaformer test"
+    encoded, info = encode_data_dnaformer(data)
+    decoded, corrected = decode_data_dnaformer(encoded, info)
+    assert decoded == data
+    assert corrected >= 0


### PR DESCRIPTION
## Summary
- implement dnaformer_codec plugin with optional dependency
- register dnaformer via `genecoder.fec` entry point
- document DNAformer install steps
- add unit test skipped when dnaformer isn't installed

## Testing
- `pre-commit run --files docs/installation.md pyproject.toml src/genecoder/dnaformer_codec.py tests/test_dnaformer_codec.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a8fe4364832686dbd4d3f7b3a2dd