### PR TITLE
Document d2sim env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Pinned dependencies to stable versions.
 - ``encode_gc_balanced`` now validates the inverted sequence and logs a warning
   if it still violates GC content or homopolymer limits.
+- Added ``--d2sim-options`` and ``GENECODER_D2SIM_OPTIONS`` to customize ``d2sim`` calls.
+- Refactored ``BaseSimulator`` for shared simulator settings.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md)
 - Flet-based GUI with analysis plots.
 - Base5 and base6 alphabet options for alternative nucleotide letters. These
   modes remap the standard ACGT symbols but **do not increase capacity**.
+- External read simulators can be invoked with ``--simulator``.
+  Extra ``d2sim`` parameters may be supplied via ``--d2sim-options`` or
+  the ``GENECODER_D2SIM_OPTIONS`` environment variable.
 
 ## Quick Start
 

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -71,3 +71,5 @@ genecoder decode --simulator d2sim --d2sim-options "--seed 42" <other options>
 ```
 
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.
+Set `GENECODER_D2SIM_OPTIONS` to forward additional flags to ``d2sim``
+automatically when the simulator is invoked.


### PR DESCRIPTION
## Summary
- explain `GENECODER_D2SIM_OPTIONS` in simulator docs
- mention simulator options in README
- update changelog

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_685c08597d048326aabfd2970bc6a59b