### PR TITLE
Remove push trigger from python CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,16 +1,6 @@
 name: Python CI
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/**'
-      - 'scripts/**'
-      - 'openai_testing/**'
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
## Summary
- streamline python-ci workflow by deleting the `push` trigger

## Testing
- `poetry run pre-commit run --files .github/workflows/python-ci.yml`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddff9c13083268346fce91316a569