### PR TITLE
Fix simulator imports

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 import logging
+import os
 from typing import Callable, Sequence
 
 __all__ = [

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -7,6 +7,7 @@ from typing import Callable, Sequence
 from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
+from .base import BaseSimulator
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
 

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,11 +1,11 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-import random
 from typing import Callable, Sequence
 
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
+from .base import BaseSimulator
 from ..error_simulation import introduce_errors
 
 __all__ = ["IlluminaChannel", "register"]


### PR DESCRIPTION
## Summary
- fix missing BaseSimulator imports in simulator modules
- include os module in nanopore simulator
- remove unused random import

## Testing
- `pre-commit run --files src/genecoder/nanopore_sim.py src/genecoder/simulators/adv_nanopore.py src/genecoder/simulators/illumina.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0856dde48326bae5d72d81681476