### PR TITLE
Fix sanitized FASTA header names

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -77,7 +77,9 @@ def run_encoding_pipeline(
     current_input = data
     fec_padding_bits = -1
     encode_map, _ = get_alphabet_maps(options.alphabet)
-    sanitized_name = Path(input_file_name).name
+    # Normalize path separators to ensure the FASTA header does not contain
+    # backslashes which can appear on Windows paths.
+    sanitized_name = os.path.basename(input_file_name.replace("\\", "/"))
     header_parts = [f"method={options.method}", f"input_file={sanitized_name}"]
 
     if options.fec == "hamming_7_4":

--- a/tests/test_header_sanitization.py
+++ b/tests/test_header_sanitization.py
@@ -1,0 +1,27 @@
+import argparse
+from genecoder.cli.encode import run_encoding_pipeline, build_encoding_options
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+
+
+def test_header_no_backslashes(tmp_path):
+    data = b"x" * 10
+    input_path = tmp_path / "subdir" / "in.bin"
+    input_path.parent.mkdir()
+    input_path.write_bytes(data)
+
+    args = argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+        alphabet="base4",
+    )
+    opts = build_encoding_options(args)
+    dna, header, *_ = run_encoding_pipeline(data, opts, "foo\\bar\\in.bin")
+    assert "\\" not in header
+    assert "input_file=in.bin" in header
+


### PR DESCRIPTION
## Summary
- ensure encode header filenames don't contain Windows path separators
- add regression test for header sanitization

## Testing
- `ruff check src/genecoder/cli/encode.py tests/test_header_sanitization.py`
- `pytest tests/test_cli_output_file_no_dir.py::test_encode_output_file_no_directory tests/test_header_sanitization.py::test_header_no_backslashes -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fb6b8abc8326b9ed9c6988075775