### PR TITLE
Add glossary term pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
         entry: pytest -q
         language: system
         pass_filenames: false
+      - id: check-glossary-terms
+        name: check glossary terms
+        entry: python scripts/check_glossary_terms.py
+        language: python
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ pre-commit run --files path/to/file.py
 
 The hook also runs automatically on each commit if installed.
 
+An additional `check-glossary-terms` hook verifies that every term in
+`docs/glossary.json` appears in at least one Markdown file. The commit
+will fail if any terms are missing.
+
 ## Running the Test Suite
 
 Unit tests use `pytest`. Install the pinned dependencies and run:

--- a/scripts/check_glossary_terms.py
+++ b/scripts/check_glossary_terms.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Fail if any glossary term is missing from the markdown docs."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    docs_dir = repo_root / "docs"
+    glossary_path = docs_dir / "glossary.json"
+
+    with glossary_path.open("r", encoding="utf-8") as fh:
+        terms: list[str] = list(json.load(fh).keys())
+
+    md_files = list(docs_dir.glob("*.md"))
+    missing: list[str] = []
+    for term in terms:
+        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        found = False
+        for md_file in md_files:
+            text = md_file.read_text(encoding="utf-8")
+            if pattern.search(text):
+                found = True
+                break
+        if not found:
+            missing.append(term)
+
+    if missing:
+        print("Missing glossary terms: " + ", ".join(sorted(missing)))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_glossary_terms.py` to ensure glossary terms appear in docs
- run check via pre-commit
- document new check in CONTRIBUTING guidelines

## Testing
- `pre-commit run --files scripts/check_glossary_terms.py .pre-commit-config.yaml CONTRIBUTING.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628611a63083268f38e749ff307002