### PR TITLE
Fix RaptorQ import initialization

### DIFF
--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Tuple, TYPE_CHECKING
 
+_rq: Any | None = None
 _HAS_RAPTORQ = False
 
 if TYPE_CHECKING:
@@ -38,6 +39,10 @@ else:  # pragma: no cover - optional dependency
 
 def _require_raptorq() -> None:  # pragma: no cover - helper
     """Ensure :mod:`raptorq` is installed."""
+    if _rq is None:
+        raise ImportError(
+            "raptorq is required for RaptorQ encoding. Install it via 'pip install raptorq'."
+        )
     if not _HAS_RAPTORQ:
         raise ImportError(
             "raptorq is required for RaptorQ encoding. Install it via 'pip install raptorq'."


### PR DESCRIPTION
## Summary
- initialize `_rq` before TYPE_CHECKING block
- check for missing `_rq` in `_require_raptorq`

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f570ca1b88326a96db6191e7e97c3