### PR TITLE
Add large streaming file roundtrip test

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -9,7 +9,7 @@ import os
 import random
 import re
 from pathlib import Path
-from dataclasses import dataclass
+from ..options import DecodingOptions
 
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
@@ -470,7 +470,6 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
-    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:

--- a/tests/test_streaming_files.py
+++ b/tests/test_streaming_files.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from genecoder.streaming import stream_encode_file, stream_decode_file
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("LOW_RESOURCE_CI") == "1",
+    reason="skipping resource-intensive test on low-resource CI",
+)
+
+
+def test_stream_encode_decode_resume(tmp_path: Path) -> None:
+    data = os.urandom(6 * 1024 * 1024)  # >5 MB
+    input_file = tmp_path / "data.bin"
+    input_file.write_bytes(data)
+    fasta_file = tmp_path / "data.fasta"
+    enc_manifest = fasta_file.with_suffix(".stream.manifest")
+
+    header = "method=base4_direct input_file=data.bin"
+    stream_encode_file(
+        str(input_file),
+        str(fasta_file),
+        header=header,
+        chunk_size=1_048_576,
+        manifest_path=str(enc_manifest),
+        resume=True,
+    )
+
+    decoded_file = tmp_path / "decoded.bin"
+    dec_manifest = decoded_file.with_suffix(".stream.manifest")
+    stream_decode_file(
+        str(fasta_file),
+        str(decoded_file),
+        chunk_size=1_048_576,
+        manifest_path=str(dec_manifest),
+        resume=True,
+    )
+
+    assert decoded_file.read_bytes() == data
+    assert enc_manifest.exists() and dec_manifest.exists()
+    assert sum(1 for _ in enc_manifest.open()) > 0
+    assert sum(1 for _ in dec_manifest.open()) > 0


### PR DESCRIPTION
## Summary
- add regression test for streaming encode/decode on >5 MB files using resume
- fix missing import in `decode` CLI module

## Testing
- `ruff check src/genecoder/cli/decode.py tests/test_streaming_files.py`
- `mypy --config-file=mypy.ini src`
- `pytest tests/test_streaming_files.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68630815aeb4832692487dd3a7d916a9