### PR TITLE
Wrap read simulators with channel classes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -355,6 +355,21 @@ desktop = ["flet-desktop (==0.28.3) ; platform_system == \"Darwin\" or platform_
 web = ["flet-web (==0.28.3)"]
 
 [[package]]
+name = "flet-webview"
+version = "0.1.0"
+description = "WebView control for Flet"
+optional = false
+python-versions = ">=3.8"
+groups = ["gui"]
+files = [
+    {file = "flet_webview-0.1.0-py3-none-any.whl", hash = "sha256:f523de312ee1c7af4f432b393541dd3ba1b6f85d59a3e4216103a56848e091fb"},
+    {file = "flet_webview-0.1.0.tar.gz", hash = "sha256:a581fae93623372ffcbf30c81c48ad4c619760f38df022576fd83adddad54d4c"},
+]
+
+[package.dependencies]
+flet = ">=0.25.2"
+
+[[package]]
 name = "fonttools"
 version = "4.58.4"
 description = "Tools to manipulate font files"
@@ -512,14 +527,14 @@ test = ["Cython (>=0.29.24)"]
 
 [[package]]
 name = "httpx"
-version = "0.28.1"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["gui", "web"]
 files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -527,6 +542,7 @@ anyio = "*"
 certifi = "*"
 httpcore = "==1.*"
 idna = "*"
+sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
@@ -1834,4 +1850,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7541d8c5ae904dd016600941975896b31c1a65c0658b415a68b55fed393a82f7"
+content-hash = "2a0e77f26ef2fcdf02492d0359bb3260c3dfadcd122fb0a5b7be746f57f8f506"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dnaformer = "genecoder.dnaformer_codec"
 [tool.poetry.plugins."genecoder.simulators"]
 nanopore = "genecoder.nanopore_sim"
 d2sim = "genecoder.d2sim_adapter"
+simple = "genecoder.channel_sim"
+indel = "genecoder.error_simulation"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -1,11 +1,14 @@
 """Simple channel error simulator for DNA sequences."""
 from __future__ import annotations
 
+import os
 import random
-from typing import Protocol
+from typing import Protocol, Callable
+
+from .channels.base import BaseChannel
 
 
-__all__ = ["simulate_errors", "RandomLike"]
+__all__ = ["simulate_errors", "RandomLike", "Channel", "register"]
 
 
 class RandomLike(Protocol):
@@ -42,3 +45,26 @@ def simulate_errors(seq: str, p_error: float, rng: Optional[random.Random] = Non
         else:
             result.append(nt)
     return "".join(result)
+
+
+def _make_rng() -> random.Random:
+    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
+
+    seed_env = os.getenv("GENECODER_SIM_SEED")
+    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
+
+
+class Channel(BaseChannel):
+    """Simple substitution error channel."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_errors(sequence, self.error_rate, rng=_make_rng())
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    """Register the simple substitution error simulator."""
+
+    register_simulator("simple", Channel())

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -1,7 +1,13 @@
 """Utilities for simulating random sequencing errors in DNA sequences."""
 from __future__ import annotations
 
+import os
 import random
+from typing import Callable
+
+from .channels.base import BaseChannel
+
+__all__ = ["introduce_errors", "apply_substitutions", "apply_insertions", "apply_deletions", "Channel", "register"]
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
@@ -89,3 +95,39 @@ def apply_insertions(sequence: str, prob: float, rng: random.Random | None = Non
 def apply_deletions(sequence: str, prob: float, rng: random.Random | None = None) -> str:
     """Delete nucleotides from ``sequence`` with probability ``prob``."""
     return introduce_errors(sequence, deletion_prob=prob, rng=rng)
+
+
+def _make_rng() -> random.Random:
+    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
+
+    seed_env = os.getenv("GENECODER_SIM_SEED")
+    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
+
+
+class Channel(BaseChannel):
+    """Channel applying substitution, insertion and deletion errors."""
+
+    def __init__(
+        self,
+        substitution_prob: float = 0.0,
+        insertion_prob: float = 0.0,
+        deletion_prob: float = 0.0,
+    ) -> None:
+        self.substitution_prob = substitution_prob
+        self.insertion_prob = insertion_prob
+        self.deletion_prob = deletion_prob
+
+    def simulate(self, sequence: str) -> str:
+        return introduce_errors(
+            sequence,
+            substitution_prob=self.substitution_prob,
+            insertion_prob=self.insertion_prob,
+            deletion_prob=self.deletion_prob,
+            rng=_make_rng(),
+        )
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    """Register the insertion/deletion error simulator."""
+
+    register_simulator("indel", Channel())

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -117,3 +117,15 @@ def load_plugins() -> None:
     else:
         for name in _nano.SIMULATOR_ADAPTERS:
             register_simulator(name, _nano.Channel(name))
+
+    from . import channel_sim as _chan
+    if hasattr(_chan, "register"):
+        _chan.register(register_simulator)
+    else:
+        register_simulator("simple", _chan.Channel())
+
+    from . import error_simulation as _err
+    if hasattr(_err, "register"):
+        _err.register(register_simulator)
+    else:
+        register_simulator("indel", _err.Channel())

--- a/tests/test_channel_sim.py
+++ b/tests/test_channel_sim.py
@@ -1,20 +1,19 @@
-import random
-from genecoder.channel_sim import simulate_errors
+from genecoder.simulators import simulate_reads
 from genecoder.encoders import encode_base4_direct, decode_base4_direct
 from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat
 
 
-def test_simulate_errors_deterministic():
-    rng = random.Random(0)
-    assert simulate_errors("AAAA", 1.0, rng=rng) == "CGCC"
+def test_simulate_errors_deterministic(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "0")
+    assert simulate_reads("AAAA", "simple", error_rate=1.0) == "CGCC"
 
 
-def test_decode_recovery_with_triple_repeat():
-    rng = random.Random(42)
+def test_decode_recovery_with_triple_repeat(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "42")
     data = b"hello"
     dna = encode_base4_direct(data)
     dna_tr = encode_triple_repeat(dna)
-    corrupted = simulate_errors(dna_tr, 0.05, rng=rng)
+    corrupted = simulate_reads(dna_tr, "simple", error_rate=0.05)
     corrected, _, _ = decode_triple_repeat(corrupted)
     recovered, _ = decode_base4_direct(corrected)
     assert recovered == data

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -3,7 +3,6 @@ import pytest
 
 from genecoder import nanopore_sim
 from genecoder.simulators import simulate_reads
-from genecoder.channel_sim import simulate_errors
 
 
 def test_simulate_errors_preserves_global_rng():
@@ -12,7 +11,7 @@ def test_simulate_errors_preserves_global_rng():
     expected_second = rng.random()
     random.seed(123)
     before = random.random()
-    simulate_errors("AAAA", 0.1)
+    simulate_reads("AAAA", "simple", error_rate=0.1)
     after = random.random()
     assert before == expected_first
     assert after == expected_second
@@ -21,7 +20,7 @@ def test_simulate_errors_preserves_global_rng():
 @pytest.mark.parametrize("prob", [-0.1, 1.1])
 def test_simulate_errors_invalid_probability(prob):
     with pytest.raises(ValueError):
-        simulate_errors("A", prob)
+        simulate_reads("A", "simple", error_rate=prob)
 
 
 def test_simulate_reads_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- introduce Channel and register function for `channel_sim`
- add Channel wrapper for `error_simulation`
- load new channels in `plugins` and expose entry points
- update tests to call `simulate_reads` via simulator registry

## Testing
- `pre-commit run --files src/genecoder/channel_sim.py src/genecoder/error_simulation.py src/genecoder/plugins.py pyproject.toml tests/test_channel_sim.py tests/test_simulators_additional.py`

------
https://chatgpt.com/codex/tasks/task_e_685a04dc0eac8326812206caf7dc1d67