### PR TITLE
Add streaming manifest and resume support

### DIFF
--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -60,6 +60,25 @@ poetry run uvicorn web.main:app --reload
 
 Open <http://localhost:8000> in your browser to view the landing page.
 
+## Streaming Encode and Resume
+
+Large files can be encoded and decoded in streaming mode to reduce memory usage.
+Specify a chunk size in bytes and pass `--resume` to continue a partial run:
+
+```bash
+# initial encode
+genecoder encode --input-files big.bin --output-file big.fasta \
+  --stream --chunk-size 1048576
+
+# resume if interrupted
+genecoder encode --input-files big.bin --output-file big.fasta \
+  --stream --chunk-size 1048576 --resume
+
+# decoding with resume support
+genecoder decode --input-files big.fasta --output-file big.bin \
+  --stream --chunk-size 1048576 --resume
+```
+
 This document condenses the key steps from the installation and usage guides into a quick demo.
 
 Contributors may prefer to run these commands inside the provided

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -155,10 +155,14 @@ def process_single_decode(
     try:
         if args.stream and args.method == "base4_direct":
             from genecoder.streaming import stream_decode_file
+            manifest_path = os.path.splitext(output_file_path)[0] + ".stream.manifest"
 
             stream_decode_file(
                 input_file_path,
                 output_file_path,
+                chunk_size=args.chunk_size,
+                manifest_path=manifest_path,
+                resume=args.resume,
                 check_parity=args.check_parity,
                 k_value=args.k_value,
                 parity_rule=args.parity_rule,
@@ -343,6 +347,17 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--stream",
         action="store_true",
         help="Stream decode large files (base4_direct only).",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=1_000_000,
+        help="Chunk size in bytes for streaming (default: 1000000).",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume a previous interrupted streaming decode.",
     )
     parser.add_argument(
         "--simulate-errors",

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -208,11 +208,15 @@ def process_single_encode(
             if args.add_parity:
                 header += f" parity_k={args.k_value} parity_rule={args.parity_rule}"
             from genecoder.streaming import stream_encode_file
+            manifest_path = os.path.splitext(output_file_path)[0] + ".stream.manifest"
 
             total_len = stream_encode_file(
                 input_file_path,
                 output_file_path,
                 header=header,
+                chunk_size=args.chunk_size,
+                manifest_path=manifest_path,
+                resume=args.resume,
                 add_parity=args.add_parity,
                 k_value=args.k_value,
                 parity_rule=args.parity_rule,
@@ -485,6 +489,17 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--stream",
         action="store_true",
         help="Stream encode large files (base4_direct only).",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=1_000_000,
+        help="Chunk size in bytes for streaming (default: 1000000).",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume a previous interrupted streaming encode.",
     )
     parser.add_argument(
         "--export-csv",

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Iterator
 import os
+import json
+import hashlib
 
 from .encoders import encode_base4_direct, decode_base4_direct
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -16,6 +18,8 @@ def stream_encode_file(
     *,
     header: str,
     chunk_size: int = 1_000_000,
+    manifest_path: str | None = None,
+    resume: bool = False,
     add_parity: bool = False,
     k_value: int = 7,
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
@@ -27,9 +31,21 @@ def stream_encode_file(
     """
 
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    manifest_file = None
+    processed_chunks = 0
+    if manifest_path:
+        mode = "a" if resume else "w"
+        if resume and os.path.exists(manifest_path):
+            with open(manifest_path, "r", encoding="utf-8") as mf:
+                processed_chunks = sum(1 for _ in mf)
+        manifest_file = open(manifest_path, mode, encoding="utf-8")
+
+    start_offset = processed_chunks * chunk_size
 
     def data_iter() -> Iterator[bytes]:
         with open(input_path, "rb") as f_in:
+            if start_offset:
+                f_in.seek(start_offset)
             while True:
                 chunk = f_in.read(chunk_size)
                 if not chunk:
@@ -41,8 +57,11 @@ def stream_encode_file(
     total_len = 0
     line_width = 80
     buffer = ""
-    with open(output_path, "w", encoding="utf-8") as f_out:
-        f_out.write(f">{header}\n")
+    mode = "a" if resume and os.path.exists(output_path) else "w"
+    with open(output_path, mode, encoding="utf-8") as f_out:
+        if mode == "w":
+            f_out.write(f">{header}\n")
+        offset = processed_chunks * chunk_size
         for dna_chunk in encode_base4_direct(
             data_iter(),
             add_parity=add_parity,
@@ -51,6 +70,10 @@ def stream_encode_file(
             encode_map=encode_map,
             stream=True,
         ):
+            if manifest_file:
+                chunk_hash = hashlib.sha256(dna_chunk.encode()).hexdigest()
+                manifest_file.write(json.dumps({"offset": offset, "hash": chunk_hash}) + "\n")
+                offset += chunk_size
             total_len += len(dna_chunk)
             buffer += dna_chunk
             while len(buffer) >= line_width:
@@ -58,6 +81,8 @@ def stream_encode_file(
                 buffer = buffer[line_width:]
         if buffer:
             f_out.write(buffer + "\n")
+        if manifest_file:
+            manifest_file.close()
     return total_len
 
 
@@ -66,6 +91,8 @@ def stream_decode_file(
     output_path: str,
     *,
     chunk_size: int = 1_000_000,
+    manifest_path: str | None = None,
+    resume: bool = False,
     check_parity: bool = False,
     k_value: int = 7,
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
@@ -74,6 +101,14 @@ def stream_decode_file(
     """Decode ``input_path`` FASTA file to ``output_path`` streaming chunks."""
 
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    manifest_file = None
+    processed_chunks = 0
+    if manifest_path:
+        mode = "a" if resume else "w"
+        if resume and os.path.exists(manifest_path):
+            with open(manifest_path, "r", encoding="utf-8") as mf:
+                processed_chunks = sum(1 for _ in mf)
+        manifest_file = open(manifest_path, mode, encoding="utf-8")
 
     _, decode_map = get_alphabet_maps(alphabet)
 
@@ -94,14 +129,28 @@ def stream_decode_file(
                     buffer = buffer[chunk_size * 4 :]
             if buffer:
                 yield buffer
-
-        with open(output_path, "wb") as f_out:
-            for decoded_chunk, _ in decode_base4_direct(
-                dna_iter(),
-                check_parity=check_parity,
-                k_value=k_value,
-                parity_rule=parity_rule,
-                decode_map=decode_map,
-                stream=True,
+        mode = "ab" if resume and os.path.exists(output_path) else "wb"
+        with open(output_path, mode) as f_out:
+            offset = processed_chunks * chunk_size
+            for idx, (decoded_chunk, _) in enumerate(
+                decode_base4_direct(
+                    dna_iter(),
+                    check_parity=check_parity,
+                    k_value=k_value,
+                    parity_rule=parity_rule,
+                    decode_map=decode_map,
+                    stream=True,
+                )
             ):
-                f_out.write(bytes(decoded_chunk))
+                if idx < processed_chunks:
+                    continue
+                chunk_bytes = bytes(decoded_chunk)
+                f_out.write(chunk_bytes)
+                if manifest_file:
+                    chunk_hash = hashlib.sha256(chunk_bytes).hexdigest()
+                    manifest_file.write(
+                        json.dumps({"offset": offset, "hash": chunk_hash}) + "\n"
+                    )
+                    offset += chunk_size
+        if manifest_file:
+            manifest_file.close()

--- a/tests/test_streaming_resume.py
+++ b/tests/test_streaming_resume.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from genecoder.streaming import (
+    stream_encode_file,
+    stream_decode_file,
+    encode_base4_direct,
+    decode_base4_direct,
+)
+
+
+def test_stream_encode_resume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = os.urandom(150_000)
+    input_file = tmp_path / "in.bin"
+    encoded_file = tmp_path / "out.fasta"
+    input_file.write_bytes(data)
+    manifest = encoded_file.with_suffix(".stream.manifest")
+    header = "method=base4_direct input_file=in.bin"
+
+    count = 0
+    orig_encode = encode_base4_direct
+
+    def fail_after_two(*args: object, **kwargs: object) -> Iterator[str]:
+        nonlocal count
+        for chunk in orig_encode(*args, **kwargs):
+            count += 1
+            if count == 2:
+                raise RuntimeError("stop")
+            yield chunk
+
+    monkeypatch.setattr("genecoder.streaming.encode_base4_direct", fail_after_two)
+    with pytest.raises(RuntimeError):
+        stream_encode_file(
+            str(input_file),
+            str(encoded_file),
+            header=header,
+            chunk_size=50_000,
+            manifest_path=str(manifest),
+        )
+    assert manifest.exists()
+    assert sum(1 for _ in manifest.open()) == 1
+
+    monkeypatch.setattr("genecoder.streaming.encode_base4_direct", orig_encode)
+    stream_encode_file(
+        str(input_file),
+        str(encoded_file),
+        header=header,
+        chunk_size=50_000,
+        manifest_path=str(manifest),
+        resume=True,
+    )
+
+    decoded = tmp_path / "decoded.bin"
+    stream_decode_file(
+        str(encoded_file),
+        str(decoded),
+        chunk_size=50_000,
+    )
+    assert decoded.read_bytes() == data
+
+
+def test_stream_decode_resume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = os.urandom(120_000)
+    bin_file = tmp_path / "data.bin"
+    bin_file.write_bytes(data)
+    fasta = tmp_path / "data.fasta"
+    header = "method=base4_direct input_file=data.bin"
+    stream_encode_file(str(bin_file), str(fasta), header=header, chunk_size=40_000)
+
+    decoded = tmp_path / "decoded.bin"
+    manifest = decoded.with_suffix(".stream.manifest")
+
+    count = 0
+    orig_decode = decode_base4_direct
+
+    def fail_after_two(*args: object, **kwargs: object) -> Iterator[tuple[bytes, list[int]]]:
+        nonlocal count
+        for chunk, errs in orig_decode(*args, **kwargs):
+            count += 1
+            if count == 2:
+                raise RuntimeError("fail")
+            yield chunk, errs
+
+    monkeypatch.setattr("genecoder.streaming.decode_base4_direct", fail_after_two)
+    with pytest.raises(RuntimeError):
+        stream_decode_file(
+            str(fasta),
+            str(decoded),
+            chunk_size=40_000,
+            manifest_path=str(manifest),
+        )
+    assert sum(1 for _ in open(manifest)) == 1
+
+    monkeypatch.setattr("genecoder.streaming.decode_base4_direct", orig_decode)
+    stream_decode_file(
+        str(fasta),
+        str(decoded),
+        chunk_size=40_000,
+        manifest_path=str(manifest),
+        resume=True,
+    )
+    assert decoded.read_bytes() == data


### PR DESCRIPTION
## Summary
- record chunk offsets and hashes in `stream_encode_file` and `stream_decode_file`
- allow `--chunk-size` and `--resume` for encode/decode CLI commands
- document streaming resume usage in vertical slice docs
- test resuming streaming encode and decode

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src/genecoder/streaming.py src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_streaming_resume.py`
- `poetry run pytest -k streaming_resume -q`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f570eba588326ab8a3896b364446b