### PR TITLE
Add glossary and doc cross references

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -3,12 +3,12 @@
 GeneCoder provides a CLI and GUI for encoding and decoding data into simulated DNA sequences. Key features include:
 
 * **CLI for encoding and decoding** using multiple methods.
-* **GC-Balanced encoding** with tunable constraints.
-* **Forward Error Correction** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and the optional FrameD C++ backend.
+* **GC-Balanced encoding** with tunable constraints on [GC content](glossary.md#gc-content).
+* **[Forward Error Correction](glossary.md#forward-error-correction-fec)** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and the optional FrameD C++ backend.
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
-* **CSV export for synthesis** with length and homopolymer validation. The analysis command warns when sequences violate these constraints.
+* **CSV export for synthesis** with length and [homopolymer](glossary.md#homopolymer) validation. The analysis command warns when sequences violate these constraints.
 
 
 ## Helix View

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,12 @@
+# Glossary
+
+This page defines key terms used throughout the GeneCoder documentation.
+
+## GC content
+The percentage of guanine (G) and cytosine (C) bases in a DNA sequence. Balanced GC content (often around 40–60%) improves stability and processability.
+
+## Homopolymer
+A run of identical nucleotides, e.g. `AAAAA`. Long homopolymers can cause synthesis and sequencing errors.
+
+## Forward Error Correction (FEC)
+Techniques that add redundancy to encoded data so errors can be detected and corrected during decoding.

--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -1,8 +1,10 @@
 # Helix Frontend
 
 The 3D helix viewer lives in `web/helix-ui`. It is a single-page React
-application that uses Three.js for rendering. Overlays indicate GC content and
-homopolymer runs while the helix itself can be colourised and animated.
+application that uses Three.js for rendering. Overlays indicate
+[GC content](glossary.md#gc-content) and
+[homopolymer](glossary.md#homopolymer) runs while the helix itself can be
+colourised and animated.
 
 The frontend now uses [Vite](https://vitejs.dev/) for development and builds.
 To explore the viewer without running the whole backend simply open the built

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,3 +18,4 @@ For more details, explore the sections below.
 * [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo.
 * [n8n Overview](n8n_overview.md) – Automate workflows with n8n.
 * [Simulators](simulators.md) – Available read simulators and how to install external tools.
+* [Glossary](glossary.md) – Key terms used throughout the docs.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,7 +108,8 @@ imported.
 
 ## FrameD FEC Backend
 
-The optional FrameD plugin wraps optimized C++ kernels using CFFI.
+The optional FrameD plugin wraps optimized C++ kernels using CFFI to provide additional
+[FEC](glossary.md#forward-error-correction-fec) methods.
 Install it using the ``framed`` extras:
 
 ```bash

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,7 +26,7 @@ def register(register_codec):
     register_codec("mycodec", encode, decode)
 ```
 
-To add a custom FEC implementation you would use the `genecoder.fec` group and
+To add a custom [FEC](glossary.md#forward-error-correction-fec) implementation you would use the `genecoder.fec` group and
 call the provided `register_fec` callback:
 
 ```toml
@@ -55,7 +55,8 @@ GeneCoder.
 ## Plugin Examples
 
 See the [plugins-examples](../plugins-examples/) directory in the source tree for
-minimal sample packages implementing a codec, a FEC backend and a read
+minimal sample packages implementing a codec, a
+[FEC](glossary.md#forward-error-correction-fec) backend and a read
 simulator. Install any of these packages with `pip install` to experiment with
 custom extensions locally.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,7 +36,7 @@ poetry install --no-interaction
 * `--input-files` – one or more input files.
 * `--output-file` – output path for a single input file.
 * `--output-dir` – directory for batch operations.
-* `--fec` – optional FEC method (`triple_repeat`, `hamming_7_4`, `reed_solomon`, `ldpc`, `fountain`).
+* `--fec` – optional [FEC](glossary.md#forward-error-correction-fec) method (`triple_repeat`, `hamming_7_4`, `reed_solomon`, `ldpc`, `fountain`).
 
 See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
@@ -225,6 +225,8 @@ python -m genecoder.flet_app
 The GUI exposes encoding options, error correction choices and displays metrics and analysis plots.
 
 The **Helix View** tab embeds a dedicated React/Three.js frontend. It renders the
-sequence in 3D with orbit controls, overlays for GC content and homopolymers and
+sequence in 3D with orbit controls, overlays for
+[GC content](glossary.md#gc-content) and
+[homopolymers](glossary.md#homopolymer) and
 an *Animate* toggle. The frontend lives under `web/helix-ui` and is loaded via a
 WebView in the GUI.

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -51,7 +51,8 @@ Decoded bytes are returned as a base64 string.
 
 ## Sequence Analysis
 
-The `/analyze` endpoint returns GC content and homopolymer statistics for a
+The `/analyze` endpoint returns [GC content](glossary.md#gc-content) and
+[homopolymer](glossary.md#homopolymer) statistics for a
 FASTA sequence.
 
 ```json
@@ -61,8 +62,9 @@ POST /analyze
 }
 ```
 
-The JSON response includes the sequence length, GC content and the longest
-homopolymer run.
+The JSON response includes the sequence length,
+[GC content](glossary.md#gc-content) and the longest
+[homopolymer](glossary.md#homopolymer) run.
 
 ## Generating Reports
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Development Vision: DEVELOPMENT_VISION.md
 
   - Plugin System: plugins.md
+  - Glossary: glossary.md
 
   - API Reference: api_reference.md
 


### PR DESCRIPTION
## Summary
- add a glossary page defining GC content, homopolymer and FEC
- link the glossary from the home page and navigation
- reference glossary terms within docs where relevant

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c483232588326beeab3acb81b4a9c