### PR TITLE
Add decode simulator fallback tests

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -19,6 +19,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+from ..options import DecodingOptions
 from typing import Callable
 
 # Delay importing heavy security module until needed

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Any, Iterable
 from types import ModuleType
 
 from .channels.base import BaseChannel
-from importlib.metadata import entry_points
+from importlib.metadata import entry_points, EntryPoints
 import importlib
 import logging
 import pkgutil
@@ -75,7 +75,7 @@ def load_plugins() -> None:
 
     failures: list[str] = []
 
-    groups = {
+    groups: dict[str, tuple[Callable[..., Any], str]] = {
         "genecoder.plugins": (register_codec, "codec"),
         "genecoder.fec": (register_fec, "FEC"),
         "genecoder.simulators": (register_simulator, "simulator"),
@@ -88,7 +88,7 @@ def load_plugins() -> None:
             if hasattr(eps, "select"):
                 entries = eps.select(group=group)
             elif isinstance(eps, dict):
-                entries = eps.get(group, [])
+                entries = eps.get(group, EntryPoints())
             else:
                 entries = [ep for ep in eps if getattr(ep, "group", None) == group]
         _load_and_register(entries, registrar, kind, failures)

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -1,5 +1,6 @@
 import argparse
 import base64
+import os
 import pytest
 
 from pathlib import Path
@@ -91,3 +92,110 @@ def test_cli_decode_duplicate_output_names(tmp_path: Path) -> None:
     out2 = tmp_path / "dup_1.bin"
     assert out1.read_bytes() == b"one"
     assert out2.read_bytes() == b"two"
+
+
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+def test_cli_decode_missing_simulator(tmp_path: Path, sim_name: str) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("missing test")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+    fasta_file = tmp_path / "in.txt.fasta"
+    assert fasta_file.exists()
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            sim_name,
+        ],
+        env=env,
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "in.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text().startswith("missing")
+
+
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+def test_cli_decode_simulator_failure(tmp_path: Path, sim_name: str) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / sim_name
+    script.write_text("#!/bin/sh\nexit 1\n")
+    script.chmod(0o755)
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("failure test")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+    fasta_file = tmp_path / "in.txt.fasta"
+    assert fasta_file.exists()
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            sim_name,
+        ],
+        env=env,
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "in.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text().startswith("failure")


### PR DESCRIPTION
## Summary
- test CLI decode fallback when simulators are missing or fail
- fix missing `DecodingOptions` import in CLI
- make plugin loader typing mypy compliant

## Testing
- `ruff check tests/test_cli_decode.py src/genecoder/cli/decode.py src/genecoder/plugins.py`
- `mypy --config-file mypy.ini src`
- `pytest tests/test_cli_decode.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68644d4ca9ec8326a77850e0eebe830d