### PR TITLE
Fix plugin initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,6 @@ See [CITATION.cff](CITATION.cff) for citation information.
 GeneCoder can be extended through plugins discovered via the
 `genecoder.plugins`, `genecoder.fec` and `genecoder.simulators` entry points.
 See [docs/plugins.md](docs/plugins.md) for details on writing and registering
-new codecs, FEC back-ends or simulators.
+new codecs, FEC back-ends or simulators. Plugins are automatically loaded when
+using the CLI or GUI. When using GeneCoder as a library call
+``genecoder.plugins.load_plugins()`` first to populate the registries.

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -21,7 +21,7 @@ from .plugins import (
 )
 from .simulators import simulate_reads
 
-load_plugins()
+
 
 __all__ = [
     *sorted(_LAZY_ATTRS),

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 from genecoder import __version__
+from genecoder.plugins import load_plugins
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight
@@ -117,6 +118,7 @@ def _handle_sim_errors(args: argparse.Namespace) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
+    load_plugins()
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -24,6 +24,7 @@ from genecoder import (
     EncodeOptions,
     perform_encoding,
 )
+from genecoder.plugins import load_plugins
 from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
@@ -40,6 +41,7 @@ decoded_bytes_to_save: bytes = b""
 
 def main(page: ft.Page) -> None:
     """Create the UI and register callbacks for Flet's event loop."""
+    load_plugins()
     page.title = "GeneCoder"
     page.vertical_alignment = ft.MainAxisAlignment.START
     page.horizontal_alignment = ft.CrossAxisAlignment.CENTER


### PR DESCRIPTION
## Summary
- stop autoloading plugins from `__init__.py`
- load plugins when starting the CLI
- load plugins when starting the Flet GUI
- document the new behaviour

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b557ba4e48326b5f9c8e6f247ddce