### PR TITLE
Prevent decode output collisions

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -39,9 +39,9 @@ def _get_header_filename(file_path: str) -> str | None:
         with open(file_path, "r", encoding="utf-8") as f_in:
             for line in f_in:
                 if line.startswith(">"):
-                    match = re.search(r"input_file=([^ ]+)", line)
+                    match = re.search(r"input_file=([^\s]+)", line)
                     if match:
-                        return os.path.basename(match.group(1))
+                        return os.path.basename(match.group(1).strip())
                     return None
     except OSError:
         logger.debug("Could not read header from %s", file_path)
@@ -281,10 +281,23 @@ def process_single_decode(
                 raise SystemExit(1)
 
         os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
-        with open(output_file_path, "wb") as f_out:
+
+        final_path = output_file_path
+        if os.path.exists(final_path):
+            base, ext = os.path.splitext(final_path)
+            i = 1
+            candidate = f"{base}_{i}{ext}"
+            while os.path.exists(candidate):
+                i += 1
+                candidate = f"{base}_{i}{ext}"
+            final_path = candidate
+
+        with open(final_path, "wb") as f_out:
             f_out.write(final_decoded_data)
 
-        logger.info(f"Successfully decoded '{input_file_path}' to '{output_file_path}'.")
+        logger.info(
+            f"Successfully decoded '{input_file_path}' to '{final_path}'."
+        )
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")
@@ -451,6 +464,7 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
+    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:
@@ -474,6 +488,15 @@ def _handle_command(args: argparse.Namespace) -> None:
                 f"Error determining output path for decoding {input_file_path}. Please check arguments."
             )
             continue
+
+        base, ext = os.path.splitext(output_file_path)
+        candidate = output_file_path
+        i = 1
+        while candidate in existing_outputs or os.path.exists(candidate):
+            candidate = f"{base}_{i}{ext}"
+            i += 1
+        output_file_path = candidate
+        existing_outputs.add(output_file_path)
         tasks.append((input_file_path, output_file_path, args))
 
     if num_input_files > 1:

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -2,12 +2,17 @@ import argparse
 import base64
 import pytest
 
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
 from genecoder.cli import (
     build_encoding_options,
     build_decoding_options,
     run_encoding_pipeline,
     run_decoding_pipeline,
 )
+from genecoder.encoders import encode_base4_direct
+from genecoder.formats import to_fasta
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder import plugins
 
@@ -56,3 +61,33 @@ def test_run_decoding_invalid_fec_info_json() -> None:
     dec_opts = _decoding_opts()
     with pytest.raises(ValueError, match="Invalid 'fec_info'"):
         run_decoding_pipeline(dna, header, dec_opts, "in.bin")
+
+
+def test_cli_decode_duplicate_output_names(tmp_path: Path) -> None:
+    dna1 = encode_base4_direct(b"one")
+    dna2 = encode_base4_direct(b"two")
+    header = "method=base4_direct input_file=dup.bin"
+    f1 = tmp_path / "a.fasta"
+    f1.write_text(to_fasta(dna1, header))
+    f2 = tmp_path / "b.fasta"
+    f2.write_text(to_fasta(dna2, header))
+
+    res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(f1),
+            str(f2),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--auto-ext",
+        ]
+    )
+    assert res.returncode == 0, res.stderr
+
+    out1 = tmp_path / "dup.bin"
+    out2 = tmp_path / "dup_1.bin"
+    assert out1.read_bytes() == b"one"
+    assert out2.read_bytes() == b"two"


### PR DESCRIPTION
## Summary
- ensure `_get_header_filename` strips whitespace
- avoid overwriting output files in `process_single_decode`
- generate unique output paths when decoding multiple files
- test duplicate `input_file` headers

## Testing
- `pre-commit run --files src/genecoder/cli/decode.py tests/test_cli_decode.py -v`

------
https://chatgpt.com/codex/tasks/task_e_686285e1d4ac83268767e273c57316c2