### PR TITLE
Add RNG test w/o env

### DIFF
--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -7,3 +7,10 @@ def test_make_rng_from_env(monkeypatch):
     rng = make_rng()
     assert isinstance(rng, random.Random)
     assert rng.random() == random.Random(42).random()
+
+
+def test_make_rng_without_env(monkeypatch):
+    monkeypatch.delenv("GENECODER_SIM_SEED", raising=False)
+    rng = make_rng()
+    assert isinstance(rng, random.Random)
+    assert 0.0 <= rng.random() < 1.0


### PR DESCRIPTION
## Summary
- add a test to ensure `make_rng()` works without `GENECODER_SIM_SEED`

## Testing
- `pre-commit run --files tests/test_random_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685ddff6dc448326939e67110040e3f7