### PR TITLE
Add shared options module

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -50,8 +50,8 @@ def __getattr__(name: str) -> Any:
         })
         return globals()[name]
     if name in _LAZY_ATTRS:
+        from .options import EncodeOptions
         from .app_helpers import (
-            EncodeOptions,
             EncodeResult,
             DecodeResult,
             perform_encoding,

--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -7,6 +7,7 @@ The helpers here form part of the integrated pipeline described in
 from __future__ import annotations
 
 from dataclasses import dataclass
+from .options import EncodeOptions
 from typing import Optional, Dict, List, Tuple, cast
 
 from .encoders import (
@@ -38,20 +39,6 @@ import base64
 import json
 import re
 
-
-@dataclass
-class EncodeOptions:
-    method: str
-    add_parity: bool = False
-    k_value: int = 7
-    fec_method: str = "None"  # "None", "Triple-Repeat", "Hamming(7,4)"
-    gc_min: float = 0.45
-    gc_max: float = 0.55
-    max_homopolymer: int = 3
-    window_size: int = 50
-    step_size: int = 10
-    min_homopolymer_len: int = 4
-    alphabet: str = "base4"
 
 
 @dataclass

--- a/src/genecoder/cli/__init__.py
+++ b/src/genecoder/cli/__init__.py
@@ -1,12 +1,11 @@
 """CLI submodules for GeneCoder."""
 
+from ..options import EncodingOptions, DecodingOptions
 from .encode import (
-    EncodingOptions,
     build_encoding_options,
     run_encoding_pipeline,
 )
 from .decode import (
-    DecodingOptions,
     build_decoding_options,
     run_decoding_pipeline,
 )

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -8,7 +8,7 @@ import logging
 import os
 import random
 import re
-from dataclasses import dataclass
+from ..options import DecodingOptions
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
 from genecoder.gc_balancer import AdvancedGCBalancer
@@ -47,14 +47,6 @@ def _get_header_filename(file_path: str) -> str | None:
         logger.debug("Could not read header from %s", file_path)
     return None
 
-
-@dataclass
-class DecodingOptions:
-    method: str
-    check_parity: bool
-    k_value: int
-    parity_rule: str
-    alphabet: str
 
 
 def build_decoding_options(args: argparse.Namespace) -> DecodingOptions:

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -8,7 +8,7 @@ import csv
 import json
 import logging
 import os
-from dataclasses import dataclass
+from ..options import EncodingOptions
 from pathlib import Path
 
 from genecoder.manifest import generate_manifest
@@ -49,18 +49,6 @@ def _ensure_security_loaded() -> None:
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class EncodingOptions:
-    method: str
-    add_parity: bool
-    k_value: int
-    parity_rule: str
-    fec: str | None
-    gc_min: float
-    gc_max: float
-    max_homopolymer: int
-    alphabet: str = "base4"
 
 
 def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -27,10 +27,8 @@ except Exception:  # pragma: no cover - optional dependency
     websockets = None
 
 # Project module imports
-from genecoder import (
-    EncodeOptions,
-    perform_encoding,
-)
+from genecoder.options import EncodeOptions
+from genecoder import perform_encoding
 from genecoder.plugins import load_plugins
 from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input

--- a/src/genecoder/options.py
+++ b/src/genecoder/options.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EncodeOptions:
+    """Options for the GUI/async encoding helpers."""
+
+    method: str
+    add_parity: bool = False
+    k_value: int = 7
+    fec_method: str = "None"  # "None", "Triple-Repeat", "Hamming(7,4)", "Reed-Solomon"
+    gc_min: float = 0.45
+    gc_max: float = 0.55
+    max_homopolymer: int = 3
+    window_size: int = 50
+    step_size: int = 10
+    min_homopolymer_len: int = 4
+    alphabet: str = "base4"
+
+
+@dataclass
+class EncodingOptions:
+    """Options for the CLI encoding pipeline."""
+
+    method: str
+    add_parity: bool
+    k_value: int
+    parity_rule: str
+    fec: str | None
+    gc_min: float
+    gc_max: float
+    max_homopolymer: int
+    alphabet: str = "base4"
+
+
+@dataclass
+class DecodingOptions:
+    """Options for the CLI decoding pipeline."""
+
+    method: str
+    check_parity: bool
+    k_value: int
+    parity_rule: str
+    alphabet: str

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -1,7 +1,8 @@
 import re
 import pytest
 
-from genecoder.app_helpers import EncodeOptions, perform_encoding, perform_decoding
+from genecoder.options import EncodeOptions
+from genecoder.app_helpers import perform_encoding, perform_decoding
 from genecoder.reed_solomon_codec import _HAS_REEDSOLO
 
 

--- a/web/main.py
+++ b/web/main.py
@@ -8,7 +8,8 @@ from dataclasses import asdict
 import asyncio
 import base64
 
-from genecoder import EncodeOptions, perform_encoding, perform_decoding
+from genecoder.options import EncodeOptions
+from genecoder import perform_encoding, perform_decoding
 from genecoder.formats import from_fasta
 from genecoder.encoders import calculate_gc_content
 from genecoder.utils import get_max_homopolymer_length


### PR DESCRIPTION
## Summary
- factor out EncodeOptions and CLI option dataclasses into `options.py`
- update imports across CLI, GUI and web modules
- update lazy import logic
- adjust tests for new module

## Testing
- `ruff check src/genecoder/options.py src/genecoder/app_helpers.py src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/cli/__init__.py src/genecoder/__init__.py src/genecoder/flet_app.py web/main.py tests/test_app_helpers.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686285eff6f4832685bd16032896ce12