### PR TITLE
Ensure tempfile uses get_temp_dir

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 
@@ -5,6 +6,23 @@ from genecoder.utils import get_temp_dir
 
 
 def test_get_temp_dir_env_override(monkeypatch):
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir=get_temp_dir()) as tmpdir:
         monkeypatch.setenv("GENECODER_TMP", tmpdir)
         assert get_temp_dir() == Path(tmpdir)
+
+
+def test_tempdir_respects_env(monkeypatch):
+    with tempfile.TemporaryDirectory(dir=get_temp_dir()) as base:
+        monkeypatch.setenv("GENECODER_TMP", base)
+        with tempfile.TemporaryDirectory(dir=get_temp_dir()) as sub:
+            assert Path(sub).parent == Path(base)
+
+
+def test_mkdtemp_respects_env(monkeypatch):
+    with tempfile.TemporaryDirectory(dir=get_temp_dir()) as base:
+        monkeypatch.setenv("GENECODER_TMP", base)
+        path = tempfile.mkdtemp(dir=get_temp_dir())
+        try:
+            assert Path(path).parent == Path(base)
+        finally:
+            os.rmdir(path)


### PR DESCRIPTION
## Summary
- ensure temporary directories respect `get_temp_dir`
- verify TemporaryDirectory behavior in tests
- add mkdtemp regression test

## Testing
- `ruff format tests/test_utils.py --silent`
- `ruff check tests/test_utils.py`
- `pytest -q tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685d92fbe0a08326987ed2a814769b55