### PR TITLE
Add CLI file-type support with auto extension

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -8,6 +8,7 @@ import logging
 import os
 import random
 import re
+from pathlib import Path
 from dataclasses import dataclass
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
@@ -41,7 +42,7 @@ def _get_header_filename(file_path: str) -> str | None:
                 if line.startswith(">"):
                     match = re.search(r"input_file=([^ ]+)", line)
                     if match:
-                        return os.path.basename(match.group(1))
+                        return os.path.basename(match.group(1).strip())
                     return None
     except OSError:
         logger.debug("Could not read header from %s", file_path)
@@ -383,6 +384,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Resume a previous interrupted streaming decode.",
     )
     parser.add_argument(
+        "--file-type",
+        type=str,
+        choices=["jpg", "png", "pdf", "txt"],
+        help="Expected output file extension if not inferrable from header.",
+    )
+    parser.add_argument(
         "--auto-ext",
         action="store_true",
         help="Automatically remove .dna and restore the original extension.",
@@ -435,14 +442,20 @@ def _handle_command(args: argparse.Namespace) -> None:
         os.environ["GENECODER_SQUIGULATOR_OPTIONS"] = args.squigulator_options
 
     num_input_files = len(args.input_files)
-    if num_input_files > 1 and not args.output_dir:
+    if num_input_files > 1 and not args.output_dir and not getattr(args, "file_type", None):
         logger.error(
-            "Error: --output-dir is required when providing multiple input files for decoding."
+            "Error: --output-dir is required when providing multiple input files for decoding unless --file-type is used."
         )
         raise SystemExit(1)
-    if num_input_files == 1 and not args.output_file and not args.output_dir:
+    if (
+        num_input_files == 1
+        and not args.output_file
+        and not args.output_dir
+        and not getattr(args, "file_type", None)
+        and _get_header_filename(args.input_files[0]) is None
+    ):
         logger.error(
-            "Error: For single input file, either --output-file or --output-dir must be specified for decoding."
+            "Error: For single input file, either --output-file or --output-dir must be specified for decoding unless the file type can be inferred."
         )
         raise SystemExit(1)
     if args.output_file and args.output_dir and num_input_files == 1:
@@ -470,10 +483,14 @@ def _handle_command(args: argparse.Namespace) -> None:
                 output_file_name = name_part + "_decoded.bin"
                 output_file_path = os.path.join(args.output_dir, output_file_name)
         else:
-            logger.error(
-                f"Error determining output path for decoding {input_file_path}. Please check arguments."
-            )
-            continue
+            header_name = _get_header_filename(input_file_path)
+            base_dir = os.path.dirname(input_file_path)
+            if header_name:
+                base = Path(header_name).stem
+            else:
+                base = Path(input_file_path).stem
+            ext = f".{args.file_type}" if getattr(args, "file_type", None) else (Path(header_name).suffix if header_name else ".bin")
+            output_file_path = os.path.join(base_dir, f"{base}{ext}")
         tasks.append((input_file_path, output_file_path, args))
 
     if num_input_files > 1:

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -300,6 +300,11 @@ def process_single_encode(
             checksum = compute_checksum(plaintext_data)
 
         options = build_encoding_options(args)
+        header_name = os.path.basename(input_file_path)
+        if getattr(args, "file_type", None):
+            stem = Path(header_name).stem
+            header_name = f"{stem}.{args.file_type}"
+
         (
             final_encoded_dna_sequence,
             fasta_header,
@@ -307,7 +312,7 @@ def process_single_encode(
             current_input_data,
             fec_padding_bits,
         ) = run_encoding_pipeline(
-            data_for_encoding, options, os.path.basename(input_file_path)
+            data_for_encoding, options, header_name
         )
 
         if checksum:
@@ -528,6 +533,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Resume a previous interrupted streaming encode.",
     )
     parser.add_argument(
+        "--file-type",
+        type=str,
+        choices=["jpg", "png", "pdf", "txt"],
+        help="File type to record in the FASTA header when inferring output paths.",
+    )
+    parser.add_argument(
         "--auto-ext",
         action="store_true",
         help="Automatically append a .dna suffix to output files.",
@@ -555,11 +566,20 @@ def _handle_command(args: argparse.Namespace) -> None:
         logger.error("Error: --chunk-size must be a positive integer.")
         raise SystemExit(1)
     num_input_files = len(args.input_files)
-    if num_input_files > 1 and not args.output_dir:
-        logger.error("Error: --output-dir is required when providing multiple input files for encoding.")
+    if num_input_files > 1 and not args.output_dir and not getattr(args, "file_type", None):
+        logger.error(
+            "Error: --output-dir is required when providing multiple input files for encoding unless --file-type is used."
+        )
         raise SystemExit(1)
-    if num_input_files == 1 and not args.output_file and not args.output_dir:
-        logger.error("Error: For single input file, either --output-file or --output-dir must be specified.")
+    if (
+        num_input_files == 1
+        and not args.output_file
+        and not args.output_dir
+        and not getattr(args, "file_type", None)
+    ):
+        logger.error(
+            "Error: For single input file, either --output-file or --output-dir must be specified unless --file-type is used."
+        )
         raise SystemExit(1)
     if args.output_file and args.output_dir and num_input_files == 1:
         logger.warning("Warning: Both --output-file and --output-dir provided for single input. Using --output-file.")
@@ -582,8 +602,12 @@ def _handle_command(args: argparse.Namespace) -> None:
             else:
                 output_file_name = base_name + ".fasta"
             output_file_path = os.path.join(args.output_dir, output_file_name)
+        elif getattr(args, "file_type", None):
+            output_file_path = f"{input_file_path}.{args.file_type}.dna"
         else:
-            logger.error(f"Error determining output path for {input_file_path}. Please check arguments.")
+            logger.error(
+                f"Error determining output path for {input_file_path}. Please check arguments."
+            )
             continue
         tasks.append((input_file_path, output_file_path, args))
 

--- a/tests/test_cli_auto_ext.py
+++ b/tests/test_cli_auto_ext.py
@@ -38,3 +38,35 @@ def test_auto_ext_roundtrip(tmp_path: Path) -> None:
     assert decoded.exists()
     assert decoded.read_text() == "auto"
 
+
+def test_file_type_roundtrip(tmp_path: Path) -> None:
+    input_file = tmp_path / "img.bin"
+    input_file.write_bytes(b"jpeg")
+
+    enc_res = run_cli_command([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--method",
+        "base4_direct",
+        "--file-type",
+        "jpg",
+    ])
+    assert enc_res.returncode == 0, enc_res.stderr
+
+    encoded = tmp_path / "img.bin.jpg.dna"
+    assert encoded.exists()
+
+    dec_res = run_cli_command([
+        "decode",
+        "--input-files",
+        str(encoded),
+        "--method",
+        "base4_direct",
+    ])
+    assert dec_res.returncode == 0, dec_res.stderr
+
+    decoded = tmp_path / "img.jpg"
+    assert decoded.exists()
+    assert decoded.read_bytes() == b"jpeg"
+


### PR DESCRIPTION
## Summary
- support `--file-type` for `encode` and `decode` commands
- infer output path using `--file-type` when none is provided
- store extension in FASTA header and strip whitespace when decoding
- test JPEG roundtrip with inferred extensions

## Testing
- `pre-commit run --files src/genecoder/cli/encode.py src/genecoder/cli/decode.py tests/test_cli_auto_ext.py`

------
https://chatgpt.com/codex/tasks/task_e_68628603981083268924136d20a067cc