### PR TITLE
Improve technology stack docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,3 +18,4 @@ For more details, explore the sections below.
 * [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo.
 * [n8n Overview](n8n_overview.md) – Automate workflows with n8n.
 * [Simulators](simulators.md) – Available read simulators and how to install external tools.
+* [Technology Stack](technology_stack.md) – Overview of dependencies and tooling.

--- a/docs/technology_stack.md
+++ b/docs/technology_stack.md
@@ -6,3 +6,28 @@
 * **Error Correction:** Triple-Repeat, Hamming(7,4), Reed-Solomon
 * **GUI Framework:** `Flet`
 * **Plotting:** `Matplotlib`
+
+## Optional Dependencies
+
+GeneCoder supports several additional FEC back-ends that are loaded only when
+installed:
+
+- **LDPC** via `pyldpc` – experimental low-density parity-check codes.
+- **Fountain** via `pyfinite` – simple rateless encoding with parity chunks.
+- **FrameD** via `cffi` – wrappers around optimized C++ kernels.
+
+Install these with Poetry extras, for example `poetry install --extras framed`.
+
+## Web Components
+
+The toolkit bundles a lightweight FastAPI server and a React/Three.js helix
+viewer built with **Vite**. The frontend lives under `web/helix-ui` and is served
+by the FastAPI app or embedded in the Flet GUI. Node.js and npm are required to
+build the React app.
+
+## Continuous Integration
+
+GitHub Actions run linting, tests and security scans. Workflows use a merge queue
+so each pull request must pass the `python-ci` job before merging. Documentation
+or comment-only changes skip heavy jobs with `scripts/only_comments_changed.py`.
+A CycloneDX SBOM is produced after successful builds.


### PR DESCRIPTION
## Summary
- document optional dependencies and CI tools
- add link to technology stack page from index

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c4835516c83269cfe2abac5f5b19e