### PR TITLE
Add plugin loading and helix UI tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
 [run]
+source =
+    src
+    plugins-examples/example_codec
+    plugins-examples/example_fec
+    plugins-examples/example_simulator
 omit =
     src/genecoder/flet_app.py
     src/genecoder/cli/*.py

--- a/tests/test_flet_gui.py
+++ b/tests/test_flet_gui.py
@@ -44,3 +44,12 @@ def test_main_registers_event_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert callable(captured["encode"].on_click)
     assert callable(captured["decode"].on_click)
+
+
+def test_show_helix_ui_returns_webview() -> None:
+    from genecoder.helix_view import show_helix_ui
+
+    elem = show_helix_ui("AC")
+    assert elem.__class__.__name__ == "WebView"
+    assert elem.width == 600
+    assert elem.height == 400

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -1,3 +1,4 @@
+import pytest
 from genecoder import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
@@ -30,4 +31,38 @@ def test_simulator_plugins_registered() -> None:
 
     assert isinstance(SIMULATOR_REGISTRY, dict)
     assert all(isinstance(ch, BaseChannel) for ch in SIMULATOR_REGISTRY.values())
+
+
+def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    from importlib.metadata import EntryPoint
+    from pathlib import Path
+
+    import genecoder.plugins as plugins
+
+    root = Path(__file__).resolve().parents[1] / "plugins-examples"
+    monkeypatch.syspath_prepend(str(root / "example_codec"))
+    monkeypatch.syspath_prepend(str(root / "example_fec"))
+    monkeypatch.syspath_prepend(str(root / "example_simulator"))
+
+    def fake_entry_points(*, group: str | None = None):
+        if group == "genecoder.plugins":
+            return [EntryPoint(name="example", value="example_codec", group=group)]
+        if group == "genecoder.fec":
+            return [EntryPoint(name="example", value="example_fec", group=group)]
+        if group == "genecoder.simulators":
+            return [EntryPoint(name="example", value="example_simulator", group=group)]
+        return []
+
+    monkeypatch.setattr(plugins, "entry_points", fake_entry_points)
+
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert "reverse" in plugins.CODEC_REGISTRY
+    assert "example" in plugins.CODEC_REGISTRY
+    assert "example" in plugins.FEC_REGISTRY
+    assert "example" in plugins.SIMULATOR_REGISTRY
 

--- a/tests/test_simulate_reads_dispatch.py
+++ b/tests/test_simulate_reads_dispatch.py
@@ -26,8 +26,7 @@ def test_simulate_reads_calls_adapter(monkeypatch, name):
     result = simulate_reads("ACGT", name)
     assert result == "external"
     assert which_called == [name]
-    expected = ([name, "-e", "0.05"], "ACGT") if name == "d2sim" else ([name], "ACGT")
-    assert run_called == [expected]
+    assert run_called == [([name, "-e", "0.05"], "ACGT")]
 
 
 @pytest.mark.parametrize("name", ["d2sim", "dnarsim", "squigulator"])


### PR DESCRIPTION
## Summary
- expand coverage to plugin example packages
- test Flet GUI `show_helix_ui` returns a `WebView`
- verify example plugins register via `load_plugins`
- fix simulator dispatch tests for new CLI flags

## Testing
- `ruff check tests/test_flet_gui.py tests/test_plugin_loading.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4833d7708326a45e2b9da804332c