### PR TITLE
Add helix UI pulses and colouring

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -15,9 +15,11 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 
 The GUI now includes a **Helix View** tab powered by a dedicated React
 application under `web/helix-ui`. The visualization renders each nucleotide as a
-colored sphere with tooltips. Orbit controls allow zooming and rotating, and the
-overlay canvas illustrates GC content and homopolymer runs. The frontend is
-loaded on demand so it works in both desktop and web deployments.
+colored sphere with tooltips. Orbit controls allow zooming and rotating. GC
+content colouring and homopolymer highlighting are shown both on the helix and
+via an overlay canvas. Animated pulses can move along the helix to illustrate
+progress. The frontend is loaded on demand so it works in both desktop and web
+deployments.
 
 <!-- screenshot omitted in this repository because binary files are not supported -->
 
@@ -31,5 +33,5 @@ webview = show_helix("ACGT", length=50, colors={"A": "#ff0000", "T": "#00ffff"})
 ```
 
 The newer `show_helix_ui` helper launches the React frontend. It accepts the
-same base sequence along with options such as `animate`, `zoom`, `gc`, `runs`
-and custom base colors.
+same base sequence along with options such as `animate`, `zoom`, `gc`, `runs`,
+animated progress pulses and custom base colors.

--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -1,8 +1,8 @@
 # Helix Frontend
 
 The 3D helix viewer lives in `web/helix-ui`. It is a single-page React
-application that uses Three.js for rendering and displays simple overlays for
-GC content and homopolymer runs.
+application that uses Three.js for rendering. Overlays indicate GC content and
+homopolymer runs while the helix itself can be colourised and animated.
 
 The frontend now uses [Vite](https://vitejs.dev/) for development and builds.
 To explore the viewer without running the whole backend simply open the built
@@ -38,5 +38,7 @@ The viewer accepts several query parameters which are also exposed by
 - `runs` – `true`/`false` to highlight homopolymers.
 - `colors` – comma-separated `base:#hex` pairs, for example
   `A:#ff0000,G:#00ff00`.
+- `pulse` – `true`/`false` to enable progress pulses.
+- `pulse_speed` – numeric speed multiplier for the pulses.
 
 Combine these parameters in the page URL or when calling `show_helix_ui`.

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -12,8 +12,8 @@ Open <http://127.0.0.1:8000> to view the landing page.
 
 The React helix viewer is available at `/helix`. It accepts optional query
 parameters used by `show_helix_ui` such as `seq`, `animate`, `zoom`, `gc`,
-`runs` and `colors`. The landing page includes an IFrame that loads this
-viewer.
+`runs`, `pulse`, `pulse_speed` and `colors`. The landing page includes an IFrame
+that loads this viewer.
 
 Set the `GENECODER_SIM_SEED` environment variable to an integer to get
 reproducible results when API endpoints invoke error simulations.

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -269,8 +269,14 @@ def show_helix_ui(
     colors: dict[str, int] | None = None,
     show_gc: bool = True,
     show_runs: bool = True,
+    pulse: bool = False,
+    pulse_speed: float = 2.0,
 ) -> flet_webview.WebView:
-    """Return a ``WebView`` pointing at the React helix frontend."""
+    """Return a ``WebView`` pointing at the React helix frontend.
+
+    Parameters enable GC colouring, homopolymer highlighting and animated
+    pulses via the corresponding query arguments.
+    """
     base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
     helix_path = base_dir / "dist" / "index.html"
     if not helix_path.is_file():
@@ -282,6 +288,8 @@ def show_helix_ui(
         f"zoom={zoom}",
         f"gc={'true' if show_gc else 'false'}",
         f"runs={'true' if show_runs else 'false'}",
+        f"pulse={'true' if pulse else 'false'}",
+        f"pulse_speed={pulse_speed}",
     ]
     if colors:
         color_str = ",".join(f"{b}:#{v:06x}" for b, v in colors.items())

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -15,6 +15,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
         colors={"A": 0x123456},
         show_gc=False,
         show_runs=False,
+        pulse=True,
+        pulse_speed=3.0,
     )
     assert webview.__class__.__name__ == "WebView"
     assert webview.url.startswith("file:")
@@ -23,6 +25,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
     assert "zoom=1.5" in parsed.query
     assert "gc=false" in parsed.query
     assert "runs=false" in parsed.query
