### PR TITLE
Improve nanopore simulator error handling

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -1,11 +1,11 @@
 """Wrapper for optional nanopore read simulators."""
 from __future__ import annotations
 
+import os
 import random
 import shutil
 import subprocess
 import tempfile
-import os
 from pathlib import Path
 import logging
 from typing import Callable, Sequence
@@ -29,6 +29,24 @@ from .channel_sim import simulate_errors
 from .formats import from_fasta, to_fasta
 
 
+def _parse_env_options(command: str) -> list[str]:
+    """Return additional options for ``command`` parsed from the environment."""
+
+    env_var = f"GENECODER_{command.upper()}_OPTIONS"
+    raw = os.getenv(env_var)
+    if not raw:
+        return []
+    import shlex
+
+    try:
+        options = shlex.split(raw)
+    except ValueError as exc:  # pragma: no cover - error path
+        logger.warning("Invalid %s value: %s", env_var, exc)
+        return []
+    logger.debug("Using %s=%r", env_var, options)
+    return options
+
+
 
 
 def _run_external(command: Sequence[str] | str, sequence: str) -> str:
@@ -42,10 +60,17 @@ def _run_external(command: Sequence[str] | str, sequence: str) -> str:
         output_path = Path(tmpdir) / "output.fasta"
         input_path.write_text(to_fasta(sequence, "seq"))
         cmd_list = [command] if isinstance(command, str) else list(command)
-        subprocess.run(cmd_list + [str(input_path), str(output_path)], check=True)
+        full_cmd = cmd_list + [str(input_path), str(output_path)]
+        logger.debug("Running external command: %s", " ".join(full_cmd))
+        try:
+            subprocess.run(full_cmd, check=True)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+            raise RuntimeError(
+                f"{cmd_list[0]} failed with exit code {exc.returncode}"
+            ) from exc
         records = from_fasta(output_path.read_text())
         if not records:
-            raise RuntimeError(f"{command} produced no FASTA output")
+            raise RuntimeError(f"{cmd_list[0]} produced no FASTA output")
         return records[0][1]
 
 
@@ -57,19 +82,15 @@ def _simulate_adapter(
     if shutil.which(command):
         try:
             cmd_list = [command]
-            env_var = f"GENECODER_{command.upper()}_OPTIONS"
             if command in {"d2sim", "dnarsim", "squigulator"}:
                 cmd_list += ["-e", str(error_rate)]
-            extra = os.getenv(env_var)
-            if extra:
-                import shlex
-                cmd_list += shlex.split(extra)
+            cmd_list += _parse_env_options(command)
             return _run_external(cmd_list, sequence)
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+        except (RuntimeError, subprocess.CalledProcessError) as exc:  # pragma: no cover - error path
             logger.warning(
-                "%s failed with return code %s; falling back to simple error model",
+                "%s failed: %s; falling back to simple error model",
                 command,
-                exc.returncode,
+                exc,
             )
     else:
         logger.warning("%s not found; falling back to simple error model", command)

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -55,6 +55,19 @@ def test_d2sim_extra_options(monkeypatch):
     assert run_called == [(["d2sim", "-e", "0.1", "--foo", "bar"], "ACGT")]
 
 
+def test_parse_options_env(monkeypatch):
+    monkeypatch.setenv("GENECODER_D2SIM_OPTIONS", "--alpha beta")
+    assert nanopore_sim._parse_env_options("d2sim") == ["--alpha", "beta"]
+
+
+def test_parse_options_invalid(monkeypatch, caplog):
+    monkeypatch.setenv("GENECODER_D2SIM_OPTIONS", '"unclosed')
+    with caplog.at_level(logging.WARNING):
+        opts = nanopore_sim._parse_env_options("d2sim")
+    assert opts == []
+    assert any("Invalid" in r.message for r in caplog.records)
+
+
 @pytest.mark.parametrize("name", ADAPTERS.keys())
 def test_adapters_fall_back(monkeypatch, name):
     func, cmd = ADAPTERS[name]
@@ -103,6 +116,33 @@ def test_adapters_external_error(monkeypatch, caplog, name):
     assert which_called == [cmd]
     expected = ([cmd, "-e", "0.2"], "ACGT")
     assert run_called == [expected]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any("falling back" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_adapters_invalid_output(monkeypatch, caplog, name):
+    func, cmd = ADAPTERS[name]
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "_run_external",
+        lambda *_: (_ for _ in ()).throw(RuntimeError("bad output")),
+    )
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT")
+
+    assert result == "fallback"
+    assert which_called == [cmd]
     assert errors_called and isinstance(errors_called[0][2], random.Random)
     assert any("falling back" in rec.message for rec in caplog.records)
 


### PR DESCRIPTION
## Summary
- add `_parse_env_options` to validate env options for simulators
- log command execution and raise clear errors when simulators fail
- use new helper in simulator adapters
- test option parsing, invalid output and fallback behaviour

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d92fce4508326a52902c1bcc7df41