### PR TITLE
Add plugin examples and CI check

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -90,6 +90,23 @@ jobs:
         pip install poetry
         poetry install --with gui,web,dev --no-interaction --no-root
 
+    - name: Install example plugins
+      run: |
+        pip install ./plugins-examples/example_codec ./plugins-examples/example_fec ./plugins-examples/example_simulator
+
+    - name: Verify example plugin registration
+      run: |
+        python - <<'PY'
+        from genecoder import plugins
+        plugins.CODEC_REGISTRY.clear()
+        plugins.FEC_REGISTRY.clear()
+        plugins.SIMULATOR_REGISTRY.clear()
+        plugins.load_plugins()
+        assert "example" in plugins.CODEC_REGISTRY, "codec not registered"
+        assert "example" in plugins.FEC_REGISTRY, "fec not registered"
+        assert "example" in plugins.SIMULATOR_REGISTRY, "simulator not registered"
+        PY
+
     - name: Restore pre-commit cache
       id: precommit-cache
       uses: actions/cache/restore@v3

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,3 +51,10 @@ the :class:`genecoder.channels.base.BaseChannel` protocol.
 
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.
+
+## Plugin Examples
+
+See the [plugins-examples](../plugins-examples/) directory in the source tree for
+minimal sample packages implementing a codec, a FEC backend and a read
+simulator. Install any of these packages with `pip install` to experiment with
+custom extensions locally.

--- a/plugins-examples/README.md
+++ b/plugins-examples/README.md
@@ -1,0 +1,16 @@
+# Plugin Examples
+
+This directory contains minimal example plugins demonstrating how to integrate
+custom codecs, FEC implementations and read simulators with GeneCoder.
+
+Each subdirectory is an installable Python package using PEP 621 metadata:
+
+- `example_codec` – registers a codec named `example`.
+- `example_fec` – registers a FEC backend named `example`.
+- `example_simulator` – registers a simulator named `example`.
+
+Install any of the packages with `pip` to experiment locally, e.g.:
+
+```bash
+pip install ./plugins-examples/example_codec
+```

--- a/plugins-examples/example_codec/example_codec/__init__.py
+++ b/plugins-examples/example_codec/example_codec/__init__.py
@@ -1,0 +1,15 @@
+from typing import Callable
+
+
+def register(
+    register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]
+) -> None:
+    """Register a simple example codec."""
+
+    def encode(data: bytes) -> str:
+        return data.hex()
+
+    def decode(text: str) -> bytes:
+        return bytes.fromhex(text)
+
+    register_codec("example", encode, decode)

--- a/plugins-examples/example_codec/pyproject.toml
+++ b/plugins-examples/example_codec/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-example-codec"
+version = "0.1.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.plugins"]
+example = "example_codec"

--- a/plugins-examples/example_fec/example_fec/__init__.py
+++ b/plugins-examples/example_fec/example_fec/__init__.py
@@ -1,0 +1,15 @@
+from typing import Any, Callable
+
+
+def register(
+    register_fec: Callable[[str, Callable[[bytes], bytes], Callable[[bytes, Any], bytes]], None]
+) -> None:
+    """Register a simple example FEC."""
+
+    def encode(data: bytes) -> bytes:
+        return data
+
+    def decode(encoded: bytes, info: Any | None = None) -> bytes:
+        return encoded
+
+    register_fec("example", encode, decode)

--- a/plugins-examples/example_fec/pyproject.toml
+++ b/plugins-examples/example_fec/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-example-fec"
+version = "0.1.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.fec"]
+example = "example_fec"

--- a/plugins-examples/example_simulator/example_simulator/__init__.py
+++ b/plugins-examples/example_simulator/example_simulator/__init__.py
@@ -1,0 +1,16 @@
+from typing import Callable
+
+from genecoder.channels.base import BaseChannel
+
+
+class PassthroughChannel:
+    """Simple channel that returns sequences unchanged."""
+
+    def simulate(self, sequence: str) -> str:
+        return sequence
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    """Register the example simulator."""
+
+    register_simulator("example", PassthroughChannel())

--- a/plugins-examples/example_simulator/pyproject.toml
+++ b/plugins-examples/example_simulator/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-example-simulator"
+version = "0.1.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.simulators"]
+example = "example_simulator"


### PR DESCRIPTION
## Summary
- add example codec, FEC, and simulator packages under `plugins-examples`
- reference sample plugins in plugin docs
- verify example plugins in CI

## Testing
- `pre-commit run --files plugins-examples/example_codec/example_codec/__init__.py plugins-examples/example_fec/example_fec/__init__.py plugins-examples/example_simulator/example_simulator/__init__.py .github/workflows/python-ci.yml docs/plugins.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a04e6cc1883268a0ccbf8b63ef2b5