### PR TITLE
Add external simulator wrappers

### DIFF
--- a/configs/illumina.yml
+++ b/configs/illumina.yml
@@ -1,0 +1,1 @@
+error_rate: 0.05

--- a/configs/nanopore.yml
+++ b/configs/nanopore.yml
@@ -1,0 +1,1 @@
+error_rate: 0.05

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -45,6 +45,7 @@ def register_builtin_plugins() -> None:
             "genecoder.channel_sim",
             "genecoder.error_simulation",
             "genecoder.simulators.illumina",
+            "genecoder.simulators.nanopore",
             "genecoder.simulators.illumina_profile",
             "genecoder.simulators.adv_nanopore",
             "genecoder.simulators.replication",

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -19,9 +19,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.options import DecodingOptions
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
-from ..options import DecodingOptions
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-from ..options import DecodingOptions
 from typing import Callable
 
 # Delay importing heavy security module until needed
@@ -473,6 +471,7 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
+    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -8,9 +8,10 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..channels.base import BaseChannel
 from ..error_simulation import introduce_errors
+from ..nanopore_sim import simulate_d2sim
 from . import register_simulator as _register_simulator
 
-__all__ = ["IlluminaChannel", "register"]
+__all__ = ["IlluminaChannel", "IlluminaD2SimChannel", "register"]
 
 
 class IlluminaChannel(BaseSimulator):
@@ -47,7 +48,18 @@ class IlluminaChannel(BaseSimulator):
         )
 
 
+class IlluminaD2SimChannel(BaseChannel):
+    """Wrapper using the external ``d2sim`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
 def register(
     registrar: Callable[[str, BaseChannel], None] = _register_simulator,
 ) -> None:
     registrar("illumina", IlluminaChannel())
+    registrar("illumina_d2sim", IlluminaD2SimChannel())

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -1,0 +1,27 @@
+"""Wrapper for the optional d2sim nanopore simulator."""
+from __future__ import annotations
+
+from typing import Callable
+
+from ..random_utils import make_rng
+from ..nanopore_sim import simulate_d2sim
+from ..channels.base import BaseChannel
+from . import register_simulator as _register_simulator
+
+__all__ = ["NanoporeChannel", "register"]
+
+
+class NanoporeChannel(BaseChannel):
+    """Channel that delegates to :mod:`d2sim` if installed."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
+def register(
+    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+) -> None:
+    registrar("nanopore_d2sim", NanoporeChannel())

--- a/tests/test_cli_simulator_selection.py
+++ b/tests/test_cli_simulator_selection.py
@@ -4,7 +4,12 @@ from tests.test_cli import run_cli_command
 
 import pytest
 
-@pytest.mark.parametrize("sim_name", ["illumina", "adv_nanopore"])
+@pytest.mark.parametrize("sim_name", [
+    "illumina",
+    "adv_nanopore",
+    "illumina_d2sim",
+    "nanopore_d2sim",
+])
 def test_cli_decode_with_builtin_simulator(tmp_path: Path, sim_name: str):
     env = os.environ.copy()
     src_path = Path(__file__).resolve().parent.parent / "src"


### PR DESCRIPTION
## Summary
- add new Illumina and Nanopore simulator wrappers
- register Nanopore wrapper as built-in
- expose new simulators in CLI tests
- provide example configs for the new simulators
- restore variable for duplicate output handling

## Testing
- `ruff check .`
- `pytest tests/test_cli_simulator_selection.py::test_cli_decode_with_builtin_simulator -q`
- `pytest tests/test_cli_decode.py::test_cli_decode_duplicate_output_names -q`


------
https://chatgpt.com/codex/tasks/task_e_6863375f604c832686347bf33e80df69