### PR TITLE
Add simulator registry and update adapters

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -16,10 +16,9 @@ _LAZY_ATTRS = {
 from .plugins import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
-    SIMULATOR_REGISTRY,
     load_plugins,
 )
-from .simulators import simulate_reads
+from .simulators import SIMULATOR_REGISTRY, simulate_reads
 
 
 

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -7,6 +7,7 @@ from typing import Protocol, Callable
 from .random_utils import make_rng
 
 from .channels.base import BaseChannel
+from .simulators import register_simulator as _register_simulator
 
 
 __all__ = ["simulate_errors", "RandomLike", "Channel", "register"]
@@ -60,7 +61,9 @@ class Channel(BaseChannel):
         return simulate_errors(sequence, self.error_rate, rng=make_rng())
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the simple substitution error simulator."""
 
-    register_simulator("simple", Channel())
+    registrar("simple", Channel())

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -3,7 +3,8 @@ import logging
 import sys
 
 from genecoder import __version__
-from genecoder.plugins import load_plugins, SIMULATOR_REGISTRY
+from genecoder.plugins import load_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -9,13 +9,14 @@ import os
 import random
 import re
 from pathlib import Path
-from dataclasses import dataclass
 
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
 from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import decode_data_with_hamming
-from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
+from genecoder.plugins import FEC_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.options import DecodingOptions
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -499,6 +500,13 @@ def _handle_command(args: argparse.Namespace) -> None:
             ext = f".{args.file_type}" if getattr(args, "file_type", None) else (Path(header_name).suffix if header_name else ".bin")
             output_file_path = os.path.join(base_dir, f"{base}{ext}")
 
+        base_output = output_file_path
+        suffix = 1
+        while output_file_path in existing_outputs:
+            base, ext = os.path.splitext(base_output)
+            output_file_path = f"{base}_{suffix}{ext}"
+            suffix += 1
+        existing_outputs.add(output_file_path)
         tasks.append((input_file_path, output_file_path, args))
 
     if num_input_files > 1:

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -5,6 +5,7 @@ import random
 from typing import Callable
 
 from .channels.base import BaseChannel
+from .simulators import register_simulator as _register_simulator
 
 from .random_utils import make_rng
 from .nanopore_sim import _simulate_adapter, _run_external
@@ -45,7 +46,9 @@ class D2SimChannel(BaseChannel):
         return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the ``d2sim`` simulator."""
 
-    register_simulator("d2sim", D2SimChannel())
+    registrar("d2sim", D2SimChannel())

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -7,6 +7,7 @@ from typing import Callable
 from .channels.base import BaseChannel
 from .random_utils import make_rng
 from .nanopore_sim import _simulate_adapter, _run_external
+from .simulators import register_simulator as _register_simulator
 
 
 class _DNARSIM:
@@ -44,7 +45,9 @@ class DNArSimChannel(BaseChannel):
         return simulate_dnarsim(sequence, error_rate=self.error_rate, rng=make_rng())
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the ``dnarsim`` simulator."""
 
-    register_simulator("dnarsim", DNArSimChannel())
+    registrar("dnarsim", DNArSimChannel())

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -7,6 +7,7 @@ from typing import Callable
 from .random_utils import make_rng
 
 from .channels.base import BaseChannel
+from .simulators import register_simulator as _register_simulator
 
 __all__ = ["introduce_errors", "apply_substitutions", "apply_insertions", "apply_deletions", "Channel", "register"]
 
@@ -123,7 +124,9 @@ class Channel(BaseChannel):
         )
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the insertion/deletion error simulator."""
 
-    register_simulator("indel", Channel())
+    registrar("indel", Channel())

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -21,6 +21,7 @@ __all__ = [
 ]
 
 from .channels.base import BaseChannel
+from .simulators import register_simulator as _register_simulator
 
 logger = logging.getLogger(__name__)
 
