### PR TITLE
Add optional gui and web extras

### DIFF
--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -7,6 +7,8 @@ This tutorial shows how to launch the Flet-based graphical interface.
 ```bash
 pip install genecoder[gui]
 ```
+This installs the optional `gui` extras which pull in Flet, Matplotlib and
+`flet-webview`.
 
 ## Running the application
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,8 @@ Install the optional GUI, web API and DNAformer components with Poetry's
 ```bash
 poetry install --with gui,web,dnaformer --no-interaction
 ```
+The `gui` extras install Flet, Matplotlib and `flet-webview` while the `web`
+extras pull in FastAPI, Uvicorn (with the `standard` extras) and HTTPX.
 
 ## Editable install with pip
 
@@ -31,6 +33,7 @@ repository in editable mode so changes take effect immediately:
 ```bash
 python -m pip install -e .[gui,web]
 ```
+This command installs the optional GUI and web dependencies in editable mode.
 
 ## Development Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ pyldpc = {version = ">=0.7,<0.8", optional = true}
 pyfinite = {version = ">=1.9,<2.0", optional = true}
 bchlib = {version = ">=2.1,<3.0", optional = true}
 raptorq = {version = ">=2.0,<3.0", optional = true}
+flet = {version = ">=0.28,<0.29", optional = true}
+matplotlib = {version = "*", optional = true}
+flet-webview = {version = "*", optional = true}
+fastapi = {version = ">=0.110", optional = true}
+uvicorn = { version = "*", extras = ["standard"], optional = true }
+httpx = {version = "<0.28", optional = true}
 
 [tool.poetry.group.gui.dependencies]
 flet = ">=0.28,<0.29"
@@ -81,6 +87,9 @@ ldpc = ["pyldpc", "numpy"]
 fountain = ["pyfinite"]
 raptorq = ["raptorq", "numpy"]
 bch = ["bchlib"]
+
+gui = ["flet", "matplotlib", "flet-webview"]
+web = ["fastapi", "uvicorn", "httpx"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add gui and web extras to `pyproject.toml`
- mention gui/web extras in installation and GUI docs
- clarify that the web extras install Uvicorn with the `standard` extras

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da93b57248326af2b39dbfb6b90d8