### PR TITLE
Validate GC range for encoding options

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -56,6 +56,11 @@ class EncodingOptions:
 
 
 def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
+    if not 0 <= args.gc_min <= 1 or not 0 <= args.gc_max <= 1:
+        raise ValueError("gc_min and gc_max must be between 0 and 1")
+    if args.gc_min > args.gc_max:
+        raise ValueError("gc_min cannot be greater than gc_max")
+
     return EncodingOptions(
         method=args.method,
         add_parity=args.add_parity,

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -134,6 +134,36 @@ def test_run_encoding_invalid_k_value():
         run_encoding_pipeline(b"abc", enc_opts, "f.bin")
 
 
+def test_build_encoding_options_invalid_gc_bounds():
+    enc_args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=-0.1,
+        gc_max=1.1,
+        max_homopolymer=3,
+    )
+    with pytest.raises(ValueError):
+        build_encoding_options(enc_args)
+
+
+def test_build_encoding_options_gc_min_greater_than_max():
+    enc_args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.6,
+        gc_max=0.4,
+        max_homopolymer=3,
+    )
+    with pytest.raises(ValueError):
+        build_encoding_options(enc_args)
+
+
 def test_run_decoding_unknown_method(tmp_path: Path):
     input_file = tmp_path / "x.bin"
     data = b"hello"


### PR DESCRIPTION
## Summary
- validate GC bounds when building encode options
- test invalid GC ranges in encoding CLI

## Testing
- `pre-commit run --files src/genecoder/cli/encode.py tests/test_cli_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6860d9bf010083269666da3bf1dececb