### PR TITLE
Add negative key test and pass key bytes via CLI

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -20,7 +20,7 @@ from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from typing import Callable
 
 # Delay importing heavy security module until needed
-decrypt_data: Callable[[bytes], bytes] | None = None
+decrypt_data: Callable[..., bytes] | None = None
 compute_checksum: Callable[[bytes], str] | None = None
 
 def _ensure_security_loaded() -> None:
@@ -234,7 +234,7 @@ def process_single_decode(
         if getattr(args, "encrypt", False):
             _ensure_security_loaded()
             assert decrypt_data is not None
-            final_decoded_data = decrypt_data(final_decoded_data)
+            final_decoded_data = decrypt_data(final_decoded_data, key=_key_bytes)
 
 
         if getattr(args, "checksum", False):

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -27,7 +27,7 @@ from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
 from typing import Callable
 
 # Delay importing heavy security module until needed
-encrypt_data: Callable[[bytes], bytes] | None = None
+encrypt_data: Callable[..., bytes] | None = None
 compute_checksum: Callable[[bytes], str] | None = None
 
 
@@ -265,7 +265,7 @@ def process_single_encode(
         if getattr(args, "encrypt", False):
             _ensure_security_loaded()
             assert encrypt_data is not None
-            data_for_encoding = encrypt_data(plaintext_data)
+            data_for_encoding = encrypt_data(plaintext_data, key=_key_bytes)
 
 
         checksum: str | None = None

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 _AES_HEADER = b"AESGCM1"
@@ -26,7 +26,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
     enc = AESGCM(aes_key).encrypt(nonce, data, None)
-    return _AES_HEADER + nonce + cast(bytes, enc)
+    return _AES_HEADER + nonce + enc
 
 
 
@@ -39,7 +39,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
+        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
 
     return _xor_cipher(data, key)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -92,6 +92,16 @@ def test_encrypt_roundtrip_key_file(tmp_path: Path) -> None:
     assert decrypt_data(enc, key=key) == data
 
 
+def test_encrypt_roundtrip_key_mismatch(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography")
+    key_path = tmp_path / "key.bin"
+    key_path.write_bytes(b"correct")
+    data = b"hello mismatch"
+    enc = encrypt_data(data, key=key_path.read_bytes())
+    with pytest.raises(Exception):
+        decrypt_data(enc, key=b"wrong")
+
+
 def test_cli_encrypt_checksum_key_file(tmp_path: Path, monkeypatch) -> None:
     pytest.importorskip("cryptography")
     key_path = tmp_path / "cli.key"
@@ -173,3 +183,47 @@ def test_cli_encrypt_key_file_roundtrip(tmp_path: Path) -> None:
     out_file = tmp_path / "secret.txt_decoded.bin"
     assert out_file.exists()
     assert out_file.read_text() == "top secret"
+
+
+def test_cli_encrypt_key_file_wrong_key(tmp_path: Path) -> None:
+    src = tmp_path / "secret2.txt"
+    src.write_text("bad secret")
+    key_file = tmp_path / "key_good.bin"
+    wrong_file = tmp_path / "key_bad.bin"
+    key_file.write_bytes(b"mykey")
+    wrong_file.write_bytes(b"other")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(src),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(key_file),
+        ]
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    fasta = tmp_path / "secret2.txt.fasta"
+    assert fasta.exists()
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--encrypt",
+            "--key",
+            str(wrong_file),
+        ]
+    )
+    assert dec_res.returncode != 0


### PR DESCRIPTION
## Summary
- use provided `--key` when encrypting and decrypting in the CLI
- avoid unnecessary casts in `security.py`
- test decrypt failure with wrong key
- test CLI decrypt failure with wrong `--key`

## Testing
- `pre-commit run --files src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/security.py tests/test_security.py`
- `pytest tests/test_security.py`

------
https://chatgpt.com/codex/tasks/task_e_685b559431348326937d236b768c81a7