### PR TITLE
Implement double helix coords and streaming

### DIFF
--- a/docs/glossary.json
+++ b/docs/glossary.json
@@ -1,0 +1,5 @@
+{
+  "GC content": "The percentage of guanine (G) and cytosine (C) bases in a DNA sequence. Balanced GC content (often around 40–60%) improves stability and processability.",
+  "Homopolymer": "A run of identical nucleotides, e.g. 'AAAAA'. Long homopolymers can cause synthesis and sequencing errors.",
+  "Forward Error Correction (FEC)": "Techniques that add redundancy to encoded data so errors can be detected and corrected during decoding."
+}

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -19,8 +19,13 @@ import flet as ft
 import os
 import asyncio  # For asynchronous operations
 import json
+from pathlib import Path
 import logging
-from typing import Optional
+from typing import Optional, Any
+try:
+    import websockets
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None
 
 # Project module imports
 from genecoder import (
@@ -31,15 +36,36 @@ from genecoder.plugins import load_plugins
 from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
-from genecoder.helix_view import show_helix_ui
+from genecoder.helix_view import show_helix
 from genecoder.formats import from_fasta
 
 
 logger = logging.getLogger(__name__)
 
+GLOSSARY: dict[str, str] = {}
+try:
+    gloss_path = Path(__file__).resolve().parent.parent / "docs" / "glossary.json"
+    with open(gloss_path, "r", encoding="utf-8") as f:
+        GLOSSARY = json.load(f)
+except Exception:
+    pass
+
 
 encode_fasta_data_to_save_ref: ft.Ref[Optional[str]] = ft.Ref[Optional[str]]()
 decoded_bytes_to_save: bytes = b""
+
+# --- optional WebSocket streaming setup ---
+ws_clients: set[Any] = set()
+if websockets:
+    async def _ws_handler(websocket: Any) -> None:
+        ws_clients.add(websocket)
+        try:
+            async for _ in websocket:
+                pass
+        finally:
+            ws_clients.discard(websocket)
+
+    asyncio.get_event_loop().create_task(websockets.serve(_ws_handler, "localhost", 8765))
 
 
 def main(page: ft.Page) -> None:
@@ -122,6 +148,7 @@ def main(page: ft.Page) -> None:
         value="50",
         width=120,
         keyboard_type=ft.KeyboardType.NUMBER,
+        tooltip=GLOSSARY.get("GC content"),
     )
     step_size_input: ft.TextField = ft.TextField(
         label="Step",
@@ -134,6 +161,7 @@ def main(page: ft.Page) -> None:
         value="4",
         width=180,
         keyboard_type=ft.KeyboardType.NUMBER,
+        tooltip=GLOSSARY.get("Homopolymer"),
     )
 
     # --- Encode Tab UI Controls ---
@@ -229,6 +257,7 @@ def main(page: ft.Page) -> None:
         ],
         value="None",
         on_change=on_fec_change,
+        tooltip=GLOSSARY.get("Forward Error Correction (FEC)"),
     )
 
     encode_button: ft.ElevatedButton = ft.ElevatedButton("Encode")
@@ -368,6 +397,11 @@ def main(page: ft.Page) -> None:
             encode_hidden_fasta_content.value = result.fasta
             encode_hidden_sequence.value = result.encoded_dna
             encode_dna_snippet_text.value = result.encoded_dna[:200]
