### PR TITLE
Unify simulator modules with registry

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -46,8 +46,8 @@ register_fec("myfec", encode, decode)
 ```
 
 Simulator plugins follow the same pattern using the `genecoder.simulators`
-group with a `register_simulator` callback that receives a function taking a
-DNA sequence and returning a mutated version.
+group with a `register_simulator` callback that receives an object implementing
+the :class:`genecoder.channels.base.BaseChannel` protocol.
 
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -138,6 +138,9 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    When a command is missing GeneCoder automatically falls back to an internal
    error model.
 
+   The same simulators can be accessed programmatically via
+   ``genecoder.simulators.simulate_reads``.
+
 
    ```bash
    genecoder decode --input-files encoded.fasta \

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -16,6 +16,7 @@ from .plugins import (
     SIMULATOR_REGISTRY,
     load_plugins,
 )
+from .simulators import simulate_reads
 
 load_plugins()
 
@@ -25,6 +26,7 @@ __all__ = [
     "CODEC_REGISTRY",
     "FEC_REGISTRY",
     "SIMULATOR_REGISTRY",
+    "simulate_reads",
     "load_plugins",
 ]
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -189,8 +189,11 @@ def process_single_decode(
             raise SystemExit(1)
 
         if args.simulator != "none":
-            channel = SIMULATOR_REGISTRY[args.simulator]
-            sequence_from_fasta = channel.simulate(sequence_from_fasta)
+            from genecoder.simulators import simulate_reads
+
+            sequence_from_fasta = simulate_reads(
+                sequence_from_fasta, args.simulator
+            )
             logger.info(
                 f"Applied {args.simulator} simulator before decoding."
             )

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 from .channels.base import BaseChannel
 
-from .nanopore_sim import _simulate_adapter, _run_external
+from .nanopore_sim import _simulate_adapter, _run_external, _make_rng
 
 
 class _D2SIM:
@@ -28,6 +28,9 @@ def simulate_d2sim(
 ) -> str:
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
+    if rng is None:
+        rng = _make_rng()
+
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
 
@@ -38,7 +41,7 @@ class D2SimChannel(BaseChannel):
         self.error_rate = error_rate
 
     def simulate(self, sequence: str) -> str:
-        return simulate_d2sim(sequence, error_rate=self.error_rate)
+        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=_make_rng())
 
 
 def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -10,12 +10,27 @@ from pathlib import Path
 import logging
 from typing import Callable, Sequence
 
+__all__ = [
+    "simulate_d2sim",
+    "simulate_dnarsim",
+    "simulate_squigulator",
+    "simulate_reads",
+    "Channel",
+]
+
 from .channels.base import BaseChannel
 
 logger = logging.getLogger(__name__)
 
 from .channel_sim import simulate_errors
 from .formats import from_fasta, to_fasta
