### PR TITLE
Expose FPS control in helix viewer

### DIFF
--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -40,6 +40,7 @@ The viewer accepts several query parameters which are also exposed by
   `A:#ff0000,G:#00ff00`.
 - `pulse` – `true`/`false` to enable progress pulses.
 - `pulse_speed` – numeric speed multiplier for the pulses.
+- `fps` – numeric frames-per-second limit for animation.
 
 Combine these parameters in the page URL or when calling `show_helix_ui`.
 
@@ -48,4 +49,10 @@ Example enabling pulses:
 ```python
 from genecoder.helix_view import show_helix_ui
 webview = show_helix_ui("ACGT", pulse=True, pulse_speed=3.0)
+```
+
+Set `fps` to cap the frame rate if the animation uses too much CPU:
+
+```python
+webview = show_helix_ui("ACGT", fps=30)
 ```

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -81,6 +81,9 @@ def main(page: ft.Page) -> None:
     zoom_slider: ft.Slider = ft.Slider(
         min=0.5, max=2.0, value=1.0, divisions=15, width=200
     )
+    fps_slider: ft.Slider = ft.Slider(
+        min=10, max=60, value=60, divisions=10, width=200, label="FPS"
+    )
     helix_length_input: ft.TextField = ft.TextField(
         label="Sequence Length",
         value="50",
@@ -830,17 +833,23 @@ def main(page: ft.Page) -> None:
                 animate_checkbox,
                 ft.Text("Zoom:"),
                 zoom_slider,
+                ft.Text("FPS:"),
+                fps_slider,
             ])
         )
         helix_container.controls.append(
             show_helix_ui(
-                dna_seq, animate=animate_checkbox.value, zoom=zoom_slider.value
+                dna_seq,
+                animate=animate_checkbox.value,
+                zoom=zoom_slider.value,
+                fps=fps_slider.value,
             )
         )
         page.update()
 
     animate_checkbox.on_change = refresh_helix_view
     zoom_slider.on_change = refresh_helix_view
+    fps_slider.on_change = refresh_helix_view
 
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -87,6 +87,7 @@ const seq = '%(DNA_SEQ)s';
 const animateHelix = %(ANIMATE)s;
 const showPulses = %(PULSE)s;
 const pulseSpeed = %(PULSE_SPEED)s;
+const fps = %(FPS)s;
 const bases = [];
 for (let i = 0; i < seq.length; i++) {
     bases.push(seq[i]);
@@ -163,8 +164,11 @@ window.addEventListener('resize', () => {
 });
 
 let offset = 0;
-function animate() {
+let last = 0;
+function animate(now) {
     requestAnimationFrame(animate);
+    if (now - last < 1000 / fps) return;
+    last = now;
     if (animateHelix) {
         group.rotation.z += 0.01;
     }
@@ -181,7 +185,7 @@ function animate() {
     controls.update();
     renderer.render(scene, camera);
 }
-animate();
+requestAnimationFrame(animate);
 </script>
 """
 
@@ -194,6 +198,7 @@ def _make_helix_html(
     zoom: float = 1.0,
     pulse: bool = False,
     pulse_speed: float = 2.0,
+    fps: float = 60.0,
     three_js_url: str = THREE_JS_URL,
     orbit_js_url: str = ORBIT_JS_URL,
 ) -> str:
@@ -212,6 +217,8 @@ def _make_helix_html(
         Enable pulsing animation of the helix segments.
     pulse_speed:
         Speed multiplier for the pulse animation.
+    fps:
+        Frames per second for rendering. Lower values reduce CPU usage.
     """
     if length is not None:
         repeats = (length + len(dna_sequence) - 1) // len(dna_sequence)
@@ -235,6 +242,7 @@ def _make_helix_html(
         "ZOOM": zoom,
         "PULSE": "true" if pulse else "false",
         "PULSE_SPEED": pulse_speed,
+        "FPS": fps,
     }
 
 
@@ -247,6 +255,7 @@ def show_helix(
     zoom: float = 1.0,
     pulse: bool = False,
     pulse_speed: float = 2.0,
+    fps: float = 60.0,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls.
 
@@ -263,6 +272,8 @@ def show_helix(
         Enable pulsing animation of the helix segments.
     pulse_speed:
         Speed multiplier for the pulse animation.
+    fps:
+        Frames per second for rendering. Lower values reduce CPU usage.
     """
     three_url: str = THREE_JS_URL
     orbit_url: str = ORBIT_JS_URL
@@ -281,6 +292,7 @@ def show_helix(
         zoom=zoom,
         pulse=pulse,
         pulse_speed=pulse_speed,
+        fps=fps,
         three_js_url=three_url,
         orbit_js_url=orbit_url,
     )
@@ -300,11 +312,13 @@ def show_helix_ui(
     show_runs: bool = True,
     pulse: bool = False,
     pulse_speed: float = 2.0,
+    fps: float = 60.0,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend.
 
     Parameters enable GC colouring, homopolymer highlighting and optional
-    pulse animations via the corresponding query arguments.
+    pulse animations via the corresponding query arguments. The ``fps``
+    argument controls the maximum frames per second.
     """
     base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
     helix_path = base_dir / "dist" / "index.html"
@@ -319,6 +333,7 @@ def show_helix_ui(
         f"runs={'true' if show_runs else 'false'}",
         f"pulse={'true' if pulse else 'false'}",
         f"pulse_speed={pulse_speed}",
+        f"fps={fps}",
     ]
     if colors:
         color_str = ",".join(f"{b}:#{v:06x}" for b, v in colors.items())

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -17,6 +17,7 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
         show_runs=False,
         pulse=True,
         pulse_speed=3.0,
+        fps=30.0,
     )
     assert webview.__class__.__name__ == "WebView"
     assert webview.url.startswith("file:")
@@ -27,6 +28,7 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
     assert "runs=false" in parsed.query
     assert "pulse=true" in parsed.query
     assert "pulse_speed=3.0" in parsed.query
+    assert "fps=30.0" in parsed.query
     assert "colors=A%3A%23123456" in parsed.query
 
 

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -54,6 +54,14 @@ def test_show_helix_pulse_params() -> None:
 
 
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
+def test_show_helix_fps_param() -> None:
+    ft, show_helix = _get_ft_and_show_helix()
+    elem = show_helix("AC", fps=30)
+    html = unquote(elem.url.split(",", 1)[1])
+    assert "const fps = 30" in html
+
+
+@pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
 def test_show_helix_cdn_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     ft, show_helix = _get_ft_and_show_helix()
     monkeypatch.setattr("genecoder.helix_view.THREE_JS_URL", "")


### PR DESCRIPTION
## Summary
- allow setting FPS in `show_helix` and `show_helix_ui`
- throttle animation in the embedded Three.js viewer
- add FPS slider in the Flet GUI
- document animation speed adjustment
- test new FPS parameter

## Testing
- `ruff check src/genecoder/helix_view.py src/genecoder/flet_app.py tests/test_helix_view.py tests/test_helix_ui.py`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c165a9af08326a00f3cb11fb1bdfc