### PR TITLE
Fix invalid seed handling

### DIFF
--- a/src/genecoder/random_utils.py
+++ b/src/genecoder/random_utils.py
@@ -3,11 +3,23 @@ from __future__ import annotations
 
 import os
 import random
+import logging
 
 __all__ = ["make_rng"]
+
+
+logger = logging.getLogger(__name__)
 
 
 def make_rng() -> random.Random:
     """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
     seed_env = os.getenv("GENECODER_SIM_SEED")
-    return random.Random(int(seed_env)) if seed_env is not None else random.Random()
+    if seed_env is not None:
+        try:
+            return random.Random(int(seed_env))
+        except ValueError:
+            logger.warning(
+                "Invalid GENECODER_SIM_SEED %r, falling back to default RNG",
+                seed_env,
+            )
+    return random.Random()

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -7,11 +7,10 @@ from typing import Any, Tuple, TYPE_CHECKING
 _rq: Any | None = None
 
 _HAS_RAPTORQ = False
-_rq: Any | None = None
 
 if TYPE_CHECKING:
     import raptorq
-    from raptorq import raptorq as _rq
+    from raptorq import raptorq as _rq  # type: ignore[no-redef]
 else:  # pragma: no cover - optional dependency
     try:
         import raptorq  # type: ignore

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,4 +1,5 @@
 import random
+import logging
 from genecoder.random_utils import make_rng
 
 
@@ -14,3 +15,13 @@ def test_make_rng_without_env(monkeypatch):
     rng = make_rng()
     assert isinstance(rng, random.Random)
     assert 0.0 <= rng.random() < 1.0
+
+
+def test_make_rng_invalid_env(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setenv("GENECODER_SIM_SEED", "invalid")
+    rng = make_rng()
+    assert isinstance(rng, random.Random)
+    assert any(
+        "Invalid GENECODER_SIM_SEED" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- improve make_rng to handle non-integer GENECODER_SIM_SEED
- add unit test for invalid seed strings
- fix mypy warning in raptorq_codec

## Testing
- `pre-commit run --files src/genecoder/random_utils.py tests/test_random_utils.py src/genecoder/raptorq_codec.py`

------
https://chatgpt.com/codex/tasks/task_e_685f6133f8f883269448e2c72bed31c3