### PR TITLE
Add PDF references

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -17,3 +17,5 @@
    - Interactive dashboards to visualize storage simulations over time.
    - Cloud-friendly architecture for scaling large simulation batches.
    - Continued collaboration with the research community to expand features.
+6. **Documentation Updates**
+   - Inline comments in `encoders.py` and `flet_app.py` now point to sections of the Development Vision PDF (Sections III and IV) for added context.

--- a/src/genecoder/encoders.py
+++ b/src/genecoder/encoders.py
@@ -5,6 +5,7 @@ Each 2-bit segment of a byte corresponds to one nucleotide. The processing
 occurs from the Most Significant Bit (MSB) to the Least Significant Bit (LSB)
 of each byte.
 """
+# See the Development Vision PDF, Section III for background on the encoder architecture.
 from typing import Tuple, List, Iterable, Iterator  # For type hints
 from genecoder.error_detection import (
     add_parity_to_sequence,

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -13,6 +13,7 @@ responsive.
 See `docs/DEVELOPMENT_VISION.md` for how the GUI fits into the project's
 integrated pipeline and extensible design.
 """
+# Refer to Section IV of the Development Vision PDF for the UI architecture overview.
 
 import flet as ft
 import os


### PR DESCRIPTION
## Summary
- reference encoder design section in the Development Vision PDF
- reference UI architecture section in the Development Vision PDF
- note these links in the roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d855ea8cc8326b0c4c80cdb32b09e