### PR TITLE
Add FEC info handling in streaming pipeline

### DIFF
--- a/src/genecoder/stream_pipeline.py
+++ b/src/genecoder/stream_pipeline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Tuple, Union
 
 EncodeFunc = Callable[[bytes], str]
 DecodeFunc = Callable[[str], bytes]
@@ -13,23 +13,29 @@ def stream_encode(
     encode_fn: EncodeFunc,
     *,
     fec_encode: Callable[[bytes], tuple[bytes, object]] | None = None,
-) -> Iterator[str]:
+) -> Iterator[Union[str, Tuple[str, object]]]:
     """Yield encoded DNA chunks with optional FEC."""
     for chunk in data_iter:
         if fec_encode:
-            chunk, _ = fec_encode(chunk)
-        yield encode_fn(chunk)
+            chunk, info = fec_encode(chunk)
+            yield encode_fn(chunk), info
+        else:
+            yield encode_fn(chunk)
 
 
 def stream_decode(
-    dna_iter: Iterable[str],
+    dna_iter: Iterable[Union[str, Tuple[str, object]]],
     decode_fn: DecodeFunc,
     *,
     fec_decode: Callable[[bytes, object], tuple[bytes, int]] | None = None,
 ) -> Iterator[bytes]:
     """Yield decoded binary chunks with optional FEC decoding."""
-    for dna in dna_iter:
+    for item in dna_iter:
+        if isinstance(item, tuple):
+            dna, info = item
+        else:
+            dna, info = item, None
         chunk = decode_fn(dna)
         if fec_decode:
-            chunk, _ = fec_decode(chunk, None)
+            chunk, _ = fec_decode(chunk, info)
         yield chunk

--- a/tests/test_stream_pipeline_fec.py
+++ b/tests/test_stream_pipeline_fec.py
@@ -1,0 +1,19 @@
+import os
+from genecoder.stream_pipeline import stream_encode, stream_decode
+from genecoder.encoders import encode_base4_direct, decode_base4_direct
+from genecoder.hamming_codec import encode_data_with_hamming, decode_data_with_hamming
+
+
+def test_stream_pipeline_roundtrip_with_fec():
+    chunks = [os.urandom(32) for _ in range(4)]
+    encoded = list(
+        stream_encode(chunks, encode_base4_direct, fec_encode=encode_data_with_hamming)
+    )
+    decoded_iter = stream_decode(
+        encoded,
+        lambda dna: decode_base4_direct(dna)[0],
+        fec_decode=decode_data_with_hamming,
+    )
+    result = b"".join(decoded_iter)
+    assert result == b"".join(chunks)
+


### PR DESCRIPTION
## Summary
- propagate FEC metadata through `stream_encode`/`stream_decode`
- add regression test for FEC roundtrip via streaming pipeline

## Testing
- `ruff check --fix src tests`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b44c8dc048326ac449361e18543bb