### PR TITLE
Fix path handling in manifests and tests

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -472,6 +472,7 @@ def _handle_command(args: argparse.Namespace) -> None:
             "Warning: Both --output-file and --output-dir provided for single input decode. Using --output-file."
         )
 
+    existing_outputs: set[str] = set()
     tasks = []
     for input_file_path in args.input_files:
         output_file_path = ""

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -79,7 +79,7 @@ def run_encoding_pipeline(
     encode_map, _ = get_alphabet_maps(options.alphabet)
     # Normalize path separators to ensure the FASTA header does not contain
     # backslashes which can appear on Windows paths.
-    sanitized_name = os.path.basename(input_file_name.replace("\\", "/"))
+    sanitized_name = Path(input_file_name.replace("\\", "/")).name
     header_parts = [f"method={options.method}", f"input_file={sanitized_name}"]
 
     if options.fec == "hamming_7_4":

--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
 from typing import Any, Mapping
+from pathlib import Path
+import os
 
 REQUIRED_ENCODING_KEYS: set[str] = {"method"}
 
 
 def generate_manifest(
-    file_name: str,
+    file_name: str | os.PathLike[str],
     encoding_params: Any,
     metrics: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -30,8 +32,10 @@ def generate_manifest(
         missing = ", ".join(sorted(missing_keys))
         raise ValueError(f"Missing required encoding parameter(s): {missing}")
 
+    file_basename = os.path.basename(Path(file_name).as_posix())
+
     return {
-        "file": file_name,
+        "file": file_basename,
         "encoding_parameters": params,
         "metrics": dict(metrics),
     }

--- a/tests/test_capsule.py
+++ b/tests/test_capsule.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import os
 from tests.test_cli import run_cli_command
 from genecoder.cache_dna import read_capsule
 import pytest
@@ -33,7 +34,7 @@ def test_encode_capsule_contents(tmp_path: Path) -> None:
     data = json.loads(capsule_path.read_text())
     assert data["version"] == 1
     assert "method=base4_direct" in data["header"]
-    assert data["metadata"]["input_file"] == "msg.txt"
+    assert data["metadata"]["input_file"] == os.path.basename(input_file.as_posix())
     assert data["metadata"]["method"] == "base4_direct"
     assert isinstance(data["sequence"], str) and data["sequence"]
 

--- a/tests/test_cli_manifest.py
+++ b/tests/test_cli_manifest.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import os
 
 from tests.test_cli import run_cli_command
 
@@ -20,5 +21,5 @@ def test_cli_writes_manifest(tmp_path: Path) -> None:
     manifest = tmp_path / "data.txt.manifest.json"
     assert manifest.exists()
     data = json.loads(manifest.read_text())
-    assert data["file"] == "data.txt"
+    assert data["file"] == os.path.basename(input_file.as_posix())
     assert data["encoding_parameters"]["method"] == "base4_direct"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from genecoder.manifest import generate_manifest
 from genecoder.cli import EncodingOptions
+from pathlib import Path
+import os
 
 
 def test_generate_manifest_basic() -> None:
@@ -18,8 +20,9 @@ def test_generate_manifest_basic() -> None:
         max_homopolymer=3,
     )
     metrics = {"dna_length": 10}
-    manifest = generate_manifest("file.txt", opts, metrics)
-    assert manifest["file"] == "file.txt"
+    file_path = Path("dir/sub") / "file.txt"
+    manifest = generate_manifest(file_path, opts, metrics)
+    assert manifest["file"] == os.path.basename(file_path.as_posix())
     assert manifest["encoding_parameters"]["method"] == "base4_direct"
     assert manifest["metrics"]["dna_length"] == 10
 
@@ -36,8 +39,9 @@ def test_generate_manifest_from_mapping() -> None:
         "max_homopolymer": 3,
     }
     metrics = {"dna_length": 20, "num_records": 1}
-    manifest = generate_manifest("data.bin", opts, metrics)
-    assert manifest["file"] == "data.bin"
+    file_path = Path("dir") / "data.bin"
+    manifest = generate_manifest(file_path, opts, metrics)
+    assert manifest["file"] == os.path.basename(file_path.as_posix())
     assert manifest["encoding_parameters"]["method"] == "huffman"
     assert manifest["metrics"]["num_records"] == 1
 


### PR DESCRIPTION
## Summary
- normalize filenames in `generate_manifest`
- sanitize input filenames with `Path` in CLI encode
- initialize `existing_outputs` set for CLI decode
- update tests to use `Path` for name comparisons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686337258834832681ad5f80c8c7f827