### PR TITLE
Add 10MB streaming runtime test

### DIFF
--- a/tests/test_streaming_large.py
+++ b/tests/test_streaming_large.py
@@ -1,4 +1,5 @@
 import os
+import time
 from genecoder.encoders import encode_base4_direct, decode_base4_direct
 
 
@@ -27,4 +28,28 @@ def test_streaming_resume_large_file(tmp_path):
     rest = b"".join(part for part, _ in dec_gen)
     decoded = first_bytes + rest
 
+    assert decoded == data
+
+
+def test_streaming_roundtrip_10mb_runtime(tmp_path, record_property):
+    chunk_size = 1_048_576  # 1 MB
+    data = os.urandom(chunk_size * 10)
+    bin_path = tmp_path / "ten_mb.bin"
+    bin_path.write_bytes(data)
+
+    start = time.perf_counter()
+    dna_chunks = list(
+        encode_base4_direct(_chunk_reader(bin_path, chunk_size), stream=True)
+    )
+    enc_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    decoded = b"".join(
+        chunk for chunk, _ in decode_base4_direct(dna_chunks, stream=True)
+    )
+    dec_time = time.perf_counter() - start
+
+    # record runtimes to help detect performance regressions
+    record_property("encode_time", enc_time)
+    record_property("decode_time", dec_time)
     assert decoded == data


### PR DESCRIPTION
## Summary
- add runtime tracked roundtrip test for streaming large files
- refine runtime test to use record_property for performance metrics

## Testing
- `pre-commit run --files tests/test_streaming_large.py`
- `pytest -q tests/test_streaming_large.py::test_streaming_roundtrip_10mb_runtime`


------
https://chatgpt.com/codex/tasks/task_e_6861e9146ecc8326bfed889067e0c471