### PR TITLE
Add encryption keyfile tests

### DIFF
--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional
+from typing import Optional, cast
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
     enc = AESGCM(aes_key).encrypt(nonce, data, None)
-    return _AES_HEADER + nonce + enc
+    return _AES_HEADER + nonce + cast(bytes, enc)
 
 
 def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
@@ -35,7 +35,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
     return _xor_cipher(data, key)
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import pytest
+
+pytest.importorskip("cryptography")
 
 from genecoder.security import (
     encrypt_data,
@@ -76,3 +79,54 @@ def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:
     out_file = tmp_path / "msg.txt_decoded.bin"
     assert out_file.exists()
     assert out_file.read_text() == "secure message"
+
+
+def test_encrypt_roundtrip_key_file(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography")
+    key_path = tmp_path / "key.bin"
+    key_bytes = b"custom-key"
+    key_path.write_bytes(key_bytes)
+    data = b"via-keyfile"
+    key = key_path.read_bytes()
+    enc = encrypt_data(data, key=key)
+    assert decrypt_data(enc, key=key) == data
+
+
+def test_cli_encrypt_checksum_key_file(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("cryptography")
+    key_path = tmp_path / "cli.key"
+    key_path.write_bytes(b"cli-key")
+    monkeypatch.setattr("genecoder.security._DEFAULT_KEY", key_path.read_bytes())
+
+    src = tmp_path / "msg2.txt"
+    src.write_text("secure keyfile")
+
+    enc_res = run_cli_command([
+        "encode",
+        "--input-files",
+        str(src),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+        "--encrypt",
+        "--checksum",
+    ])
+    assert enc_res.returncode == 0, enc_res.stderr
+    fasta = tmp_path / "msg2.txt.fasta"
+    assert fasta.exists()
+    dec_res = run_cli_command([
+        "decode",
+        "--input-files",
+        str(fasta),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+        "--encrypt",
+        "--checksum",
+    ])
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "msg2.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text() == "secure keyfile"


### PR DESCRIPTION
## Summary
- add cryptography import skip so `test_security` is skipped if the library is absent
- add round-trip tests using encryption key files
- fix mypy errors for security encryption

## Testing
- `ruff check tests/test_security.py src/genecoder/security.py`
- `pytest -q tests/test_security.py`
- `mypy --config-file mypy.ini src`


------
https://chatgpt.com/codex/tasks/task_e_685aa6a678f08326a27c54a2fa078d04