### PR TITLE
Add GUI handler and plugin loading tests

### DIFF
--- a/tests/test_flet_gui.py
+++ b/tests/test_flet_gui.py
@@ -1,0 +1,46 @@
+import pytest
+
+ft = pytest.importorskip("flet")
+
+
+class _DummyPage:
+    def __init__(self) -> None:
+        self.overlay = []
+
+    def add(self, *args, **kwargs):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+
+def test_main_registers_event_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
+    ft.colors = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
+
+    captured: dict[str, ft.ElevatedButton] = {}
+    orig_btn = ft.ElevatedButton
+
+    def capture_button(*args, **kwargs):
+        btn = orig_btn(*args, **kwargs)
+        if args and args[0] == "Encode":
+            captured["encode"] = btn
+        elif args and args[0] == "Decode":
+            captured["decode"] = btn
+        return btn
+
+    monkeypatch.setattr(ft, "ElevatedButton", capture_button)
+
+    def fake_app(*, target, view=ft.AppView.FLET_APP, **kwargs):
+        page = _DummyPage()
+        target(page)
+        return page
+
+    monkeypatch.setattr(ft, "app", fake_app)
+
+    from genecoder import flet_app
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    assert callable(captured["encode"].on_click)
+    assert callable(captured["decode"].on_click)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from genecoder import plugins
+
+
+def test_external_plugin_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pkg = tmp_path / "plugins"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "ext.py").write_text(
+        """
+from typing import Callable, Tuple
+
+def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]):
+    def enc(data: bytes) -> str:
+        return 'Y'
+    def dec(text: str) -> bytes:
+        return b'Y'
+    register_codec('ext_codec', enc, dec)
+
+def register_fec(register_fec: Callable[[str, Callable[[bytes], Tuple[bytes, int]], Callable[[bytes, int], Tuple[bytes, int]]], None]):
+    def enc(data: bytes) -> Tuple[bytes, int]:
+        return data + b'ZZ', 2
+    def dec(data: bytes, nsym: int) -> Tuple[bytes, int]:
+        return data[:-nsym], nsym
+    register_fec('ext_fec', enc, dec)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    import plugins as builtin_plugins
+    monkeypatch.setattr(builtin_plugins, '__path__', list(getattr(builtin_plugins, '__path__', [])) + [str(pkg)])
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.load_plugins()
+    assert 'ext_codec' in plugins.CODEC_REGISTRY
+    assert 'ext_fec' in plugins.FEC_REGISTRY
+    # restore built-ins
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.load_plugins()


### PR DESCRIPTION
## Summary
- ensure Flet GUI registers callbacks using a minimal ft.app stub
- test loading codecs and FEC implementations from an external plugin package
- include new tests in coverage reporting

## Testing
- `ruff check tests/test_flet_gui.py tests/test_plugins.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a04f8a3108326bee1ee67fdd22a96