### PR TITLE
Add replication and transcription simulators

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -9,6 +9,8 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 - **indel** — introduces insertions and deletions in addition to substitutions.
 - **none** — disable simulation (the default).
 - **nanopore** — alias for `d2sim`.
+- **replication** — basic DNA copying with low error rates.
+- **transcription** — converts DNA to RNA while introducing errors.
 
 `GENECODER_SIM_SEED` can be set to an integer to reproduce the randomness used
 by these simulators.
@@ -83,6 +85,13 @@ Apply simple substitutions with a chosen probability:
 
 ```bash
 genecoder decode --simulate-errors 0.02 <other options>
+```
+
+Invoke the replication or transcription models:
+
+```bash
+genecoder decode --simulator replication <other options>
+genecoder decode --simulator transcription <other options>
 ```
 
 Invoke an external simulator before decoding:

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -46,6 +46,8 @@ def register_builtin_plugins() -> None:
             "genecoder.error_simulation",
             "genecoder.simulators.illumina",
             "genecoder.simulators.adv_nanopore",
+            "genecoder.simulators.replication",
+            "genecoder.simulators.transcription",
         ],
         register_simulator,
         "builtin",

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -6,11 +6,15 @@ from ..plugins import SIMULATOR_REGISTRY
 from .base import BaseSimulator
 from .illumina import IlluminaChannel
 from .adv_nanopore import AdvancedNanoporeChannel
+from .replication import ReplicationSimulator
+from .transcription import TranscriptionSimulator
 
 __all__ = [
     "BaseSimulator",
     "IlluminaChannel",
     "AdvancedNanoporeChannel",
+    "ReplicationSimulator",
+    "TranscriptionSimulator",
     "simulate_reads",
 ]
 

--- a/src/genecoder/simulators/replication.py
+++ b/src/genecoder/simulators/replication.py
@@ -1,0 +1,46 @@
+"""DNA replication simulator stub."""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from .base import BaseSimulator
+from ..random_utils import make_rng
+from ..error_simulation import introduce_errors
+from ..channels.base import BaseChannel
+
+__all__ = ["ReplicationSimulator", "register"]
+
+
+class ReplicationSimulator(BaseSimulator):
+    """Simplified DNA replication error model."""
+
+    def __init__(
+        self,
+        substitution_rate: float = 1e-4,
+        insertion_rate: float = 1e-5,
+        deletion_rate: float = 1e-5,
+        coverage: int = 1,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=0,
+            quality_profile=quality_profile,
+        )
+
+    def simulate(self, sequence: str) -> str:
+        rng = make_rng()
+        return introduce_errors(
+            sequence,
+            substitution_prob=self.substitution_rate,
+            insertion_prob=self.insertion_rate,
+            deletion_prob=self.deletion_rate,
+            rng=rng,
+        )
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    register_simulator("replication", ReplicationSimulator())

--- a/src/genecoder/simulators/transcription.py
+++ b/src/genecoder/simulators/transcription.py
@@ -1,0 +1,47 @@
+"""RNA transcription simulator stub."""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from .base import BaseSimulator
+from ..random_utils import make_rng
+from ..error_simulation import introduce_errors
+from ..channels.base import BaseChannel
+
+__all__ = ["TranscriptionSimulator", "register"]
+
+
+class TranscriptionSimulator(BaseSimulator):
+    """Simplified transcription error model."""
+
+    def __init__(
+        self,
+        substitution_rate: float = 1e-4,
+        insertion_rate: float = 1e-5,
+        deletion_rate: float = 1e-5,
+        coverage: int = 1,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=0,
+            quality_profile=quality_profile,
+        )
+
+    def simulate(self, sequence: str) -> str:
+        rng = make_rng()
+        dna = introduce_errors(
+            sequence,
+            substitution_prob=self.substitution_rate,
+            insertion_prob=self.insertion_rate,
+            deletion_prob=self.deletion_rate,
+            rng=rng,
+        )
+        return dna.replace("T", "U")
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    register_simulator("transcription", TranscriptionSimulator())

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -1,6 +1,8 @@
 
 from genecoder.simulators.illumina import IlluminaChannel, register as reg_illumina
 from genecoder.simulators.adv_nanopore import AdvancedNanoporeChannel, register as reg_advnano
+from genecoder.simulators.replication import ReplicationSimulator, register as reg_replication
+from genecoder.simulators.transcription import TranscriptionSimulator, register as reg_transcription
 from genecoder.simulators import BaseSimulator
 
 
@@ -9,8 +11,12 @@ def test_register_channels():
     registry: dict[str, BaseChannel] = {}
     reg_illumina(lambda n, ch: registry.setdefault(n, ch))
     reg_advnano(lambda n, ch: registry.setdefault(n, ch))
+    reg_replication(lambda n, ch: registry.setdefault(n, ch))
+    reg_transcription(lambda n, ch: registry.setdefault(n, ch))
     assert "illumina" in registry and isinstance(registry["illumina"], BaseSimulator)
     assert "adv_nanopore" in registry and isinstance(registry["adv_nanopore"], BaseSimulator)
+    assert "replication" in registry and isinstance(registry["replication"], BaseSimulator)
+    assert "transcription" in registry and isinstance(registry["transcription"], BaseSimulator)
     assert all(isinstance(ch, BaseChannel) for ch in registry.values())
 
 
@@ -27,3 +33,14 @@ def test_adv_nanopore_homopolymer_bias(monkeypatch):
     result = channel.simulate("AAAAAA")
     # with high deletion rate and homopolymer bias we expect length < input
     assert len(result) < 6
+
+
+def test_transcription_converts_to_rna():
+    channel = TranscriptionSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
+    assert channel.simulate("ATCG") == "AUCG"
+
+
+def test_replication_identity(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "3")
+    channel = ReplicationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
+    assert channel.simulate("GGCC") == "GGCC"


### PR DESCRIPTION
## Summary
- add replication and transcription simulator classes
- register new simulators as built-ins
- document their usage
- test simulator registration and behaviour

## Testing
- `ruff check src/genecoder/simulators/replication.py src/genecoder/simulators/transcription.py src/genecoder/simulators/__init__.py src/genecoder/builtin_plugins.py tests/test_simulators_additional.py`
- `mypy --config-file mypy.ini src/genecoder/simulators/replication.py src/genecoder/simulators/transcription.py src/genecoder/simulators/__init__.py src/genecoder/builtin_plugins.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861de467ed8832697d1aee8dc31ebe8