### PR TITLE
Add mirror helix viewer

### DIFF
--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -89,6 +89,13 @@ genecoder decode --input-files big.fasta --output-file big.bin \
   --stream --chunk-size 1048576 --resume
 ```
 
+Using `--mirror` on the `encode` command automatically launches the helix
+viewer displaying the sequence and its reverse complement:
+
+```bash
+genecoder encode --input-files hello.txt --output-file hello.fasta --mirror
+```
+
 This document condenses the key steps from the installation and usage guides into a quick demo.
 
 Contributors may prefer to run these commands inside the provided

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -323,6 +323,15 @@ def process_single_encode(
         with open(output_file_path, "w", encoding="utf-8") as f_out:
             f_out.write(fasta_output)
 
+        if getattr(args, "mirror", False):
+            try:
+                from genecoder.helix_view import show_helix_ui
+
+                rc_seq = reverse_complement(final_encoded_dna_sequence)
+                show_helix_ui(final_encoded_dna_sequence, seq2=rc_seq)
+            except Exception as exc:  # pragma: no cover - optional GUI
+                logger.warning("Could not launch helix viewer: %s", exc)
+
         if getattr(args, "capsule", None):
             from genecoder.cache_dna import write_capsule
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import pytest
 import subprocess
 import os
@@ -6,7 +7,8 @@ import tempfile
 from pathlib import Path
 from genecoder.utils import get_temp_dir
 from src.genecoder.formats import to_fasta, from_fasta
-from src.genecoder.cli.encode import reverse_complement
+from src.genecoder.cli.encode import reverse_complement, process_single_encode
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 
 # Helper to get the root of the project
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -177,28 +179,42 @@ def test_gc_balanced_params_in_header_default_and_custom(temp_dir: Path):
     assert "max_homopolymer=4" in header_custom
 
 
-def test_encode_mirror(tmp_path: Path) -> None:
+def test_encode_mirror(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("flet")
     input_file = tmp_path / "msg.txt"
     input_file.write_text("mirror")
     output_file = tmp_path / "seq.fasta"
 
-    cmd_args = [
-        "encode",
-        "--input-files",
-        str(input_file),
-        "--output-file",
-        str(output_file),
-        "--method",
-        "base4_direct",
-        "--mirror",
-    ]
-    result = run_cli_command(cmd_args)
-    assert result.returncode == 0, result.stderr
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_show(seq: str, *, seq2: str | None = None, **_: object) -> None:
+        calls.append((seq, seq2))
+
+    monkeypatch.setattr("genecoder.helix_view.show_helix_ui", fake_show)
+
+    args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+        alphabet="base4",
+        stream=False,
+        capsule=None,
+        export_csv=None,
+        mirror=True,
+    )
+
+    process_single_encode(str(input_file), str(output_file), args)
 
     records = from_fasta(output_file.read_text())
     assert len(records) == 2
     assert records[1][1] == reverse_complement(records[0][1])
     assert "mirror=rc" in records[1][0]
+    assert len(calls) == 1
 
 # --- Test Scenarios for Batch Decoding ---
 


### PR DESCRIPTION
## Summary
- open helix viewer after encoding when --mirror is set
- note new behaviour in vertical slice docs
- ensure helix viewer is invoked in encode mirror test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862860ce7508326a5d2e735430dcbbd