### PR TITLE
Fix encryption typing and add variable annotations

### DIFF
--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -25,7 +25,7 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     key = key or _DEFAULT_KEY
     aes_key = hashlib.sha256(key).digest()
     nonce = os.urandom(12)
-    enc = AESGCM(aes_key).encrypt(nonce, data, None)
+    enc: bytes = AESGCM(aes_key).encrypt(nonce, data, None)
 
 
     return _AES_HEADER + nonce + enc
@@ -42,7 +42,8 @@ def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
         ciphertext = data[len(_AES_HEADER) + 12 :]
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+        return dec
 
 
     return _xor_cipher(data, key)


### PR DESCRIPTION
## Summary
- assign AESGCM results to typed variables
- return typed decrypt output
- run typing and tests

## Testing
- `ruff check src/genecoder/security.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da93ce4e483268f5cbaadac21cc29