### PR TITLE
Add encryption support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,6 +37,7 @@ poetry install --no-interaction
 * `--output-file` – output path for a single input file.
 * `--output-dir` – directory for batch operations.
 * `--fec` – optional FEC method (`triple_repeat`, `hamming_7_4`, `reed_solomon`, `ldpc`, `fountain`).
+* `--encryption-key` – hex encoded key for AES-256 encryption/decryption.
 
 See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
@@ -139,6 +140,18 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    ```bash
    genecoder decode --input-files encoded.fasta \
        --output-file decoded.bin --simulator squigulator
+   ```
+
+12. **Encode and decode with AES-256 encryption**
+
+   ```bash
+   KEY=$(openssl rand -hex 32)
+   genecoder encode --input-files secrets.txt \
+       --output-dir secure/ --method base4_direct \
+       --encryption-key "$KEY"
+   genecoder decode --input-files secure/secrets.txt.fasta \
+       --output-dir secure/ --method base4_direct \
+       --encryption-key "$KEY"
    ```
 
 ### Manifest files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.10"
 reedsolo = "*"
+cryptography = "*"
 
 [tool.poetry.group.gui.dependencies]
 flet = ">=0.28,<0.29"

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,6 +3,7 @@ matplotlib==3.10.3
 pytest==8.4.0
 pytest-cov==6.2.1
 reedsolo==1.7.0
+cryptography==45.0.4
 pyfinite==1.9.1
 pyldpc==0.7.9
 httpx==0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ reedsolo
 pyfinite
 pyldpc
 httpx
+cryptography

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -15,7 +15,11 @@ from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import decode_data_with_hamming
 from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
-from genecoder.utils import get_alphabet_maps
+from genecoder.utils import (
+    get_alphabet_maps,
+    decrypt_bytes,
+    sha256_checksum,
+)
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 
 logger = logging.getLogger(__name__)
@@ -141,6 +145,9 @@ def process_single_decode(
         f"\nProcessing decode for input: {input_file_path} -> output: {output_file_path}"
     )
     try:
+        if getattr(args, "encryption_key", None) and args.stream:
+            logger.error("Error: --encryption-key cannot be used with --stream.")
+            raise SystemExit(1)
         if args.stream and args.method == "base4_direct":
             from genecoder.streaming import stream_decode_file
 
@@ -212,6 +219,30 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
+        if "encrypted=aes256" in header:
+            if not getattr(args, "encryption_key", None):
+                logger.error("Error: --encryption-key is required for encrypted input.")
+                raise SystemExit(1)
+            try:
+                key_bytes = bytes.fromhex(args.encryption_key)
+            except ValueError:
+                logger.error("Error: --encryption-key must be hex-encoded.")
+                raise SystemExit(1)
+            if len(key_bytes) != 32:
+                logger.error("Error: --encryption-key must be 32 bytes (64 hex characters).")
+                raise SystemExit(1)
+            final_decoded_data = decrypt_bytes(final_decoded_data, key_bytes)
+            checksum_match = re.search(r"sha256=([0-9a-fA-F]{64})", header)
+            if checksum_match:
+                expected = checksum_match.group(1).lower()
+                actual = sha256_checksum(final_decoded_data)
+                if expected != actual:
+                    logger.warning(
+                        f"SHA-256 checksum mismatch for {input_file_path}: expected {expected} got {actual}"
+                    )
+        elif getattr(args, "encryption_key", None):
+            logger.warning("--encryption-key provided but input not encrypted")
+
         os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "wb") as f_out:
             f_out.write(final_decoded_data)
@@ -281,6 +312,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--stream",
         action="store_true",
         help="Stream decode large files (base4_direct only).",
