### PR TITLE
Add mirror toggle and helix streaming

### DIFF
--- a/docs/glossary.json
+++ b/docs/glossary.json
@@ -1,5 +1,6 @@
 {
   "GC content": "The percentage of guanine (G) and cytosine (C) bases in a DNA sequence. Balanced GC content (often around 40–60%) improves stability and processability.",
   "Homopolymer": "A run of identical nucleotides, e.g. 'AAAAA'. Long homopolymers can cause synthesis and sequencing errors.",
-  "Forward Error Correction (FEC)": "Techniques that add redundancy to encoded data so errors can be detected and corrected during decoding."
+  "Forward Error Correction (FEC)": "Techniques that add redundancy to encoded data so errors can be detected and corrected during decoding.",
+  "Mirror": "Output both the forward and reverse-complement DNA sequences."
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,3 +17,6 @@ A run of identical nucleotides, e.g. `AAAAA`. Long homopolymers can cause synthe
 
 ## Forward Error Correction (FEC)
 Techniques that add redundancy to encoded data so errors can be detected and corrected during decoding.
+
+## Mirror
+Output both the forward and reverse-complement DNA sequences.

--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -23,6 +23,10 @@ The application window contains three main tabs:
 3. **Helix View** – render the resulting DNA sequence in 3D. See the
    [Helix Frontend guide](helix_frontend.md) for viewer options.
 
+The Encode tab includes a **Mirror** checkbox to output the reverse-complement
+alongside the main sequence. Toggle this on to view both strands together in the
+Helix View.
+
 ![GUI screenshot](https://flet.dev/docs/images/screenshot.png)
 
 Use the buttons at the bottom of each tab to start the selected operation.

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -9,7 +9,6 @@ import os
 import random
 import re
 from pathlib import Path
-from dataclasses import dataclass
 
 
 from genecoder.encoders import decode_base4_direct, decode_gc_balanced, decode_triple_repeat
@@ -19,6 +18,7 @@ from genecoder.plugins import FEC_REGISTRY, SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from ..options import DecodingOptions
 from typing import Callable
 
 # Delay importing heavy security module until needed
@@ -470,7 +470,6 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
-    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -323,7 +323,7 @@ def process_single_encode(
                 from genecoder.helix_view import show_helix_ui
 
                 rc_seq = reverse_complement(final_encoded_dna_sequence)
-                show_helix_ui(final_encoded_dna_sequence, seq2=rc_seq)
+                show_helix_ui(final_encoded_dna_sequence, strand2_sequence=rc_seq)
             except Exception as exc:  # pragma: no cover - optional GUI
                 logger.warning("Could not launch helix viewer: %s", exc)
 

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -34,7 +34,8 @@ from genecoder.manifest import generate_manifest
 from genecoder.flet_helpers import parse_int_input
 from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix_ui
-from genecoder.formats import from_fasta
+from genecoder.formats import from_fasta, to_fasta
+from genecoder.cli.encode import reverse_complement
 from genecoder.glossary_tooltips import (
     load_glossary,
     load_glossary_full,
@@ -283,6 +284,12 @@ def main(page: ft.Page) -> None:
         tooltip=GLOSSARY.get("Forward Error Correction (FEC)"),
     )
 
+    mirror_checkbox: ft.Checkbox = ft.Checkbox(
+        label="Mirror",
+        value=False,
+        tooltip=GLOSSARY.get("Mirror"),
+    )
+
     encode_button: ft.ElevatedButton = ft.ElevatedButton("Encode")
 
     encode_status_text: ft.Text = ft.Text("", selectable=True)
@@ -433,14 +440,23 @@ def main(page: ft.Page) -> None:
                 page.update()
                 return
 
-            encode_hidden_fasta_content.value = result.fasta
-            encode_hidden_sequence.value = result.encoded_dna
-            encode_dna_snippet_text.value = result.encoded_dna[:200]
+            final_fasta = result.fasta
+            forward_seq = result.encoded_dna
+            if mirror_checkbox.value:
+                rc_seq = reverse_complement(forward_seq)
+                rc_header = result.fasta.splitlines()[0][1:] + " mirror=rc"
+                final_fasta += to_fasta(rc_seq, rc_header, line_width=80)
+            encode_hidden_fasta_content.value = final_fasta
+            encode_hidden_sequence.value = forward_seq
+            encode_dna_snippet_text.value = forward_seq[:200]
             if ws_clients:
-                async def _broadcast(msg: str) -> None:
-                    await asyncio.gather(*(c.send(msg) for c in ws_clients))
+                async def _stream_bases(seq: str, step: int = 50) -> None:
+                    for i in range(0, len(seq), step):
+                        chunk = seq[i : i + step]
+                        await asyncio.gather(*(c.send(chunk) for c in ws_clients))
+                        await asyncio.sleep(0)
 
-                asyncio.create_task(_broadcast(result.encoded_dna))
+                asyncio.create_task(_stream_bases(forward_seq))
             encode_save_button.visible = True
             manifest = generate_manifest(
                 os.path.basename(input_path), options, result.metrics
@@ -850,6 +866,7 @@ def main(page: ft.Page) -> None:
                             alphabet_dropdown,
                             ft.Row([parity_checkbox, k_value_input]),
                             fec_dropdown,
+                            mirror_checkbox,
                             ft.Row(
                                 [encode_button, encode_progress_ring]
                             ),  # Added progress ring
@@ -910,6 +927,7 @@ def main(page: ft.Page) -> None:
             parsed = from_fasta(encode_hidden_fasta_content.value)
             if parsed:
                 dna_seq = parsed[0][1]
+        rc_seq = reverse_complement(dna_seq) if mirror_checkbox.value else None
         helix_container.controls.clear()
         helix_container.controls.append(
             ft.Row([
@@ -930,10 +948,12 @@ def main(page: ft.Page) -> None:
         helix_container.controls.append(
             show_helix_ui(
                 dna_seq,
+                strand2_sequence=rc_seq,
                 animate=animate_checkbox.value,
                 zoom=zoom_slider.value,
                 colors=colors,
                 fps=fps_slider.value,
+                ws_url="ws://localhost:8765",
             )
         )
         page.update()

--- a/src/genecoder/helix_view.py
+++ b/src/genecoder/helix_view.py
@@ -380,6 +380,7 @@ def show_helix_ui(
     pulse: bool = False,
     pulse_speed: float = 2.0,
     fps: float = 60.0,
+    ws_url: str | None = None,
 ) -> flet_webview.WebView:
     """Return a ``WebView`` pointing at the React helix frontend.
 
@@ -413,6 +414,8 @@ def show_helix_ui(
         f"pulse_speed={pulse_speed}",
         f"fps={fps}",
     ]
+    if ws_url:
+        params.append(f"ws={quote(ws_url)}")
     if colors:
         color_str = ",".join(f"{b}:#{v:06x}" for b, v in colors.items())
         params.append(f"colors={quote(color_str)}")

--- a/web/helix-ui/src/App.jsx
+++ b/web/helix-ui/src/App.jsx
@@ -38,9 +38,12 @@ export default function App() {
 
   const [animate, setAnimate] = useState(params.get('animate') !== 'false');
   const [zoom] = useState(parseFloat(params.get('zoom') || '1'));
-  const seq = params.get('seq') || 'ACGT';
-  const seq2 = params.get('seq2') || complementSeq(seq);
-  const gcRatio = seq.split('').filter((b) => b === 'G' || b === 'C').length / seq.length;
+  const seqParam = params.get('seq') || 'ACGT';
+  const seq2Param = params.get('seq2');
+  const [sequence, setSequence] = useState(seqParam);
+  const [sequence2, setSequence2] = useState(seq2Param || complementSeq(seqParam));
+  const wsUrl = params.get('ws');
+  const gcRatio = sequence.split('').filter((b) => b === 'G' || b === 'C').length / sequence.length;
   const [showGC, setShowGC] = useState(params.get('gc') !== 'false');
   const [showRuns, setShowRuns] = useState(params.get('runs') !== 'false');
   const [showGCBars, setShowGCBars] = useState(params.get('gc_bars') === 'true');
@@ -56,6 +59,19 @@ export default function App() {
   useEffect(() => {
     applyGlossary();
   }, []);
+
+  useEffect(() => {
+    if (!wsUrl) return;
+    const ws = new WebSocket(wsUrl);
+    ws.addEventListener('message', (e) => {
+      const chunk = e.data;
+      setSequence((prev) => prev + chunk);
+      if (!seq2Param) {
+        setSequence2((prev) => prev + complementSeq(chunk));
+      }
+    });
+    return () => ws.close();
+  }, [wsUrl]);
 
   useEffect(() => {
     const width = mount.current.clientWidth;
@@ -74,8 +90,8 @@ export default function App() {
     controls.enableDamping = true;
 
     const group = new THREE.Group();
-    const bases = seq.split('');
-    const compBases = seq2.split('');
+    const bases = sequence.split('');
+    const compBases = sequence2.split('');
     const len = Math.min(bases.length, compBases.length);
     const runs = new Array(bases.length).fill(1);
     for (let i = 1; i < bases.length; i++) {
@@ -173,7 +189,7 @@ export default function App() {
       cancelAnimationFrame(frameId);
       renderer.dispose();
     };
-  }, [seq, seq2, animate, zoom, colors, showGC, showRuns, showGCBars, showRunBars, showPulses, pulseSpeed, showGauge, flashErrors]);
+  }, [sequence, sequence2, animate, zoom, colors, showGC, showRuns, showGCBars, showRunBars, showPulses, pulseSpeed, showGauge, flashErrors]);
 
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative' }}>


### PR DESCRIPTION
## Summary
- stream encoded DNA to the helix viewer over WebSocket
- allow mirror encoding from the GUI
- support `ws` param for the helix viewer
- add tooltips for the Mirror option
- update glossary and docs for mirror toggle
- fix decode CLI imports and remove unused variable

## Testing
- `pre-commit run --files src/genecoder/cli/decode.py src/genecoder/cli/encode.py src/genecoder/flet_app.py src/genecoder/helix_view.py web/helix-ui/src/App.jsx docs/glossary.json docs/glossary.md docs/gui_tutorial.md`


------
https://chatgpt.com/codex/tasks/task_e_6863080bf0e08326af7cfb1eec66a412