### PR TITLE
Improve websocket startup handling

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -65,7 +65,12 @@ if websockets:
         finally:
             ws_clients.discard(websocket)
 
-    asyncio.get_event_loop().create_task(websockets.serve(_ws_handler, "localhost", 8765))
+    try:
+        asyncio.get_event_loop().create_task(
+            websockets.serve(_ws_handler, "localhost", 8765)
+        )
+    except OSError as exc:  # pragma: no cover - depends on environment
+        logger.error("Failed to start WebSocket server: %s", exc)
 
 
 def main(page: ft.Page) -> None:

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Tuple, TYPE_CHECKING
 
-_rq: Any | None = None
-
 _HAS_RAPTORQ = False
 _rq: Any | None = None
 
 if TYPE_CHECKING:
     import raptorq
-    from raptorq import raptorq as _rq
+    from raptorq import raptorq as _rq  # type: ignore[no-redef]
 else:  # pragma: no cover - optional dependency
     try:
         import raptorq  # type: ignore

--- a/tests/test_flet_app_websocket.py
+++ b/tests/test_flet_app_websocket.py
@@ -1,0 +1,29 @@
+import asyncio
+import importlib
+import sys
+import types
+import logging
+
+import pytest
+
+ft = pytest.importorskip("flet")
+
+
+def test_websocket_start_error_logged(monkeypatch, caplog):
+    dummy_ws = types.SimpleNamespace(
+        serve=lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
+    )
+    monkeypatch.setitem(sys.modules, "websockets", dummy_ws)
+
+    loop = asyncio.new_event_loop()
+    monkeypatch.setattr(asyncio, "get_event_loop", lambda: loop)
+
+    if "genecoder.flet_app" in sys.modules:
+        del sys.modules["genecoder.flet_app"]
+
+    with caplog.at_level(logging.ERROR):
+        importlib.import_module("genecoder.flet_app")
+
+    assert any(
+        "Failed to start WebSocket server" in rec.message for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- handle `OSError` when starting the websocket server
- test that failures to start the websocket server are logged
- fix mypy issue in RaptorQ codec
- fix websocket error test to create an event loop

## Testing
- `mypy --config-file mypy.ini src` 
- `pytest -q tests/test_flet_app_websocket.py`
- `pre-commit run --files src/genecoder/flet_app.py tests/test_flet_app_websocket.py src/genecoder/raptorq_codec.py`

------
https://chatgpt.com/codex/tasks/task_e_685f61370e6483269b27a1427695ef6f