### PR TITLE
Refactor simulators with abstract base

### DIFF
--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -2,38 +2,26 @@
 from __future__ import annotations
 
 from typing import Sequence
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
 
 
 __all__ = ["BaseSimulator"]
 
 
-class BaseSimulator:
+@dataclass
+class BaseSimulator(ABC):
     """Base class for read simulators with simple error settings."""
+    substitution_rate: float = 0.0
+    insertion_rate: float = 0.0
+    deletion_rate: float = 0.0
+    coverage: int = 1
+    read_length: int = 150
+    quality_profile: Sequence[float] | None = None
 
-    substitution_rate: float
-    insertion_rate: float
-    deletion_rate: float
-    coverage: int
-    read_length: int
-    quality_profile: tuple[float, ...] | None
-
-    def __init__(
-        self,
-        substitution_rate: float = 0.0,
-        insertion_rate: float = 0.0,
-        deletion_rate: float = 0.0,
-        coverage: int = 1,
-        read_length: int = 150,
-        quality_profile: Sequence[float] | None = None,
-    ) -> None:
-        self.substitution_rate = substitution_rate
-        self.insertion_rate = insertion_rate
-        self.deletion_rate = deletion_rate
-        self.coverage = coverage
-        self.read_length = read_length
-        self.quality_profile = (
-            tuple(quality_profile) if quality_profile is not None else None
-        )
+    def __post_init__(self) -> None:
+        if self.quality_profile is not None:
+            self.quality_profile = tuple(self.quality_profile)
 
     def get_coverage(self, sequence: str) -> int:
         """Hook returning desired coverage for ``sequence``."""
@@ -47,13 +35,15 @@ class BaseSimulator:
         """Hook returning per-base quality values for ``sequence``."""
         if self.quality_profile is None:
             return None
-        if len(self.quality_profile) >= length:
-            return self.quality_profile[:length]
-        if not self.quality_profile:
+        profile = tuple(self.quality_profile)
+        if len(profile) >= length:
+            return profile[:length]
+        if not profile:
             return None
-        tail = self.quality_profile[-1]
-        return self.quality_profile + (tail,) * (length - len(self.quality_profile))
+        tail = profile[-1]
+        return profile + (tail,) * (length - len(profile))
 
+    @abstractmethod
     def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
         """Return a possibly corrupted version of ``sequence``."""
         raise NotImplementedError

--- a/src/genecoder/simulators/replication.py
+++ b/src/genecoder/simulators/replication.py
@@ -1,7 +1,8 @@
 """DNA replication simulator stub."""
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
+from dataclasses import dataclass
 
 from .base import BaseSimulator
 from ..random_utils import make_rng
@@ -11,25 +12,14 @@ from ..channels.base import BaseChannel
 __all__ = ["ReplicationSimulator", "register"]
 
 
+@dataclass
 class ReplicationSimulator(BaseSimulator):
     """Simplified DNA replication error model."""
 
-    def __init__(
-        self,
-        substitution_rate: float = 1e-4,
-        insertion_rate: float = 1e-5,
-        deletion_rate: float = 1e-5,
-        coverage: int = 1,
-        quality_profile: Sequence[float] | None = None,
-    ) -> None:
-        super().__init__(
-            substitution_rate=substitution_rate,
-            insertion_rate=insertion_rate,
-            deletion_rate=deletion_rate,
-            coverage=coverage,
-            read_length=0,
-            quality_profile=quality_profile,
-        )
+    substitution_rate: float = 1e-4
+    insertion_rate: float = 1e-5
+    deletion_rate: float = 1e-5
+    read_length: int = 0
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()

--- a/src/genecoder/simulators/transcription.py
+++ b/src/genecoder/simulators/transcription.py
@@ -1,7 +1,8 @@
 """RNA transcription simulator stub."""
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable
+from dataclasses import dataclass
 
 from .base import BaseSimulator
 from ..random_utils import make_rng
@@ -11,25 +12,14 @@ from ..channels.base import BaseChannel
 __all__ = ["TranscriptionSimulator", "register"]
 
 
+@dataclass
 class TranscriptionSimulator(BaseSimulator):
     """Simplified transcription error model."""
 
-    def __init__(
-        self,
-        substitution_rate: float = 1e-4,
-        insertion_rate: float = 1e-5,
-        deletion_rate: float = 1e-5,
-        coverage: int = 1,
-        quality_profile: Sequence[float] | None = None,
-    ) -> None:
-        super().__init__(
-            substitution_rate=substitution_rate,
-            insertion_rate=insertion_rate,
-            deletion_rate=deletion_rate,
-            coverage=coverage,
-            read_length=0,
-            quality_profile=quality_profile,
-        )
+    substitution_rate: float = 1e-4
+    insertion_rate: float = 1e-5
+    deletion_rate: float = 1e-5
+    read_length: int = 0
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()

--- a/src/genecoder/simulators/translation.py
+++ b/src/genecoder/simulators/translation.py
@@ -1,7 +1,8 @@
 """mRNA translation simulator stub."""
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable, ClassVar
+from dataclasses import dataclass
 
 from .base import BaseSimulator
 from ..random_utils import make_rng
@@ -11,10 +12,11 @@ from ..channels.base import BaseChannel
 __all__ = ["TranslationSimulator", "register"]
 
 
+@dataclass
 class TranslationSimulator(BaseSimulator):
     """Simplified translation model converting RNA to amino acids."""
 
-    CODON_TABLE: dict[str, str] = {
+    CODON_TABLE: ClassVar[dict[str, str]] = {
         # Phenylalanine
         "UUU": "F",
         "UUC": "F",
@@ -101,22 +103,10 @@ class TranslationSimulator(BaseSimulator):
         "UGA": "*",
     }
 
-    def __init__(
-        self,
-        substitution_rate: float = 1e-4,
-        insertion_rate: float = 1e-5,
-        deletion_rate: float = 1e-5,
-        coverage: int = 1,
-        quality_profile: Sequence[float] | None = None,
-    ) -> None:
-        super().__init__(
-            substitution_rate=substitution_rate,
-            insertion_rate=insertion_rate,
-            deletion_rate=deletion_rate,
-            coverage=coverage,
-            read_length=0,
-            quality_profile=quality_profile,
-        )
+    substitution_rate: float = 1e-4
+    insertion_rate: float = 1e-5
+    deletion_rate: float = 1e-5
+    read_length: int = 0
 
     def simulate(self, sequence: str) -> str:
         """Return the translated peptide from ``sequence``."""


### PR DESCRIPTION
## Summary
- turn `BaseSimulator` into an abstract dataclass
- subclass it directly in replication, transcription and translation simulators

## Testing
- `ruff check --fix .`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686285f70a0c83269376a0a17f77f452