### PR TITLE
Add Translation Simulator

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -48,6 +48,7 @@ def register_builtin_plugins() -> None:
             "genecoder.simulators.adv_nanopore",
             "genecoder.simulators.replication",
             "genecoder.simulators.transcription",
+            "genecoder.simulators.translation",
         ],
         register_simulator,
         "builtin",

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -8,6 +8,7 @@ from .illumina import IlluminaChannel
 from .adv_nanopore import AdvancedNanoporeChannel
 from .replication import ReplicationSimulator
 from .transcription import TranscriptionSimulator
+from .translation import TranslationSimulator
 
 __all__ = [
     "BaseSimulator",
@@ -15,6 +16,7 @@ __all__ = [
     "AdvancedNanoporeChannel",
     "ReplicationSimulator",
     "TranscriptionSimulator",
+    "TranslationSimulator",
     "simulate_reads",
 ]
 

--- a/src/genecoder/simulators/translation.py
+++ b/src/genecoder/simulators/translation.py
@@ -1,0 +1,148 @@
+"""mRNA translation simulator stub."""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from .base import BaseSimulator
+from ..random_utils import make_rng
+from ..error_simulation import introduce_errors
+from ..channels.base import BaseChannel
+
+__all__ = ["TranslationSimulator", "register"]
+
+
+class TranslationSimulator(BaseSimulator):
+    """Simplified translation model converting RNA to amino acids."""
+
+    CODON_TABLE: dict[str, str] = {
+        # Phenylalanine
+        "UUU": "F",
+        "UUC": "F",
+        # Leucine
+        "UUA": "L",
+        "UUG": "L",
+        "CUU": "L",
+        "CUC": "L",
+        "CUA": "L",
+        "CUG": "L",
+        # Isoleucine / Methionine
+        "AUU": "I",
+        "AUC": "I",
+        "AUA": "I",
+        "AUG": "M",
+        # Valine
+        "GUU": "V",
+        "GUC": "V",
+        "GUA": "V",
+        "GUG": "V",
+        # Serine
+        "UCU": "S",
+        "UCC": "S",
+        "UCA": "S",
+        "UCG": "S",
+        "AGU": "S",
+        "AGC": "S",
+        # Proline
+        "CCU": "P",
+        "CCC": "P",
+        "CCA": "P",
+        "CCG": "P",
+        # Threonine
+        "ACU": "T",
+        "ACC": "T",
+        "ACA": "T",
+        "ACG": "T",
+        # Alanine
+        "GCU": "A",
+        "GCC": "A",
+        "GCA": "A",
+        "GCG": "A",
+        # Tyrosine
+        "UAU": "Y",
+        "UAC": "Y",
+        # Histidine
+        "CAU": "H",
+        "CAC": "H",
+        # Glutamine
+        "CAA": "Q",
+        "CAG": "Q",
+        # Asparagine
+        "AAU": "N",
+        "AAC": "N",
+        # Lysine
+        "AAA": "K",
+        "AAG": "K",
+        # Aspartic Acid
+        "GAU": "D",
+        "GAC": "D",
+        # Glutamic Acid
+        "GAA": "E",
+        "GAG": "E",
+        # Cysteine
+        "UGU": "C",
+        "UGC": "C",
+        # Tryptophan
+        "UGG": "W",
+        # Arginine
+        "CGU": "R",
+        "CGC": "R",
+        "CGA": "R",
+        "CGG": "R",
+        "AGA": "R",
+        "AGG": "R",
+        # Glycine
+        "GGU": "G",
+        "GGC": "G",
+        "GGA": "G",
+        "GGG": "G",
+        # Stop codons
+        "UAA": "*",
+        "UAG": "*",
+        "UGA": "*",
+    }
+
+    def __init__(
+        self,
+        substitution_rate: float = 1e-4,
+        insertion_rate: float = 1e-5,
+        deletion_rate: float = 1e-5,
+        coverage: int = 1,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=0,
+            quality_profile=quality_profile,
+        )
+
+    def simulate(self, sequence: str) -> str:
+        """Return the translated peptide from ``sequence``."""
+        dna = sequence.replace("U", "T")
+        rng = make_rng()
+        mutated = introduce_errors(
+            dna,
+            substitution_prob=self.substitution_rate,
+            insertion_prob=self.insertion_rate,
+            deletion_prob=self.deletion_rate,
+            rng=rng,
+        )
+        rna = mutated.replace("T", "U")
+        peptide: list[str] = []
+        for i in range(0, len(rna) - 2, 3):
+            codon = rna[i : i + 3]
+            if len(codon) < 3:
+                break
+            aa = self.CODON_TABLE.get(codon)
+            if not aa:
+                continue
+            if aa == "*":
+                break
+            peptide.append(aa)
+        return "".join(peptide)
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    register_simulator("translation", TranslationSimulator())

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -3,6 +3,7 @@ from genecoder.simulators.illumina import IlluminaChannel, register as reg_illum
 from genecoder.simulators.adv_nanopore import AdvancedNanoporeChannel, register as reg_advnano
 from genecoder.simulators.replication import ReplicationSimulator, register as reg_replication
 from genecoder.simulators.transcription import TranscriptionSimulator, register as reg_transcription
+from genecoder.simulators.translation import TranslationSimulator, register as reg_translation
 from genecoder.simulators import BaseSimulator
 
 
@@ -13,10 +14,12 @@ def test_register_channels():
     reg_advnano(lambda n, ch: registry.setdefault(n, ch))
     reg_replication(lambda n, ch: registry.setdefault(n, ch))
     reg_transcription(lambda n, ch: registry.setdefault(n, ch))
+    reg_translation(lambda n, ch: registry.setdefault(n, ch))
     assert "illumina" in registry and isinstance(registry["illumina"], BaseSimulator)
     assert "adv_nanopore" in registry and isinstance(registry["adv_nanopore"], BaseSimulator)
     assert "replication" in registry and isinstance(registry["replication"], BaseSimulator)
     assert "transcription" in registry and isinstance(registry["transcription"], BaseSimulator)
+    assert "translation" in registry and isinstance(registry["translation"], BaseSimulator)
     assert all(isinstance(ch, BaseChannel) for ch in registry.values())
 
 
@@ -38,6 +41,11 @@ def test_adv_nanopore_homopolymer_bias(monkeypatch):
 def test_transcription_converts_to_rna():
     channel = TranscriptionSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
     assert channel.simulate("ATCG") == "AUCG"
+
+
+def test_translation_produces_peptide():
+    channel = TranslationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
+    assert channel.simulate("AUGGCUUAA") == "MA"
 
 
 def test_replication_identity(monkeypatch):


### PR DESCRIPTION
## Summary
- implement translation simulator for RNA->protein with error model
- register the translation simulator as a builtin plugin
- expose `TranslationSimulator` in `genecoder.simulators`
- validate translation in existing simulator tests

## Testing
- `pre-commit run --files src/genecoder/simulators/translation.py src/genecoder/simulators/__init__.py src/genecoder/builtin_plugins.py tests/test_simulators_additional.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e8ff40248326bd15cb338acee1b2