### PR TITLE
Fix GUI smoke tests and update skip logic

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -107,7 +107,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry install --with gui,web,dev --extras ldpc --no-interaction --no-root
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          poetry.bat install --with gui,web,dev --extras ldpc --no-interaction --no-root
+        else
+          poetry install --with gui,web,dev --extras ldpc --no-interaction --no-root
+        fi
 
     - name: Install example plugins
       run: |
@@ -240,13 +244,13 @@ jobs:
       shell: bash
       run: |
         if command -v timeout >/dev/null 2>&1; then
-          timeout 10 python -m genecoder.flet_app || true
+          timeout 20 python -m genecoder.flet_app || true
         elif command -v gtimeout >/dev/null 2>&1; then
-          gtimeout 10 python -m genecoder.flet_app || true
+          gtimeout 20 python -m genecoder.flet_app || true
         else
           python -m genecoder.flet_app &
           PID=$!
-          sleep 10
+          sleep 20
           kill $PID || true
         fi
 
@@ -254,9 +258,9 @@ jobs:
       shell: bash
       run: |
         if command -v timeout >/dev/null 2>&1; then
-          timeout 10 poetry run uvicorn web.main:app --port 8000 &
+          timeout 20 poetry run uvicorn web.main:app --port 8000 &
         elif command -v gtimeout >/dev/null 2>&1; then
-          gtimeout 10 poetry run uvicorn web.main:app --port 8000 &
+          gtimeout 20 poetry run uvicorn web.main:app --port 8000 &
         else
           poetry run uvicorn web.main:app --port 8000 &
         fi

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -19,9 +19,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.options import DecodingOptions
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
-from ..options import DecodingOptions
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-from ..options import DecodingOptions
 from typing import Callable
 
 # Delay importing heavy security module until needed
@@ -473,6 +471,7 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
 
     tasks = []
+    existing_outputs: set[str] = set()
     for input_file_path in args.input_files:
         output_file_path = ""
         if args.output_file and num_input_files == 1:

--- a/src/genecoder/glossary_tooltips.py
+++ b/src/genecoder/glossary_tooltips.py
@@ -11,8 +11,9 @@ from typing import Dict, List, cast
 import flet as ft
 
 
-_GLOSSARY_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.json"
-_GLOSSARY_MD_PATH = Path(__file__).resolve().parent.parent / "docs" / "glossary.md"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_GLOSSARY_PATH = PROJECT_ROOT / "docs" / "glossary.json"
+_GLOSSARY_MD_PATH = PROJECT_ROOT / "docs" / "glossary.md"
 
 
 def load_glossary() -> Dict[str, str]:

--- a/tests/test_flet_app_interactions.py
+++ b/tests/test_flet_app_interactions.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,8 @@ ft = pytest.importorskip("flet")
 
 
 def _setup_flet(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(sys.modules, "websockets", None)
+    asyncio.set_event_loop(asyncio.new_event_loop())
     ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
     ft.colors = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
     for name in [

--- a/tests/test_flet_app_startup.py
+++ b/tests/test_flet_app_startup.py
@@ -1,4 +1,5 @@
 
+import asyncio
 import pytest
 
 ft = pytest.importorskip("flet")
@@ -16,6 +17,7 @@ class _DummyPage:
 
 
 def test_flet_app_main_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.set_event_loop(asyncio.new_event_loop())
     called = False
 
     def fake_app(*, target, view=ft.AppView.FLET_APP, **kwargs):

--- a/tests/test_importorskip_behavior.py
+++ b/tests/test_importorskip_behavior.py
@@ -13,7 +13,16 @@ def _simulate_missing(module: str, missing: str, monkeypatch: pytest.MonkeyPatch
             return None
         return real_find_spec(name, *args, **kwargs)
 
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name: str, globals=None, locals=None, fromlist=(), level=0):
+        if name == missing:
+            raise ModuleNotFoundError
+        return real_import(name, globals, locals, fromlist, level)
+
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
     sys.modules.pop(module, None)
     with pytest.raises(pytest.skip.Exception):
         importlib.import_module(module)


### PR DESCRIPTION
## Summary
- fix missing `existing_outputs` variable in CLI decode logic
- load glossary from project root
- set up event loop and disable websockets during GUI tests
- ensure flet app startup test sets event loop
- patch import skipping test to emulate missing modules

## Testing
- `pre-commit run ruff --files src/genecoder/cli/decode.py src/genecoder/glossary_tooltips.py tests/test_flet_app_interactions.py tests/test_flet_app_startup.py tests/test_importorskip_behavior.py`
- `pre-commit run mypy --files src/genecoder/cli/decode.py src/genecoder/glossary_tooltips.py tests/test_flet_app_interactions.py tests/test_flet_app_startup.py tests/test_importorskip_behavior.py`
- `python scripts/check_glossary_terms.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686337619374832681ce123b658ebbf3