### PR TITLE
Check positive chunk-size in CLI commands

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -404,6 +404,9 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if args.chunk_size <= 0:
+        logger.error("Error: --chunk-size must be a positive integer.")
+        raise SystemExit(1)
     if getattr(args, "d2sim_options", None):
         os.environ["GENECODER_D2SIM_OPTIONS"] = args.d2sim_options
     if getattr(args, "dnarsim_options", None):

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -517,6 +517,9 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if args.chunk_size <= 0:
+        logger.error("Error: --chunk-size must be a positive integer.")
+        raise SystemExit(1)
     num_input_files = len(args.input_files)
     if num_input_files > 1 and not args.output_dir:
         logger.error("Error: --output-dir is required when providing multiple input files for encoding.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,3 +373,51 @@ def test_invalid_fec_none_choice(temp_dir: Path):
     assert result.returncode != 0
     assert "invalid choice" in result.stderr
 
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_encode_invalid_chunk_size(temp_dir: Path, chunk_size: int) -> None:
+    """Streaming encode should fail for non-positive chunk sizes."""
+    input_file = temp_dir / "in.txt"
+    input_file.write_text("data")
+    output_file = temp_dir / "out.fasta"
+
+    cmd_args = [
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+        "--method",
+        "base4_direct",
+        "--stream",
+        "--chunk-size",
+        str(chunk_size),
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode != 0
+    assert "chunk-size" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_decode_invalid_chunk_size(temp_dir: Path, chunk_size: int) -> None:
+    """Streaming decode should fail for non-positive chunk sizes."""
+    fasta_file = temp_dir / "seq.fasta"
+    create_dummy_fasta_file(fasta_file, "hello")
+    output_file = temp_dir / "out.bin"
+
+    cmd_args = [
+        "decode",
+        "--input-files",
+        str(fasta_file),
+        "--output-file",
+        str(output_file),
+        "--method",
+        "base4_direct",
+        "--stream",
+        "--chunk-size",
+        str(chunk_size),
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode != 0
+    assert "chunk-size" in result.stderr.lower()
+


### PR DESCRIPTION
## Summary
- validate that `--chunk-size` is greater than zero in encode/decode commands
- test invalid chunk sizes for both commands

## Testing
- `ruff check src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_cli.py`
- `mypy --config-file mypy.ini src`
- `pytest tests/test_cli.py::test_encode_invalid_chunk_size tests/test_cli.py::test_decode_invalid_chunk_size -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d9bd7328832684d82a6263679f5b