### PR TITLE
Handle malformed fec_info

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -140,8 +140,16 @@ def run_decoding_pipeline(
                 if info_match:
                     import base64
                     import json
+                    import binascii
 
-                    info = json.loads(base64.b64decode(info_match.group(1)).decode())
+                    try:
+                        info_b64 = info_match.group(1)
+                        decoded = base64.b64decode(info_b64)
+                        info = json.loads(decoded.decode())
+                    except (binascii.Error, json.JSONDecodeError) as exc:
+                        raise ValueError(
+                            "Invalid 'fec_info' in header: failed to decode"
+                        ) from exc
                 final_data, _ = FEC_REGISTRY[fec_name]["decode"](final_data, info)
     return final_data
 

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -1,0 +1,58 @@
+import argparse
+import base64
+import pytest
+
+from genecoder.cli import (
+    build_encoding_options,
+    build_decoding_options,
+    run_encoding_pipeline,
+    run_decoding_pipeline,
+)
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from genecoder import plugins
+
+
+def _sample_dna(data: bytes) -> tuple[str, str]:
+    plugins.load_plugins()
+    enc_args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+    )
+    enc_opts = build_encoding_options(enc_args)
+    dna, header, *_ = run_encoding_pipeline(data, enc_opts, "in.bin")
+    return dna, header
+
+
+def _decoding_opts():
+    plugins.load_plugins()
+    dec_args = argparse.Namespace(
+        method="base4_direct",
+        check_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+    )
+    dec_opts = build_decoding_options(dec_args)
+    return dec_opts
+
+
+def test_run_decoding_invalid_fec_info_base64() -> None:
+    dna, header = _sample_dna(b"abc")
+    header += " fec=reed_solomon fec_info=abc"
+    dec_opts = _decoding_opts()
+    with pytest.raises(ValueError, match="Invalid 'fec_info'"):
+        run_decoding_pipeline(dna, header, dec_opts, "in.bin")
+
+
+def test_run_decoding_invalid_fec_info_json() -> None:
+    dna, header = _sample_dna(b"abc")
+    bad_json = base64.b64encode(b"not json").decode()
+    header += f" fec=reed_solomon fec_info={bad_json}"
+    dec_opts = _decoding_opts()
+    with pytest.raises(ValueError, match="Invalid 'fec_info'"):
+        run_decoding_pipeline(dna, header, dec_opts, "in.bin")


### PR DESCRIPTION
## Summary
- handle malformed `fec_info` in decode pipeline
- add tests for invalid `fec_info` strings

## Testing
- `ruff check src/genecoder/cli/decode.py tests/test_cli_decode.py`
- `mypy src/genecoder/cli/decode.py`
- `pytest tests/test_cli_decode.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f61358584832697ec7331f9288236