### PR TITLE
Refactor plugin loading

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,6 +52,13 @@ the :class:`genecoder.channels.base.BaseChannel` protocol.
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.
 
+## Built-in Plugins
+
+GeneCoder includes a set of codec, FEC and simulator plugins that ship with the
+project. These are registered when :func:`genecoder.plugins.load_plugins` imports
+the :mod:`genecoder.builtin_plugins` module before discovering any third-party
+extensions.
+
 ## Plugin Examples
 
 See the [plugins-examples](../plugins-examples/) directory in the source tree for

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Register built-in GeneCoder plugins."""
+
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from .plugins import register_codec, register_fec, register_simulator, _load_and_register
+
+
+def register_builtin_plugins() -> None:
+    """Register all built-in GeneCoder plugins."""
+
+    try:
+        module = import_module("plugins.reverse_codec")
+    except ModuleNotFoundError:  # pragma: no cover - fallback when a plugins.py module is present
+        spec = spec_from_file_location(
+            "plugins.reverse_codec",
+            Path(__file__).resolve().parents[1] / "plugins" / "reverse_codec.py",
+        )
+        assert spec and spec.loader
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+    register = getattr(module, "register", None)
+    if callable(register):
+        register(register_codec)
+
+    _load_and_register(
+        [
+            "genecoder.reed_solomon_codec",
+            "genecoder.ldpc_codec",
+            "genecoder.fountain_codec",
+            "genecoder.bch_codec",
+            "genecoder.raptorq_codec",
+            "genecoder.fec.framed",
+        ],
+        register_fec,
+        "builtin",
+    )
+
+    _load_and_register(
+        [
+            "genecoder.nanopore_sim",
+            "genecoder.channel_sim",
+            "genecoder.error_simulation",
+            "genecoder.simulators.illumina",
+            "genecoder.simulators.adv_nanopore",
+        ],
+        register_simulator,
+        "builtin",
+    )

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -55,6 +55,11 @@ def _load_and_register(items: Iterable[Any], registrar: Callable[..., Any], kind
 def load_plugins() -> None:
     """Load plugins defined via GeneCoder entry points."""
 
+    # First load built-in plugin modules
+    builtin = importlib.import_module("genecoder.builtin_plugins")
+    if hasattr(builtin, "register_builtin_plugins"):
+        builtin.register_builtin_plugins()
+
     _load_and_register(entry_points(group="genecoder.plugins"), register_codec, "codec")
     _load_and_register(entry_points(group="genecoder.fec"), register_fec, "FEC")
     _load_and_register(
@@ -95,28 +100,3 @@ def load_plugins() -> None:
         if callable(register_s):
             register_s(register_simulator)
 
-    # Load built-in back-ends directly when running from source
-    _load_and_register(["plugins.reverse_codec"], register_codec, "builtin")
-    _load_and_register(
-        [
-            "genecoder.reed_solomon_codec",
-            "genecoder.ldpc_codec",
-            "genecoder.fountain_codec",
-            "genecoder.bch_codec",
-            "genecoder.raptorq_codec",
-            "genecoder.fec.framed",
-        ],
-        register_fec,
-        "builtin",
-    )
-    _load_and_register(
-        [
-            "genecoder.nanopore_sim",
-            "genecoder.channel_sim",
-            "genecoder.error_simulation",
-            "genecoder.simulators.illumina",
-            "genecoder.simulators.adv_nanopore",
-        ],
-        register_simulator,
-        "builtin",
-    )

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional
+from typing import Optional, cast
 
 
 _AES_HEADER = b"AESGCM1"
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = AESGCM(aes_key).encrypt(nonce, data, None)
+    enc = cast(bytes, AESGCM(aes_key).encrypt(nonce, data, None))
 
     return _AES_HEADER + nonce + enc
 
@@ -41,7 +41,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
 
 
     return _xor_cipher(data, key)


### PR DESCRIPTION
## Summary
- load built-in plugins from new `genecoder.builtin_plugins`
- ensure built-in plugins register every time `load_plugins()` runs
- document new module in plugin docs
- fix `encrypt_data()` and `decrypt_data()` return typing

## Testing
- `ruff check src/genecoder/builtin_plugins.py src/genecoder/plugins.py src/genecoder/security.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d8530925483269a50a67d6dd71cc9