+    )
+    parser.add_argument(
+        "--encryption-key",
+        type=str,
+        help="Hex encoded 32-byte key used to decrypt the payload if needed.",
     )
     parser.add_argument(
         "--simulate-errors",

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -16,8 +16,9 @@ from genecoder.hamming_codec import decode_data_with_hamming
 from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import (
-    get_alphabet_maps,
     decrypt_bytes,
+    get_alphabet_maps,
+    parse_encryption_key,
     sha256_checksum,
 )
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -224,12 +225,9 @@ def process_single_decode(
                 logger.error("Error: --encryption-key is required for encrypted input.")
                 raise SystemExit(1)
             try:
-                key_bytes = bytes.fromhex(args.encryption_key)
-            except ValueError:
-                logger.error("Error: --encryption-key must be hex-encoded.")
-                raise SystemExit(1)
-            if len(key_bytes) != 32:
-                logger.error("Error: --encryption-key must be 32 bytes (64 hex characters).")
+                key_bytes = parse_encryption_key(args.encryption_key)
+            except ValueError as exc:
+                logger.error("Error: %s", exc)
                 raise SystemExit(1)
             final_decoded_data = decrypt_bytes(final_decoded_data, key_bytes)
             checksum_match = re.search(r"sha256=([0-9a-fA-F]{64})", header)

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -24,9 +24,10 @@ from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import (
-    get_max_homopolymer_length,
-    get_alphabet_maps,
     encrypt_bytes,
+    get_alphabet_maps,
+    get_max_homopolymer_length,
+    parse_encryption_key,
     sha256_checksum,
 )
 
@@ -258,12 +259,9 @@ def process_single_encode(
                 logger.error("Error: --encryption-key cannot be used with --stream.")
                 raise SystemExit(1)
             try:
-                key_bytes = bytes.fromhex(args.encryption_key)
-            except ValueError:
-                logger.error("Error: --encryption-key must be hex-encoded.")
-                raise SystemExit(1)
-            if len(key_bytes) != 32:
-                logger.error("Error: --encryption-key must be 32 bytes (64 hex characters).")
+                key_bytes = parse_encryption_key(args.encryption_key)
+            except ValueError as exc:
+                logger.error("Error: %s", exc)
                 raise SystemExit(1)
             extra_header = (
                 f" encrypted=aes256 sha256={sha256_checksum(original_input_data)}"

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -23,7 +23,12 @@ from genecoder.plugins import FEC_REGISTRY
 from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
+from genecoder.utils import (
+    get_max_homopolymer_length,
+    get_alphabet_maps,
+    encrypt_bytes,
+    sha256_checksum,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +194,9 @@ def process_single_encode(
         f"\nProcessing encode for input: {input_file_path} -> output: {output_file_path}"
     )
     try:
+        if getattr(args, "encryption_key", None) and args.stream:
+            logger.error("Error: --encryption-key cannot be used with --stream.")
+            raise SystemExit(1)
         if args.stream and args.method == "base4_direct" and args.fec is None:
             header = f"method=base4_direct input_file={os.path.basename(input_file_path)}"
             if args.add_parity:
@@ -243,6 +251,25 @@ def process_single_encode(
         with open(input_file_path, "rb") as f_in:
             original_input_data = f_in.read()
 
+        data_to_encode = original_input_data
+        extra_header = ""
+        if getattr(args, "encryption_key", None):
+            if args.stream:
+                logger.error("Error: --encryption-key cannot be used with --stream.")
+                raise SystemExit(1)
+            try:
+                key_bytes = bytes.fromhex(args.encryption_key)
+            except ValueError:
+                logger.error("Error: --encryption-key must be hex-encoded.")
+                raise SystemExit(1)
+            if len(key_bytes) != 32:
+                logger.error("Error: --encryption-key must be 32 bytes (64 hex characters).")
+                raise SystemExit(1)
+            extra_header = (
+                f" encrypted=aes256 sha256={sha256_checksum(original_input_data)}"
+            )
+            data_to_encode = encrypt_bytes(original_input_data, key_bytes)
+
         options = build_encoding_options(args)
         (
             final_encoded_dna_sequence,
@@ -251,8 +278,11 @@ def process_single_encode(
             current_input_data,
             fec_padding_bits,
         ) = run_encoding_pipeline(
-            original_input_data, options, os.path.basename(input_file_path)
+            data_to_encode, options, os.path.basename(input_file_path)
         )
+
+        if extra_header:
+            fasta_header += extra_header
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
 
@@ -431,6 +461,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--stream",
         action="store_true",
         help="Stream encode large files (base4_direct only).",
+    )
+    parser.add_argument(
+        "--encryption-key",
+        type=str,
+        help="Hex encoded 32-byte key to encrypt the input before encoding.",
     )
     parser.add_argument(
         "--export-csv",

--- a/src/genecoder/utils.py
+++ b/src/genecoder/utils.py
@@ -1,5 +1,10 @@
 """Utility helpers shared across modules."""
 
+from __future__ import annotations
+
+import hashlib
+import os
+
 DNA_ENCODE_MAP = {"00": "A", "01": "C", "10": "G", "11": "T"}
 """Mapping from two-bit binary strings to DNA bases (Base-4 alphabet)."""
 
@@ -65,4 +70,45 @@ def get_max_homopolymer_length(dna_sequence: str) -> int:
 def check_homopolymer_length(dna_sequence: str, max_len: int) -> bool:
     """Checks if any homopolymer in the DNA sequence exceeds a maximum length."""
     return get_max_homopolymer_length(dna_sequence) > max_len
+
+
+def encrypt_bytes(data: bytes, key: bytes) -> bytes:
+    """Encrypt ``data`` with AES-256 CBC using ``key``.
+
+    The 16-byte IV is prepended to the returned ciphertext.
+    """
+    if len(key) != 32:
+        raise ValueError("AES-256 key must be 32 bytes")
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives.padding import PKCS7
+
+    iv = os.urandom(16)
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    padder = PKCS7(128).padder()
+    padded = padder.update(data) + padder.finalize()
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+    return iv + bytes(ciphertext)
+
+
+def decrypt_bytes(data: bytes, key: bytes) -> bytes:
+    """Decrypt AES-256 CBC ``data`` using ``key``."""
+    if len(key) != 32:
+        raise ValueError("AES-256 key must be 32 bytes")
+    if len(data) < 16:
+        raise ValueError("Ciphertext too short")
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives.padding import PKCS7
+
+    iv, ciphertext = data[:16], data[16:]
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+    unpadder = PKCS7(128).unpadder()
+    return bytes(unpadder.update(padded) + unpadder.finalize())
+
+
+def sha256_checksum(data: bytes) -> str:
+    """Return the SHA-256 checksum of ``data`` as a hex string."""
+    return hashlib.sha256(data).hexdigest()
 

--- a/src/genecoder/utils.py
+++ b/src/genecoder/utils.py
@@ -112,3 +112,29 @@ def sha256_checksum(data: bytes) -> str:
     """Return the SHA-256 checksum of ``data`` as a hex string."""
     return hashlib.sha256(data).hexdigest()
 
+
+def parse_encryption_key(key_str: str) -> bytes:
+    """Return the binary key from a hex string.
+
+    Raises ``ValueError`` if the key is not hex encoded or not 32 bytes.
+    """
+    try:
+        key_bytes = bytes.fromhex(key_str)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError("--encryption-key must be hex-encoded") from exc
+    if len(key_bytes) != 32:
+        raise ValueError("--encryption-key must be 32 bytes (64 hex characters).")
+    return key_bytes
+
+
+__all__ = [
+    "ALPHABETS",
+    "check_homopolymer_length",
+    "decrypt_bytes",
+    "encrypt_bytes",
+    "get_alphabet_maps",
+    "get_max_homopolymer_length",
+    "parse_encryption_key",
+    "sha256_checksum",
+]
+

--- a/tests/test_cli_encryption.py
+++ b/tests/test_cli_encryption.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from tests.test_cli import run_cli_command
 
 
-def test_cli_encryption_roundtrip(tmp_path: Path):
+def test_cli_encryption_roundtrip(tmp_path: Path) -> None:
     key = '00' * 32
     input_file = tmp_path / 'secret.txt'
     input_file.write_text('top secret')

--- a/tests/test_cli_encryption.py
+++ b/tests/test_cli_encryption.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+
+def test_cli_encryption_roundtrip(tmp_path: Path):
+    key = '00' * 32
+    input_file = tmp_path / 'secret.txt'
+    input_file.write_text('top secret')
+
+    encode_res = run_cli_command([
+        'encode',
+        '--input-files', str(input_file),
+        '--output-dir', str(tmp_path),
+        '--method', 'base4_direct',
+        '--encryption-key', key,
+    ])
+    assert encode_res.returncode == 0, encode_res.stderr
+    fasta_file = tmp_path / 'secret.txt.fasta'
+    assert fasta_file.exists()
+
+    decode_res = run_cli_command([
+        'decode',
+        '--input-files', str(fasta_file),
+        '--output-dir', str(tmp_path),
+        '--method', 'base4_direct',
+        '--encryption-key', key,
+    ])
+    assert decode_res.returncode == 0, decode_res.stderr
+    out_file = tmp_path / 'secret.txt_decoded.bin'
+    assert out_file.exists()
+    assert out_file.read_text() == 'top secret'

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,16 @@
+import hashlib
+from genecoder.utils import encrypt_bytes, decrypt_bytes, sha256_checksum
+
+
+def test_encrypt_decrypt_roundtrip():
+    key = bytes.fromhex('00' * 32)
+    data = b'secret message'
+    encrypted = encrypt_bytes(data, key)
+    assert encrypted != data
+    decrypted = decrypt_bytes(encrypted, key)
+    assert decrypted == data
+
+
+def test_sha256_checksum():
+    data = b'abc'
+    assert sha256_checksum(data) == hashlib.sha256(data).hexdigest()

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -2,7 +2,7 @@ import hashlib
 from genecoder.utils import encrypt_bytes, decrypt_bytes, sha256_checksum
 
 
-def test_encrypt_decrypt_roundtrip():
+def test_encrypt_decrypt_roundtrip() -> None:
     key = bytes.fromhex('00' * 32)
     data = b'secret message'
     encrypted = encrypt_bytes(data, key)
@@ -11,6 +11,6 @@ def test_encrypt_decrypt_roundtrip():
     assert decrypted == data
 
 
-def test_sha256_checksum():
+def test_sha256_checksum() -> None:
     data = b'abc'
     assert sha256_checksum(data) == hashlib.sha256(data).hexdigest()


### PR DESCRIPTION
## Summary
- support AES-256 encryption utilities and checksum helpers
- allow `--encryption-key` in encode/decode CLI
- document encryption usage
- test encryption functions and CLI roundtrip
- pin cryptography dependency

## Testing
- `pre-commit run --files docs/usage.md pyproject.toml requirements.lock requirements.txt src/genecoder/cli/decode.py src/genecoder/cli/encode.py src/genecoder/utils.py tests/test_cli_encryption.py tests/test_encryption.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a8ff5ebc8326882bd1199d7a393a