### PR TITLE
Add project vision references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ For full usage instructions and additional documentation see the [docs/](docs/) 
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
 
+GeneCoder's long-term goal is to provide an integrated research platform that
+bridges encoding algorithms with sequencing and synthesis simulations while
+remaining easy to extend. The guiding ideas are summarized in
+[docs/DEVELOPMENT_VISION.md](docs/DEVELOPMENT_VISION.md).
+
 ## Features
 
 - Multiple encoding strategies including Base-4 Direct, Huffman-4 and GC-Balanced.

--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -1,3 +1,9 @@
+"""Utility functions shared by the GUI and CLI.
+
+The helpers here form part of the integrated pipeline described in
+`docs/DEVELOPMENT_VISION.md`.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -10,6 +10,8 @@ The application relies heavily on the :mod:`genecoder` package
 `plotting` utilities which themselves use `matplotlib`).  It runs most
 heavy tasks asynchronously with :mod:`asyncio` so the interface remains
 responsive.
+See `docs/DEVELOPMENT_VISION.md` for how the GUI fits into the project's
+integrated pipeline and extensible design.
 """
 
 import flet as ft

--- a/src/genecoder/flet_helpers.py
+++ b/src/genecoder/flet_helpers.py
@@ -1,4 +1,8 @@
-"""Helper utilities for the Flet GUI that do not depend on Flet itself."""
+"""Helper utilities for the Flet GUI that do not depend on Flet itself.
+
+These functions support the extensibility goals described in
+`docs/DEVELOPMENT_VISION.md`.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- mention the development vision in the README
- reference the vision document in flet_app, flet_helpers and app_helpers modules

No tests were run since only comments and documentation were changed.

------
https://chatgpt.com/codex/tasks/task_e_685c166c899c832687d0a79d93082732