### PR TITLE
Fix header path handling

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 from genecoder.manifest import generate_manifest
 from genecoder.encoders import (
@@ -75,7 +76,8 @@ def run_encoding_pipeline(
     current_input = data
     fec_padding_bits = -1
     encode_map, _ = get_alphabet_maps(options.alphabet)
-    header_parts = [f"method={options.method}", f"input_file={input_file_name}"]
+    sanitized_name = Path(input_file_name).name
+    header_parts = [f"method={options.method}", f"input_file={sanitized_name}"]
 
     if options.fec == "hamming_7_4":
         if options.add_parity:

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Tuple, TYPE_CHECKING
 
 _HAS_RAPTORQ = False
+_rq: Any | None = None
 
 if TYPE_CHECKING:
     import raptorq

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -14,7 +14,9 @@ from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 
 def test_run_encoding_and_decoding_pipeline(tmp_path: Path):
     data = b"CLI helper test"
-    input_file = tmp_path / "input.bin"
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    input_file = nested / "input.bin"
     input_file.write_bytes(data)
 
     enc_args = argparse.Namespace(
@@ -28,7 +30,8 @@ def test_run_encoding_and_decoding_pipeline(tmp_path: Path):
         max_homopolymer=3,
     )
     enc_opts = build_encoding_options(enc_args)
-    dna, header, *_ = run_encoding_pipeline(data, enc_opts, input_file.name)
+    dna, header, *_ = run_encoding_pipeline(data, enc_opts, str(input_file))
+    assert f"input_file={input_file.name}" in header
     fasta = to_fasta(dna, header)
     fasta_file = tmp_path / "encoded.fasta"
     fasta_file.write_text(fasta)


### PR DESCRIPTION
## Summary
- sanitize input filenames in `run_encoding_pipeline`
- ensure `_rq` is typed in `raptorq_codec`
- update helper test to cover sanitized header

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f570c5c848326b513381515b5275d