### PR TITLE
Add quality-aware Illumina simulator

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -45,6 +45,7 @@ def register_builtin_plugins() -> None:
             "genecoder.channel_sim",
             "genecoder.error_simulation",
             "genecoder.simulators.illumina",
+            "genecoder.simulators.illumina_profile",
             "genecoder.simulators.adv_nanopore",
             "genecoder.simulators.replication",
             "genecoder.simulators.transcription",

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 from genecoder import __version__
-from genecoder.plugins import load_plugins
+from genecoder.plugins import load_plugins, SIMULATOR_REGISTRY
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight
@@ -79,6 +79,18 @@ def build_parser() -> argparse.ArgumentParser:
     sim_parser.add_argument("--sub-prob", type=float, default=0.01, help="Substitution probability per nucleotide.")
     sim_parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide.")
     sim_parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide.")
+    sim_choices = list(sorted(SIMULATOR_REGISTRY.keys())) or ["none"]
+    sim_parser.add_argument(
+        "--simulator",
+        type=str,
+        choices=sim_choices,
+        help="Use a named simulator instead of simple probabilities.",
+    )
+    sim_parser.add_argument(
+        "--read-length",
+        type=int,
+        help="Override read length when using a simulator.",
+    )
     sim_parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output.")
     sim_parser.set_defaults(func=_handle_sim_errors)
 
@@ -88,6 +100,7 @@ def build_parser() -> argparse.ArgumentParser:
 def _handle_sim_errors(args: argparse.Namespace) -> None:
     from genecoder.formats import to_fasta, from_fasta
     from genecoder.error_simulation import introduce_errors
+    from genecoder.simulators import SIMULATOR_REGISTRY
     import os
     import random
 
@@ -100,13 +113,30 @@ def _handle_sim_errors(args: argparse.Namespace) -> None:
             raise SystemExit(1)
         header, seq = records[0]
         rng = random.Random(args.seed)
-        corrupted = introduce_errors(
-            seq,
-            substitution_prob=args.sub_prob,
-            insertion_prob=args.ins_prob,
-            deletion_prob=args.del_prob,
-            rng=rng,
-        )
+        sim_name = getattr(args, "simulator", None)
+        if sim_name:
+            if sim_name not in SIMULATOR_REGISTRY:
+                logger.error("Unknown simulator: %s", sim_name)
+                raise SystemExit(1)
+            channel = SIMULATOR_REGISTRY[sim_name]
+            if hasattr(channel, "substitution_rate"):
+                channel.substitution_rate = args.sub_prob
+            if hasattr(channel, "insertion_rate"):
+                channel.insertion_rate = args.ins_prob
+            if hasattr(channel, "deletion_rate"):
+                channel.deletion_rate = args.del_prob
+            read_len = getattr(args, "read_length", None)
+            if read_len is not None and hasattr(channel, "read_length"):
+                channel.read_length = read_len
+            corrupted = channel.simulate(seq)
+        else:
+            corrupted = introduce_errors(
+                seq,
+                substitution_prob=args.sub_prob,
+                insertion_prob=args.ins_prob,
+                deletion_prob=args.del_prob,
+                rng=rng,
+            )
         new_header = f"{header} sub_prob={args.sub_prob} ins_prob={args.ins_prob} del_prob={args.del_prob}"
         fasta_out = to_fasta(corrupted, new_header, line_width=80)
         os.makedirs(os.path.dirname(args.output_file) or ".", exist_ok=True)

