### PR TITLE
Add FrameD FEC backend

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 
 * **CLI for encoding and decoding** using multiple methods.
 * **GC-Balanced encoding** with tunable constraints.
-* **Forward Error Correction** options such as Triple-Repeat, Hamming(7,4) and Reed-Solomon.
+* **Forward Error Correction** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and the optional FrameD C++ backend.
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,6 +98,18 @@ pip install dnaformer torch
 Once installed, GeneCoder will automatically register the codec when
 imported.
 
+## FrameD FEC Backend
+
+The optional FrameD plugin wraps optimized C++ kernels using CFFI.
+Install the package from PyPI before using the backend:
+
+```bash
+pip install FrameD
+```
+
+The `framed` FEC method becomes available automatically after
+installation.
+
 ## Configuring the OpenAI API Key
 
 The OpenAI testing agent requires an API key. Set the `OPENAI_API_KEY`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ldpc = "genecoder.ldpc_codec"
 fountain = "genecoder.fountain_codec"
 bch = "genecoder.bch_codec"
 raptorq = "genecoder.raptorq_codec"
+framed = "genecoder.fec.framed"
 dnaformer = "genecoder.dnaformer_codec"
 
 [tool.poetry.plugins."genecoder.simulators"]

--- a/src/genecoder/fec/framed.py
+++ b/src/genecoder/fec/framed.py
@@ -1,0 +1,81 @@
+"""FrameD FEC backend implemented using CFFI."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple, TYPE_CHECKING
+
+_HAS_FRAMED = False
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from cffi.api import FFI
+    _ffi: FFI | None
+    _lib: Any | None
+else:  # pragma: no cover - optional dependency
+    try:
+        from cffi import FFI
+        _ffi: FFI | None
+        _lib: Any | None
+        
+        _ffi = FFI()
+        _ffi.cdef(
+            """
+            void* framed_encode(const uint8_t* data, size_t len, size_t* out_len);
+            void* framed_decode(const uint8_t* data, size_t len, size_t* out_len, int* corrected);
+            void framed_free(void* ptr);
+            """
+        )
+        _lib = _ffi.dlopen("libframed.so")
+        _HAS_FRAMED = True
+    except Exception:
+        _ffi = None
+        _lib = None
+        _HAS_FRAMED = False
+
+
+def _require_framed() -> None:  # pragma: no cover - helper
+    """Ensure the FrameD library is available."""
+
+    if not _HAS_FRAMED:
+        raise ImportError(
+            "FrameD is required for this FEC backend. Install it via 'pip install FrameD' "
+            "and ensure libframed.so is in your library path."
+        )
+
+
+def encode_data_framed(data: bytes) -> Tuple[bytes, Any]:
+    """Encode ``data`` using FrameD's C++ kernels."""
+
+    _require_framed()
+    assert _ffi is not None and _lib is not None
+    out_len = _ffi.new("size_t*")
+    buf = _lib.framed_encode(data, len(data), out_len)
+    encoded = bytes(_ffi.buffer(buf, out_len[0]))
+    _lib.framed_free(buf)
+    return encoded, {}
+
+
+def decode_data_framed(encoded: bytes, info: Any) -> Tuple[bytes, int]:
+    """Decode bytes produced by :func:`encode_data_framed`."""
+
+    _require_framed()
+    assert _ffi is not None and _lib is not None
+    out_len = _ffi.new("size_t*")
+    corrected = _ffi.new("int*")
+    buf = _lib.framed_decode(encoded, len(encoded), out_len, corrected)
+    data = bytes(_ffi.buffer(buf, out_len[0]))
+    _lib.framed_free(buf)
+    return data, int(corrected[0])
+
+
+from typing import Callable
+
+
+def register(
+    register_fec: Callable[
+        [str, Callable[[bytes], Tuple[bytes, Any]], Callable[[bytes, Any], Tuple[bytes, int]]],
+        None,
+    ]
+) -> None:
+    """Register this module's FEC backend."""
+
+    register_fec("framed", encode_data_framed, decode_data_framed)

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -109,6 +109,8 @@ def load_plugins() -> None:
     _bch.register(register_fec)
     from . import raptorq_codec as _raptorq
     _raptorq.register(register_fec)
+    from .fec import framed as _framed
+    _framed.register(register_fec)
     from . import nanopore_sim as _nano
     if hasattr(_nano, "register"):
         _nano.register(register_simulator)

--- a/tests/test_framed_codec.py
+++ b/tests/test_framed_codec.py
@@ -1,0 +1,13 @@
+import pytest
+
+from genecoder.fec.framed import _HAS_FRAMED, encode_data_framed, decode_data_framed
+
+pytestmark = pytest.mark.skipif(not _HAS_FRAMED, reason="FrameD not installed")
+
+
+def test_framed_roundtrip() -> None:
+    data = b"hello framed"
+    encoded, info = encode_data_framed(data)
+    decoded, corrected = decode_data_framed(encoded, info)
+    assert decoded == data
+    assert corrected >= 0

--- a/tests/test_missing_imports.py
+++ b/tests/test_missing_imports.py
@@ -51,6 +51,14 @@ CASES = [
         {"m": 5, "t": 2},
         "bchlib is required",
     ),
+    (
+        "genecoder.fec.framed",
+        "cffi",
+        "encode_data_framed",
+        (b"data",),
+        {},
+        "FrameD is required",
+    ),
 ]
 
 

--- a/tests/test_plugin_file_module.py
+++ b/tests/test_plugin_file_module.py
@@ -22,3 +22,4 @@ def test_plugins_py_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     assert "fountain" in plugins.FEC_REGISTRY
     assert "bch" in plugins.FEC_REGISTRY
     assert "raptorq" in plugins.FEC_REGISTRY
+    assert "framed" in plugins.FEC_REGISTRY

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -22,6 +22,7 @@ def test_fec_plugins_registered() -> None:
     assert "fountain" in FEC_REGISTRY
     assert "bch" in FEC_REGISTRY
     assert "raptorq" in FEC_REGISTRY
+    assert "framed" in FEC_REGISTRY
 
 
 def test_simulator_plugins_registered() -> None:


### PR DESCRIPTION
## Summary
- wrap FrameD's C++ kernels via CFFI in new `genecoder.fec.framed`
- register the backend in `pyproject.toml` and built-in plugin loader
- test plugin discovery and roundtrip encode/decode
- document FrameD installation and feature overview

## Testing
- `pre-commit run --files src/genecoder/fec/framed.py src/genecoder/fec/__init__.py src/genecoder/plugins.py pyproject.toml tests/test_framed_codec.py tests/test_plugin_loading.py tests/test_plugin_file_module.py tests/test_missing_imports.py docs/features.md docs/installation.md`

------
https://chatgpt.com/codex/tasks/task_e_6859f85440508326be3fd304774667cd