### PR TITLE
Add d2sim option forwarding

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -64,4 +64,10 @@ Invoke an external simulator before decoding:
 genecoder decode --simulator d2sim <other options>
 ```
 
+Provide additional parameters to ``d2sim`` using ``--d2sim-options``:
+
+```bash
+genecoder decode --simulator d2sim --d2sim-options "--seed 42" <other options>
+```
+
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -361,10 +361,18 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         choices=sim_choices,
         help="Apply an external simulator before decoding (default: none).",
     )
+    parser.add_argument(
+        "--d2sim-options",
+        type=str,
+        help="Extra command line options forwarded to d2sim.",
+    )
     parser.set_defaults(func=_handle_command)
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if getattr(args, "d2sim_options", None):
+        os.environ["GENECODER_D2SIM_OPTIONS"] = args.d2sim_options
+
     num_input_files = len(args.input_files)
     if num_input_files > 1 and not args.output_dir:
         logger.error(

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -61,6 +61,10 @@ def _simulate_adapter(
             cmd_list = [command]
             if command == "d2sim":
                 cmd_list += ["-e", str(error_rate)]
+                extra = os.getenv("GENECODER_D2SIM_OPTIONS")
+                if extra:
+                    import shlex
+                    cmd_list += shlex.split(extra)
             return _run_external(cmd_list, sequence)
         except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
             logger.warning(

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 _AES_HEADER = b"AESGCM1"
@@ -26,7 +26,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
     enc = AESGCM(aes_key).encrypt(nonce, data, None)
-    return _AES_HEADER + nonce + cast(bytes, enc)
+    return _AES_HEADER + nonce + enc
 
 
 
@@ -39,7 +39,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
+        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
 
     return _xor_cipher(data, key)
 

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -38,6 +38,23 @@ def test_adapters_run_external(monkeypatch, name):
     assert run_called == [expected]
 
 
+def test_d2sim_extra_options(monkeypatch):
+    which_called = []
+    run_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "_run_external",
+        lambda cmd, seq: run_called.append((cmd, seq)) or "ok",
+    )
+    monkeypatch.setenv("GENECODER_D2SIM_OPTIONS", "--foo bar")
+
+    result = nanopore_sim.simulate_d2sim("ACGT", error_rate=0.1)
+    assert result == "ok"
+    assert run_called == [(["d2sim", "-e", "0.1", "--foo", "bar"], "ACGT")]
+
+
 @pytest.mark.parametrize("name", ADAPTERS.keys())
 def test_adapters_fall_back(monkeypatch, name):
     func, cmd = ADAPTERS[name]


### PR DESCRIPTION
## Summary
- allow passing `--d2sim-options` via CLI
- forward GENECODER_D2SIM_OPTIONS in nanopore simulator
- document new option
- keep mypy happy with latest version
- test d2sim extra options

## Testing
- `pre-commit run --files src/genecoder/cli/decode.py src/genecoder/nanopore_sim.py src/genecoder/security.py tests/test_nanopore_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685b558dde808326a43038969e0b1bd7