### PR TITLE
Add glossary tooltip helper and integrate

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -19,7 +19,6 @@ import flet as ft
 import os
 import asyncio  # For asynchronous operations
 import json
-from pathlib import Path
 import logging
 from typing import Optional, Any
 try:
@@ -38,17 +37,15 @@ from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix
 from genecoder.formats import from_fasta
+from genecoder.glossary_tooltips import load_glossary, wrap_glossary_terms
 
 
 logger = logging.getLogger(__name__)
 
-GLOSSARY: dict[str, str] = {}
 try:
-    gloss_path = Path(__file__).resolve().parent.parent / "docs" / "glossary.json"
-    with open(gloss_path, "r", encoding="utf-8") as f:
-        GLOSSARY = json.load(f)
+    GLOSSARY: dict[str, str] = load_glossary()
 except Exception:
-    pass
+    GLOSSARY = {}
 
 
 encode_fasta_data_to_save_ref: ft.Ref[Optional[str]] = ft.Ref[Optional[str]]()
@@ -149,7 +146,7 @@ def main(page: ft.Page) -> None:
 
 
     window_size_input: ft.TextField = ft.TextField(
-        label="GC Window Size",
+        label=wrap_glossary_terms("GC Window Size", GLOSSARY),
         value="50",
         width=120,
         keyboard_type=ft.KeyboardType.NUMBER,
@@ -162,7 +159,7 @@ def main(page: ft.Page) -> None:
         keyboard_type=ft.KeyboardType.NUMBER,
     )
     min_homopolymer_input: ft.TextField = ft.TextField(
-        label="Min Homopolymer Length",
+        label=wrap_glossary_terms("Min Homopolymer Length", GLOSSARY),
         value="4",
         width=180,
         keyboard_type=ft.KeyboardType.NUMBER,
@@ -253,7 +250,7 @@ def main(page: ft.Page) -> None:
         page.update()
 
     fec_dropdown: ft.Dropdown = ft.Dropdown(
-        label="FEC Method",
+        label=wrap_glossary_terms("FEC Method", GLOSSARY),
         options=[
             ft.dropdown.Option("None"),
             ft.dropdown.Option("Triple-Repeat"),
@@ -272,9 +269,17 @@ def main(page: ft.Page) -> None:
     encode_dna_len_text: ft.Text = ft.Text("Encoded DNA length: - nucleotides")
     encode_comp_ratio_text: ft.Text = ft.Text("Compression ratio: -")
     encode_bits_per_nt_text: ft.Text = ft.Text("Bits per nucleotide: - bits/nt")
-    encode_actual_gc_text: ft.Text = ft.Text("Actual GC content (payload): -")
-    encode_actual_homopolymer_text: ft.Text = ft.Text(
-        "Actual max homopolymer (payload): -"
+    encode_actual_gc_value: ft.Text = ft.Text("-")
+    encode_actual_gc_text: ft.Row = wrap_glossary_terms(
+        "Actual GC content (payload): ", GLOSSARY
+    )
+    encode_actual_gc_text.controls.append(encode_actual_gc_value)
+    encode_actual_homopolymer_value: ft.Text = ft.Text("-")
+    encode_actual_homopolymer_text: ft.Row = wrap_glossary_terms(
+        "Actual max homopolymer (payload): ", GLOSSARY
+    )
+    encode_actual_homopolymer_text.controls.append(
+        encode_actual_homopolymer_value
     )
     encode_progress_ring: ft.ProgressRing = ft.ProgressRing(
         visible=False, width=20, height=20
@@ -346,8 +351,8 @@ def main(page: ft.Page) -> None:
         encode_dna_len_text.value = "Encoded DNA length: - nucleotides"
         encode_comp_ratio_text.value = "Compression ratio: -"
         encode_bits_per_nt_text.value = "Bits per nucleotide: - bits/nt"
-        encode_actual_gc_text.value = "Actual GC content (payload): -"
-        encode_actual_homopolymer_text.value = "Actual max homopolymer (payload): -"
+        encode_actual_gc_value.value = "-"
+        encode_actual_homopolymer_value.value = "-"
         encode_dna_snippet_text.value = ""
         encode_save_button.visible = False
         encode_manifest_save_button.visible = False
@@ -429,15 +434,11 @@ def main(page: ft.Page) -> None:
             )
 
             if options.method == "GC-Balanced":
-                encode_actual_gc_text.value = (
-                    f"Actual GC content (payload, pre-FEC): {metrics['actual_gc']:.2%}"
-                )
-                encode_actual_homopolymer_text.value = f"Actual max homopolymer (payload, pre-FEC): {metrics['max_homopolymer']}"
+                encode_actual_gc_value.value = f"{metrics['actual_gc']:.2%}"
+                encode_actual_homopolymer_value.value = f"{metrics['max_homopolymer']}"
             else:
-                encode_actual_gc_text.value = "Actual GC content (payload): N/A"
-                encode_actual_homopolymer_text.value = (
-                    "Actual max homopolymer (payload): N/A"
-                )
+                encode_actual_gc_value.value = "N/A"
+                encode_actual_homopolymer_value.value = "N/A"
 
             codeword_hist_image.src_base64 = result.plots.get("codeword_hist")
             nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
@@ -761,8 +762,8 @@ def main(page: ft.Page) -> None:
             ),
             nucleotide_freq_image,
             ft.Divider(),  # New divider
-            ft.Text(
-                "Sequence GC & Homopolymer Analysis:", weight=ft.FontWeight.BOLD
+            wrap_glossary_terms(
+                "Sequence GC & Homopolymer Analysis:", GLOSSARY
             ),  # New title
             ft.Row(
                 [

--- a/src/genecoder/glossary_tooltips.py
+++ b/src/genecoder/glossary_tooltips.py
@@ -1,0 +1,45 @@
+"""Utilities for adding glossary tooltips to Flet controls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import re
+from typing import Dict, List, cast
+
+import flet as ft
+
+
+_GLOSSARY_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.json"
+
+
+def load_glossary() -> Dict[str, str]:
+    """Load glossary terms from the project's ``glossary.json`` file."""
+    with open(_GLOSSARY_PATH, "r", encoding="utf-8") as f:
+        return cast(Dict[str, str], json.load(f))
+
+
+def wrap_glossary_terms(text: str, glossary: Dict[str, str]) -> ft.Row:
+    """Wrap glossary terms in ``text`` with :class:`~flet.Tooltip` widgets."""
+    if not glossary:
+        return ft.Row([ft.Text(text)], spacing=0, wrap=True)
+
+    # Build regex matching any glossary term, preferring longer terms first
+    pattern = re.compile(
+        "|".join(re.escape(t) for t in sorted(glossary, key=len, reverse=True))
+    )
+
+    controls: List[ft.Control] = []
+    last = 0
+    for match in pattern.finditer(text):
+        if match.start() > last:
+            controls.append(ft.Text(text[last : match.start()]))
+        term = match.group(0)
+        message = glossary.get(term, "")
+        controls.append(ft.Text(term, tooltip=message))
+        last = match.end()
+
+    if last < len(text):
+        controls.append(ft.Text(text[last:]))
+
+    return ft.Row(controls, spacing=0, wrap=True)

--- a/tests/test_glossary_tooltips.py
+++ b/tests/test_glossary_tooltips.py
@@ -1,0 +1,23 @@
+import pytest
+
+ft = pytest.importorskip("flet")
+
+from genecoder.glossary_tooltips import wrap_glossary_terms
+
+
+def test_wrap_glossary_terms_basic():
+    glossary = {"GC content": "desc", "Homopolymer": "info"}
+    row = wrap_glossary_terms(
+        "Check GC content and Homopolymer issues", glossary
+    )
+    assert isinstance(row, ft.Row)
+    tips = [getattr(c, "tooltip", None) for c in row.controls]
+    assert [t for t in tips if t] == ["desc", "info"]
+
+
+def test_wrap_glossary_terms_no_match():
+    glossary = {"GC content": "desc"}
+    row = wrap_glossary_terms("No terms here", glossary)
+    assert isinstance(row, ft.Row)
+    assert len(row.controls) == 1
+    assert isinstance(row.controls[0], ft.Text)


### PR DESCRIPTION
## Summary
- implement `glossary_tooltips.wrap_glossary_terms` helper
- use glossary tooltips in Flet GUI labels and metrics
- load glossary via new helper
- unit tests for the tooltip helper

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861de478c1c8326a947ad3e8740bff7