### PR TITLE
Add streaming PNG roundtrip test

### DIFF
--- a/tests/test_streaming_png.py
+++ b/tests/test_streaming_png.py
@@ -1,0 +1,35 @@
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from genecoder.streaming import stream_encode_file, stream_decode_file
+
+
+def test_streaming_png_roundtrip(tmp_path: Path, record_property: Any) -> None:
+    chunk_size = 1_048_576  # 1 MB
+    total_size = chunk_size * 10
+    png_data = b"\x89PNG\r\n\x1a\n" + os.urandom(total_size - 8)
+    png_path = tmp_path / "dummy.png"
+    png_path.write_bytes(png_data)
+
+    encoded_file = tmp_path / "encoded.fasta"
+    decoded_file = tmp_path / "decoded.png"
+
+    start = time.perf_counter()
+    stream_encode_file(
+        str(png_path),
+        str(encoded_file),
+        header="method=base4_direct input_file=dummy.png",
+        chunk_size=chunk_size,
+    )
+    enc_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    stream_decode_file(str(encoded_file), str(decoded_file), chunk_size=chunk_size)
+    dec_time = time.perf_counter() - start
+
+    record_property("encode_time_png", enc_time)
+    record_property("decode_time_png", dec_time)
+
+    assert decoded_file.read_bytes() == png_data


### PR DESCRIPTION
## Summary
- test stream_encode_file() and stream_decode_file() with a 10 MB PNG

## Testing
- `ruff check tests/test_streaming_png.py`
- `mypy --config-file mypy.ini tests/test_streaming_png.py`
- `pytest -k test_streaming_png_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6862860f91e48326abef552e533d3855