### PR TITLE
Add validation for GC encoder parameters

### DIFF
--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -62,6 +62,11 @@ def encode_gc_balanced(data: bytes, target_gc_min: float, target_gc_max: float, 
     """
     from .encoders import encode_base4_direct  # Local import to avoid circular dependency
 
+    if target_gc_min > target_gc_max:
+        raise ValueError("target_gc_min cannot be greater than target_gc_max")
+    if max_homopolymer < 1:
+        raise ValueError("max_homopolymer must be at least 1")
+
     if not data:
         return "0"
 

--- a/tests/test_gc_constrained_encoder.py
+++ b/tests/test_gc_constrained_encoder.py
@@ -435,3 +435,17 @@ def test_encode_gc_balanced_boundary_gc(mock_encode_base4):
     assert result == "0" + seq
     mock_encode_base4.assert_called_once_with(data, add_parity=False)
 
+
+@patch("genecoder.encoders.encode_base4_direct")
+def test_encode_gc_balanced_invalid_gc_range(mock_encode_base4):
+    with pytest.raises(ValueError, match="target_gc_min cannot be greater than target_gc_max"):
+        encode_gc_balanced(b"data", target_gc_min=0.7, target_gc_max=0.6, max_homopolymer=2)
+    mock_encode_base4.assert_not_called()
+
+
+@patch("genecoder.encoders.encode_base4_direct")
+def test_encode_gc_balanced_invalid_homopolymer(mock_encode_base4):
+    with pytest.raises(ValueError, match="max_homopolymer must be at least 1"):
+        encode_gc_balanced(b"data", target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=0)
+    mock_encode_base4.assert_not_called()
+


### PR DESCRIPTION
## Summary
- validate parameters in `encode_gc_balanced`
- ensure invalid GC range and homopolymer values raise `ValueError`
- add unit tests for the new validation logic

## Testing
- `ruff check src/genecoder/gc_constrained_encoder.py tests/test_gc_constrained_encoder.py --fix`
- `mypy --config-file mypy.ini src/genecoder/gc_constrained_encoder.py`
- `pytest tests/test_gc_constrained_encoder.py::test_encode_gc_balanced_invalid_gc_range tests/test_gc_constrained_encoder.py::test_encode_gc_balanced_invalid_homopolymer -q`

------
https://chatgpt.com/codex/tasks/task_e_685f613d929c8326a0ed3e64c1dbe598