### PR TITLE
Refactor Flet app startup test

### DIFF
--- a/tests/test_flet_app_startup.py
+++ b/tests/test_flet_app_startup.py
@@ -1,37 +1,32 @@
-import os
-import sys
-import subprocess
-import textwrap
-import time
-from pathlib import Path
 
 import pytest
 
 ft = pytest.importorskip("flet")
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+class _DummyPage:
+    def __init__(self) -> None:
+        self.overlay = []
+
+    def add(self, *args, **kwargs) -> None:  # noqa: D401 - minimal stub
+        pass
+
+    def update(self, *args, **kwargs) -> None:  # noqa: D401 - minimal stub
+        pass
 
 
-def test_flet_app_main_starts(tmp_path: Path):
-    script = textwrap.dedent(
-        """
-        import flet as ft
-        from genecoder.flet_app import main
-        ft.app(target=main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
-        """
-    )
-    script_file = tmp_path / "run_app.py"
-    script_file.write_text(script)
+def test_flet_app_main_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(PROJECT_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    def fake_app(*, target, view=ft.AppView.FLET_APP, **kwargs):
+        nonlocal called
+        assert view == ft.AppView.FLET_APP_HIDDEN
+        target(_DummyPage())
+        called = True
 
-    proc = subprocess.Popen([sys.executable, str(script_file)], env=env)
-    time.sleep(2)
-    assert proc.poll() is None
-    proc.terminate()
-    try:
-        proc.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait(timeout=5)
+    monkeypatch.setattr(ft, "app", fake_app)
+
+    from genecoder import flet_app
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+    assert called


### PR DESCRIPTION
## Summary
- avoid launching Flet app in `test_flet_app_startup`
- run the target directly through a monkeypatched `ft.app`
- remove delay and assert the patched app was invoked

## Testing
- `ruff check tests/test_flet_app_startup.py`
- `mypy --config-file mypy.ini src`
- `pytest -q tests/test_flet_app_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_685ddff7daa88326bd84a3353d504ae3