### PR TITLE
Add RNG utility and update simulators

### DIFF
--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -1,9 +1,10 @@
 """Simple channel error simulator for DNA sequences."""
 from __future__ import annotations
 
-import os
 import random
 from typing import Protocol, Callable
+
+from .random_utils import make_rng
 
 from .channels.base import BaseChannel
 
@@ -47,11 +48,6 @@ def simulate_errors(seq: str, p_error: float, rng: Optional[random.Random] = Non
     return "".join(result)
 
 
-def _make_rng() -> random.Random:
-    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
-
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 class Channel(BaseChannel):
@@ -61,7 +57,7 @@ class Channel(BaseChannel):
         self.error_rate = error_rate
 
     def simulate(self, sequence: str) -> str:
-        return simulate_errors(sequence, self.error_rate, rng=_make_rng())
+        return simulate_errors(sequence, self.error_rate, rng=make_rng())
 
 
 def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -6,7 +6,8 @@ from typing import Callable
 
 from .channels.base import BaseChannel
 
-from .nanopore_sim import _simulate_adapter, _run_external, _make_rng
+from .random_utils import make_rng
+from .nanopore_sim import _simulate_adapter, _run_external
 
 
 class _D2SIM:
@@ -29,7 +30,7 @@ def simulate_d2sim(
     """Use ``d2sim`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
-        rng = _make_rng()
+        rng = make_rng()
 
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
@@ -41,7 +42,7 @@ class D2SimChannel(BaseChannel):
         self.error_rate = error_rate
 
     def simulate(self, sequence: str) -> str:
-        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=_make_rng())
+        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
 
 
 def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -1,9 +1,10 @@
 """Utilities for simulating random sequencing errors in DNA sequences."""
 from __future__ import annotations
 
-import os
 import random
 from typing import Callable
+
+from .random_utils import make_rng
 
 from .channels.base import BaseChannel
 
@@ -97,11 +98,6 @@ def apply_deletions(sequence: str, prob: float, rng: random.Random | None = None
     return introduce_errors(sequence, deletion_prob=prob, rng=rng)
 
 
-def _make_rng() -> random.Random:
-    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
-
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 class Channel(BaseChannel):
@@ -123,7 +119,7 @@ class Channel(BaseChannel):
             substitution_prob=self.substitution_prob,
             insertion_prob=self.insertion_prob,
             deletion_prob=self.deletion_prob,
-            rng=_make_rng(),
+            rng=make_rng(),
         )
 
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -1,7 +1,6 @@
 """Wrapper for optional nanopore read simulators."""
 from __future__ import annotations
 
-import os
 import random
 import shutil
 import subprocess
@@ -22,15 +21,11 @@ from .channels.base import BaseChannel
 
 logger = logging.getLogger(__name__)
 
+from .random_utils import make_rng
 from .channel_sim import simulate_errors
 from .formats import from_fasta, to_fasta
 
 
-def _make_rng() -> random.Random:
-    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
-
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 def _run_external(command: Sequence[str] | str, sequence: str) -> str:
@@ -73,7 +68,7 @@ def _simulate_adapter(
     # use a deterministic local RNG for external simulators and forward it when
     # falling back to :func:`simulate_errors` so calls remain reproducible
     if rng is None:
-        rng = _make_rng()
+        rng = make_rng()
     return simulate_errors(sequence, error_rate, rng=rng)
 
 
@@ -88,7 +83,7 @@ def simulate_d2sim(
 
 
     if rng is None:
-        rng = _make_rng()
+        rng = make_rng()
 
     return _simulate_adapter("d2sim", sequence, error_rate, rng)
 
@@ -108,7 +103,7 @@ def simulate_dnarsim(
 
 
     if rng is None:
-        rng = _make_rng()
+        rng = make_rng()
 
     return _simulate_adapter("dnarsim", sequence, error_rate, rng)
 
@@ -124,7 +119,7 @@ def simulate_squigulator(
 
 
     if rng is None:
-        rng = _make_rng()
+        rng = make_rng()
 
     return _simulate_adapter("squigulator", sequence, error_rate, rng)
 
@@ -183,7 +178,7 @@ class Channel(BaseChannel):
 
     def simulate(self, sequence: str) -> str:
         adapter = SIMULATOR_ADAPTERS[self.name]
-        return adapter(sequence, self.error_rate, _make_rng())
+        return adapter(sequence, self.error_rate, make_rng())
 
 
 

--- a/src/genecoder/random_utils.py
+++ b/src/genecoder/random_utils.py
@@ -1,0 +1,13 @@
+"""Utility helpers for reproducible randomness."""
+from __future__ import annotations
+
+import os
+import random
+
+__all__ = ["make_rng"]
+
+
+def make_rng() -> random.Random:
+    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
+    seed_env = os.getenv("GENECODER_SIM_SEED")
+    return random.Random(int(seed_env)) if seed_env is not None else random.Random()

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -1,18 +1,16 @@
 """Advanced Nanopore sequencing simulator with homopolymer bias."""
 from __future__ import annotations
 
-import os
 import random
 from typing import Callable, Sequence
+
+from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
 
 
-def _make_rng() -> random.Random:
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 def _simulate_homopolymer_errors(
@@ -67,7 +65,7 @@ class AdvancedNanoporeChannel(BaseChannel):
         self.quality_profile = tuple(quality_profile) if quality_profile is not None else None
 
     def simulate(self, sequence: str) -> str:
-        rng = _make_rng()
+        rng = make_rng()
         read = sequence[: self.read_length]
         return _simulate_homopolymer_errors(
             read,

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,9 +1,10 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-import os
 import random
 from typing import Callable, Sequence
+
+from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
 from ..error_simulation import introduce_errors
@@ -11,9 +12,6 @@ from ..error_simulation import introduce_errors
 __all__ = ["IlluminaChannel", "register"]
 
 
-def _make_rng() -> random.Random:
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
 
 
 class IlluminaChannel(BaseChannel):
@@ -36,7 +34,7 @@ class IlluminaChannel(BaseChannel):
         self.quality_profile = tuple(quality_profile) if quality_profile is not None else None
 
     def simulate(self, sequence: str) -> str:
-        rng = _make_rng()
+        rng = make_rng()
         read = sequence[: self.read_length]
         return introduce_errors(
             read,

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,0 +1,9 @@
+import random
+from genecoder.random_utils import make_rng
+
+
+def test_make_rng_from_env(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "42")
+    rng = make_rng()
+    assert isinstance(rng, random.Random)
+    assert rng.random() == random.Random(42).random()


### PR DESCRIPTION
## Summary
- add `random_utils.make_rng` for reproducible randomness
- use the new helper across simulators and adapters
- test new helper

## Testing
- `ruff check src tests/test_random_utils.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf773401c8326b9a84ea0f086be12