+
+
+def _make_rng() -> random.Random:
+    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
+
+    seed_env = os.getenv("GENECODER_SIM_SEED")
+    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 def _run_external(command: Sequence[str] | str, sequence: str) -> str:
@@ -58,7 +73,7 @@ def _simulate_adapter(
     # use a deterministic local RNG for external simulators and forward it when
     # falling back to :func:`simulate_errors` so calls remain reproducible
     if rng is None:
-        rng = random.Random()
+        rng = _make_rng()
     return simulate_errors(sequence, error_rate, rng=rng)
 
 
@@ -73,7 +88,7 @@ def simulate_d2sim(
 
 
     if rng is None:
-        rng = random.Random()
+        rng = _make_rng()
 
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
@@ -93,7 +108,7 @@ def simulate_dnarsim(
 
 
     if rng is None:
-        rng = random.Random()
+        rng = _make_rng()
 
     return _simulate_adapter("dnarsim", sequence, error_rate, rng)
 
@@ -109,7 +124,7 @@ def simulate_squigulator(
 
 
     if rng is None:
-        rng = random.Random()
+        rng = _make_rng()
 
     return _simulate_adapter("squigulator", sequence, error_rate, rng)
 
@@ -140,28 +155,26 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]]
 
 
 def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
-    """Return ``sequence`` corrupted using the chosen simulator.
+    """Return ``sequence`` corrupted using the chosen simulator."""
 
-    A per-call :class:`~random.Random` instance is used so calls do not affect
-    the global RNG.  If the ``GENECODER_SIM_SEED`` environment variable is set,
-    it will be used to seed this local RNG.  If the requested simulator command
-    isn't available, fall back to a simple substitution error model implemented
-    in :func:`simulate_errors`.
-    """
-
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    rng = random.Random(int(seed_env)) if seed_env is not None else random.Random()
-
+    from .plugins import SIMULATOR_REGISTRY
 
     try:
-        adapter = SIMULATOR_ADAPTERS[simulator]
+        channel = SIMULATOR_REGISTRY[simulator]
     except KeyError as exc:
         raise ValueError(f"Unknown simulator: {simulator}") from exc
 
-    return adapter(sequence, error_rate, rng)
+    if hasattr(channel, "error_rate"):
+        old_rate = channel.error_rate
+        channel.error_rate = error_rate
+        try:
+            return channel.simulate(sequence)
+        finally:
+            channel.error_rate = old_rate
+    return channel.simulate(sequence)
 
 
-class _Channel(BaseChannel):
+class Channel(BaseChannel):
     """Adapter implementing :class:`BaseChannel` for built-in simulators."""
 
     def __init__(self, name: str, error_rate: float = 0.05) -> None:
@@ -169,7 +182,8 @@ class _Channel(BaseChannel):
         self.error_rate = error_rate
 
     def simulate(self, sequence: str) -> str:
-        return simulate_reads(sequence, self.name, self.error_rate)
+        adapter = SIMULATOR_ADAPTERS[self.name]
+        return adapter(sequence, self.error_rate, _make_rng())
 
 
 
@@ -177,6 +191,6 @@ def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
     """Register the builtin simulators."""
 
     for name in SIMULATOR_ADAPTERS:
-        register_simulator(name, _Channel(name))
+        register_simulator(name, Channel(name))
 
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -114,4 +114,4 @@ def load_plugins() -> None:
         _nano.register(register_simulator)
     else:
         for name in _nano.SIMULATOR_ADAPTERS:
-            register_simulator(name, _nano._Channel(name))
+            register_simulator(name, _nano.Channel(name))

--- a/src/genecoder/simulators.py
+++ b/src/genecoder/simulators.py
@@ -1,0 +1,19 @@
+from .plugins import SIMULATOR_REGISTRY
+__all__ = ["simulate_reads"]
+
+def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
+    """Return ``sequence`` processed by the named simulator."""
+
+    try:
+        channel = SIMULATOR_REGISTRY[simulator]
+    except KeyError as exc:
+        raise ValueError(f"Unknown simulator: {simulator}") from exc
+
+    if hasattr(channel, "error_rate"):
+        old_rate = getattr(channel, "error_rate")
+        setattr(channel, "error_rate", error_rate)
+        try:
+            return channel.simulate(sequence)
+        finally:
+            setattr(channel, "error_rate", old_rate)
+    return channel.simulate(sequence)

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 
 from genecoder import nanopore_sim
+from genecoder.plugins import SIMULATOR_REGISTRY
+from genecoder.simulators import simulate_reads
 
 ADAPTERS = {
     "d2sim": (nanopore_sim.simulate_d2sim, "d2sim"),
@@ -119,28 +121,35 @@ def test_adapters_command_not_found_warning(monkeypatch, caplog, name):
 
 def test_simulate_reads_dispatch(monkeypatch):
     called = []
-    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
-        called.append((seq, rate, isinstance(rng, random.Random)))
+    class DummyChannel(nanopore_sim.Channel):
+        def __init__(self):
+            super().__init__("dummy", 0.05)
 
-        return "ok"
+        def simulate(self, sequence: str) -> str:
+            called.append((sequence, self.error_rate))
+            return "ok"
 
-    monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
-    assert nanopore_sim.simulate_reads("AAAA", "dummy") == "ok"
-    assert called == [("AAAA", 0.05, True)]
+    monkeypatch.setitem(SIMULATOR_REGISTRY, "dummy", DummyChannel())
+    assert simulate_reads("AAAA", "dummy") == "ok"
+    assert called == [("AAAA", 0.05)]
 
 
 def test_simulate_reads_preserves_global_rng(monkeypatch):
-    def fake_adapter(seq: str, rate: float = 0.05, rng=None) -> str:
-        return seq
+    class DummyChannel(nanopore_sim.Channel):
+        def __init__(self):
+            super().__init__("dummy")
 
-    monkeypatch.setitem(nanopore_sim.SIMULATOR_ADAPTERS, "dummy", fake_adapter)
+        def simulate(self, sequence: str) -> str:
+            return sequence
+
+    monkeypatch.setitem(SIMULATOR_REGISTRY, "dummy", DummyChannel())
 
     rng = random.Random(123)
     expected_first = rng.random()
     expected_second = rng.random()
     random.seed(123)
     before = random.random()
-    nanopore_sim.simulate_reads("ACGT", "dummy")
+    simulate_reads("ACGT", "dummy")
     after = random.random()
     assert before == expected_first
     assert after == expected_second
@@ -148,7 +157,7 @@ def test_simulate_reads_preserves_global_rng(monkeypatch):
 
 def test_simulate_reads_unknown_simulator():
     with pytest.raises(ValueError, match="Unknown simulator"):
-        nanopore_sim.simulate_reads("ACGT", "bogus")
+        simulate_reads("ACGT", "bogus")
 
 
 def test_register_returns_channels():

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -2,6 +2,7 @@ import random
 import pytest
 
 from genecoder import nanopore_sim
+from genecoder.simulators import simulate_reads
 from genecoder.channel_sim import simulate_errors
 
 
@@ -35,7 +36,7 @@ def test_simulate_reads_fallback(monkeypatch):
         lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
     )
 
-    result = nanopore_sim.simulate_reads("ACGT", "d2sim", error_rate=0.1)
+    result = simulate_reads("ACGT", "d2sim", error_rate=0.1)
     assert result == "fallback"
     assert which_called == ["d2sim"]
     assert errors_called and isinstance(errors_called[0][2], random.Random)


### PR DESCRIPTION
## Summary
- expose a simple `simulate_reads` dispatcher in new `simulators` module
- ensure built-in simulators implement `BaseChannel` with `Channel`
- register simulators consistently in the plugin loader
- update CLI to use the dispatcher
- document simulator plugins and usage
- adjust unit tests for the new interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f84894f48326a2d53d49a56d9046