### PR TITLE
Add wrappers for dnarsim and squigulator simulators

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -97,6 +97,13 @@ Provide additional parameters to ``d2sim`` using ``--d2sim-options``:
 genecoder decode --simulator d2sim --d2sim-options "--seed 42" <other options>
 ```
 
+Provide extra flags to ``dnarsim`` or ``squigulator`` in the same way:
+
+```bash
+genecoder decode --simulator dnarsim --dnarsim-options "<opts>" <other options>
+genecoder decode --simulator squigulator --squigulator-options "<opts>" <other options>
+```
+
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.
 Set `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
 `GENECODER_SQUIGULATOR_OPTIONS` to forward extra flags to the respective

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ dnaformer = "genecoder.dnaformer_codec"
 [tool.poetry.plugins."genecoder.simulators"]
 nanopore = "genecoder.nanopore_sim"
 d2sim = "genecoder.d2sim_adapter"
+dnarsim = "genecoder.dnarsim_adapter"
+squigulator = "genecoder.squigulator_adapter"
 simple = "genecoder.channel_sim"
 indel = "genecoder.error_simulation"
 illumina = "genecoder.simulators.illumina"

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -1,0 +1,50 @@
+"""Adapter for the optional ``dnarsim`` read simulator."""
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .channels.base import BaseChannel
+from .random_utils import make_rng
+from .nanopore_sim import _simulate_adapter, _run_external
+
+
+class _DNARSIM:
+    """Internal helper to invoke the :mod:`dnarsim` binary."""
+
+    command = "dnarsim"
+
+    @staticmethod
+    def run(sequence: str) -> str:
+        """Run ``dnarsim`` on ``sequence`` via :func:`_run_external`."""
+
+        return _run_external(_DNARSIM.command, sequence)
+
+
+def simulate_dnarsim(
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+) -> str:
+    """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng)
+
+
+class DNArSimChannel(BaseChannel):
+    """Channel wrapper for the optional ``dnarsim`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_dnarsim(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    """Register the ``dnarsim`` simulator."""
+
+    register_simulator("dnarsim", DNArSimChannel())

--- a/src/genecoder/squigulator_adapter.py
+++ b/src/genecoder/squigulator_adapter.py
@@ -1,0 +1,50 @@
+"""Adapter for the optional ``squigulator`` read simulator."""
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .channels.base import BaseChannel
+from .random_utils import make_rng
+from .nanopore_sim import _simulate_adapter, _run_external
+
+
+class _SQUIGULATOR:
+    """Internal helper to invoke the :mod:`squigulator` binary."""
+
+    command = "squigulator"
+
+    @staticmethod
+    def run(sequence: str) -> str:
+        """Run ``squigulator`` on ``sequence`` via :func:`_run_external`."""
+
+        return _run_external(_SQUIGULATOR.command, sequence)
+
+
+def simulate_squigulator(
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+) -> str:
+    """Use ``squigulator`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("squigulator", sequence, error_rate, rng)
+
+
+class SquigulatorChannel(BaseChannel):
+    """Channel wrapper for the optional ``squigulator`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_squigulator(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    """Register the ``squigulator`` simulator."""
+
+    register_simulator("squigulator", SquigulatorChannel())

--- a/tests/test_dnarsim_squigulator_adapter.py
+++ b/tests/test_dnarsim_squigulator_adapter.py
@@ -1,0 +1,143 @@
+import subprocess
+import random
+import logging
+import pytest
+
+from genecoder import dnarsim_adapter, squigulator_adapter, nanopore_sim
+
+ADAPTERS = {
+    "dnarsim": (dnarsim_adapter.simulate_dnarsim, dnarsim_adapter._DNARSIM, "dnarsim"),
+    "squigulator": (
+        squigulator_adapter.simulate_squigulator,
+        squigulator_adapter._SQUIGULATOR,
+        "squigulator",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_run_external(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    run_called = []
+
+    def fake_which(target):
+        which_called.append(target)
+        return "/usr/bin/" + target
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        return "external"
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+
+    result = func("ACGT")
+    assert result == "external"
+    assert which_called == [cmd]
+    assert run_called == [([cmd, "-e", "0.05"], "ACGT")]
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_fall_back(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+
+    result = func("ACGT", error_rate=0.1)
+    assert result == "fallback"
+    assert which_called == [cmd]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_external_error(monkeypatch, caplog, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    run_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t)
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT", error_rate=0.2)
+
+    assert result == "fallback"
+    assert which_called == [cmd]
+    assert run_called == [([cmd, "-e", "0.2"], "ACGT")]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any("falling back" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_command_not_found_warning(monkeypatch, caplog, name):
+    func, cls, cmd = ADAPTERS[name]
+    errors_called = []
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: None)
+
+    def boom(*_):
+        raise AssertionError("_run_external should not be called")
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", boom)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT")
+
+    assert result == "fallback"
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any(
+        rec.levelno == logging.WARNING and "not found" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_class_run(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    called = []
+
+    def fake_run_external(c, seq):
+        called.append((c, seq))
+        return "ok"
+
+    monkeypatch.setattr(cls, "command", cmd)
+    monkeypatch.setattr(dnarsim_adapter if name == "dnarsim" else squigulator_adapter, "_run_external", fake_run_external)
+
+    result = cls.run("ACGT")
+    assert result == "ok"
+    assert called == [(cmd, "ACGT")]
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_channel_object(monkeypatch, name):
+    from genecoder.channels.base import BaseChannel
+
+    module = dnarsim_adapter if name == "dnarsim" else squigulator_adapter
+    registry: dict[str, BaseChannel] = {}
+    module.register(lambda n, ch: registry.setdefault(n, ch))
+
+    assert name in registry
+    assert isinstance(registry[name], BaseChannel)


### PR DESCRIPTION
## Summary
- add `dnarsim_adapter` and `squigulator_adapter` modules
- register new simulators in `pyproject.toml`
- document extra CLI options for dnarsim and squigulator
- test adapters for both simulators

## Testing
- `pre-commit run --files docs/simulators.md pyproject.toml src/genecoder/dnarsim_adapter.py src/genecoder/squigulator_adapter.py tests/test_dnarsim_squigulator_adapter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d854f7f8c8326ba3da4d345a5db7c