### PR TITLE
Improve Huffman parameter errors

### DIFF
--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -239,15 +239,21 @@ def perform_decoding(fasta_data: str, alphabet: str = "base4") -> DecodeResult:
         try:
             params, idx = decoder.raw_decode(json_field)
         except json.JSONDecodeError as exc:
-            raise ValueError("Invalid Huffman parameters") from exc
+            raise ValueError(
+                "Invalid Huffman parameters: malformed JSON"
+            ) from exc
 
         if json_field[idx:].strip():
-            raise ValueError("Invalid Huffman parameters")
+            raise ValueError(
+                "Invalid Huffman parameters: extra text after JSON"
+            )
 
         table_str = params.get("table")
         num_padding_bits = params.get("padding")
-        if table_str is None or num_padding_bits is None:
-            raise ValueError("Invalid Huffman parameters")
+        if table_str is None:
+            raise ValueError("Invalid Huffman parameters: missing table")
+        if num_padding_bits is None:
+            raise ValueError("Invalid Huffman parameters: missing padding")
 
         huffman_table = {int(k): v for k, v in table_str.items()}
     elif "method=base4_direct" in header:

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -54,7 +54,7 @@ def test_triple_repeat_length_warning():
 
 def test_decoding_invalid_huffman_json():
     fasta = ">method=huffman input_file=x huffman_params={\"table\":{\"65\":\"0\"},\"padding\":0\nAAAA\n"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="malformed JSON"):
         perform_decoding(fasta)
 
 
@@ -64,7 +64,19 @@ def test_decoding_huffman_extra_text_after_json():
         "huffman_params={\"table\":{\"65\":\"0\"},\"padding\":0} extratext\n"
         "AAAA\n"
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="extra text after JSON"):
+        perform_decoding(fasta)
+
+
+def test_decoding_huffman_missing_table():
+    fasta = ">method=huffman input_file=x huffman_params={\"padding\":0}\nAAAA\n"
+    with pytest.raises(ValueError, match="missing table"):
+        perform_decoding(fasta)
+
+
+def test_decoding_huffman_missing_padding():
+    fasta = ">method=huffman input_file=x huffman_params={\"table\":{\"65\":\"0\"}}\nAAAA\n"
+    with pytest.raises(ValueError, match="missing padding"):
         perform_decoding(fasta)
 
 


### PR DESCRIPTION
## Summary
- improve ValueError messages for Huffman decoding failures
- add/extend tests for new error messages

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f83b27848326abd4119bff8c81ef