### PR TITLE
Add simulator hooks and CLI tests

### DIFF
--- a/configs/adv_nanopore.yaml
+++ b/configs/adv_nanopore.yaml
@@ -1,0 +1,6 @@
+substitution_rate: 0.02
+insertion_rate: 0.04
+deletion_rate: 0.04
+coverage: 1
+read_length: 500
+quality_profile: null

--- a/configs/illumina.yaml
+++ b/configs/illumina.yaml
@@ -1,0 +1,6 @@
+substitution_rate: 0.001
+insertion_rate: 0.0001
+deletion_rate: 0.0001
+coverage: 1
+read_length: 150
+quality_profile: null

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Tuple, TYPE_CHECKING
 
+_rq: Any | None = None
+
 _HAS_RAPTORQ = False
 
 if TYPE_CHECKING:

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -68,7 +68,8 @@ class AdvancedNanoporeChannel(BaseSimulator):
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()
-        read = sequence[: self.read_length]
+        read_length = self.get_read_length(sequence)
+        read = sequence[:read_length]
         return _simulate_homopolymer_errors(
             read,
             substitution_rate=self.substitution_rate,

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -15,7 +15,7 @@ class BaseSimulator:
     deletion_rate: float
     coverage: int
     read_length: int
-    quality_profile: Sequence[float] | None
+    quality_profile: tuple[float, ...] | None
 
     def __init__(
         self,
@@ -34,6 +34,25 @@ class BaseSimulator:
         self.quality_profile = (
             tuple(quality_profile) if quality_profile is not None else None
         )
+
+    def get_coverage(self, sequence: str) -> int:
+        """Hook returning desired coverage for ``sequence``."""
+        return self.coverage
+
+    def get_read_length(self, sequence: str) -> int:
+        """Hook returning read length for ``sequence``."""
+        return self.read_length
+
+    def get_quality_profile(self, sequence: str, length: int) -> Sequence[float] | None:
+        """Hook returning per-base quality values for ``sequence``."""
+        if self.quality_profile is None:
+            return None
+        if len(self.quality_profile) >= length:
+            return self.quality_profile[:length]
+        if not self.quality_profile:
+            return None
+        tail = self.quality_profile[-1]
+        return self.quality_profile + (tail,) * (length - len(self.quality_profile))
 
     def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
         """Return a possibly corrupted version of ``sequence``."""

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -35,7 +35,8 @@ class IlluminaChannel(BaseSimulator):
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()
-        read = sequence[: self.read_length]
+        read_length = self.get_read_length(sequence)
+        read = sequence[:read_length]
         return introduce_errors(
             read,
             substitution_prob=self.substitution_rate,

--- a/tests/test_cli_simulator_selection.py
+++ b/tests/test_cli_simulator_selection.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+import pytest
+
+@pytest.mark.parametrize("sim_name", ["illumina", "adv_nanopore"])
+def test_cli_decode_with_builtin_simulator(tmp_path: Path, sim_name: str):
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "sim.txt"
+    input_file.write_text("built-in simulator test")
+
+    encode_result = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert encode_result.returncode == 0, encode_result.stderr
+    fasta_file = tmp_path / "sim.txt.fasta"
+    assert fasta_file.exists()
+
+    decode_result = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            sim_name,
+        ],
+        env=env,
+    )
+    assert decode_result.returncode == 0, decode_result.stderr
+    assert (
+        f"Applied {sim_name} simulator before decoding." in decode_result.stdout
+    )


### PR DESCRIPTION
## Summary
- add hook methods for coverage, read length and quality profile
- update Illumina and Nanopore simulators to use the hooks
- provide sample simulator configuration files
- test CLI simulator selection

## Testing
- `pre-commit run --files src/genecoder/simulators/base.py src/genecoder/simulators/illumina.py src/genecoder/simulators/adv_nanopore.py src/genecoder/raptorq_codec.py tests/test_cli_simulator_selection.py configs/illumina.yaml configs/adv_nanopore.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685f57136fd4832685ef6da75f934805