### PR TITLE
Enhance nanopore simulator adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md)
 - Base5 and base6 alphabet options for alternative nucleotide letters. These
   modes remap the standard ACGT symbols but **do not increase capacity**.
 - External read simulators can be invoked with ``--simulator``.
-  Extra ``d2sim`` parameters may be supplied via ``--d2sim-options`` or
-  the ``GENECODER_D2SIM_OPTIONS`` environment variable.
+   Extra parameters may be supplied via ``--d2sim-options``,
+   ``--dnarsim-options`` or ``--squigulator-options``. The same values can be
+   provided using the environment variables ``GENECODER_D2SIM_OPTIONS``,
+   ``GENECODER_DNARSIM_OPTIONS`` and ``GENECODER_SQUIGULATOR_OPTIONS``.
 
 ## Quick Start
 

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -50,6 +50,33 @@ d2sim --help
 Once the binary is accessible, GeneCoder can invoke it via the `--simulator`
 option or `simulate_reads()` API.
 
+### Installing `d2sim`
+
+```bash
+git clone https://github.com/kurimsw/d2sim.git
+cd d2sim
+make
+sudo make install  # or copy the binary to a directory on your PATH
+```
+
+### Installing `DNArSim`
+
+```bash
+git clone https://github.com/Purdue-ScottLab/DNArSim.git
+cd DNArSim
+make
+sudo make install
+```
+
+### Installing `squigulator`
+
+```bash
+git clone https://github.com/hasindu2008/squigulator.git
+cd squigulator
+make
+sudo make install
+```
+
 ## Command-line usage
 
 Apply simple substitutions with a chosen probability:
@@ -71,5 +98,7 @@ genecoder decode --simulator d2sim --d2sim-options "--seed 42" <other options>
 ```
 
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.
-Set `GENECODER_D2SIM_OPTIONS` to forward additional flags to ``d2sim``
-automatically when the simulator is invoked.
+Set `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
+`GENECODER_SQUIGULATOR_OPTIONS` to forward extra flags to the respective
+simulator automatically. The same options can be specified on the command line
+with ``--d2sim-options``, ``--dnarsim-options`` and ``--squigulator-options``.

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -367,12 +367,26 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         type=str,
         help="Extra command line options forwarded to d2sim.",
     )
+    parser.add_argument(
+        "--dnarsim-options",
+        type=str,
+        help="Extra command line options forwarded to dnarsim.",
+    )
+    parser.add_argument(
+        "--squigulator-options",
+        type=str,
+        help="Extra command line options forwarded to squigulator.",
+    )
     parser.set_defaults(func=_handle_command)
 
 
 def _handle_command(args: argparse.Namespace) -> None:
     if getattr(args, "d2sim_options", None):
         os.environ["GENECODER_D2SIM_OPTIONS"] = args.d2sim_options
+    if getattr(args, "dnarsim_options", None):
+        os.environ["GENECODER_DNARSIM_OPTIONS"] = args.dnarsim_options
+    if getattr(args, "squigulator_options", None):
+        os.environ["GENECODER_SQUIGULATOR_OPTIONS"] = args.squigulator_options
 
     num_input_files = len(args.input_files)
     if num_input_files > 1 and not args.output_dir:

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -8,7 +8,6 @@ import tempfile
 import os
 from pathlib import Path
 import logging
-import os
 from typing import Callable, Sequence
 
 __all__ = [
@@ -56,12 +55,13 @@ def _simulate_adapter(
     if shutil.which(command):
         try:
             cmd_list = [command]
-            if command == "d2sim":
+            env_var = f"GENECODER_{command.upper()}_OPTIONS"
+            if command in {"d2sim", "dnarsim", "squigulator"}:
                 cmd_list += ["-e", str(error_rate)]
-                extra = os.getenv("GENECODER_D2SIM_OPTIONS")
-                if extra:
-                    import shlex
-                    cmd_list += shlex.split(extra)
+            extra = os.getenv(env_var)
+            if extra:
+                import shlex
+                cmd_list += shlex.split(extra)
             return _run_external(cmd_list, sequence)
         except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
             logger.warning(

--- a/tests/test_cli_simulator_fallback.py
+++ b/tests/test_cli_simulator_fallback.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+import pytest
+from tests.test_cli import run_cli_command
+
+
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+def test_cli_simulator_fallback(tmp_path: Path, sim_name: str):
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / sim_name
+    script.write_text("#!/bin/sh\nexit 1\n")
+    script.chmod(0o755)
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("fallback test")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "in.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            sim_name,
+        ],
+        env=env,
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    output_file = tmp_path / "in.txt_decoded.bin"
+    assert output_file.exists()
+    assert output_file.read_text().startswith("fallback")

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -34,7 +34,7 @@ def test_adapters_run_external(monkeypatch, name):
     result = func("ACGT")
     assert result == "external"
     assert which_called == [cmd]
-    expected = ([cmd, "-e", "0.05"], "ACGT") if cmd == "d2sim" else ([cmd], "ACGT")
+    expected = ([cmd, "-e", "0.05"], "ACGT")
     assert run_called == [expected]
 
 
@@ -101,7 +101,7 @@ def test_adapters_external_error(monkeypatch, caplog, name):
 
     assert result == "fallback"
     assert which_called == [cmd]
-    expected = ([cmd, "-e", "0.2"], "ACGT") if cmd == "d2sim" else ([cmd], "ACGT")
+    expected = ([cmd, "-e", "0.2"], "ACGT")
     assert run_called == [expected]
     assert errors_called and isinstance(errors_called[0][2], random.Random)
     assert any("falling back" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- extend nanopore simulators to pass options to installed binaries
- expose `--dnarsim-options` and `--squigulator-options` in CLI
- document installation of external simulators
- test CLI simulator fallback behaviour

## Testing
- `ruff check src/genecoder/nanopore_sim.py src/genecoder/cli/decode.py tests/test_nanopore_sim.py tests/test_cli_simulator_fallback.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c16575f248326b45ddd1632f6b75b