--- a/src/genecoder/formats.py
+++ b/src/genecoder/formats.py
@@ -5,7 +5,7 @@ sequences, where nucleotides or amino acids are represented using single-letter
 codes. A sequence in FASTA format consists of a single-line description (header),
 followed by lines of sequence data.
 """
-from typing import List, Tuple  # For type hints
+from typing import List, Tuple, Sequence  # For type hints
 
 # The set of valid characters for FASTA sequence lines.
 # Valid characters are the uppercase ASCII letters ``A``-``Z``, the digits
@@ -126,5 +126,58 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
     # After the loop, save the last processed record, if any.
     if current_header is not None:
         records.append((current_header, "".join(current_sequence_parts)))
+
+    return records
+
+
+def to_fastq(
+    dna_sequence: str,
+    header: str,
+    qualities: Sequence[int] | str,
+) -> str:
+    """Formats a DNA sequence and qualities into FASTQ format."""
+    sanitized_header = header.strip()
+    if not sanitized_header or "@" in sanitized_header or any(c in sanitized_header for c in "\n\r"):
+        raise ValueError("Invalid FASTQ header")
+    if not sanitized_header.isprintable():
+        raise ValueError("Invalid FASTQ header")
+
+    if isinstance(qualities, str):
+        qual_str = qualities
+    else:
+        if len(qualities) != len(dna_sequence):
+            raise ValueError("Quality scores length must match sequence length")
+        qual_str = "".join(chr(q + 33) for q in qualities)
+
+    if len(qual_str) != len(dna_sequence):
+        raise ValueError("Quality string length must match sequence length")
+
+    return f"@{sanitized_header}\n{dna_sequence}\n+\n{qual_str}\n"
+
+
+def from_fastq(fastq_content: str) -> List[Tuple[str, str, str]]:
+    """Parses content in FASTQ format and extracts sequence records."""
+    records: List[Tuple[str, str, str]] = []
+    lines = [ln.strip() for ln in fastq_content.splitlines() if ln.strip()]
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith("@"):  # Skip non-record lines before first header
+            i += 1
+            continue
+        if i + 3 >= len(lines):
+            break
+        header = line[1:].strip()
+        seq = lines[i + 1].strip()
+        plus = lines[i + 2].strip()
+        qual = lines[i + 3].strip()
+        if not plus.startswith("+"):
+            raise ValueError("Invalid FASTQ record: missing '+' line")
+        if len(seq) != len(qual):
+            raise ValueError("Quality string length does not match sequence length")
+        if any(ch.islower() for ch in seq) or not set(seq).issubset(FASTA_ALLOWED_CHARS):
+            raise ValueError("Invalid characters in FASTQ sequence line")
+        records.append((header, seq, qual))
+        i += 4
 
     return records

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -18,6 +18,7 @@ def _simulate_homopolymer_errors(
     substitution_rate: float,
     insertion_rate: float,
     deletion_rate: float,
+    homopolymer_factor: float,
     rng: random.Random,
 ) -> str:
     result: list[str] = []
@@ -33,8 +34,8 @@ def _simulate_homopolymer_errors(
         ins_prob = insertion_rate
         del_prob = deletion_rate
         if run >= 3:
-            ins_prob *= 2
-            del_prob *= 2
+            ins_prob *= homopolymer_factor
+            del_prob *= homopolymer_factor
         if rng.random() < del_prob:
             continue
         if rng.random() < sub_prob:
@@ -53,6 +54,7 @@ class AdvancedNanoporeChannel(BaseSimulator):
         substitution_rate: float = 0.02,
         insertion_rate: float = 0.04,
         deletion_rate: float = 0.04,
+        homopolymer_factor: float = 2.0,
         coverage: int = 1,
         read_length: int = 500,
         quality_profile: Sequence[float] | None = None,
@@ -65,6 +67,7 @@ class AdvancedNanoporeChannel(BaseSimulator):
             read_length=read_length,
             quality_profile=quality_profile,
         )
+        self.homopolymer_factor = homopolymer_factor
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()
@@ -75,6 +78,7 @@ class AdvancedNanoporeChannel(BaseSimulator):
             substitution_rate=self.substitution_rate,
             insertion_rate=self.insertion_rate,
             deletion_rate=self.deletion_rate,
+            homopolymer_factor=self.homopolymer_factor,
             rng=rng,
         )
 

--- a/src/genecoder/simulators/illumina_profile.py
+++ b/src/genecoder/simulators/illumina_profile.py
@@ -1,0 +1,61 @@
+"""Illumina simulator using quality profile for per-base error rates."""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from .base import BaseSimulator
+from ..random_utils import make_rng
+from ..channels.base import BaseChannel
+
+__all__ = ["IlluminaProfileChannel", "register"]
+
+
+class IlluminaProfileChannel(BaseSimulator):
+    """Illumina simulator with per-base quality influenced substitutions."""
+
+    def __init__(
+        self,
+        substitution_rate: float = 0.001,
+        insertion_rate: float = 0.0001,
+        deletion_rate: float = 0.0001,
+        coverage: int = 1,
+        read_length: int = 150,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+            read_length=read_length,
+            quality_profile=quality_profile,
+        )
+
+    def _quality_error_prob(self, q: float) -> float:
+        """Return error probability from a phred quality value."""
+        return 10 ** (-q / 10)
+
+    def simulate(self, sequence: str) -> str:
+        rng = make_rng()
+        read_length = self.get_read_length(sequence)
+        read = sequence[:read_length]
+        q_profile = self.get_quality_profile(read, read_length)
+        result: list[str] = []
+        for idx, nt in enumerate(read):
+            sub_prob = self.substitution_rate
+            if q_profile:
+                sub_prob = min(1.0, sub_prob + self._quality_error_prob(q_profile[idx]))
+            if sub_prob + self.insertion_rate + self.deletion_rate > 1.0:
+                raise ValueError("sum of error probabilities must not exceed 1")
+            if rng.random() < self.deletion_rate:
+                continue
+            if rng.random() < sub_prob:
+                nt = rng.choice([b for b in "ATCG" if b != nt])
+            result.append(nt)
+            if rng.random() < self.insertion_rate:
+                result.append(rng.choice(list("ATCG")))
+        return "".join(result)
+
+
+def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+    register_simulator("illumina_profile", IlluminaProfileChannel())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -364,6 +364,8 @@ def test_simulate_errors_command(temp_dir: Path, small_fasta_file: Path):
         str(small_fasta_file),
         "--output-file",
         str(out_file),
+        "--simulator",
+        "illumina_profile",
         "--sub-prob",
         "0.5",
         "--seed",

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,6 +1,11 @@
 import pytest
 
-from genecoder.formats import to_fasta, from_fasta  # noqa: E402
+from genecoder.formats import (
+    to_fasta,
+    from_fasta,
+    to_fastq,
+    from_fastq,
+)
 
 
 def test_empty_sequence():
@@ -170,3 +175,22 @@ def test_from_fasta_invalid_character_error_line_number():
     content = ">seq_invalid\nACGT\naXYZ\n"
     with pytest.raises(ValueError, match="line 3"):
         from_fasta(content)
+
+
+def test_fastq_roundtrip_string_qualities():
+    seq = "ATGC"
+    qual = "IIII"
+    fq = to_fastq(seq, "seq1", qual)
+    header, parsed_seq, parsed_qual = from_fastq(fq)[0]
+    assert header == "seq1"
+    assert parsed_seq == seq
+    assert parsed_qual == qual
+
+
+def test_fastq_numeric_qualities():
+    seq = "ATGC"
+    quals = [40, 39, 38, 37]
+    fq = to_fastq(seq, "qseq", quals)
+    _, parsed_seq, parsed_qual = from_fastq(fq)[0]
+    assert parsed_seq == seq
+    assert parsed_qual == "IHGF"

--- a/tests/test_illumina_profile_channel.py
+++ b/tests/test_illumina_profile_channel.py
@@ -1,0 +1,17 @@
+from genecoder.simulators.illumina_profile import IlluminaProfileChannel
+
+
+def test_quality_profile_influences_errors(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    channel = IlluminaProfileChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        read_length=4,
+        quality_profile=[0, 40, 0, 40],
+    )
+    result = channel.simulate("ATCG")
+    # Low quality positions should mutate
+    assert result[0] != "A" and result[2] != "C"
+    # High quality bases remain unchanged
+    assert result[1] == "T" and result[3] == "G"


### PR DESCRIPTION
## Summary
- implement `IlluminaProfileChannel` simulator with per-base quality handling
- allow homopolymer factor customization in `AdvancedNanoporeChannel`
- expose simulators to CLI `simulate-errors` command via `--simulator`
- register new simulator in builtin plugins
- test new simulator and CLI integration

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f51bbef8832690a792eff036b7f3