+            if ws_clients:
+                async def _broadcast(msg: str) -> None:
+                    await asyncio.gather(*(c.send(msg) for c in ws_clients))
+
+                asyncio.create_task(_broadcast(result.encoded_dna))
             encode_save_button.visible = True
             manifest = generate_manifest(
                 os.path.basename(input_path), options, result.metrics
@@ -841,11 +875,12 @@ def main(page: ft.Page) -> None:
             ])
         )
         helix_container.controls.append(
-            show_helix_ui(
+            show_helix(
                 dna_seq,
                 animate=animate_checkbox.value,
                 zoom=zoom_slider.value,
                 fps=fps_slider.value,
+                ws_url="ws://localhost:8765" if ws_clients else None,
             )
         )
         page.update()

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 import base64
 import pkgutil
 import logging
+import math
 from pathlib import Path
 
 # Flet <0.29 removed ``HtmlElement``. Provide a minimal fallback for tests.
@@ -58,6 +59,31 @@ DEFAULT_COLORS: dict[str, int] = {
     "T": 0xFFFF55,
 }
 
+_COMPLEMENT_MAP = str.maketrans("ACGTacgt", "TGCAtgca")
+
+
+def complement(seq: str) -> str:
+    """Return the Watson-Crick complement of ``seq``."""
+
+    return seq.translate(_COMPLEMENT_MAP)
+
+
+def base_pair_coordinates(
+    seq: str, *, radius: float = 0.1, height: float = 0.4, angle_step: float = 0.3
+) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]]]:
+    """Return coordinates for a simple double helix."""
+
+    strand1: list[tuple[float, float, float]] = []
+    strand2: list[tuple[float, float, float]] = []
+    for i in range(len(seq)):
+        angle = i * angle_step
+        x = radius * math.cos(angle)
+        y = radius * math.sin(angle)
+        z = i * height
+        strand1.append((x, y, z))
+        strand2.append((-x, -y, z))
+    return strand1, strand2
+
 HELIX_TEMPLATE = """
 <div id='helix-container' style='position:relative;width:100%%;height:100%%'></div>
 <div id='tooltip' style='position:absolute;display:none;padding:2px;background:#fff;border:1px solid #333;font-size:12px;pointer-events:none'></div>
@@ -84,6 +110,16 @@ controls.enableDamping = true;
 controls.update();
 
 const seq = '%(DNA_SEQ)s';
+const compSeq = '%(COMP_SEQ)s';
+const coords1 = %(COORDS1)s;
+const coords2 = %(COORDS2)s;
+const wsUrl = '%(WS_URL)s';
+if (wsUrl) {
+    const ws = new WebSocket(wsUrl);
+    ws.addEventListener('message', (e) => {
+        console.log('seq chunk', e.data);
+    });
+}
 const animateHelix = %(ANIMATE)s;
 const showPulses = %(PULSE)s;
 const pulseSpeed = %(PULSE_SPEED)s;
@@ -91,22 +127,33 @@ const fps = %(FPS)s;
 const bases = [];
 for (let i = 0; i < seq.length; i++) {
     bases.push(seq[i]);
-
 }
-
 
 const colors = %(COLOR_MAP)s;
 const group = new THREE.Group();
 const radius = 0.1;
-const height = 0.4;
 for (let i = 0; i < bases.length; i++) {
     const geometry = new THREE.SphereGeometry(radius, 16, 16);
     const material = new THREE.MeshPhongMaterial({ color: colors[bases[i]] || 0xffffff });
     const mesh = new THREE.Mesh(geometry, material);
-    const angle = i * 0.3;
-    mesh.position.set(Math.cos(angle), Math.sin(angle), i * height);
+    mesh.position.set(...coords1[i]);
     mesh.userData = { info: `${bases[i]} (${i})` };
     group.add(mesh);
+
+    const cgeom = new THREE.SphereGeometry(radius, 16, 16);
+    const cmaterial = new THREE.MeshPhongMaterial({ color: colors[compSeq[i]] || 0xffffff });
+    const cmesh = new THREE.Mesh(cgeom, cmaterial);
+    cmesh.position.set(...coords2[i]);
+    cmesh.userData = { info: `${compSeq[i]} (${i})` };
+    group.add(cmesh);
+
+    const pts = [
+        new THREE.Vector3(...coords1[i]),
+        new THREE.Vector3(...coords2[i])
+    ];
+    const lineGeom = new THREE.BufferGeometry().setFromPoints(pts);
+    const line = new THREE.Line(lineGeom, new THREE.LineBasicMaterial({color: 0xaaaaaa}));
+    group.add(line);
 }
 scene.add(group);
 
@@ -201,6 +248,7 @@ def _make_helix_html(
     fps: float = 60.0,
     three_js_url: str = THREE_JS_URL,
     orbit_js_url: str = ORBIT_JS_URL,
+    ws_url: str | None = None,
 ) -> str:
     """Return HTML for the helix viewer.
 
