### PR TITLE
Ensure plugin registries reset on load

### DIFF
--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -55,6 +55,10 @@ def _load_and_register(items: Iterable[Any], registrar: Callable[..., Any], kind
 def load_plugins() -> None:
     """Load plugins defined via GeneCoder entry points."""
 
+    CODEC_REGISTRY.clear()
+    FEC_REGISTRY.clear()
+    SIMULATOR_REGISTRY.clear()
+
     # First load built-in plugin modules
     builtin = importlib.import_module("genecoder.builtin_plugins")
     if hasattr(builtin, "register_builtin_plugins"):

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -7,11 +7,9 @@ from typing import Any, Tuple, TYPE_CHECKING
 _rq: Any | None = None
 
 _HAS_RAPTORQ = False
-_rq: Any | None = None
 
 if TYPE_CHECKING:
     import raptorq
-    from raptorq import raptorq as _rq
 else:  # pragma: no cover - optional dependency
     try:
         import raptorq  # type: ignore

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -44,7 +44,7 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.syspath_prepend(str(root / "example_fec"))
     monkeypatch.syspath_prepend(str(root / "example_simulator"))
 
-    def fake_entry_points(*, group: str | None = None):
+    def fake_entry_points(*, group: str | None = None) -> list[EntryPoint]:
         if group == "genecoder.plugins":
             return [EntryPoint(name="example", value="example_codec", group=group)]
         if group == "genecoder.fec":
@@ -65,4 +65,22 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "example" in plugins.CODEC_REGISTRY
     assert "example" in plugins.FEC_REGISTRY
     assert "example" in plugins.SIMULATOR_REGISTRY
+
+
+def test_load_plugins_idempotent() -> None:
+    CODEC_REGISTRY.clear()
+    FEC_REGISTRY.clear()
+    SIMULATOR_REGISTRY.clear()
+
+    load_plugins()
+
+    codec_keys = set(CODEC_REGISTRY)
+    fec_keys = set(FEC_REGISTRY)
+    sim_keys = set(SIMULATOR_REGISTRY)
+
+    load_plugins()
+
+    assert set(CODEC_REGISTRY) == codec_keys
+    assert set(FEC_REGISTRY) == fec_keys
+    assert set(SIMULATOR_REGISTRY) == sim_keys
 


### PR DESCRIPTION
## Summary
- clear plugin registries inside `load_plugins`
- remove duplicate `_rq` variable definition
- annotate test helper return type and verify idempotence

## Testing
- `pytest -q tests/test_plugin_loading.py::test_load_plugins_idempotent`
- `ruff check tests/test_plugin_loading.py src/genecoder/raptorq_codec.py src/genecoder/plugins.py --fix`
- `mypy src/genecoder/plugins.py src/genecoder/raptorq_codec.py tests/test_plugin_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_685f61385f7883269317f2166e1903b2