### PR TITLE
Add GC-content and homopolymer overlay bars

### DIFF
--- a/docs/helix_frontend.md
+++ b/docs/helix_frontend.md
@@ -38,6 +38,8 @@ The viewer accepts several query parameters which are also exposed by
 - `zoom` – numeric zoom factor.
 - `gc` – `true`/`false` to show the GC-content overlay.
 - `runs` – `true`/`false` to highlight homopolymers.
+- `gc_bars` – `true`/`false` to draw GC-content bars.
+- `run_bars` – `true`/`false` to draw homopolymer bars.
 - `gauge` – `true`/`false` to display overall GC percentage gauges.
 - `flash` – `true`/`false` to show error flashes.
 - `colors` – comma-separated `base:#hex` pairs, for example
@@ -65,4 +67,16 @@ Disable the GC gauge and show flashing error hints:
 
 ```python
 webview = show_helix_ui("ACGT", show_gauge=False, flash_errors=True)
+```
+
+Enable GC-content and homopolymer bars only:
+
+```python
+webview = show_helix_ui(
+    "ACGT",
+    show_gc_bars=True,
+    show_run_bars=True,
+    show_gc=False,
+    show_runs=False,
+)
 ```

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -310,6 +310,8 @@ def show_helix_ui(
     colors: dict[str, int] | None = None,
     show_gc: bool = True,
     show_runs: bool = True,
+    show_gc_bars: bool = False,
+    show_run_bars: bool = False,
     show_gauge: bool = True,
     flash_errors: bool = False,
     pulse: bool = False,
@@ -318,8 +320,9 @@ def show_helix_ui(
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend.
 
-    Parameters enable GC colouring, homopolymer highlighting, GC ratio gauges
-    and error flashes via the corresponding query arguments. The ``fps``
+    Parameters enable GC colouring, homopolymer highlighting, GC ratio gauges,
+    optional GC-content and homopolymer bars and error flashes via the
+    corresponding query arguments. The ``fps``
     argument controls the maximum frames per second.
     """
     base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
@@ -333,6 +336,8 @@ def show_helix_ui(
         f"zoom={zoom}",
         f"gc={'true' if show_gc else 'false'}",
         f"runs={'true' if show_runs else 'false'}",
+        f"gc_bars={'true' if show_gc_bars else 'false'}",
+        f"run_bars={'true' if show_run_bars else 'false'}",
         f"gauge={'true' if show_gauge else 'false'}",
         f"flash={'true' if flash_errors else 'false'}",
         f"pulse={'true' if pulse else 'false'}",

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 _AES_HEADER = b"AESGCM1"
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = cast(bytes, AESGCM(aes_key).encrypt(nonce, data, None))
+    enc = AESGCM(aes_key).encrypt(nonce, data, None)
 
 
     return _AES_HEADER + nonce + enc
@@ -42,7 +42,7 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, None))
+        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
 
 
     return _xor_cipher(data, key)

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -15,6 +15,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
         colors={"A": 0x123456},
         show_gc=False,
         show_runs=False,
+        show_gc_bars=True,
+        show_run_bars=True,
         show_gauge=False,
         flash_errors=True,
         pulse=True,
@@ -28,6 +30,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
     assert "zoom=1.5" in parsed.query
     assert "gc=false" in parsed.query
     assert "runs=false" in parsed.query
+    assert "gc_bars=true" in parsed.query
+    assert "run_bars=true" in parsed.query
     assert "gauge=false" in parsed.query
     assert "flash=true" in parsed.query
     assert "pulse=true" in parsed.query
@@ -51,3 +55,26 @@ def test_helix_ui_screenshot(tmp_path: Path) -> None:
         browser.close()
 
     assert screenshot.is_file()
+
+
+def test_helix_ui_overlays(tmp_path: Path) -> None:
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import sync_playwright
+
+    webview = show_helix_ui(
+        "ACGTACGT",
+        show_gc_bars=True,
+        show_run_bars=True,
+        show_gc=False,
+        show_runs=False,
+    )
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(webview.url)
+        data = page.evaluate(
+            "() => Array.from(document.querySelector('canvas').getContext('2d').getImageData(0,0,1,1).data)"
+        )
+        browser.close()
+
+    assert any(channel != 0 for channel in data[:3])

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -33,6 +33,8 @@ export default function App() {
   const gcRatio = seq.split('').filter((b) => b === 'G' || b === 'C').length / seq.length;
   const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
   const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
+  const [showGCBars, setShowGCBars] = useState(params.get('gc_bars') === 'true');
+  const [showRunBars, setShowRunBars] = useState(params.get('run_bars') === 'true');
   const [showPulses, setShowPulses] = useState(params.get('pulse') === 'true');
   const [pulseSpeed] = useState(parseFloat(params.get('pulse_speed') || '2'));
   const [showGauge, setShowGauge] = useState(params.get('gauge') !== 'false');
@@ -90,11 +92,11 @@ export default function App() {
     const ctx = metricsRef.current.getContext('2d');
     const bw = metricsRef.current.width / bases.length;
     for (let i = 0; i < bases.length; i++) {
-      if (showGC) {
+      if (showGCBars) {
         ctx.fillStyle = bases[i] === 'G' || bases[i] === 'C' ? '#88f' : '#ddd';
         ctx.fillRect(i * bw, 0, bw, 14);
       }
-      if (showRuns) {
+      if (showRunBars) {
         const intensity = Math.min(runs[i] / 6, 1);
         ctx.fillStyle = `rgba(255,0,0,${intensity})`;
         ctx.fillRect(i * bw, 16, bw, 14);
@@ -138,7 +140,7 @@ export default function App() {
       cancelAnimationFrame(frameId);
       renderer.dispose();
     };
-  }, [seq, animate, zoom, colors, showGC, showRuns, showPulses, pulseSpeed, showGauge, flashErrors]);
+  }, [seq, animate, zoom, colors, showGC, showRuns, showGCBars, showRunBars, showPulses, pulseSpeed, showGauge, flashErrors]);
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>
@@ -157,6 +159,12 @@ export default function App() {
         </label>
         <label style={{ marginLeft: 8 }}>
           <input type="checkbox" checked={showRuns} onChange={(e) => setShowRuns(e.target.checked)} /> Runs
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showGCBars} onChange={(e) => setShowGCBars(e.target.checked)} /> GC Bars
+        </label>
+        <label style={{ marginLeft: 8 }}>
+          <input type="checkbox" checked={showRunBars} onChange={(e) => setShowRunBars(e.target.checked)} /> Run Bars
         </label>
         <label style={{ marginLeft: 8 }}>
           <input type="checkbox" checked={showPulses} onChange={(e) => setShowPulses(e.target.checked)} /> Pulse


### PR DESCRIPTION
## Summary
- support optional GC-content and homopolymer overlay bars
- expose new `gc_bars` and `run_bars` parameters in `show_helix_ui`
- draw overlay bars in the React frontend
- document the new parameters and show usage
- test that the query parameters and overlays work

## Testing
- `pre-commit run --files docs/helix_frontend.md src/genecoder/helix_view.py tests/test_helix_ui.py web/helix-ui/src/App.jsx src/genecoder/security.py`

------
https://chatgpt.com/codex/tasks/task_e_685d931305d08326a97560d097e3a8d9