@@ -233,10 +281,20 @@ def _make_helix_html(
 
     colors_js = "{ " + ", ".join(f"{b}: 0x{v:06x}" for b, v in color_map.items()) + " }"
 
+    comp_seq = complement(dna_sequence)
+    strand1, strand2 = base_pair_coordinates(dna_sequence)
+
+    def _coords_js(coords: list[tuple[float, float, float]]) -> str:
+        return "[" + ",".join(f"[{x:.3f},{y:.3f},{z:.3f}]" for x, y, z in coords) + "]"
+
     return HELIX_TEMPLATE % {
         "THREE_JS_URL": three_js_url,
         "ORBIT_JS_URL": orbit_js_url,
         "DNA_SEQ": dna_sequence,
+        "COMP_SEQ": comp_seq,
+        "COORDS1": _coords_js(strand1),
+        "COORDS2": _coords_js(strand2),
+        "WS_URL": ws_url or "",
         "COLOR_MAP": colors_js,
         "ANIMATE": "true" if animate else "false",
         "ZOOM": zoom,
@@ -256,6 +314,7 @@ def show_helix(
     pulse: bool = False,
     pulse_speed: float = 2.0,
     fps: float = 60.0,
+    ws_url: str | None = None,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` displaying a DNA helix scene with controls.
 
@@ -274,6 +333,8 @@ def show_helix(
         Speed multiplier for the pulse animation.
     fps:
         Frames per second for rendering. Lower values reduce CPU usage.
+    ws_url:
+        Optional WebSocket URL for streaming sequence updates.
     """
     three_url: str = THREE_JS_URL
     orbit_url: str = ORBIT_JS_URL
@@ -295,6 +356,7 @@ def show_helix(
         fps=fps,
         three_js_url=three_url,
         orbit_js_url=orbit_url,
+        ws_url=ws_url,
     )
 
     data_url: str = "data:text/html," + quote(helix_html)

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Tuple, TYPE_CHECKING
 
+_rq: Any | None = None
+
 _HAS_RAPTORQ = False
 
 if TYPE_CHECKING:

--- a/tests/test_helix_view.py
+++ b/tests/test_helix_view.py
@@ -62,6 +62,23 @@ def test_show_helix_fps_param() -> None:
 
 
 @pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
+def test_show_helix_complement_and_coords() -> None:
+    ft, show_helix = _get_ft_and_show_helix()
+    elem = show_helix("AT")
+    html = unquote(elem.url.split(",", 1)[1])
+    assert "const compSeq" in html
+    assert "coords1" in html
+
+
+@pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
+def test_show_helix_ws_url() -> None:
+    ft, show_helix = _get_ft_and_show_helix()
+    elem = show_helix("AC", ws_url="ws://test")
+    html = unquote(elem.url.split(",", 1)[1])
+    assert "ws://test" in html
+
+
+@pytest.mark.skipif(not hasattr(ft, "HtmlElement"), reason="HtmlElement missing")
 def test_show_helix_cdn_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     ft, show_helix = _get_ft_and_show_helix()
     monkeypatch.setattr("genecoder.helix_view.THREE_JS_URL", "")


### PR DESCRIPTION
## Summary
- add complement and coordinate helpers for helix rendering
- support WebSocket streaming in Flet GUI
- load glossary tooltips from `glossary.json`
- expose WebSocket and complement data in viewer
- test new helix viewer controls

## Testing
- `ruff check . --fix`
- `mypy --config-file mypy.ini src`
- `pytest -q tests/test_helix_view.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f571dbca88326a4c345b5c9bfc830