### PR TITLE
Fix lint errors and ensure mypy passes

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import subprocess
 import tempfile
+import os
 from pathlib import Path
 import logging
 from typing import Callable, Sequence

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional
+from typing import Optional, cast
 
 
 _AES_HEADER = b"AESGCM1"
@@ -26,7 +26,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
     enc = AESGCM(aes_key).encrypt(nonce, data, None)
-    return _AES_HEADER + nonce + enc
+    return _AES_HEADER + nonce + cast(bytes, enc)
 
 
 
@@ -39,7 +39,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
 
     return _xor_cipher(data, key)
 

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -7,6 +7,7 @@ from typing import Callable, Sequence
 from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
+from .base import BaseSimulator
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
 

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,12 +1,12 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-import random
 from typing import Callable, Sequence
 
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
 from ..error_simulation import introduce_errors
+from .base import BaseSimulator
 
 __all__ = ["IlluminaChannel", "register"]
 


### PR DESCRIPTION
## Summary
- include missing `os` import for nanopore simulator
- register `BaseSimulator` in simulator modules
- fix unused import warning in Illumina simulator
- cast cryptography results in security utilities

## Testing
- `ruff check src tests`
- `mypy src`

------
https://chatgpt.com/codex/tasks/task_e_685c0858150083269bab9607ecb5a67f