### PR TITLE
Add tests for optional codecs and update coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,9 @@ source =
     plugins-examples/example_codec
     plugins-examples/example_fec
     plugins-examples/example_simulator
+    src/genecoder/ldpc_codec.py
+    src/genecoder/fountain_codec.py
+    src/genecoder/d2sim_adapter.py
 omit =
     src/genecoder/flet_app.py
     src/genecoder/cli/*.py

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -125,3 +125,25 @@ def test_channel_object(monkeypatch):
 
     assert "d2sim" in registry
     assert isinstance(registry["d2sim"], BaseChannel)
+
+
+def test_d2sim_channel_simulate(monkeypatch):
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(
+        nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None
+    )
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate)) or "fallback",
+    )
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+
+    channel = d2sim_adapter.D2SimChannel(error_rate=0.1)
+    result = channel.simulate("ACGT")
+
+    assert result == "fallback"
+    assert which_called == ["d2sim"]
+    assert errors_called == [("ACGT", 0.1)]

--- a/tests/test_ldpc_fountain_extended.py
+++ b/tests/test_ldpc_fountain_extended.py
@@ -37,3 +37,9 @@ def test_fountain_parity(monkeypatch):
     decoded, _ = decode_data_fountain(encoded, info)
     assert decoded == data
     assert any(parity) and len(parity) == 4
+
+
+def test_fountain_missing_dependency(monkeypatch):
+    monkeypatch.setattr('genecoder.fountain_codec._HAS_PYFINITE', False)
+    with pytest.raises(ImportError):
+        encode_data_fountain(b"data")


### PR DESCRIPTION
## Summary
- add mocks for Fountain codec dependency and fallback tests
- add channel simulate test for the d2sim adapter
- ensure ldpc, fountain, and d2sim modules are counted for coverage

## Testing
- `ruff check tests/test_d2sim_adapter.py tests/test_ldpc_fountain_extended.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9324916c8326b8e88a64d04c53c4