### PR TITLE
Add BaseSimulator and refactor simulators

### DIFF
--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 
 from ..plugins import SIMULATOR_REGISTRY
 
+from .base import BaseSimulator
 from .illumina import IlluminaChannel
 from .adv_nanopore import AdvancedNanoporeChannel
 
-__all__ = ["IlluminaChannel", "AdvancedNanoporeChannel", "simulate_reads"]
+__all__ = [
+    "BaseSimulator",
+    "IlluminaChannel",
+    "AdvancedNanoporeChannel",
+    "simulate_reads",
+]
 
 
 def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -5,6 +5,7 @@ import os
 import random
 from typing import Callable, Sequence
 
+from .base import BaseSimulator
 from ..channels.base import BaseChannel
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
@@ -47,7 +48,7 @@ def _simulate_homopolymer_errors(
     return "".join(result)
 
 
-class AdvancedNanoporeChannel(BaseChannel):
+class AdvancedNanoporeChannel(BaseSimulator):
     """Nanopore channel with simple homopolymer indel bias."""
 
     def __init__(
@@ -59,12 +60,14 @@ class AdvancedNanoporeChannel(BaseChannel):
         read_length: int = 500,
         quality_profile: Sequence[float] | None = None,
     ) -> None:
-        self.substitution_rate = substitution_rate
-        self.insertion_rate = insertion_rate
-        self.deletion_rate = deletion_rate
-        self.coverage = coverage
-        self.read_length = read_length
-        self.quality_profile = tuple(quality_profile) if quality_profile is not None else None
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=read_length,
+            quality_profile=quality_profile,
+        )
 
     def simulate(self, sequence: str) -> str:
         rng = _make_rng()

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -1,0 +1,40 @@
+"""Common base classes for sequencing simulators."""
+from __future__ import annotations
+
+from typing import Sequence
+
+
+__all__ = ["BaseSimulator"]
+
+
+class BaseSimulator:
+    """Base class for read simulators with simple error settings."""
+
+    substitution_rate: float
+    insertion_rate: float
+    deletion_rate: float
+    coverage: int
+    read_length: int
+    quality_profile: Sequence[float] | None
+
+    def __init__(
+        self,
+        substitution_rate: float = 0.0,
+        insertion_rate: float = 0.0,
+        deletion_rate: float = 0.0,
+        coverage: int = 1,
+        read_length: int = 150,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
+        self.substitution_rate = substitution_rate
+        self.insertion_rate = insertion_rate
+        self.deletion_rate = deletion_rate
+        self.coverage = coverage
+        self.read_length = read_length
+        self.quality_profile = (
+            tuple(quality_profile) if quality_profile is not None else None
+        )
+
+    def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
+        """Return a possibly corrupted version of ``sequence``."""
+        raise NotImplementedError

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -5,6 +5,7 @@ import os
 import random
 from typing import Callable, Sequence
 
+from .base import BaseSimulator
 from ..channels.base import BaseChannel
 from ..error_simulation import introduce_errors
 
@@ -16,7 +17,7 @@ def _make_rng() -> random.Random:
     return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
-class IlluminaChannel(BaseChannel):
+class IlluminaChannel(BaseSimulator):
     """Channel modeling basic Illumina read errors."""
 
     def __init__(
@@ -28,12 +29,14 @@ class IlluminaChannel(BaseChannel):
         read_length: int = 150,
         quality_profile: Sequence[float] | None = None,
     ) -> None:
-        self.substitution_rate = substitution_rate
-        self.insertion_rate = insertion_rate
-        self.deletion_rate = deletion_rate
-        self.coverage = coverage
-        self.read_length = read_length
-        self.quality_profile = tuple(quality_profile) if quality_profile is not None else None
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=read_length,
+            quality_profile=quality_profile,
+        )
 
     def simulate(self, sequence: str) -> str:
         rng = _make_rng()

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -1,6 +1,7 @@
 
 from genecoder.simulators.illumina import IlluminaChannel, register as reg_illumina
 from genecoder.simulators.adv_nanopore import AdvancedNanoporeChannel, register as reg_advnano
+from genecoder.simulators import BaseSimulator
 
 
 def test_register_channels():
@@ -8,8 +9,9 @@ def test_register_channels():
     registry: dict[str, BaseChannel] = {}
     reg_illumina(lambda n, ch: registry.setdefault(n, ch))
     reg_advnano(lambda n, ch: registry.setdefault(n, ch))
-    assert "illumina" in registry and isinstance(registry["illumina"], BaseChannel)
-    assert "adv_nanopore" in registry and isinstance(registry["adv_nanopore"], BaseChannel)
+    assert "illumina" in registry and isinstance(registry["illumina"], BaseSimulator)
+    assert "adv_nanopore" in registry and isinstance(registry["adv_nanopore"], BaseSimulator)
+    assert all(isinstance(ch, BaseChannel) for ch in registry.values())
 
 
 def test_illumina_simulator_deterministic(monkeypatch):


### PR DESCRIPTION
## Summary
- introduce `BaseSimulator` class in `genecoder.simulators`
- inherit from `BaseSimulator` in `IlluminaChannel` and `AdvancedNanoporeChannel`
- export new base class from `genecoder.simulators`
- update tests for new base class

## Testing
- `ruff check src/genecoder/security.py src/genecoder/simulators/base.py src/genecoder/simulators/illumina.py src/genecoder/simulators/adv_nanopore.py src/genecoder/simulators/__init__.py tests/test_simulators_additional.py`
- `mypy --config-file mypy.ini src/genecoder/simulators/base.py src/genecoder/simulators/illumina.py src/genecoder/simulators/adv_nanopore.py src/genecoder/simulators/__init__.py src/genecoder/security.py`
- `pytest -q tests/test_simulators_additional.py`

------
https://chatgpt.com/codex/tasks/task_e_685b557b51748326bcbcc521c0a227cc