### PR TITLE
Implement React-based helix UI

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -29,3 +29,7 @@ Import `show_helix` and pass a DNA sequence. Optional `length` and `colors` argu
 from genecoder.helix_view import show_helix
 webview = show_helix("ACGT", length=50, colors={"A": "#ff0000", "T": "#00ffff"})
 ```
+
+The newer `show_helix_ui` helper launches the React frontend. It accepts the
+same base sequence along with options such as `animate`, `zoom`, `gc`, `runs`
+and custom base colors.

--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -4,13 +4,39 @@ The 3D helix viewer lives in `web/helix-ui`. It is a single-page React
 application that uses Three.js for rendering and displays simple overlays for
 GC content and homopolymer runs.
 
-To explore the viewer without running the whole backend simply open
-`web/helix-ui/index.html` in a browser or start a local HTTP server:
+The frontend now uses [Vite](https://vitejs.dev/) for development and builds.
+To explore the viewer without running the whole backend simply open the built
+`dist/index.html` in a browser or start a local HTTP server:
 
 ```bash
-python -m http.server --directory web/helix-ui 8001
+python -m http.server --directory web/helix-ui/dist 8001
 ```
 
-During development you can edit `index.html` and reload the page. The Flet GUI
-and FastAPI web app load the same file via a WebView/IFrame, so changes are
-reflected automatically.
+## Building the React App
+
+Install the Node dependencies once and run the build:
+
+```bash
+cd web/helix-ui
+npm install
+npm run build
+```
+
+The build output appears in `web/helix-ui/dist`. The Flet GUI and FastAPI web
+app load this directory via a WebView/IFrame so changes are reflected after
+rebuilding.
+
+### Query Parameters
+
+The viewer accepts several query parameters which are also exposed by
+`show_helix_ui`:
+
+- `seq` – DNA sequence to visualize.
+- `animate` – `true` or `false` to spin the helix.
+- `zoom` – numeric zoom factor.
+- `gc` – `true`/`false` to show the GC-content overlay.
+- `runs` – `true`/`false` to highlight homopolymers.
+- `colors` – comma-separated `base:#hex` pairs, for example
+  `A:#ff0000,G:#00ff00`.
+
+Combine these parameters in the page URL or when calling `show_helix_ui`.

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -10,9 +10,10 @@ uvicorn web.main:app --reload
 
 Open <http://127.0.0.1:8000> to view the landing page.
 
