### PR TITLE
Add CLI security options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -192,6 +192,18 @@ genecoder encode --input-files msg.txt \
     --output-dir out/ --method base4_direct \
     --capsule seq.capsule
 ```
+### Security Options
+
+Use `--encrypt` to XOR-encrypt the input bytes with a built-in key before
+encoding. The `--checksum` flag stores a SHA256 checksum of the plaintext in the
+FASTA header which is validated during decoding.
+
+```bash
+genecoder encode --input-files secret.txt \
+    --output-dir out/ --method base4_direct --encrypt --checksum
+genecoder decode --input-files out/secret.txt.fasta \
+    --output-dir decoded/ --method base4_direct --encrypt --checksum
+```
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -17,6 +17,7 @@ from .plugins import (
     load_plugins,
 )
 from .simulators import simulate_reads
+from .security import decrypt_data, encrypt_data, compute_checksum
 
 load_plugins()
 
@@ -28,6 +29,9 @@ __all__ = [
     "SIMULATOR_REGISTRY",
     "simulate_reads",
     "load_plugins",
+    "encrypt_data",
+    "decrypt_data",
+    "compute_checksum",
 ]
 
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -17,6 +17,7 @@ from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from genecoder.security import decrypt_data, compute_checksum
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +216,22 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
+        if getattr(args, "encrypt", False):
+            final_decoded_data = decrypt_data(final_decoded_data)
+
+        if getattr(args, "checksum", False):
+            m = re.search(r"checksum=([0-9a-f]+)", header)
+            if not m:
+                logger.error(
+                    f"Checksum requested but missing in header for {input_file_path}."
+                )
+                raise SystemExit(1)
+            expected = m.group(1)
+            actual = compute_checksum(final_decoded_data)
+            if expected != actual:
+                logger.error(f"Checksum mismatch for {input_file_path}.")
+                raise SystemExit(1)
+
         os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "wb") as f_out:
             f_out.write(final_decoded_data)
@@ -285,6 +302,16 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
             "Alphabet mapping used during encoding. base5 and base6 remap"
             " letters only and do not increase capacity (default: base4)."
         ),
+    )
+    parser.add_argument(
+        "--encrypt",
+        action="store_true",
+        help="Decrypt output assuming the encoded data was encrypted.",
+    )
+    parser.add_argument(
+        "--checksum",
+        action="store_true",
+        help="Validate checksum stored in the FASTA header.",
     )
     parser.add_argument(
         "--stream",

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -24,6 +24,7 @@ from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
+from genecoder.security import encrypt_data, compute_checksum
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +242,15 @@ def process_single_encode(
             return os.path.basename(input_file_path), dna_sequence
 
         with open(input_file_path, "rb") as f_in:
-            original_input_data = f_in.read()
+            plaintext_data = f_in.read()
+
+        data_for_encoding = plaintext_data
+        if getattr(args, "encrypt", False):
+            data_for_encoding = encrypt_data(plaintext_data)
+
+        checksum: str | None = None
+        if getattr(args, "checksum", False):
+            checksum = compute_checksum(plaintext_data)
 
         options = build_encoding_options(args)
         (
@@ -251,8 +260,11 @@ def process_single_encode(
             current_input_data,
             fec_padding_bits,
         ) = run_encoding_pipeline(
-            original_input_data, options, os.path.basename(input_file_path)
+            data_for_encoding, options, os.path.basename(input_file_path)
         )
+
+        if checksum:
+            fasta_header = f"{fasta_header} checksum={checksum}"
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
 
@@ -276,7 +288,7 @@ def process_single_encode(
             )
             logger.info(f"Capsule written to {args.capsule}")
 
-        original_size_bytes = len(original_input_data)
+        original_size_bytes = len(plaintext_data)
         final_encoded_length_nucleotides = len(final_encoded_dna_sequence)
         dna_equivalent_bytes = final_encoded_length_nucleotides * 0.25
 
@@ -432,6 +444,16 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
             "Alphabet mapping to use. base5 and base6 simply remap the ACGT"
             " symbols and do not increase capacity (default: base4)."
         ),
+    )
+    parser.add_argument(
+        "--encrypt",
+        action="store_true",
+        help="Encrypt input bytes before encoding.",
+    )
+    parser.add_argument(
+        "--checksum",
+        action="store_true",
+        help="Store checksum of plaintext in the FASTA header.",
     )
     parser.add_argument(
         "--stream",

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -1,0 +1,24 @@
+"""Simple security utilities for optional CLI encryption and checksums."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Optional
+
+_DEFAULT_KEY = b"GeneCoder"
+
+
+def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
+    """XOR-encrypt ``data`` using ``key`` (defaults to a static value)."""
+    key = key or _DEFAULT_KEY
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
+    """Decrypt data previously encrypted with :func:`encrypt_data`."""
+    return encrypt_data(data, key)
+
+
+def compute_checksum(data: bytes) -> str:
+    """Return a hexadecimal SHA256 checksum for ``data``."""
+    return hashlib.sha256(data).hexdigest()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from genecoder.security import encrypt_data, decrypt_data, compute_checksum
+from tests.test_cli import run_cli_command
+
+
+def test_encrypt_roundtrip() -> None:
+    data = b"hello"
+    enc = encrypt_data(data)
+    dec = decrypt_data(enc)
+    assert dec == data
+
+
+def test_checksum() -> None:
+    data = b"abc"
+    import hashlib
+
+    expected = hashlib.sha256(data).hexdigest()
+    assert compute_checksum(data) == expected
+
+
+def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:
+    src = tmp_path / "msg.txt"
+    src.write_text("secure message")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(src),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--checksum",
+        ]
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    fasta = tmp_path / "msg.txt.fasta"
+    assert fasta.exists()
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--checksum",
+        ]
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "msg.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text() == "secure message"


### PR DESCRIPTION
## Summary
- add simple XOR-based `security` utilities with checksum helper
- support `--encrypt` and `--checksum` flags in CLI encode/decode commands
- document new Security Options in usage docs
- test encryption round-trips and CLI checksum validation

## Testing
- `pre-commit run --files src/genecoder/security.py src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/__init__.py tests/test_security.py`

------
https://chatgpt.com/codex/tasks/task_e_685a04d308e8832686bf6b5a5a21d4f5