### PR TITLE
Add GC gauge and error flash options

### DIFF
--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -38,6 +38,8 @@ The viewer accepts several query parameters which are also exposed by
 - `zoom` – numeric zoom factor.
 - `gc` – `true`/`false` to show the GC-content overlay.
 - `runs` – `true`/`false` to highlight homopolymers.
+- `gauge` – `true`/`false` to display overall GC percentage gauges.
+- `flash` – `true`/`false` to show error flashes.
 - `colors` – comma-separated `base:#hex` pairs, for example
   `A:#ff0000,G:#00ff00`.
 - `pulse` – `true`/`false` to enable progress pulses.
@@ -57,4 +59,10 @@ Set `fps` to cap the frame rate if the animation uses too much CPU:
 
 ```python
 webview = show_helix_ui("ACGT", fps=30)
+```
+
+Disable the GC gauge and show flashing error hints:
+
+```python
+webview = show_helix_ui("ACGT", show_gauge=False, flash_errors=True)
 ```

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -310,14 +310,16 @@ def show_helix_ui(
     colors: dict[str, int] | None = None,
     show_gc: bool = True,
     show_runs: bool = True,
+    show_gauge: bool = True,
+    flash_errors: bool = False,
     pulse: bool = False,
     pulse_speed: float = 2.0,
     fps: float = 60.0,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend.
 
-    Parameters enable GC colouring, homopolymer highlighting and optional
-    pulse animations via the corresponding query arguments. The ``fps``
+    Parameters enable GC colouring, homopolymer highlighting, GC ratio gauges
+    and error flashes via the corresponding query arguments. The ``fps``
     argument controls the maximum frames per second.
     """
     base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
@@ -331,6 +333,8 @@ def show_helix_ui(
         f"zoom={zoom}",
         f"gc={'true' if show_gc else 'false'}",
         f"runs={'true' if show_runs else 'false'}",
+        f"gauge={'true' if show_gauge else 'false'}",
+        f"flash={'true' if flash_errors else 'false'}",
         f"pulse={'true' if pulse else 'false'}",
         f"pulse_speed={pulse_speed}",
         f"fps={fps}",

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -15,6 +15,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
         colors={"A": 0x123456},
         show_gc=False,
         show_runs=False,
+        show_gauge=False,
+        flash_errors=True,
         pulse=True,
         pulse_speed=3.0,
         fps=30.0,
@@ -26,6 +28,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
     assert "zoom=1.5" in parsed.query
     assert "gc=false" in parsed.query
     assert "runs=false" in parsed.query
+    assert "gauge=false" in parsed.query
+    assert "flash=true" in parsed.query
     assert "pulse=true" in parsed.query
     assert "pulse_speed=3.0" in parsed.query
     assert "fps=30.0" in parsed.query

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -30,10 +30,13 @@ export default function App() {
   const [animate, setAnimate] = useState(params.get('animate') !== 'false');
   const [zoom] = useState(parseFloat(params.get('zoom') || '1'));
   const seq = params.get('seq') || 'ACGT';
+  const gcRatio = seq.split('').filter((b) => b === 'G' || b === 'C').length / seq.length;
   const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
   const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
   const [showPulses, setShowPulses] = useState(params.get('pulse') === 'true');
   const [pulseSpeed] = useState(parseFloat(params.get('pulse_speed') || '2'));
+  const [showGauge, setShowGauge] = useState(params.get('gauge') !== 'false');
+  const [flashErrors, setFlashErrors] = useState(params.get('flash') === 'true');
 
   const colorParam = params.get('colors');
   const colors = { ...DEFAULT_COLORS, ...(parseColors(colorParam) || {}) };
@@ -97,9 +100,16 @@ export default function App() {
         ctx.fillRect(i * bw, 16, bw, 14);
       }
     }
+    if (showGauge) {
+      ctx.fillStyle = '#ddd';
+      ctx.fillRect(0, 28, metricsRef.current.width, 2);
+      ctx.fillStyle = '#88f';
+      ctx.fillRect(0, 28, metricsRef.current.width * gcRatio, 2);
+    }
 
     let frameId;
     let pulsePhase = 0;
+    let flashPhase = 0;
     const loop = () => {
       controls.update();
       if (animate) group.rotation.z += 0.01;
@@ -112,6 +122,14 @@ export default function App() {
       } else {
         group.children.forEach((mesh) => mesh.scale.set(1, 1, 1));
       }
+      if (flashErrors) {
+        flashPhase += 0.1;
+        group.children.forEach((mesh, i) => {
+          const intensity = 0.5 + 0.5 * Math.sin(flashPhase - i * 0.3);
+          mesh.material.emissive = new THREE.Color(0xff00ff);
+          mesh.material.emissiveIntensity = intensity;
+        });
+      }
       renderer.render(scene, camera);
       frameId = requestAnimationFrame(loop);
     };
@@ -120,7 +138,7 @@ export default function App() {
       cancelAnimationFrame(frameId);
       renderer.dispose();
     };
-  }, [seq, animate, zoom, colors, showGC, showRuns, showPulses, pulseSpeed]);
+  }, [seq, animate, zoom, colors, showGC, showRuns, showPulses, pulseSpeed, showGauge, flashErrors]);
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -143,6 +161,20 @@ export default function App() {
         <label style={{ marginLeft: 8 }}>
           <input type="checkbox" checked={showPulses} onChange={(e) => setShowPulses(e.target.checked)} /> Pulse
         </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showGauge} onChange={(e) => setShowGauge(e.target.checked)} /> Gauge
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={flashErrors} onChange={(e) => setFlashErrors(e.target.checked)} /> Errors
+        </label>
+        {showGauge && (
+          <div style={{ marginTop: 4 }}>
+            <div style={{ width: 100, height: 6, background: '#eee' }}>
+              <div style={{ width: `${gcRatio * 100}%`, height: '100%', background: '#88f' }} />
+            </div>
+            <div style={{ fontSize: 10 }}>{Math.round(gcRatio * 100)}% GC</div>
+          </div>
+        )}
       </div>
       <div ref={mount} style={{ width: '100%', height: '100%' }} />
     </div>


### PR DESCRIPTION
## Summary
- enhance helix-ui React app with GC gauges and error flashes
- expose `show_gauge` and `flash_errors` options via `show_helix_ui`
- document new parameters in helix_frontend.md
- test coverage for new query arguments

## Testing
- `pre-commit run --files web/helix-ui/src/App.jsx src/genecoder/helix_view.py tests/test_helix_ui.py docs/helix_frontend.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d85564fdc8326985e4276861c5817