### PR TITLE
Use JSON for FEC metadata

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -128,9 +128,9 @@ def run_decoding_pipeline(
                 info = None
                 if info_match:
                     import base64
-                    import pickle
+                    import json
 
-                    info = pickle.loads(base64.b64decode(info_match.group(1)))
+                    info = json.loads(base64.b64decode(info_match.group(1)).decode())
                 final_data, _ = FEC_REGISTRY[fec_name]["decode"](final_data, info)
     return final_data
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -85,9 +85,9 @@ def run_encoding_pipeline(
         header_parts.append(f"fec={options.fec}")
         if info is not None:
             import base64
-            import pickle
+            import json
 
-            encoded_info = base64.b64encode(pickle.dumps(info)).decode()
+            encoded_info = base64.b64encode(json.dumps(info).encode()).decode()
             header_parts.append(f"fec_info={encoded_info}")
         logger.info(
             f"Applied {options.fec} FEC to {input_file_name}. Original binary size: {len(data)}, encoded size: {len(current_input)}."

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -96,6 +96,12 @@ def test_reed_solomon_pipeline(tmp_path: Path):
     dna, header, *_ = run_encoding_pipeline(data, enc_opts, input_file.name)
     assert "fec=reed_solomon" in header
     assert "fec_info=" in header
+    fec_info_b64 = header.split("fec_info=")[1].split()[0]
+    import base64
+    import json
+
+    rs_info = json.loads(base64.b64decode(fec_info_b64).decode())
+    assert rs_info == 10
     assert "parity_k" not in header
 
     dec_args = argparse.Namespace(


### PR DESCRIPTION
## Summary
- store FEC info with `json.dumps` during encoding
- read FEC info with `json.loads` during decoding
- verify JSON-encoded FEC info in tests

## Testing
- `ruff check src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_cli_helpers.py`
- `mypy --config-file mypy.ini src/genecoder/cli/encode.py src/genecoder/cli/decode.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa1923d8883269b35c67d2e5da32c