@@ -211,10 +212,12 @@ class Channel(BaseChannel):
 
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the builtin simulators."""
 
     for name in SIMULATOR_ADAPTERS:
-        register_simulator(name, Channel(name))
+        registrar(name, Channel(name))
 
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -9,11 +9,12 @@ import importlib
 import logging
 import pkgutil
 
+from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
+
 logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-SIMULATOR_REGISTRY: Dict[str, BaseChannel] = {}
 
 
 def register_codec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
@@ -28,7 +29,7 @@ def register_fec(name: str, encode: Callable[..., Any], decode: Callable[..., An
 
 def register_simulator(name: str, channel: BaseChannel) -> None:
     """Register a read simulator under ``name``."""
-    SIMULATOR_REGISTRY[name] = channel
+    _register_simulator(name, channel)
 
 
 def _load_and_register(

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -1,18 +1,31 @@
-"""Sequencing simulator implementations."""
+"""Sequencing simulator implementations and registry."""
 from __future__ import annotations
 
-from ..plugins import SIMULATOR_REGISTRY
+from typing import Dict
+
+from ..channels.base import BaseChannel
+
+SIMULATOR_REGISTRY: Dict[str, BaseChannel] = {}
+
+
+def register_simulator(name: str, channel: BaseChannel) -> None:
+    """Register ``channel`` under ``name``."""
+    SIMULATOR_REGISTRY[name] = channel
 
 from .base import BaseSimulator
 from .illumina import IlluminaChannel
+from .illumina_profile import IlluminaProfileChannel
 from .adv_nanopore import AdvancedNanoporeChannel
 from .replication import ReplicationSimulator
 from .transcription import TranscriptionSimulator
 from .translation import TranslationSimulator
 
 __all__ = [
+    "SIMULATOR_REGISTRY",
+    "register_simulator",
     "BaseSimulator",
     "IlluminaChannel",
+    "IlluminaProfileChannel",
     "AdvancedNanoporeChannel",
     "ReplicationSimulator",
     "TranscriptionSimulator",

--- a/src/genecoder/simulators/adv_nanopore.py
+++ b/src/genecoder/simulators/adv_nanopore.py
@@ -9,6 +9,7 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 
 from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
 
 __all__ = ["AdvancedNanoporeChannel", "register"]
 
@@ -83,5 +84,7 @@ class AdvancedNanoporeChannel(BaseSimulator):
         )
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("adv_nanopore", AdvancedNanoporeChannel())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("adv_nanopore", AdvancedNanoporeChannel())

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -8,6 +8,7 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
 from ..error_simulation import introduce_errors
+from . import register_simulator as _register_simulator
 
 __all__ = ["IlluminaChannel", "register"]
 
@@ -46,5 +47,7 @@ class IlluminaChannel(BaseSimulator):
         )
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("illumina", IlluminaChannel())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("illumina", IlluminaChannel())

--- a/src/genecoder/simulators/illumina_profile.py
+++ b/src/genecoder/simulators/illumina_profile.py
@@ -6,6 +6,7 @@ from typing import Callable, Sequence
 from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
 
 __all__ = ["IlluminaProfileChannel", "register"]
 
@@ -57,5 +58,7 @@ class IlluminaProfileChannel(BaseSimulator):
         return "".join(result)
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("illumina_profile", IlluminaProfileChannel())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("illumina_profile", IlluminaProfileChannel())

--- a/src/genecoder/simulators/replication.py
+++ b/src/genecoder/simulators/replication.py
@@ -8,6 +8,7 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..error_simulation import introduce_errors
 from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
 
 __all__ = ["ReplicationSimulator", "register"]
 
@@ -32,5 +33,7 @@ class ReplicationSimulator(BaseSimulator):
         )
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("replication", ReplicationSimulator())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("replication", ReplicationSimulator())

--- a/src/genecoder/simulators/transcription.py
+++ b/src/genecoder/simulators/transcription.py
@@ -8,6 +8,7 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..error_simulation import introduce_errors
 from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
 
 __all__ = ["TranscriptionSimulator", "register"]
 
@@ -33,5 +34,7 @@ class TranscriptionSimulator(BaseSimulator):
         return dna.replace("T", "U")
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("transcription", TranscriptionSimulator())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("transcription", TranscriptionSimulator())

--- a/src/genecoder/simulators/translation.py
+++ b/src/genecoder/simulators/translation.py
@@ -8,6 +8,7 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..error_simulation import introduce_errors
 from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
 
 __all__ = ["TranslationSimulator", "register"]
 
@@ -134,5 +135,7 @@ class TranslationSimulator(BaseSimulator):
         return "".join(peptide)
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
-    register_simulator("translation", TranslationSimulator())
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("translation", TranslationSimulator())

--- a/src/genecoder/squigulator_adapter.py
+++ b/src/genecoder/squigulator_adapter.py
@@ -7,6 +7,7 @@ from typing import Callable
 from .channels.base import BaseChannel
 from .random_utils import make_rng
 from .nanopore_sim import _simulate_adapter, _run_external
+from .simulators import register_simulator as _register_simulator
 
 
 class _SQUIGULATOR:
@@ -44,7 +45,9 @@ class SquigulatorChannel(BaseChannel):
         return simulate_squigulator(sequence, error_rate=self.error_rate, rng=make_rng())
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
     """Register the ``squigulator`` simulator."""
 
-    register_simulator("squigulator", SquigulatorChannel())
+    registrar("squigulator", SquigulatorChannel())

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 from genecoder import nanopore_sim
-from genecoder.plugins import SIMULATOR_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.simulators import simulate_reads
 
 ADAPTERS = {

--- a/tests/test_simulate_reads_dispatch.py
+++ b/tests/test_simulate_reads_dispatch.py
@@ -2,8 +2,7 @@ import random
 import pytest
 
 from genecoder import nanopore_sim
-from genecoder.simulators import simulate_reads
-from genecoder.plugins import SIMULATOR_REGISTRY
+from genecoder.simulators import simulate_reads, SIMULATOR_REGISTRY
 
 
 @pytest.mark.parametrize("name", ["d2sim", "dnarsim", "squigulator"])

--- a/tests/test_simulator_registry.py
+++ b/tests/test_simulator_registry.py
@@ -1,0 +1,13 @@
+from genecoder.simulators import SIMULATOR_REGISTRY, simulate_reads
+
+
+def test_illumina_registered_and_deterministic(monkeypatch):
+    assert "illumina" in SIMULATOR_REGISTRY
+    seq = "A" * 50
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    first = simulate_reads(seq, "illumina")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    second = simulate_reads(seq, "illumina")
+    assert first == second
+    assert isinstance(first, str)
+


### PR DESCRIPTION
## Summary
- create SIMULATOR_REGISTRY in `genecoder.simulators`
- register built-in simulators using the new registry
- expose the registry in the CLI
- update decode logic for unique output filenames
- test simulator registration and deterministic output

## Testing
- `ruff check --fix src/genecoder/__init__.py src/genecoder/channel_sim.py src/genecoder/cli/cli.py src/genecoder/cli/decode.py src/genecoder/d2sim_adapter.py src/genecoder/dnarsim_adapter.py src/genecoder/error_simulation.py src/genecoder/nanopore_sim.py src/genecoder/plugins.py src/genecoder/simulators/__init__.py src/genecoder/simulators/adv_nanopore.py src/genecoder/simulators/illumina.py src/genecoder/simulators/illumina_profile.py src/genecoder/simulators/replication.py src/genecoder/simulators/transcription.py src/genecoder/simulators/translation.py src/genecoder/squigulator_adapter.py tests/test_nanopore_sim.py tests/test_simulate_reads_dispatch.py tests/test_simulator_registry.py`
- `mypy --config-file mypy.ini src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630802467483269010c6aa6abfdd39