### PR TITLE
Centralize read simulation dispatch

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -156,23 +156,23 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]]
 
 
 def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
-    """Return ``sequence`` corrupted using the chosen simulator."""
+    """Return ``sequence`` processed by the named simulator.
 
-    from .plugins import SIMULATOR_REGISTRY
+    .. deprecated:: 0.2
+       Use :func:`genecoder.simulators.simulate_reads` instead.
+    """
 
-    try:
-        channel = SIMULATOR_REGISTRY[simulator]
-    except KeyError as exc:
-        raise ValueError(f"Unknown simulator: {simulator}") from exc
+    import warnings
 
-    if hasattr(channel, "error_rate"):
-        old_rate = channel.error_rate
-        channel.error_rate = error_rate
-        try:
-            return channel.simulate(sequence)
-        finally:
-            channel.error_rate = old_rate
-    return channel.simulate(sequence)
+    warnings.warn(
+        "genecoder.nanopore_sim.simulate_reads is deprecated; use genecoder.simulators.simulate_reads",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    from .simulators import simulate_reads as _simulate_reads
+
+    return _simulate_reads(sequence, simulator, error_rate=error_rate)
 
 
 class Channel(BaseChannel):

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 _AES_HEADER = b"AESGCM1"
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = cast(bytes, AESGCM(aes_key).encrypt(nonce, data, None))
+    enc = AESGCM(aes_key).encrypt(nonce, data, None)
 
     return _AES_HEADER + nonce + enc
 
@@ -41,7 +41,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
+        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
 
 
     return _xor_cipher(data, key)

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -186,3 +186,22 @@ def test_register_returns_channels():
 
     assert registry
     assert all(isinstance(chan, BaseChannel) for chan in registry.values())
+
+
+def test_simulate_reads_wrapper_deprecated(monkeypatch):
+    called = []
+
+    def fake_sim(seq: str, sim: str, error_rate: float = 0.05) -> str:
+        called.append((seq, sim, error_rate))
+        return "wrapped"
+
+    monkeypatch.setattr(
+        "genecoder.simulators.simulate_reads",
+        fake_sim,
+    )
+
+    with pytest.deprecated_call():
+        result = nanopore_sim.simulate_reads("ACGT", "none", error_rate=0.2)
+
+    assert result == "wrapped"
+    assert called == [("ACGT", "none", 0.2)]

--- a/tests/test_simulate_reads_dispatch.py
+++ b/tests/test_simulate_reads_dispatch.py
@@ -26,7 +26,7 @@ def test_simulate_reads_calls_adapter(monkeypatch, name):
     result = simulate_reads("ACGT", name)
     assert result == "external"
     assert which_called == [name]
-    expected = ([name, "-e", "0.05"], "ACGT") if name == "d2sim" else ([name], "ACGT")
+    expected = ([name, "-e", "0.05"], "ACGT")
     assert run_called == [expected]
 
 


### PR DESCRIPTION
## Summary
- forward nanopore simulator dispatch to `genecoder.simulators.simulate_reads`
- warn when using the deprecated wrapper
- update CLI tests for new behaviour
- fix mypy warnings in the security helper

## Testing
- `ruff check src/genecoder/security.py tests/test_nanopore_sim.py tests/test_simulate_reads_dispatch.py src/genecoder/nanopore_sim.py`
- `pytest -q tests/test_nanopore_sim.py tests/test_simulate_reads_dispatch.py`
- `mypy --config-file mypy.ini -p genecoder.security`
- `mypy --config-file mypy.ini -p genecoder.nanopore_sim`


------
https://chatgpt.com/codex/tasks/task_e_685c4826f67c8326a4b90a505d747f7d