### PR TITLE
Clarify base5/base6 alphabet remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md)
 - Optional error correction with Triple-Repeat, Hamming(7,4), Reed-Solomon, LDPC and Fountain codes.
 - Batch processing, parity checks and streaming support.
 - Flet-based GUI with analysis plots.
+- Base5 and base6 alphabet options for alternative nucleotide letters. These
+  modes remap the standard ACGT symbols but **do not increase capacity**.
 
 ## Quick Start
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,6 +71,10 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file encoded_base6.fasta --alphabet base6
    ```
 
+   Base5 and base6 are convenience alphabets that map the 2-bit output of
+   `base4_direct` to different nucleotide symbols. They do **not** store more
+   information per base.
+
 5. **Encode with Base-4 Direct and Hamming(7,4) FEC**
 
    ```bash

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -278,7 +278,10 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         type=str,
         default="base4",
         choices=["base4", "base5", "base6"],
-        help="Alphabet mapping used during encoding (default: base4).",
+        help=(
+            "Alphabet mapping used during encoding. base5 and base6 remap"
+            " letters only and do not increase capacity (default: base4)."
+        ),
     )
     parser.add_argument(
         "--stream",

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -428,7 +428,10 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         type=str,
         default="base4",
         choices=["base4", "base5", "base6"],
-        help="Alphabet mapping to use (default: base4).",
+        help=(
+            "Alphabet mapping to use. base5 and base6 simply remap the ACGT"
+            " symbols and do not increase capacity (default: base4)."
+        ),
     )
     parser.add_argument(
         "--stream",


### PR DESCRIPTION
## Summary
- document that `base5` and `base6` don't expand capacity
- add note in usage docs
- clarify `--alphabet` help text for encode/decode

## Testing
- `pre-commit run --files README.md docs/usage.md src/genecoder/cli/decode.py src/genecoder/cli/encode.py`

------
https://chatgpt.com/codex/tasks/task_e_6859f83ad0cc8326a525cad5a189b3c0