### PR TITLE
Add glossary tooltips to helix UI

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,6 +2,13 @@
 
 This page defines key terms used throughout the GeneCoder documentation.
 
+### Using Glossary Tooltips
+
+The GUI and helix viewer highlight glossary terms at runtime. Hovering a term
+shows its short definition and clicking opens an overlay with the full text.
+This behaviour is provided by a small JavaScript helper that loads
+`glossary.json`. Call `applyGlossary()` after rendering HTML to enable it.
+
 ## GC content
 The percentage of guanine (G) and cytosine (C) bases in a DNA sequence. Balanced GC content (often around 40–60%) improves stability and processability.
 

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -35,7 +35,7 @@ from genecoder.plugins import load_plugins
 from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
-from genecoder.helix_view import show_helix
+from genecoder.helix_view import show_helix_ui
 from genecoder.formats import from_fasta
 from genecoder.glossary_tooltips import load_glossary, wrap_glossary_terms
 
@@ -880,13 +880,20 @@ def main(page: ft.Page) -> None:
                 fps_slider,
             ])
         )
+        colors = {
+            "A": int(helix_color_a.value.lstrip("#"), 16),
+            "C": int(helix_color_c.value.lstrip("#"), 16),
+            "G": int(helix_color_g.value.lstrip("#"), 16),
+            "T": int(helix_color_t.value.lstrip("#"), 16),
+        }
+
         helix_container.controls.append(
-            show_helix(
+            show_helix_ui(
                 dna_seq,
                 animate=animate_checkbox.value,
                 zoom=zoom_slider.value,
+                colors=colors,
                 fps=fps_slider.value,
-                ws_url="ws://localhost:8765" if ws_clients else None,
             )
         )
         page.update()

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import applyGlossary from './glossary.js';
 
 const DEFAULT_COLORS = {
   A: 0xff5555,
@@ -42,6 +43,10 @@ export default function App() {
 
   const colorParam = params.get('colors');
   const colors = { ...DEFAULT_COLORS, ...(parseColors(colorParam) || {}) };
+
+  useEffect(() => {
+    applyGlossary();
+  }, []);
 
   useEffect(() => {
     const width = mount.current.clientWidth;

--- a/web/helix-ui/src/glossary.js
+++ b/web/helix-ui/src/glossary.js
@@ -1,0 +1,73 @@
+import glossary from '@docs/glossary.json';
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function applyGlossary(container = document.body) {
+  const terms = Object.keys(glossary);
+  if (!terms.length) return;
+  const pattern = new RegExp(terms.sort((a,b) => b.length - a.length).map(escapeRegex).join('|'), 'g');
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node.parentNode && node.nodeValue.trim()) nodes.push(node);
+  }
+
+  for (const node of nodes) {
+    const html = node.nodeValue.replace(pattern, (m) => `<span class="glossary-term" data-term="${m}">${m}</span>`);
+    if (html !== node.nodeValue) {
+      const span = document.createElement('span');
+      span.innerHTML = html;
+      node.parentNode.replaceChild(span, node);
+    }
+  }
+
+  for (const el of container.querySelectorAll('.glossary-term')) {
+    const term = el.dataset.term;
+    const def = glossary[term];
+    el.title = def;
+    el.style.textDecoration = 'underline dotted';
+    el.style.cursor = 'help';
+    el.addEventListener('click', () => showOverlay(term, def));
+  }
+}
+
+function showOverlay(term, definition) {
+  let overlay = document.getElementById('glossary-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'glossary-overlay';
+    Object.assign(overlay.style, {
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0,0,0,0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    });
+    overlay.addEventListener('click', () => overlay.remove());
+    document.body.appendChild(overlay);
+  } else {
+    overlay.innerHTML = '';
+    overlay.style.display = 'flex';
+  }
+  const box = document.createElement('div');
+  Object.assign(box.style, {
+    background: '#fff',
+    padding: '1em',
+    borderRadius: '8px',
+    maxWidth: '600px',
+  });
+  box.addEventListener('click', (e) => e.stopPropagation());
+  box.innerHTML = `<h3>${term}</h3><p>${definition}</p>`;
+  overlay.appendChild(box);
+}
+
+export default applyGlossary;

--- a/web/helix-ui/vite.config.js
+++ b/web/helix-ui/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
   base: './',
+  resolve: {
+    alias: {
+      '@docs': resolve(__dirname, '../../docs'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- highlight glossary terms in the React helix viewer
- allow the viewer to load glossary terms with Vite alias
- integrate React viewer into the Flet app
- document how to enable glossary tooltips

## Testing
- `npm run build` in `web/helix-ui`
- `pytest -k glossary_tooltips -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e8fcecc48326938a7f4e315d4e63