### PR TITLE
Add auto-ext option for encode/decode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,7 @@ poetry install --no-interaction
 * `--output-file` – output path for a single input file.
 * `--output-dir` – directory for batch operations.
 * `--fec` – optional [FEC](glossary.md#forward-error-correction-fec) method (`triple_repeat`, `hamming_7_4`, `reed_solomon`, `ldpc`, `fountain`).
+* `--auto-ext` – save encoded files with a `.dna` suffix and decode back to the original extension.
 
 See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
@@ -128,18 +129,20 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
    simulated substitutions deterministic across runs.
 
-11. **Encode, corrupt and decode a file**
+11. **Encode, corrupt and decode a file with automatic extensions**
 
    ```bash
-   genecoder encode --input-files hello.jpg --method base4_direct --output-file hello.dna
-   genecoder simulate-errors hello.dna --sub-rate 0.01 --output-file corrupted.dna
-   genecoder decode corrupted.dna --output-file hello_out.jpg
+   genecoder encode --input-files hello.jpg --output-dir encoded \
+       --method base4_direct --auto-ext
+   genecoder simulate-errors encoded/hello.jpg.dna --sub-rate 0.01 \
+       --output-file corrupted.dna
+   genecoder decode corrupted.dna --output-dir decoded --auto-ext
    ```
 
    Verify the round-trip checksum:
 
    ```bash
-   sha256sum hello.jpg hello_out.jpg
+   sha256sum hello.jpg decoded/hello.jpg
    ```
 
    Add `--checksum` to the encode and decode commands for automatic validation.

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -33,6 +33,21 @@ def _ensure_security_loaded() -> None:
 logger = logging.getLogger(__name__)
 
 
+def _get_header_filename(file_path: str) -> str | None:
+    """Return the original filename from the FASTA header if available."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f_in:
+            for line in f_in:
+                if line.startswith(">"):
+                    match = re.search(r"input_file=([^ ]+)", line)
+                    if match:
+                        return os.path.basename(match.group(1))
+                    return None
+    except OSError:
+        logger.debug("Could not read header from %s", file_path)
+    return None
+
+
 @dataclass
 class DecodingOptions:
     method: str
@@ -368,6 +383,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Resume a previous interrupted streaming decode.",
     )
     parser.add_argument(
+        "--auto-ext",
+        action="store_true",
+        help="Automatically remove .dna and restore the original extension.",
+    )
+    parser.add_argument(
         "--simulate-errors",
         type=float,
         default=0.0,
@@ -435,11 +455,20 @@ def _handle_command(args: argparse.Namespace) -> None:
         output_file_path = ""
         if args.output_file and num_input_files == 1:
             output_file_path = args.output_file
+            if args.auto_ext:
+                if output_file_path.endswith(".dna"):
+                    output_file_path = output_file_path[:-4]
         elif args.output_dir:
             base_name = os.path.basename(input_file_path)
-            name_part, _ = os.path.splitext(base_name)
-            output_file_name = name_part + "_decoded.bin"
-            output_file_path = os.path.join(args.output_dir, output_file_name)
+            if args.auto_ext:
+                orig_name = _get_header_filename(input_file_path) or base_name
+                if orig_name.endswith(".dna"):
+                    orig_name = orig_name[:-4]
+                output_file_path = os.path.join(args.output_dir, orig_name)
+            else:
+                name_part, _ = os.path.splitext(base_name)
+                output_file_name = name_part + "_decoded.bin"
+                output_file_path = os.path.join(args.output_dir, output_file_name)
         else:
             logger.error(
                 f"Error determining output path for decoding {input_file_path}. Please check arguments."

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -509,6 +509,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Resume a previous interrupted streaming encode.",
     )
     parser.add_argument(
+        "--auto-ext",
+        action="store_true",
+        help="Automatically append a .dna suffix to output files.",
+    )
+    parser.add_argument(
         "--export-csv",
         type=str,
         help="Path to write a Twist/IDT order CSV with Name and Sequence columns.",
@@ -544,9 +549,14 @@ def _handle_command(args: argparse.Namespace) -> None:
         output_file_path = ""
         if args.output_file and num_input_files == 1:
             output_file_path = args.output_file
+            if args.auto_ext and not output_file_path.endswith(".dna"):
+                output_file_path += ".dna"
         elif args.output_dir:
             base_name = os.path.basename(input_file_path)
-            output_file_name = base_name + ".fasta"
+            if args.auto_ext:
+                output_file_name = base_name + ".dna"
+            else:
+                output_file_name = base_name + ".fasta"
             output_file_path = os.path.join(args.output_dir, output_file_name)
         else:
             logger.error(f"Error determining output path for {input_file_path}. Please check arguments.")

--- a/tests/test_cli_auto_ext.py
+++ b/tests/test_cli_auto_ext.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_auto_ext_roundtrip(tmp_path: Path) -> None:
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("auto")
+
+    enc_res = run_cli_command([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+        "--auto-ext",
+    ])
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    encoded = tmp_path / "msg.txt.dna"
+    assert encoded.exists()
+
+    dec_res = run_cli_command([
+        "decode",
+        "--input-files",
+        str(encoded),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+        "--auto-ext",
+    ])
+    assert dec_res.returncode == 0, dec_res.stderr
+
+    decoded = tmp_path / "msg.txt"
+    assert decoded.exists()
+    assert decoded.read_text() == "auto"
+


### PR DESCRIPTION
## Summary
- add `--auto-ext` option to encode/decode commands
- handle automatic `.dna` suffix and restore original extension
- document the new option and example usage
- test automatic extension roundtrip
- fix auto-ext example path
- narrow exception handling in decode header reader

## Testing
- `ruff check src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_cli_auto_ext.py`
- `mypy --config-file mypy.ini src`
- `pytest -q tests/test_cli_auto_ext.py`


------
https://chatgpt.com/codex/tasks/task_e_6861e8efc4948326ad104c863432d40d