### PR TITLE
Align docs on Poetry setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md)
 
 ## Quick Start
 
-GeneCoder requires **Python 3.10+**. Install the dependencies using
-[Poetry](https://python-poetry.org/):
+GeneCoder requires **Python 3.10+** and uses
+[Poetry](https://python-poetry.org/) for dependency management. Install the
+dependencies with:
 
 ```bash
 poetry install --no-interaction
@@ -33,12 +34,6 @@ Install optional extras for the GUI or web API with:
 poetry install --with gui,web --no-interaction
 ```
 
-Alternatively, use `pip` with **Python 3.10+** to install the project in
-editable mode:
-
-```bash
-python -m pip install -e .[gui,web]
-```
 
 Desktop packages are available on the [releases page](https://github.com/d0tTino/GeneCoder/releases).
 Download the `.msix` file for Windows or the `.dmg` for macOS and follow your

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -5,7 +5,7 @@ This guide demonstrates a minimal end-to-end run of GeneCoder.
 ## Prerequisites
 
 - **Python 3.10+**
-- **Poetry** for dependency management
+- GeneCoder uses **Poetry** for dependency management
 
 ## Environment Setup
 


### PR DESCRIPTION
## Summary
- recommend Poetry as the single setup method
- drop pip installation instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aa691fdb48326be8ea78d78992681