### PR TITLE
Add mirror encoding and double helix display

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,6 +9,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
 * **CSV export for synthesis** with length and [homopolymer](glossary.md#homopolymer) validation. The analysis command warns when sequences violate these constraints.
+* **Mirror encoding** via `--mirror` to output forward and reverse-complement sequences.
 
 
 ## Helix View
@@ -34,4 +35,13 @@ webview = show_helix("ACGT", length=50, colors={"A": "#ff0000", "T": "#00ffff"})
 
 The newer `show_helix_ui` helper launches the React frontend. It accepts the
 same base sequence along with options such as `animate`, `zoom`, `gc`, `runs`,
-animated progress pulses and custom base colors.
+animated progress pulses and custom base colors. Pass a second sequence to
+render two strands side by side:
+
+```python
+from genecoder.helix_view import show_helix_ui
+webview = show_helix_ui(seq1, seq2)
+```
+
+The `--mirror` flag on the CLI writes both forward and reverse-complement
+records which can be viewed together using `show_helix_ui` as above.

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -27,6 +27,14 @@ from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
 from typing import Callable
 
+_COMPLEMENT_MAP = str.maketrans("ACGTacgt", "TGCAtgca")
+
+
+def reverse_complement(seq: str) -> str:
+    """Return the Watson-Crick reverse complement of ``seq``."""
+
+    return seq.translate(_COMPLEMENT_MAP)[::-1]
+
 # Delay importing heavy security module until needed
 encrypt_data: Callable[..., bytes] | None = None
 compute_checksum: Callable[[bytes], str] | None = None
@@ -263,6 +271,13 @@ def process_single_encode(
             parsed_records = from_fasta(fasta_content)
             dna_sequence = parsed_records[0][1] if parsed_records else ""
 
+            if getattr(args, "mirror", False) and dna_sequence:
+                rc_seq = reverse_complement(dna_sequence)
+                rc_header = f"{header} mirror=rc"
+                with open(output_file_path, "a", encoding="utf-8") as f_out:
+                    f_out.write(to_fasta(rc_seq, rc_header, line_width=80))
+                parsed_records.append((rc_header, rc_seq))
+
             return os.path.basename(input_file_path), dna_sequence
 
         with open(input_file_path, "rb") as f_in:
@@ -299,6 +314,10 @@ def process_single_encode(
             fasta_header = f"{fasta_header} checksum={checksum}"
 
         fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
+        if getattr(args, "mirror", False):
+            rc_seq = reverse_complement(final_encoded_dna_sequence)
+            rc_header = f"{fasta_header} mirror=rc"
+            fasta_output += to_fasta(rc_seq, rc_header, line_width=80)
 
         os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "w", encoding="utf-8") as f_out:
@@ -517,6 +536,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--capsule",
         type=str,
         help="Write capsule JSON with header, sequence and metadata.",
+    )
+    parser.add_argument(
+        "--mirror",
+        action="store_true",
+        help="Also output the reverse-complement sequence.",
     )
     parser.set_defaults(func=_handle_command)
 

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -366,6 +366,7 @@ def show_helix(
 
 def show_helix_ui(
     dna_sequence: str = "ACGT",
+    strand2_sequence: str | None = None,
     *,
     animate: bool = True,
     zoom: float = 1.0,
@@ -382,18 +383,24 @@ def show_helix_ui(
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend.
 
-    Parameters enable GC colouring, homopolymer highlighting, GC ratio gauges,
-    optional GC-content and homopolymer bars and error flashes via the
-    corresponding query arguments. The ``fps``
-    argument controls the maximum frames per second.
+    ``strand2_sequence`` specifies an optional second strand to render. If not
+    provided the Watson-Crick complement of ``dna_sequence`` is used. Parameters
+    enable GC colouring, homopolymer highlighting, GC ratio gauges, optional
+    GC-content and homopolymer bars and error flashes via the corresponding
+    query arguments. The ``fps`` argument controls the maximum frames per
+    second.
     """
     base_dir = Path(__file__).resolve().parent.parent / "web" / "helix-ui"
     helix_path = base_dir / "dist" / "index.html"
     if not helix_path.is_file():
         helix_path = base_dir / "index.html"
 
+    if strand2_sequence is None:
+        strand2_sequence = complement(dna_sequence)
+
     params = [
         f"seq={quote(dna_sequence)}",
+        f"seq2={quote(strand2_sequence)}",
         f"animate={'true' if animate else 'false'}",
         f"zoom={zoom}",
         f"gc={'true' if show_gc else 'false'}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from genecoder.utils import get_temp_dir
 from src.genecoder.formats import to_fasta, from_fasta
+from src.genecoder.cli.encode import reverse_complement
 
 # Helper to get the root of the project
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -174,6 +175,30 @@ def test_gc_balanced_params_in_header_default_and_custom(temp_dir: Path):
     assert "gc_min=0.4" in header_custom
     assert "gc_max=0.6" in header_custom
     assert "max_homopolymer=4" in header_custom
+
+
+def test_encode_mirror(tmp_path: Path) -> None:
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("mirror")
+    output_file = tmp_path / "seq.fasta"
+
+    cmd_args = [
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+        "--method",
+        "base4_direct",
+        "--mirror",
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode == 0, result.stderr
+
+    records = from_fasta(output_file.read_text())
+    assert len(records) == 2
+    assert records[1][1] == reverse_complement(records[0][1])
+    assert "mirror=rc" in records[1][0]
 
 # --- Test Scenarios for Batch Decoding ---
 

--- a/tests/test_helix_ui.py
+++ b/tests/test_helix_ui.py
@@ -26,6 +26,8 @@ def test_show_helix_ui_url(tmp_path: Path) -> None:
     assert webview.__class__.__name__ == "WebView"
     assert webview.url.startswith("file:")
     parsed = urlparse(webview.url)
+    assert "seq=ACGT" in parsed.query
+    assert "seq2=TGCA" in parsed.query
     assert "animate=false" in parsed.query
     assert "zoom=1.5" in parsed.query
     assert "gc=false" in parsed.query

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -9,6 +9,14 @@ const DEFAULT_COLORS = {
   T: 0xffff55,
 };
 
+function complementSeq(s) {
+  const map = { A: 'T', T: 'A', C: 'G', G: 'C' };
+  return s
+    .split('')
+    .map((b) => map[b.toUpperCase()] || b)
+    .join('');
+}
+
 function parseColors(param) {
   if (!param) return null;
   const map = {};
@@ -30,6 +38,7 @@ export default function App() {
   const [animate, setAnimate] = useState(params.get('animate') !== 'false');
   const [zoom] = useState(parseFloat(params.get('zoom') || '1'));
   const seq = params.get('seq') || 'ACGT';
+  const seq2 = params.get('seq2') || complementSeq(seq);
   const gcRatio = seq.split('').filter((b) => b === 'G' || b === 'C').length / seq.length;
   const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
   const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
@@ -61,28 +70,47 @@ export default function App() {
 
     const group = new THREE.Group();
     const bases = seq.split('');
+    const compBases = seq2.split('');
+    const len = Math.min(bases.length, compBases.length);
     const runs = new Array(bases.length).fill(1);
     for (let i = 1; i < bases.length; i++) {
       runs[i] = bases[i] === bases[i - 1] ? runs[i - 1] + 1 : 1;
     }
     const radius = 0.1;
     const h = 0.4;
-    bases.forEach((b, i) => {
-      const geom = new THREE.SphereGeometry(radius, 16, 16);
-      let color = colors[b] || 0xffffff;
-      if (showGC) {
-        color = b === 'G' || b === 'C' ? 0x8888ff : 0xffffaa;
-      }
-      const mat = new THREE.MeshPhongMaterial({ color });
-      const mesh = new THREE.Mesh(geom, mat);
+    for (let i = 0; i < len; i++) {
       const angle = i * 0.3;
-      mesh.position.set(Math.cos(angle), Math.sin(angle), i * h);
-      if (showRuns && runs[i] >= 3) {
-        mesh.material.emissive = new THREE.Color(0xff0000);
-        mesh.material.emissiveIntensity = Math.min((runs[i] - 2) / 4, 1);
+
+      const geom1 = new THREE.SphereGeometry(radius, 16, 16);
+      let color1 = colors[bases[i]] || 0xffffff;
+      if (showGC) {
+        color1 = bases[i] === 'G' || bases[i] === 'C' ? 0x8888ff : 0xffffaa;
       }
-      group.add(mesh);
-    });
+      const mesh1 = new THREE.Mesh(geom1, new THREE.MeshPhongMaterial({ color: color1 }));
+      mesh1.position.set(Math.cos(angle), Math.sin(angle), i * h);
+      if (showRuns && runs[i] >= 3) {
+        mesh1.material.emissive = new THREE.Color(0xff0000);
+        mesh1.material.emissiveIntensity = Math.min((runs[i] - 2) / 4, 1);
+      }
+      group.add(mesh1);
+
+      const geom2 = new THREE.SphereGeometry(radius, 16, 16);
+      let color2 = colors[compBases[i]] || 0xffffff;
+      if (showGC) {
+        color2 = compBases[i] === 'G' || compBases[i] === 'C' ? 0x8888ff : 0xffffaa;
+      }
+      const mesh2 = new THREE.Mesh(geom2, new THREE.MeshPhongMaterial({ color: color2 }));
+      mesh2.position.set(-Math.cos(angle), -Math.sin(angle), i * h);
+      group.add(mesh2);
+
+      const pts = [
+        new THREE.Vector3(Math.cos(angle), Math.sin(angle), i * h),
+        new THREE.Vector3(-Math.cos(angle), -Math.sin(angle), i * h)
+      ];
+      const lineGeom = new THREE.BufferGeometry().setFromPoints(pts);
+      const line = new THREE.Line(lineGeom, new THREE.LineBasicMaterial({ color: 0xaaaaaa }));
+      group.add(line);
+    }
     scene.add(group);
 
     const light = new THREE.DirectionalLight(0xffffff, 1);
@@ -140,7 +168,7 @@ export default function App() {
       cancelAnimationFrame(frameId);
       renderer.dispose();
     };
-  }, [seq, animate, zoom, colors, showGC, showRuns, showGCBars, showRunBars, showPulses, pulseSpeed, showGauge, flashErrors]);
+  }, [seq, seq2, animate, zoom, colors, showGC, showRuns, showGCBars, showRunBars, showPulses, pulseSpeed, showGauge, flashErrors]);
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>


### PR DESCRIPTION
## Summary
- support reverse-complement output via `--mirror`
- allow `show_helix_ui` to render two sequences
- update helix UI frontend for dual strands
- document the feature and provide example usage
- test new CLI flag and updated helix viewer

## Testing
- `ruff check --fix .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e8fa13648326800e595d6632f374