### PR TITLE
Add reproducibility tests for sequencing simulators

### DIFF
--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 _AES_HEADER = b"AESGCM1"
@@ -26,7 +26,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
     enc = AESGCM(aes_key).encrypt(nonce, data, None)
-    return _AES_HEADER + nonce + cast(bytes, enc)
+    return _AES_HEADER + nonce + enc
 
 
 
@@ -39,7 +39,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
+        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
 
     return _xor_cipher(data, key)
 

--- a/tests/test_simulator_seed_reproducibility.py
+++ b/tests/test_simulator_seed_reproducibility.py
@@ -1,0 +1,36 @@
+import pytest
+
+from genecoder.simulators.illumina import IlluminaChannel
+from genecoder.simulators.adv_nanopore import AdvancedNanoporeChannel
+from genecoder.error_simulation import Channel as ErrorChannel
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+@pytest.mark.parametrize(
+    "channel_cls,args,sequence",
+    [
+        (
+            IlluminaChannel,
+            dict(substitution_rate=0.5, insertion_rate=0.3, deletion_rate=0.2, read_length=6),
+            "ACGTACGT",
+        ),
+        (
+            AdvancedNanoporeChannel,
+            dict(substitution_rate=0.5, insertion_rate=0.3, deletion_rate=0.2, read_length=6),
+            "AAAAAA",
+        ),
+        (
+            ErrorChannel,
+            dict(substitution_prob=0.5, insertion_prob=0.3, deletion_prob=0.2),
+            "ACGTACGT",
+        ),
+    ],
+)
+def test_reproducible_simulation(monkeypatch, channel_cls, args, sequence, seed):
+    monkeypatch.setenv("GENECODER_SIM_SEED", str(seed))
+    channel = channel_cls(**args)
+    first = channel.simulate(sequence)
+    monkeypatch.setenv("GENECODER_SIM_SEED", str(seed))
+    channel = channel_cls(**args)
+    second = channel.simulate(sequence)
+    assert first == second


### PR DESCRIPTION
## Summary
- add parameterized test verifying deterministic output from IlluminaChannel, AdvancedNanoporeChannel and the generic error Channel when `GENECODER_SIM_SEED` is set
- fix mypy complaints in `security.py` by removing redundant casts

## Testing
- `pre-commit run --files tests/test_simulator_seed_reproducibility.py src/genecoder/security.py`
- `pytest -q tests/test_simulator_seed_reproducibility.py`


------
https://chatgpt.com/codex/tasks/task_e_685b5595106483269abbe4472f323943