### PR TITLE
Add streaming resume integrity check

### DIFF
--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -73,7 +73,10 @@ Open <http://localhost:8000> in your browser to view the landing page.
 ## Streaming Encode and Resume
 
 Large files can be encoded and decoded in streaming mode to reduce memory usage.
-Specify a chunk size in bytes and pass `--resume` to continue a partial run:
+Each streaming run writes a `<output>.stream.manifest` file containing chunk offsets
+and SHA-256 hashes. Specify a chunk size in bytes and pass `--resume` to
+continue a partial run. Previously completed chunks are verified against the
+manifest before processing resumes:
 
 ```bash
 # initial encode

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -9,7 +9,8 @@ import os
 import random
 import re
 from pathlib import Path
-from dataclasses import dataclass
+
+from genecoder.options import DecodingOptions
 
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
@@ -470,7 +471,6 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
-    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -33,11 +33,41 @@ def stream_encode_file(
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
     manifest_file = None
     processed_chunks = 0
+    manifest_lines: list[dict[str, int | str]] = []
+    encode_map, _ = get_alphabet_maps(alphabet)
     if manifest_path:
         mode = "a" if resume else "w"
         if resume and os.path.exists(manifest_path):
             with open(manifest_path, "r", encoding="utf-8") as mf:
-                processed_chunks = sum(1 for _ in mf)
+                manifest_lines = [json.loads(line) for line in mf]
+            processed_chunks = len(manifest_lines)
+            # verify previously written chunks
+            if processed_chunks:
+                with open(input_path, "rb") as f_in:
+                    for idx in range(processed_chunks):
+                        chunk = f_in.read(chunk_size)
+                        if not chunk:
+                            raise ValueError(
+                                "Manifest exceeds input file length during resume"
+                            )
+                        dna_iter = encode_base4_direct(
+                            [chunk],
+                            add_parity=add_parity,
+                            k_value=k_value,
+                            parity_rule=parity_rule,
+                            encode_map=encode_map,
+                            stream=True,
+                        )
+                        dna_chunk = next(iter(dna_iter))
+                        expected = hashlib.sha256(dna_chunk.encode()).hexdigest()
+                        entry = manifest_lines[idx]
+                        if (
+                            entry["hash"] != expected
+                            or entry["offset"] != idx * chunk_size
+                        ):
+                            raise ValueError(
+                                f"Manifest hash mismatch at chunk {idx}"
+                            )
         manifest_file = open(manifest_path, mode, encoding="utf-8")
 
     start_offset = processed_chunks * chunk_size
@@ -51,8 +81,6 @@ def stream_encode_file(
                 if not chunk:
                     break
                 yield chunk
-
-    encode_map, _ = get_alphabet_maps(alphabet)
 
     total_len = 0
     line_width = 80
@@ -103,11 +131,30 @@ def stream_decode_file(
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
     manifest_file = None
     processed_chunks = 0
+    manifest_lines: list[dict[str, int | str]] = []
     if manifest_path:
         mode = "a" if resume else "w"
         if resume and os.path.exists(manifest_path):
             with open(manifest_path, "r", encoding="utf-8") as mf:
-                processed_chunks = sum(1 for _ in mf)
+                manifest_lines = [json.loads(line) for line in mf]
+            processed_chunks = len(manifest_lines)
+            if processed_chunks and os.path.exists(output_path):
+                with open(output_path, "rb") as verify_f:
+                    for idx in range(processed_chunks):
+                        chunk = verify_f.read(chunk_size)
+                        if not chunk:
+                            raise ValueError(
+                                "Manifest exceeds output file length during resume"
+                            )
+                        expected = hashlib.sha256(chunk).hexdigest()
+                        entry = manifest_lines[idx]
+                        if (
+                            entry["hash"] != expected
+                            or entry["offset"] != idx * chunk_size
+                        ):
+                            raise ValueError(
+                                f"Manifest hash mismatch at chunk {idx}"
+                            )
         manifest_file = open(manifest_path, mode, encoding="utf-8")
 
     _, decode_map = get_alphabet_maps(alphabet)

--- a/tests/test_streaming_resume.py
+++ b/tests/test_streaming_resume.py
@@ -110,3 +110,100 @@ def test_stream_decode_resume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert decoded.read_bytes() == data
     lines = [json.loads(line) for line in open(manifest)]
     assert len(lines) == 3
+
+
+def test_stream_encode_resume_integrity_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = os.urandom(150_000)
+    input_file = tmp_path / "in.bin"
+    encoded_file = tmp_path / "out.fasta"
+    input_file.write_bytes(data)
+    manifest = encoded_file.with_suffix(".stream.manifest")
+    header = "method=base4_direct input_file=in.bin"
+
+    count = 0
+    orig_encode = encode_base4_direct
+
+    def fail_after_one(*args: object, **kwargs: object) -> Iterator[str]:
+        nonlocal count
+        for chunk in orig_encode(*args, **kwargs):
+            count += 1
+            if count == 2:
+                raise RuntimeError("stop")
+            yield chunk
+
+    monkeypatch.setattr("genecoder.streaming.encode_base4_direct", fail_after_one)
+    with pytest.raises(RuntimeError):
+        stream_encode_file(
+            str(input_file),
+            str(encoded_file),
+            header=header,
+            chunk_size=50_000,
+            manifest_path=str(manifest),
+        )
+
+    lines = [json.loads(line) for line in manifest.open()]
+    lines[0]["hash"] = "0" * 64
+    manifest.write_text("\n".join(json.dumps(entry) for entry in lines) + "\n")
+
+    monkeypatch.setattr("genecoder.streaming.encode_base4_direct", orig_encode)
+    with pytest.raises(ValueError):
+        stream_encode_file(
+            str(input_file),
+            str(encoded_file),
+            header=header,
+            chunk_size=50_000,
+            manifest_path=str(manifest),
+            resume=True,
+        )
+
+
+def test_stream_decode_resume_integrity_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = os.urandom(120_000)
+    bin_file = tmp_path / "data.bin"
+    bin_file.write_bytes(data)
+    fasta = tmp_path / "data.fasta"
+    header = "method=base4_direct input_file=data.bin"
+    stream_encode_file(str(bin_file), str(fasta), header=header, chunk_size=40_000)
+
+    decoded = tmp_path / "decoded.bin"
+    manifest = decoded.with_suffix(".stream.manifest")
+
+    count = 0
+    orig_decode = decode_base4_direct
+
+    def fail_after_one(*args: object, **kwargs: object) -> Iterator[tuple[bytes, list[int]]]:
+        nonlocal count
+        for chunk, errs in orig_decode(*args, **kwargs):
+            count += 1
+            if count == 2:
+                raise RuntimeError("fail")
+            yield chunk, errs
+
+    monkeypatch.setattr("genecoder.streaming.decode_base4_direct", fail_after_one)
+    with pytest.raises(RuntimeError):
+        stream_decode_file(
+            str(fasta),
+            str(decoded),
+            chunk_size=40_000,
+            manifest_path=str(manifest),
+        )
+
+    with open(decoded, "r+b") as f:
+        first = f.read(1)
+        if first:
+            f.seek(0)
+            f.write(bytes([first[0] ^ 0x01]))
+
+    monkeypatch.setattr("genecoder.streaming.decode_base4_direct", orig_decode)
+    with pytest.raises(ValueError):
+        stream_decode_file(
+            str(fasta),
+            str(decoded),
+            chunk_size=40_000,
+            manifest_path=str(manifest),
+            resume=True,
+        )


### PR DESCRIPTION
## Summary
- verify previous chunks with manifest hashes when resuming streaming operations
- document the manifest behavior in the vertical slice guide
- test encode/decode resume integrity verification
- fix missing import in CLI decode and remove unused variable

## Testing
- `pre-commit run --files docs/vertical_slice.md src/genecoder/streaming.py src/genecoder/cli/decode.py tests/test_streaming_resume.py`
- `pytest tests/test_streaming_resume.py::test_stream_encode_resume_integrity_check -q`
- `pytest tests/test_streaming_resume.py::test_stream_decode_resume_integrity_check -q`


------
https://chatgpt.com/codex/tasks/task_e_6863080698cc8326858462efb6c03687