### PR TITLE
Handle redis-less API mode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,3 +265,14 @@ sequence in 3D with orbit controls, overlays for
 **pulses**, GC gauges and homopolymer bars along the helix. An *Animate* toggle
 and fullscreen button make the visualization interactive. The frontend lives
 under `web/helix-ui` and is loaded via a WebView in the GUI.
+
+## Web API
+
+Start the FastAPI server for browser-based access:
+
+```bash
+uvicorn web.main:app --reload
+```
+
+Rate limiting depends on Redis. Simply leave `GENECODER_REDIS_URL` unset to run
+without Redis; the API will work normally but requests won't be limited.

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -16,10 +16,8 @@ from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import decode_data_with_hamming
 from genecoder.plugins import FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
-from genecoder.options import DecodingOptions
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
-from ..options import DecodingOptions
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from ..options import DecodingOptions
 from typing import Callable
@@ -472,6 +470,7 @@ def _handle_command(args: argparse.Namespace) -> None:
             "Warning: Both --output-file and --output-dir provided for single input decode. Using --output-file."
         )
 
+    existing_outputs: set[str] = set()
     tasks = []
     for input_file_path in args.input_files:
         output_file_path = ""

--- a/tests/test_web_api_no_redis.py
+++ b/tests/test_web_api_no_redis.py
@@ -1,0 +1,25 @@
+import base64
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+import web.main as main
+
+client = TestClient(main.app)
+
+
+def test_chunk_endpoints_without_redis(tmp_path):
+    main.FastAPILimiter.redis = None
+    data = b"no redis"
+    payload = {
+        "file_id": "file",
+        "offset": 0,
+        "data": base64.b64encode(data).decode(),
+    }
+    r = client.post("/upload-chunk", json=payload)
+    assert r.status_code == 200
+    r2 = client.get("/download-chunk", params={"file_id": "file", "offset": 0})
+    assert r2.status_code == 200
+    assert base64.b64decode(r2.json()["data"]) == data

--- a/web/main.py
+++ b/web/main.py
@@ -239,8 +239,11 @@ class ChunkUploadRequest(BaseModel):  # type: ignore[misc]
 @app.post("/upload-chunk")  # type: ignore[misc]
 async def upload_chunk(
     req: ChunkUploadRequest,
-    _rl: None = Depends(rate_limit),
+    request: Request,
+    response: Response,
 ) -> dict[str, str]:
+    if FastAPILimiter.redis:
+        await rate_limit(request, response)
     base_dir = get_temp_dir() / "chunks" / req.file_id
     base_dir.mkdir(parents=True, exist_ok=True)
     chunk_bytes = base64.b64decode(req.data.encode("utf-8"), validate=True)
@@ -258,10 +261,13 @@ async def upload_chunk(
 async def download_chunk(
     file_id: str,
     offset: int,
-    _rl: None = Depends(rate_limit),
+    request: Request,
+    response: Response,
 ) -> dict[str, str]:
+    if FastAPILimiter.redis:
+        await rate_limit(request, response)
     chunk_path = get_temp_dir() / "chunks" / file_id / f"{offset}.chunk"
     if not chunk_path.is_file():
         raise HTTPException(status_code=404, detail="Chunk not found")
     data = chunk_path.read_bytes()
-    return {"offset": offset, "data": base64.b64encode(data).decode("utf-8")}
+    return {"offset": str(offset), "data": base64.b64encode(data).decode("utf-8")}


### PR DESCRIPTION
## Summary
- skip rate limiter when Redis isn't available
- document running the API without Redis
- test upload/download chunks with Redis disabled
- fix `existing_outputs` undefined in decode CLI

## Testing
- `ruff check web/main.py tests/test_web_api_no_redis.py src/genecoder/cli/decode.py`
- `mypy --config-file mypy.ini src`
- `pytest tests/test_web_api_no_redis.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686337260ee88326a9c343a0ec9ee3c9