-The React helix viewer is available at `/helix`. It accepts optional `seq`,
-`zoom` and `animate` query parameters. The landing page includes an IFrame that
-loads this viewer.
+The React helix viewer is available at `/helix`. It accepts optional query
+parameters used by `show_helix_ui` such as `seq`, `animate`, `zoom`, `gc`,
+`runs` and `colors`. The landing page includes an IFrame that loads this
+viewer.
 
 Set the `GENECODER_SIM_SEED` environment variable to an integer to get
 reproducible results when API endpoints invoke error simulations.

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -266,10 +266,26 @@ def show_helix_ui(
     *,
     animate: bool = True,
     zoom: float = 1.0,
+    colors: dict[str, int] | None = None,
+    show_gc: bool = True,
+    show_runs: bool = True,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend."""
-    helix_path = Path(__file__).resolve().parent.parent / "web" / "helix-ui" / "index.html"
-    params = (
-        f"?seq={quote(dna_sequence)}&animate={'true' if animate else 'false'}&zoom={zoom}"
-    )
-    return flet_webview.WebView(url=helix_path.as_uri() + params, width=600, height=400)
+    base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
+    helix_path = base_dir / "dist" / "index.html"
+    if not helix_path.is_file():
+        helix_path = base_dir / "index.html"
+
+    params = [
+        f"seq={quote(dna_sequence)}",
+        f"animate={'true' if animate else 'false'}",
+        f"zoom={zoom}",
+        f"gc={'true' if show_gc else 'false'}",
+        f"runs={'true' if show_runs else 'false'}",
+    ]
+    if colors:
+        color_str = ",".join(f"{b}:#{v:06x}" for b, v in colors.items())
+        params.append(f"colors={quote(color_str)}")
+
+    query = "?" + "&".join(params)
+    return flet_webview.WebView(url=helix_path.as_uri() + query, width=600, height=400)

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -8,12 +8,22 @@ from genecoder.helix_view import show_helix_ui
 
 
 def test_show_helix_ui_url(tmp_path: Path) -> None:
-    webview = show_helix_ui("ACGT", animate=False, zoom=1.5)
+    webview = show_helix_ui(
+        "ACGT",
+        animate=False,
+        zoom=1.5,
+        colors={"A": 0x123456},
+        show_gc=False,
+        show_runs=False,
+    )
     assert webview.__class__.__name__ == "WebView"
     assert webview.url.startswith("file:")
     parsed = urlparse(webview.url)
     assert "animate=false" in parsed.query
     assert "zoom=1.5" in parsed.query
+    assert "gc=false" in parsed.query
+    assert "runs=false" in parsed.query
+    assert "colors=A%3A%23123456" in parsed.query
 
 
 def test_helix_ui_screenshot(tmp_path: Path) -> None:

--- a/web/helix-ui/index.html
+++ b/web/helix-ui/index.html
@@ -1,102 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Helix Viewer</title>
-  <style>
-    html, body, #root { margin:0; width:100%; height:100%; overflow:hidden; }
-    #metrics { position:absolute; top:0; left:0; pointer-events:none; opacity:0.6; }
-    #controls { position:absolute; top:10px; left:10px; z-index:1; background:#fff; padding:4px; border-radius:4px; }
-  </style>
-</head>
-<body>
-  <div id="root"></div>
-  <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
-  <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.min.js';
-    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/controls/OrbitControls.js';
-
-    const {useRef,useEffect,useState} = React;
-
-    function HelixViewer() {
-      const mount = useRef(null);
-      const metricsRef = useRef(null);
-      const params = new URLSearchParams(location.search);
-      const [animate, setAnimate] = useState(params.get('animate') !== 'false');
-      const seq = params.get('seq') || 'ACGT';
-      const zoom = parseFloat(params.get('zoom') || '1');
-
-      useEffect(() => {
-        const width = mount.current.clientWidth;
-        const height = mount.current.clientHeight;
-        const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(75,width/height,0.1,1000);
-        camera.position.set(2*zoom,2*zoom,5*zoom);
-        const renderer = new THREE.WebGLRenderer({antialias:true});
-        renderer.setSize(width,height);
-        mount.current.appendChild(renderer.domElement);
-        metricsRef.current.width = width;
-        metricsRef.current.height = 30;
-        const controls = new OrbitControls(camera, renderer.domElement);
-        controls.enableDamping = true;
-
-        const group = new THREE.Group();
-        const bases = seq.split('');
-        const colors = {A:0xff5555,C:0x5555ff,G:0x55ff55,T:0xffff55};
-        const radius=0.1;
-        const h=0.4;
-        bases.forEach((b,i)=>{
-          const geom=new THREE.SphereGeometry(radius,16,16);
-          const mat=new THREE.MeshPhongMaterial({color:colors[b]||0xffffff});
-          const mesh=new THREE.Mesh(geom,mat);
-          const angle=i*0.3;
-          mesh.position.set(Math.cos(angle),Math.sin(angle),i*h);
-          group.add(mesh);
-        });
-        scene.add(group);
-        const light=new THREE.DirectionalLight(0xffffff,1);
-        light.position.set(5,5,5);
-        scene.add(light);
-
-        const ctx=metricsRef.current.getContext('2d');
-        const bw=metricsRef.current.width/bases.length;
-        const runs=new Array(bases.length).fill(1);
-        for(let i=0;i<bases.length;i++){
-          if(i>0 && bases[i]===bases[i-1]) runs[i]=runs[i-1]+1;
-          ctx.fillStyle=bases[i]==='G'||bases[i]==='C'?'#88f':'#ddd';
-          ctx.fillRect(i*bw,0,bw,14);
-        }
-        for(let i=0;i<bases.length;i++){
-          const intensity=Math.min(runs[i]/6,1);
-          ctx.fillStyle=`rgba(255,0,0,${intensity})`;
-          ctx.fillRect(i*bw,16,bw,14);
-        }
-
-        let frameId;
-        function loop(){
-          controls.update();
-          if(animate) group.rotation.z += 0.01;
-          renderer.render(scene,camera);
-          frameId=requestAnimationFrame(loop);
-        }
-        loop();
-        return () => cancelAnimationFrame(frameId);
-      },[seq,animate,zoom]);
-
-      return React.createElement('div',{style:{width:'100%',height:'100%',position:'relative'}},
-        React.createElement('canvas',{ref:metricsRef,id:'metrics'}),
-        React.createElement('div',{id:'controls'},
-          React.createElement('label',null,
-            React.createElement('input',{type:'checkbox',checked:animate,onChange:e=>setAnimate(e.target.checked)}),
-            ' Animate'
-          )
-        ),
-        React.createElement('div',{ref:mount,style:{width:'100%',height:'100%'}})
-      );
-    }
-
-    ReactDOM.render(React.createElement(HelixViewer), document.getElementById('root'));
-  </script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Helix Viewer</title>
+    <style>
+      html, body, #root { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/web/helix-ui/package.json
+++ b/web/helix-ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "helix-ui",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.164.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+const DEFAULT_COLORS = {
+  A: 0xff5555,
+  C: 0x5555ff,
+  G: 0x55ff55,
+  T: 0xffff55,
+};
+
+function parseColors(param) {
+  if (!param) return null;
+  const map = {};
+  param.split(',').forEach((p) => {
+    const [b, c] = p.split(':');
+    if (b && c) {
+      const hex = c.startsWith('#') ? c.slice(1) : c.replace(/^0x/, '');
+      map[b.toUpperCase()] = parseInt(hex, 16);
+    }
+  });
+  return map;
+}
+
+export default function App() {
+  const mount = useRef(null);
+  const metricsRef = useRef(null);
+  const params = new URLSearchParams(window.location.search);
+
+  const [animate, setAnimate] = useState(params.get('animate') !== 'false');
+  const [zoom] = useState(parseFloat(params.get('zoom') || '1'));
+  const seq = params.get('seq') || 'ACGT';
+  const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
+  const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
+
+  const colorParam = params.get('colors');
+  const colors = { ...DEFAULT_COLORS, ...(parseColors(colorParam) || {}) };
+
+  useEffect(() => {
+    const width = mount.current.clientWidth;
+    const height = mount.current.clientHeight;
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    camera.position.set(2 * zoom, 2 * zoom, 5 * zoom);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    mount.current.appendChild(renderer.domElement);
+
+    metricsRef.current.width = width;
+    metricsRef.current.height = 30;
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const group = new THREE.Group();
+    const bases = seq.split('');
+    const radius = 0.1;
+    const h = 0.4;
+    bases.forEach((b, i) => {
+      const geom = new THREE.SphereGeometry(radius, 16, 16);
+      const mat = new THREE.MeshPhongMaterial({ color: colors[b] || 0xffffff });
+      const mesh = new THREE.Mesh(geom, mat);
+      const angle = i * 0.3;
+      mesh.position.set(Math.cos(angle), Math.sin(angle), i * h);
+      group.add(mesh);
+    });
+    scene.add(group);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 5, 5);
+    scene.add(light);
+
+    const ctx = metricsRef.current.getContext('2d');
+    const bw = metricsRef.current.width / bases.length;
+    const runs = new Array(bases.length).fill(1);
+    for (let i = 0; i < bases.length; i++) {
+      if (i > 0 && bases[i] === bases[i - 1]) runs[i] = runs[i - 1] + 1;
+      if (showGC) {
+        ctx.fillStyle = bases[i] === 'G' || bases[i] === 'C' ? '#88f' : '#ddd';
+        ctx.fillRect(i * bw, 0, bw, 14);
+      }
+    }
+    for (let i = 0; i < bases.length; i++) {
+      if (showRuns) {
+        const intensity = Math.min(runs[i] / 6, 1);
+        ctx.fillStyle = `rgba(255,0,0,${intensity})`;
+        ctx.fillRect(i * bw, 16, bw, 14);
+      }
+    }
+
+    let frameId;
+    const loop = () => {
+      controls.update();
+      if (animate) group.rotation.z += 0.01;
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(loop);
+    };
+    loop();
+    return () => {
+      cancelAnimationFrame(frameId);
+      renderer.dispose();
+    };
+  }, [seq, animate, zoom, colors, showGC, showRuns]);
+
+  return (
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <canvas
+        ref={metricsRef}
+        style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none', opacity: 0.6 }}
+      />
+      <div
+        style={{ position: 'absolute', top: 10, left: 10, zIndex: 1, background: '#fff', padding: 4, borderRadius: 4 }}
+      >
+        <label>
+          <input type="checkbox" checked={animate} onChange={(e) => setAnimate(e.target.checked)} /> Animate
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showGC} onChange={(e) => setShowGC(e.target.checked)} /> GC
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showRuns} onChange={(e) => setShowRuns(e.target.checked)} /> Runs
+        </label>
+      </div>
+      <div ref={mount} style={{ width: '100%', height: '100%' }} />
+    </div>
+  );
+}

--- a/web/helix-ui/src/main.jsx
+++ b/web/helix-ui/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/helix-ui/vite.config.js
+++ b/web/helix-ui/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+});

--- a/web/main.py
+++ b/web/main.py
@@ -19,7 +19,9 @@ helix_ui_dir = Path(__file__).parent / "helix-ui"
 app.mount("/helix-ui", StaticFiles(directory=helix_ui_dir), name="helix-ui")
 
 index_path = static_dir / "index.html"
-helix_index_path = helix_ui_dir / "index.html"
+helix_index_path = helix_ui_dir / "dist" / "index.html"
+if not helix_index_path.is_file():
+    helix_index_path = helix_ui_dir / "index.html"
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]
 async def index() -> str:
@@ -32,7 +34,7 @@ async def helix() -> str:
     return helix_index_path.read_text(encoding="utf-8")
 
 
-class EncodeOptionsModel(BaseModel):
+class EncodeOptionsModel(BaseModel):  # type: ignore[misc]
     method: str
     add_parity: bool = False
     k_value: int = 7
@@ -46,26 +48,26 @@ class EncodeOptionsModel(BaseModel):
     alphabet: str = "base4"
 
 
-class EncodeRequest(BaseModel):
+class EncodeRequest(BaseModel):  # type: ignore[misc]
     data: str
     options: EncodeOptionsModel
 
 
-class DecodeRequest(BaseModel):
+class DecodeRequest(BaseModel):  # type: ignore[misc]
     fasta_data: str
     alphabet: str = "base4"
 
 
-@app.post("/encode")
-async def encode(req: EncodeRequest) -> dict:
+@app.post("/encode")  # type: ignore[misc]
+async def encode(req: EncodeRequest) -> dict[str, object]:
     data_bytes = base64.b64decode(req.data.encode("utf-8"), validate=True)
     opts = EncodeOptions(**req.options.model_dump())
     result = await asyncio.to_thread(perform_encoding, data_bytes, opts)
     return asdict(result)
 
 
-@app.post("/decode")
-async def decode(req: DecodeRequest) -> dict:
+@app.post("/decode")  # type: ignore[misc]
+async def decode(req: DecodeRequest) -> dict[str, object]:
     result = await asyncio.to_thread(
         perform_decoding, req.fasta_data, req.alphabet
     )


### PR DESCRIPTION
## Summary
- migrate helix-ui to a Vite+React build
- add GC-content and homopolymer toggles
- expose UI parameters via `show_helix_ui`
- document building the frontend
- serve the built viewer from the API and document query parameters

## Testing
- `poetry run ruff check web/helix-ui src tests web/main.py --fix`
- `poetry run mypy src web/main.py`
- `poetry run pytest tests/test_helix_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685a04e50ca88326a21ab64593ac79f8