### PR TITLE
Add n8n overview link to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,3 +16,4 @@ For more details, explore the sections below.
 
 * [Plugin System](plugins.md) – Extend GeneCoder with custom codecs and viewers.
 * [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo.
+* [n8n Overview](n8n_overview.md) – Automate workflows with n8n.


### PR DESCRIPTION
## Summary
- link the n8n overview page from the docs index
- verified the MkDocs navigation already lists this page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858a90c9a3c8326b67d2b989159503e