### PR TITLE
Fix AESGCM optional import

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -17,7 +17,6 @@ from .plugins import (
     load_plugins,
 )
 from .simulators import simulate_reads
-from .security import decrypt_data, encrypt_data, compute_checksum
 
 load_plugins()
 
@@ -39,6 +38,14 @@ from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    if name in {"encrypt_data", "decrypt_data", "compute_checksum"}:
+        from .security import decrypt_data, encrypt_data, compute_checksum
+        globals().update({
+            "encrypt_data": encrypt_data,
+            "decrypt_data": decrypt_data,
+            "compute_checksum": compute_checksum,
+        })
+        return globals()[name]
     if name in _LAZY_ATTRS:
         from .app_helpers import (
             EncodeOptions,

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -7,7 +7,6 @@ import hashlib
 import os
 from typing import Optional
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 _AES_HEADER = b"AESGCM1"
 
@@ -21,21 +20,25 @@ def _xor_cipher(data: bytes, key: bytes) -> bytes:
 
 def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     """Encrypt ``data`` using AES-GCM with a random nonce."""
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = AESGCM(aes_key).encrypt(nonce, data, None)
+    enc = bytes(AESGCM(aes_key).encrypt(nonce, data, None))
     return _AES_HEADER + nonce + enc
 
 
 def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     """Decrypt data produced by :func:`encrypt_data` or legacy XOR."""
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
     key = key or _DEFAULT_KEY
     if data.startswith(_AES_HEADER):
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return bytes(AESGCM(aes_key).decrypt(nonce, ciphertext, None))
     return _xor_cipher(data, key)
 
 


### PR DESCRIPTION
## Summary
- delay importing `cryptography` AES code until encryption is used
- update module lazy loader to fetch security helpers on demand

## Testing
- `pre-commit run --files src/genecoder/security.py src/genecoder/__init__.py`
- `pytest -q`
- `mypy --config-file mypy.ini src`


------
https://chatgpt.com/codex/tasks/task_e_685aa68da7bc8326bd090942ba1eebbe