+    assert "pulse=true" in parsed.query
+    assert "pulse_speed=3.0" in parsed.query
     assert "colors=A%3A%23123456" in parsed.query
 
 

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -32,6 +32,8 @@ export default function App() {
   const seq = params.get('seq') || 'ACGT';
   const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
   const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
+  const [showPulses, setShowPulses] = useState(params.get('pulse') === 'true');
+  const [pulseSpeed] = useState(parseFloat(params.get('pulse_speed') || '2'));
 
   const colorParam = params.get('colors');
   const colors = { ...DEFAULT_COLORS, ...(parseColors(colorParam) || {}) };
@@ -54,14 +56,26 @@ export default function App() {
 
     const group = new THREE.Group();
     const bases = seq.split('');
+    const runs = new Array(bases.length).fill(1);
+    for (let i = 1; i < bases.length; i++) {
+      runs[i] = bases[i] === bases[i - 1] ? runs[i - 1] + 1 : 1;
+    }
     const radius = 0.1;
     const h = 0.4;
     bases.forEach((b, i) => {
       const geom = new THREE.SphereGeometry(radius, 16, 16);
-      const mat = new THREE.MeshPhongMaterial({ color: colors[b] || 0xffffff });
+      let color = colors[b] || 0xffffff;
+      if (showGC) {
+        color = b === 'G' || b === 'C' ? 0x8888ff : 0xffffaa;
+      }
+      const mat = new THREE.MeshPhongMaterial({ color });
       const mesh = new THREE.Mesh(geom, mat);
       const angle = i * 0.3;
       mesh.position.set(Math.cos(angle), Math.sin(angle), i * h);
+      if (showRuns && runs[i] >= 3) {
+        mesh.material.emissive = new THREE.Color(0xff0000);
+        mesh.material.emissiveIntensity = Math.min((runs[i] - 2) / 4, 1);
+      }
       group.add(mesh);
     });
     scene.add(group);
@@ -72,15 +86,11 @@ export default function App() {
 
     const ctx = metricsRef.current.getContext('2d');
     const bw = metricsRef.current.width / bases.length;
-    const runs = new Array(bases.length).fill(1);
     for (let i = 0; i < bases.length; i++) {
-      if (i > 0 && bases[i] === bases[i - 1]) runs[i] = runs[i - 1] + 1;
       if (showGC) {
         ctx.fillStyle = bases[i] === 'G' || bases[i] === 'C' ? '#88f' : '#ddd';
         ctx.fillRect(i * bw, 0, bw, 14);
       }
-    }
-    for (let i = 0; i < bases.length; i++) {
       if (showRuns) {
         const intensity = Math.min(runs[i] / 6, 1);
         ctx.fillStyle = `rgba(255,0,0,${intensity})`;
@@ -89,9 +99,19 @@ export default function App() {
     }
 
     let frameId;
+    let pulsePhase = 0;
     const loop = () => {
       controls.update();
       if (animate) group.rotation.z += 0.01;
+      if (showPulses) {
+        pulsePhase += 0.05 * pulseSpeed;
+        group.children.forEach((mesh, i) => {
+          const scale = 1 + 0.3 * Math.sin(pulsePhase - i * 0.5);
+          mesh.scale.set(scale, scale, scale);
+        });
+      } else {
+        group.children.forEach((mesh) => mesh.scale.set(1, 1, 1));
+      }
       renderer.render(scene, camera);
       frameId = requestAnimationFrame(loop);
     };
@@ -100,7 +120,7 @@ export default function App() {
       cancelAnimationFrame(frameId);
       renderer.dispose();
     };
-  }, [seq, animate, zoom, colors, showGC, showRuns]);
+  }, [seq, animate, zoom, colors, showGC, showRuns, showPulses, pulseSpeed]);
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -119,6 +139,9 @@ export default function App() {
         </label>
         <label style={{ marginLeft: 8 }}>
           <input type="checkbox" checked={showRuns} onChange={(e) => setShowRuns(e.target.checked)} /> Runs
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showPulses} onChange={(e) => setShowPulses(e.target.checked)} /> Pulse
         </label>
       </div>
       <div ref={mount} style={{ width: '100%', height: '100%' }} />


### PR DESCRIPTION
## Summary
- highlight GC content and homopolymers directly on the 3D helix
- add animated pulse effect
- expose `pulse` and `pulse_speed` in `show_helix_ui`
- document new parameters
- test query parameter generation

## Testing
- `ruff check src/genecoder/helix_view.py tests/test_helix_ui.py`
- `mypy --config-file mypy.ini src`
- `pytest -q tests/test_helix_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_685b44d688c08326827e96a75cff5cc9