### PR TITLE
Fix CLI encryption key handling

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -20,7 +20,7 @@ from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from typing import Callable
 
 # Delay importing heavy security module until needed
-decrypt_data: Callable[[bytes], bytes] | None = None
+decrypt_data: Callable[..., bytes] | None = None
 compute_checksum: Callable[[bytes], str] | None = None
 
 def _ensure_security_loaded() -> None:
@@ -234,7 +234,10 @@ def process_single_decode(
         if getattr(args, "encrypt", False):
             _ensure_security_loaded()
             assert decrypt_data is not None
-            final_decoded_data = decrypt_data(final_decoded_data)
+            if _key_bytes is not None:
+                final_decoded_data = decrypt_data(final_decoded_data, _key_bytes)
+            else:
+                final_decoded_data = decrypt_data(final_decoded_data)
 
 
         if getattr(args, "checksum", False):

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -27,7 +27,7 @@ from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
 from typing import Callable
 
 # Delay importing heavy security module until needed
-encrypt_data: Callable[[bytes], bytes] | None = None
+encrypt_data: Callable[..., bytes] | None = None
 compute_checksum: Callable[[bytes], str] | None = None
 
 
@@ -265,7 +265,10 @@ def process_single_encode(
         if getattr(args, "encrypt", False):
             _ensure_security_loaded()
             assert encrypt_data is not None
-            data_for_encoding = encrypt_data(plaintext_data)
+            if _key_bytes is not None:
+                data_for_encoding = encrypt_data(plaintext_data, _key_bytes)
+            else:
+                data_for_encoding = encrypt_data(plaintext_data)
 
 
         checksum: str | None = None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -173,3 +173,67 @@ def test_cli_encrypt_key_file_roundtrip(tmp_path: Path) -> None:
     out_file = tmp_path / "secret.txt_decoded.bin"
     assert out_file.exists()
     assert out_file.read_text() == "top secret"
+
+
+def test_cli_encrypt_wrong_key_fails(tmp_path: Path) -> None:
+    src = tmp_path / "wrong.txt"
+    src.write_text("secrets")
+    key_ok = tmp_path / "key_ok.bin"
+    key_wrong = tmp_path / "key_wrong.bin"
+    key_ok.write_bytes(b"key-ok")
+    key_wrong.write_bytes(b"key-no")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(src),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_ok),
+        ]
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    fasta = tmp_path / "wrong.txt.fasta"
+    assert fasta.exists()
+
+    fail_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_wrong),
+        ]
+    )
+    assert fail_res.returncode != 0
+    out_file = tmp_path / "wrong.txt_decoded.bin"
+    assert not out_file.exists()
+
+    ok_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_ok),
+        ]
+    )
+    assert ok_res.returncode == 0, ok_res.stderr
+    assert out_file.exists()
+    assert out_file.read_text() == "secrets"


### PR DESCRIPTION
## Summary
- allow passing encryption key bytes through CLI
- fix decrypting with supplied key
- add regression test for wrong key failure

## Testing
- `ruff check --fix src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_security.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5561f1d88326b09649e73f7f9870