### PR TITLE
Fix duplicate imports causing F811 errors

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -8,7 +8,6 @@ import tempfile
 import os
 from pathlib import Path
 import logging
-import os
 from typing import Callable, Sequence
 
 __all__ = [

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -9,11 +9,8 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
-from .base import BaseSimulator
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
-
-
 
 
 def _simulate_homopolymer_errors(

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -7,13 +7,9 @@ from .base import BaseSimulator
 
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
-from .base import BaseSimulator
 from ..error_simulation import introduce_errors
-from .base import BaseSimulator
 
 __all__ = ["IlluminaChannel", "register"]
-
-
 
 
 class IlluminaChannel(BaseSimulator):


### PR DESCRIPTION
## Summary
- clean up duplicate imports in nanopore and simulator modules
- trim extra blank lines after `__all__` declarations

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c16450b2883268b62eec4123f1fdd