### PR TITLE
Fix CLI path sanitization

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -209,7 +209,8 @@ def process_single_encode(
     )
     try:
         if args.stream and args.method == "base4_direct" and args.fec is None:
-            header = f"method=base4_direct input_file={os.path.basename(input_file_path)}"
+            sanitized_name = os.path.basename(input_file_path.replace("\\", "/"))
+            header = f"method=base4_direct input_file={sanitized_name}"
             if args.add_parity:
                 header += f" parity_k={args.k_value} parity_rule={args.parity_rule}"
             from genecoder.streaming import stream_encode_file
@@ -290,7 +291,7 @@ def process_single_encode(
             checksum = compute_checksum(plaintext_data)
 
         options = build_encoding_options(args)
-        header_name = os.path.basename(input_file_path)
+        header_name = os.path.basename(input_file_path.replace("\\", "/"))
         if getattr(args, "file_type", None):
             stem = Path(header_name).stem
             header_name = f"{stem}.{args.file_type}"

--- a/tests/test_cli_encode.py
+++ b/tests/test_cli_encode.py
@@ -1,0 +1,54 @@
+import argparse
+from pathlib import Path
+
+from genecoder.cli.encode import process_single_encode
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from genecoder.formats import from_fasta
+
+
+def _encode_args(stream: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        method="base4_direct",
+        add_parity=False,
+        k_value=7,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        fec=None,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=3,
+        alphabet="base4",
+        stream=stream,
+        chunk_size=1024,
+        resume=False,
+        key=None,
+        encrypt=False,
+        checksum=False,
+        file_type=None,
+        mirror=False,
+        capsule=None,
+        export_csv=None,
+    )
+
+
+def test_process_single_encode_windows_path(tmp_path: Path) -> None:
+    input_file = tmp_path / "C:\\data\\file.txt"
+    input_file.write_text("hi")
+    output_file = tmp_path / "out.fasta"
+    process_single_encode(str(input_file), str(output_file), _encode_args())
+
+    records = from_fasta(output_file.read_text())
+    header = records[0][0]
+    assert "input_file=file.txt" in header
+    assert "\\" not in header
+
+
+def test_process_single_encode_windows_path_stream(tmp_path: Path) -> None:
+    input_file = tmp_path / "C:\\path\\seq.bin"
+    input_file.write_text("data")
+    output_file = tmp_path / "out_stream.fasta"
+    process_single_encode(str(input_file), str(output_file), _encode_args(stream=True))
+
+    records = from_fasta(output_file.read_text())
+    header = records[0][0]
+    assert "input_file=seq.bin" in header
+    assert "\\" not in header


### PR DESCRIPTION
## Summary
- normalize input file path in `process_single_encode`
- test that encode CLI headers strip Windows path separators

## Testing
- `ruff check src/genecoder/cli/encode.py tests/test_cli_encode.py --fix`
- `mypy --config-file mypy.ini tests/test_cli_encode.py`
- `pytest -q tests/test_cli_encode.py`


------
https://chatgpt.com/codex/tasks/task_e_686337257678832681e5e7e438405c1b