### PR TITLE
Add CLI key file option for encryption

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -195,14 +195,15 @@ genecoder encode --input-files msg.txt \
 ### Security Options
 
 Use `--encrypt` to XOR-encrypt the input bytes with a built-in key before
-encoding. The `--checksum` flag stores a SHA256 checksum of the plaintext in the
-FASTA header which is validated during decoding.
+encoding. Provide `--key <file>` to read custom key bytes from a file. The
+`--checksum` flag stores a SHA256 checksum of the plaintext in the FASTA header
+which is validated during decoding.
 
 ```bash
 genecoder encode --input-files secret.txt \
-    --output-dir out/ --method base4_direct --encrypt --checksum
+    --output-dir out/ --method base4_direct --encrypt --key key.bin --checksum
 genecoder decode --input-files out/secret.txt.fasta \
-    --output-dir decoded/ --method base4_direct --encrypt --checksum
+    --output-dir decoded/ --method base4_direct --encrypt --key key.bin --checksum
 ```
 ## Graphical User Interface (GUI)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.10"
 reedsolo = "*"
+cryptography = "^45.0.4"
 
 [tool.poetry.group.gui.dependencies]
 flet = ">=0.28,<0.29"
@@ -42,7 +43,6 @@ pytest-cov = "*"
 pre-commit = "*"
 ruff = "*"
 mypy = "*"
-cryptography = "^45.0.4"
 
 [tool.poetry.scripts]
 genecoder = "genecoder.cli.cli:main"

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -216,8 +216,12 @@ def process_single_decode(
             sequence_from_fasta, header, options, os.path.basename(input_file_path)
         )
 
+        key_bytes = None
+        if getattr(args, "key", None):
+            with open(args.key, "rb") as kf:
+                key_bytes = kf.read()
         if getattr(args, "encrypt", False):
-            final_decoded_data = decrypt_data(final_decoded_data)
+            final_decoded_data = decrypt_data(final_decoded_data, key=key_bytes)
 
         if getattr(args, "checksum", False):
             m = re.search(r"checksum=([0-9a-f]+)", header)
@@ -307,6 +311,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--encrypt",
         action="store_true",
         help="Decrypt output assuming the encoded data was encrypted.",
+    )
+    parser.add_argument(
+        "--key",
+        type=str,
+        help="Path to file containing encryption key bytes.",
     )
     parser.add_argument(
         "--checksum",

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -245,8 +245,12 @@ def process_single_encode(
             plaintext_data = f_in.read()
 
         data_for_encoding = plaintext_data
+        key_bytes = None
+        if getattr(args, "key", None):
+            with open(args.key, "rb") as kf:
+                key_bytes = kf.read()
         if getattr(args, "encrypt", False):
-            data_for_encoding = encrypt_data(plaintext_data)
+            data_for_encoding = encrypt_data(plaintext_data, key=key_bytes)
 
         checksum: str | None = None
         if getattr(args, "checksum", False):
@@ -449,6 +453,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--encrypt",
         action="store_true",
         help="Encrypt input bytes before encoding.",
+    )
+    parser.add_argument(
+        "--key",
+        type=str,
+        help="Path to file containing encryption key bytes.",
     )
     parser.add_argument(
         "--checksum",

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -24,7 +24,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = AESGCM(aes_key).encrypt(nonce, data, None)
+    enc: bytes = AESGCM(aes_key).encrypt(nonce, data, None)
     return _AES_HEADER + nonce + enc
 
 
@@ -35,7 +35,8 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return dec
     return _xor_cipher(data, key)
 
 

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -24,7 +24,10 @@ def test_cli_version(tmp_path: Path):
     genecoder_path = venv_dir / bin_dir / "genecoder"
 
     subprocess.run([str(pip_path), "install", "-U", "pip", "setuptools", "wheel"], check=True)
-    subprocess.run([str(pip_path), "install", "matplotlib", "flet>=0.28,<0.29", "reedsolo"], check=True)
+    subprocess.run(
+        [str(pip_path), "install", "matplotlib", "flet>=0.28,<0.29", "reedsolo", "cryptography"],
+        check=True,
+    )
 
     subprocess.run([
         str(pip_path),

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -76,3 +76,48 @@ def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:
     out_file = tmp_path / "msg.txt_decoded.bin"
     assert out_file.exists()
     assert out_file.read_text() == "secure message"
+
+
+def test_cli_encrypt_key_file_roundtrip(tmp_path: Path) -> None:
+    src = tmp_path / "secret.txt"
+    src.write_text("top secret")
+    key_file = tmp_path / "key.bin"
+    key_file.write_bytes(b"mykey")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(src),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_file),
+        ]
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    fasta = tmp_path / "secret.txt.fasta"
+    assert fasta.exists()
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_file),
+        ]
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "secret.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text() == "top secret"


### PR DESCRIPTION
## Summary
- support `--key FILE` in `encode` and `decode`
- load custom key when encrypting/decrypting
- test encode/decode roundtrip with custom key
- document new option in usage docs
- type annotate security functions
- move cryptography to runtime dependencies and update packaging test

## Testing
- `SKIP_PACKAGING_TESTS=1 pre-commit run --files src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/security.py tests/test_security.py tests/test_cli_version.py docs/usage.md pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_685aa68cef4c83268b65d268ee03f800