### PR TITLE
Add modal glossary tooltips

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -37,15 +37,22 @@ from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix_ui
 from genecoder.formats import from_fasta
-from genecoder.glossary_tooltips import load_glossary, wrap_glossary_terms
+from genecoder.glossary_tooltips import (
+    load_glossary,
+    load_glossary_full,
+    wrap_glossary_terms,
+    glossary_modal_text,
+)
 
 
 logger = logging.getLogger(__name__)
 
 try:
     GLOSSARY: dict[str, str] = load_glossary()
+    GLOSSARY_FULL: dict[str, str] = load_glossary_full()
 except Exception:
     GLOSSARY = {}
+    GLOSSARY_FULL = {}
 
 
 encode_fasta_data_to_save_ref: ft.Ref[Optional[str]] = ft.Ref[Optional[str]]()
@@ -146,7 +153,14 @@ def main(page: ft.Page) -> None:
 
 
     window_size_input: ft.TextField = ft.TextField(
-        label=wrap_glossary_terms("GC Window Size", GLOSSARY),
+        label=ft.Row(
+            [
+                ft.Text("GC Window Size ("),
+                glossary_modal_text("GC content", page, GLOSSARY, GLOSSARY_FULL),
+                ft.Text(")"),
+            ],
+            spacing=0,
+        ),
         value="50",
         width=120,
         keyboard_type=ft.KeyboardType.NUMBER,
@@ -159,7 +173,16 @@ def main(page: ft.Page) -> None:
         keyboard_type=ft.KeyboardType.NUMBER,
     )
     min_homopolymer_input: ft.TextField = ft.TextField(
-        label=wrap_glossary_terms("Min Homopolymer Length", GLOSSARY),
+        label=ft.Row(
+            [
+                ft.Text("Min "),
+                glossary_modal_text(
+                    "Homopolymer", page, GLOSSARY, GLOSSARY_FULL
+                ),
+                ft.Text(" Length"),
+            ],
+            spacing=0,
+        ),
         value="4",
         width=180,
         keyboard_type=ft.KeyboardType.NUMBER,
@@ -270,16 +293,24 @@ def main(page: ft.Page) -> None:
     encode_comp_ratio_text: ft.Text = ft.Text("Compression ratio: -")
     encode_bits_per_nt_text: ft.Text = ft.Text("Bits per nucleotide: - bits/nt")
     encode_actual_gc_value: ft.Text = ft.Text("-")
-    encode_actual_gc_text: ft.Row = wrap_glossary_terms(
-        "Actual GC content (payload): ", GLOSSARY
+    encode_actual_gc_text: ft.Row = ft.Row(
+        [
+            ft.Text("Actual "),
+            glossary_modal_text("GC content", page, GLOSSARY, GLOSSARY_FULL),
+            ft.Text(" (payload): "),
+            encode_actual_gc_value,
+        ],
+        spacing=0,
     )
-    encode_actual_gc_text.controls.append(encode_actual_gc_value)
     encode_actual_homopolymer_value: ft.Text = ft.Text("-")
-    encode_actual_homopolymer_text: ft.Row = wrap_glossary_terms(
-        "Actual max homopolymer (payload): ", GLOSSARY
-    )
-    encode_actual_homopolymer_text.controls.append(
-        encode_actual_homopolymer_value
+    encode_actual_homopolymer_text: ft.Row = ft.Row(
+        [
+            ft.Text("Actual max "),
+            glossary_modal_text("Homopolymer", page, GLOSSARY, GLOSSARY_FULL),
+            ft.Text(" (payload): "),
+            encode_actual_homopolymer_value,
+        ],
+        spacing=0,
     )
     encode_progress_ring: ft.ProgressRing = ft.ProgressRing(
         visible=False, width=20, height=20
@@ -762,8 +793,19 @@ def main(page: ft.Page) -> None:
             ),
             nucleotide_freq_image,
             ft.Divider(),  # New divider
-            wrap_glossary_terms(
-                "Sequence GC & Homopolymer Analysis:", GLOSSARY
+            ft.Row(
+                [
+                    ft.Text("Sequence "),
+                    glossary_modal_text(
+                        "GC content", page, GLOSSARY, GLOSSARY_FULL
+                    ),
+                    ft.Text(" & "),
+                    glossary_modal_text(
+                        "Homopolymer", page, GLOSSARY, GLOSSARY_FULL
+                    ),
+                    ft.Text(" Analysis:"),
+                ],
+                spacing=0,
             ),  # New title
             ft.Row(
                 [

--- a/src/genecoder/glossary_tooltips.py
+++ b/src/genecoder/glossary_tooltips.py
@@ -11,12 +11,32 @@ import flet as ft
 
 
 _GLOSSARY_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.json"
+_GLOSSARY_MD_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.md"
 
 
 def load_glossary() -> Dict[str, str]:
     """Load glossary terms from the project's ``glossary.json`` file."""
     with open(_GLOSSARY_PATH, "r", encoding="utf-8") as f:
         return cast(Dict[str, str], json.load(f))
+
+
+def load_glossary_full() -> Dict[str, str]:
+    """Load full glossary definitions from ``glossary.md``."""
+    terms: Dict[str, str] = {}
+    current: str | None = None
+    buffer: list[str] = []
+    with open(_GLOSSARY_MD_PATH, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("## "):
+                if current:
+                    terms[current] = " ".join(buffer).strip()
+                current = line[3:].strip()
+                buffer = []
+            elif current:
+                buffer.append(line.strip())
+        if current:
+            terms[current] = " ".join(buffer).strip()
+    return terms
 
 
 def wrap_glossary_terms(text: str, glossary: Dict[str, str]) -> ft.Row:
@@ -43,3 +63,30 @@ def wrap_glossary_terms(text: str, glossary: Dict[str, str]) -> ft.Row:
         controls.append(ft.Text(text[last:]))
 
     return ft.Row(controls, spacing=0, wrap=True)
+
+
+def glossary_modal_text(
+    term: str,
+    page: ft.Page,
+    glossary: Dict[str, str],
+    full_defs: Dict[str, str],
+) -> ft.Text:
+    """Return clickable text that opens a modal showing the term definition."""
+
+    tooltip = glossary.get(term, "")
+    full_text = full_defs.get(term, tooltip)
+    dialog = ft.AlertDialog(title=ft.Text(term), content=ft.Text(full_text), modal=True)
+
+    def _open_dialog(_: ft.ControlEvent) -> None:
+        page.dialog = dialog
+        dialog.open = True
+        page.update()
+
+    text_ctrl = ft.Text(
+        term,
+        tooltip=tooltip,
+        style=ft.TextStyle(decoration=ft.TextDecoration.UNDERLINE),
+        color=ft.colors.BLUE_500,
+    )
+    text_ctrl.on_click = _open_dialog
+    return text_ctrl

--- a/tests/test_flet_gui.py
+++ b/tests/test_flet_gui.py
@@ -1,11 +1,14 @@
 import pytest
 
 ft = pytest.importorskip("flet")
+ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
+ft.colors = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
 
 
 class _DummyPage:
     def __init__(self) -> None:
         self.overlay = []
+        self.dialog = None
 
     def add(self, *args, **kwargs):
         pass
@@ -53,3 +56,20 @@ def test_show_helix_ui_returns_webview() -> None:
     assert elem.__class__.__name__ == "WebView"
     assert elem.width == 600
     assert elem.height == 400
+
+
+def test_glossary_modal_text_opens_dialog() -> None:
+    from genecoder.glossary_tooltips import glossary_modal_text
+
+    page = _DummyPage()
+    glossary = {"GC content": "short"}
+    full = {"GC content": "long definition"}
+
+    txt = glossary_modal_text("GC content", page, glossary, full)
+
+    txt.on_click(None)
+
+    assert isinstance(page.dialog, ft.AlertDialog)
+    assert page.dialog.open is True
+    assert page.dialog.title.value == "GC content"
+    assert page.dialog.content.value == "long definition"


### PR DESCRIPTION
## Summary
- add `load_glossary_full()` and `glossary_modal_text()` helper
- embed clickable glossary terms in flet UI
- open modal dialog with definitions from docs
- test modal text helper

## Testing
- `ruff check src/genecoder/glossary_tooltips.py src/genecoder/flet_app.py tests/test_flet_gui.py`
- `pytest tests/test_flet_gui.py::test_glossary_modal_text_opens_dialog -q`

------
https://chatgpt.com/codex/tasks/task_e_68628608c7b08326a5503faf45f00dbb