### PR TITLE
Fix BaseSimulator imports in simulators

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 import logging
+import os
 from typing import Callable, Sequence
 
 __all__ = [

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional
+from typing import Optional, cast
 
 
 _AES_HEADER = b"AESGCM1"
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = AESGCM(aes_key).encrypt(nonce, data, None)
+    enc = cast(bytes, AESGCM(aes_key).encrypt(nonce, data, None))
     return _AES_HEADER + nonce + enc
 
 
@@ -39,7 +39,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
 
     return _xor_cipher(data, key)
 

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import random
 from typing import Callable, Sequence
 
+from .base import BaseSimulator
+
 from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,8 +1,9 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-import random
 from typing import Callable, Sequence
+
+from .base import BaseSimulator
 
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel


### PR DESCRIPTION
## Summary
- import `BaseSimulator` in `illumina` simulator and drop unused `random`
- import `BaseSimulator` in `adv_nanopore` simulator
- fix missing `os` import in nanopore simulator
- cast AESGCM encrypt/decrypt to `bytes`
- run `ruff`, `mypy`, and `pytest`

## Testing
- `ruff check --fix src/genecoder/security.py`
- `mypy src/genecoder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c084abe848326b7a9e590b67cf73f