### PR TITLE
Handle missing glossary file gracefully

### DIFF
--- a/src/genecoder/glossary_tooltips.py
+++ b/src/genecoder/glossary_tooltips.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import logging
 import re
 from typing import Dict, List, cast
 
@@ -15,8 +16,12 @@ _GLOSSARY_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.jso
 
 def load_glossary() -> Dict[str, str]:
     """Load glossary terms from the project's ``glossary.json`` file."""
-    with open(_GLOSSARY_PATH, "r", encoding="utf-8") as f:
-        return cast(Dict[str, str], json.load(f))
+    try:
+        with open(_GLOSSARY_PATH, "r", encoding="utf-8") as f:
+            return cast(Dict[str, str], json.load(f))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        logging.warning("Could not load glossary file %s: %s", _GLOSSARY_PATH, exc)
+        return {}
 
 
 def wrap_glossary_terms(text: str, glossary: Dict[str, str]) -> ft.Row:

--- a/tests/test_glossary_tooltips.py
+++ b/tests/test_glossary_tooltips.py
@@ -2,7 +2,7 @@ import pytest
 
 ft = pytest.importorskip("flet")
 
-from genecoder.glossary_tooltips import wrap_glossary_terms
+from genecoder.glossary_tooltips import wrap_glossary_terms, load_glossary, _GLOSSARY_PATH
 
 
 def test_wrap_glossary_terms_basic():
@@ -21,3 +21,13 @@ def test_wrap_glossary_terms_no_match():
     assert isinstance(row, ft.Row)
     assert len(row.controls) == 1
     assert isinstance(row.controls[0], ft.Text)
+
+
+def test_load_glossary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    glossary_path = _GLOSSARY_PATH
+    backup = glossary_path.with_suffix(glossary_path.suffix + ".bak")
+    glossary_path.rename(backup)
+    try:
+        assert load_glossary() == {}
+    finally:
+        backup.rename(glossary_path)


### PR DESCRIPTION
## Summary
- tolerate missing or corrupt `glossary.json`
- warn the user and return an empty glossary
- test missing-glossary case

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686285e36eec8326925a6a323c0dc6a7