### PR TITLE
Add manifest key validation

### DIFF
--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -25,6 +25,11 @@ def generate_manifest(
     else:
         raise ValueError("encoding_params must be a dataclass or mapping")
 
+    missing_keys = REQUIRED_ENCODING_KEYS - params.keys()
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise ValueError(f"Missing required encoding parameter(s): {missing}")
+
     return {
         "file": file_name,
         "encoding_parameters": params,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,5 +1,6 @@
 
 import pytest
+from dataclasses import dataclass
 
 from genecoder.manifest import generate_manifest
 from genecoder.cli import EncodingOptions
@@ -49,4 +50,19 @@ def test_generate_manifest_invalid_type() -> None:
 def test_generate_manifest_dataclass_type() -> None:
     with pytest.raises(ValueError, match="encoding_params must be a dataclass or mapping"):
         generate_manifest("bad.txt", EncodingOptions, {"dna_length": 1})
+
+
+def test_generate_manifest_missing_required_key_mapping() -> None:
+    opts = {"add_parity": False}
+    with pytest.raises(ValueError, match="Missing required encoding parameter\(s\): method"):
+        generate_manifest("bad.txt", opts, {"dna_length": 1})
+
+
+def test_generate_manifest_missing_required_key_dataclass() -> None:
+    @dataclass
+    class NoMethod:
+        add_parity: bool = False
+
+    with pytest.raises(ValueError, match="Missing required encoding parameter\(s\): method"):
+        generate_manifest("bad.txt", NoMethod(), {"dna_length": 1})
 


### PR DESCRIPTION
## Summary
- validate that manifest generation parameters contain required keys
- test for success and failure when required keys are missing

## Testing
- `pre-commit run ruff --files src/genecoder/manifest.py tests/test_manifest.py`
- `mypy --config-file mypy.ini src/genecoder/manifest.py tests/test_manifest.py`
- `pytest -k manifest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c480e1fa0832689d5add472c3f415