### PR TITLE
Add additional codec and simulator tests

### DIFF
--- a/tests/test_bch_codec_additional.py
+++ b/tests/test_bch_codec_additional.py
@@ -1,0 +1,20 @@
+import pytest
+from genecoder.bch_codec import _HAS_BCHLIB, encode_data_bch, decode_data_bch, bchlib
+
+pytestmark = pytest.mark.skipif(not _HAS_BCHLIB, reason="bchlib not installed")
+
+
+def test_bch_decode_failure(monkeypatch):
+    data = b"fail"
+    encoded, info = encode_data_bch(data, m=5, t=2)
+
+    class FakeBCH:
+        def __init__(self, m, t):
+            self.ecc_bytes = len(encoded) - len(data)
+
+        def decode(self, data_bytes, ecc):
+            return None, 0
+
+    monkeypatch.setattr(bchlib, "BCH", FakeBCH)
+    with pytest.raises(ValueError, match="BCH decode failed"):
+        decode_data_bch(encoded, info)

--- a/tests/test_ldpc_codec_additional.py
+++ b/tests/test_ldpc_codec_additional.py
@@ -1,0 +1,14 @@
+import pytest
+from genecoder.ldpc_codec import _HAS_PYLDPC, encode_data_ldpc, decode_data_ldpc
+
+pytestmark = pytest.mark.skipif(not _HAS_PYLDPC, reason="pyldpc not installed")
+
+
+def test_ldpc_decode_corrections():
+    data = b"LDPC" * 2
+    encoded, info = encode_data_ldpc(data)
+    corrupted = bytearray(encoded)
+    corrupted[0] ^= 1
+    decoded, corrections = decode_data_ldpc(bytes(corrupted), info)
+    assert decoded.startswith(data)
+    assert corrections > 0

--- a/tests/test_raptorq_codec_additional.py
+++ b/tests/test_raptorq_codec_additional.py
@@ -1,0 +1,19 @@
+import pytest
+from genecoder.raptorq_codec import _HAS_RAPTORQ, encode_data_raptorq, decode_data_raptorq, raptorq
+
+pytestmark = pytest.mark.skipif(not _HAS_RAPTORQ, reason="raptorq not installed")
+
+
+def test_raptorq_decode_failure(monkeypatch):
+    data = b"rq"
+    encoded, info = encode_data_raptorq(data, symbol_size=4)
+
+    class FakeDecoder:
+        def __init__(self, symbol_size, orig_len):
+            pass
+        def decode(self, payload):
+            return None
+
+    monkeypatch.setattr(raptorq, "Decoder", FakeDecoder)
+    with pytest.raises(ValueError, match="RaptorQ decode failed"):
+        decode_data_raptorq(encoded, info)

--- a/tests/test_simulate_reads_dispatch.py
+++ b/tests/test_simulate_reads_dispatch.py
@@ -1,0 +1,50 @@
+import random
+import pytest
+
+from genecoder import nanopore_sim
+from genecoder.simulators import simulate_reads
+from genecoder.plugins import SIMULATOR_REGISTRY
+
+
+@pytest.mark.parametrize("name", ["d2sim", "dnarsim", "squigulator"])
+def test_simulate_reads_calls_adapter(monkeypatch, name):
+    which_called = []
+    run_called = []
+
+    def fake_which(target):
+        which_called.append(target)
+        return "/usr/bin/" + target
+
+    def fake_run_external(cmd, seq):
+        run_called.append((cmd, seq))
+        return "external"
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run_external)
+    monkeypatch.setitem(SIMULATOR_REGISTRY, name, nanopore_sim.Channel(name))
+
+    result = simulate_reads("ACGT", name)
+    assert result == "external"
+    assert which_called == [name]
+    expected = ([name, "-e", "0.05"], "ACGT") if name == "d2sim" else ([name], "ACGT")
+    assert run_called == [expected]
+
+
+@pytest.mark.parametrize("name", ["d2sim", "dnarsim", "squigulator"])
+def test_simulate_reads_adapter_fallback(monkeypatch, name):
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+    monkeypatch.setitem(SIMULATOR_REGISTRY, name, nanopore_sim.Channel(name))
+
+    result = simulate_reads("ACGT", name, error_rate=0.1)
+    assert result == "fallback"
+    assert which_called == [name]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)


### PR DESCRIPTION
## Summary
- extend tests for BCH, RaptorQ and LDPC codecs
- test `simulate_reads` adapter dispatch and fallback logic
- restore type casts in security helpers to satisfy mypy

## Testing
- `ruff check tests/test_bch_codec_additional.py tests/test_ldpc_codec_additional.py tests/test_raptorq_codec_additional.py tests/test_simulate_reads_dispatch.py src/genecoder/security.py`
- `mypy --config-file mypy.ini src/genecoder/security.py`
- `pytest -q tests/test_bch_codec_additional.py tests/test_ldpc_codec_additional.py tests/test_raptorq_codec_additional.py tests/test_simulate_reads_dispatch.py`


------
https://chatgpt.com/codex/tasks/task_e_685c166f879483269a0920bd6fa6fd70