### PR TITLE
Add drag-and-drop and helix viewer auto-open

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
+* **Drag-and-drop file selection** on the Encode tab.
 * **CSV export for synthesis** with length and [homopolymer](glossary.md#homopolymer) validation. The analysis command warns when sequences violate these constraints.
 * **Mirror encoding** via `--mirror` to output forward and reverse-complement sequences.
 
@@ -21,6 +22,8 @@ content colouring and homopolymer highlighting are shown both on the helix and
 via an overlay canvas. Animated pulses can move along the helix to illustrate
 progress. The frontend is loaded on demand so it works in both desktop and web
 deployments.
+Encoding results automatically trigger the viewer so you can inspect the output
+sequence right away.
 
 ![Visualizer tab GUI](https://flet.dev/docs/images/screenshot.png)
 

--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -26,6 +26,8 @@ The application window contains three main tabs:
 The Encode tab includes a **Mirror** checkbox to output the reverse-complement
 alongside the main sequence. Toggle this on to view both strands together in the
 Visualizer.
+Drag files onto the Encode tab or use the **Browse File** button to select an
+input file.
 
 ![GUI screenshot](https://flet.dev/docs/images/screenshot.png)
 

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -222,6 +222,19 @@ def main(page: ft.Page) -> None:
             allow_multiple=False, dialog_title="Select Input File for Encoding"
         )
 
+    def on_encode_file_drop(e: ft.ControlEvent) -> None:
+        """Handle files dropped onto the encode drop zone."""
+        files = getattr(e, "files", None)
+        if files and len(files) > 0:
+            selected_encode_input_file_path.current = files[0].path
+            encode_selected_input_file_text.value = (
+                f"Selected: {os.path.basename(files[0].name)}"
+            )
+        else:
+            selected_encode_input_file_path.current = ""
+            encode_selected_input_file_text.value = "File drop cancelled."
+        page.update()
+
     icons = getattr(ft, "icons", ft.Icons)
     colors = getattr(ft, "colors", ft.Colors)
     encode_browse_button: ft.ElevatedButton = ft.ElevatedButton(
@@ -229,6 +242,23 @@ def main(page: ft.Page) -> None:
         icon=getattr(icons, "FOLDER_OPEN", None),
         on_click=_open_encode_file_picker,
     )
+
+    DropTarget = getattr(ft, "DropTarget", getattr(ft, "DragTarget", None))
+    encode_drop_zone = None
+    if DropTarget:
+        drop_kwargs = {
+            "on_drop" if hasattr(DropTarget, "on_drop") else "on_accept": on_encode_file_drop
+        }
+        encode_drop_zone = DropTarget(
+            content=ft.Container(
+                ft.Text("Drop file"),
+                width=150,
+                height=80,
+                border=ft.border.all(1, ft.colors.BLUE_GREY_200),
+                alignment=ft.alignment.center,
+            ),
+            **drop_kwargs,
+        )
 
     method_dropdown: ft.Dropdown = ft.Dropdown(
         label="Encoding Method",
@@ -522,6 +552,10 @@ def main(page: ft.Page) -> None:
                 status_prefix + " " if status_prefix else ""
             ) + "Encoding successful! Click 'Save Encoded FASTA...' to save."
             encode_status_text.color =  colors.GREEN_700
+
+            refresh_helix_view()
+            app_tabs.selected_index = 3
+            page.update()
 
         except FileNotFoundError:
             encode_status_text.value = f"Error: Input file '{input_path}' not found."
@@ -869,6 +903,7 @@ def main(page: ft.Page) -> None:
                             ft.Row(
                                 [encode_browse_button, encode_selected_input_file_text]
                             ),
+                            encode_drop_zone if encode_drop_zone else ft.Container(),
                             method_dropdown,
                             alphabet_dropdown,
                             ft.Row([parity_checkbox, k_value_input]),

--- a/tests/test_flet_app_interactions.py
+++ b/tests/test_flet_app_interactions.py
@@ -34,7 +34,7 @@ def _setup_flet(monkeypatch: pytest.MonkeyPatch):
         if hasattr(ft.alignment, attr):
             setattr(ft.alignment, attr.upper(), getattr(ft.alignment, attr))
 
-    captured: dict[str, ft.ElevatedButton] = {}
+    captured: dict[str, ft.Control] = {}
     orig_button = ft.ElevatedButton
 
     def capture_button(*args, **kwargs):
@@ -46,6 +46,18 @@ def _setup_flet(monkeypatch: pytest.MonkeyPatch):
         return btn
 
     monkeypatch.setattr(ft, "ElevatedButton", capture_button)
+    drop_class = getattr(ft, "DropTarget", getattr(ft, "DragTarget", None))
+    if drop_class:
+        orig_drop = drop_class
+
+        def capture_drop(*args, **kwargs):
+            if "on_drop" in kwargs and not hasattr(orig_drop, "on_drop"):
+                kwargs.pop("on_drop")
+            dt = orig_drop(*args, **kwargs)
+            captured["drop"] = dt
+            return dt
+
+        monkeypatch.setattr(ft, drop_class.__name__, capture_drop)
     orig_tab = ft.Tab
     monkeypatch.setattr(ft, "Tab", lambda *a, disabled=False, **k: orig_tab(*a, **k))
 
@@ -163,6 +175,28 @@ def test_encode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
     asyncio.run(encode_cb(None))
     assert "bad input" in enc_vars["encode_status_text"].value
+
+
+def test_drop_zone_updates_selected_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    drop = captured.get("drop")
+    assert drop is not None
+    handler = getattr(drop, "on_drop", None) or getattr(drop, "on_accept", None)
+    assert handler is not None
+    vars_ = {n: c.cell_contents for n, c in zip(handler.__code__.co_freevars, handler.__closure__)}
+
+    file_path = tmp_path / "in.bin"
+    file_path.write_bytes(b"x")
+    evt = type("Evt", (), {
+        "files": [ft.core.file_picker.FilePickerFile(name=file_path.name, path=str(file_path), size=1, id=0)]
+    })()
+
+    handler(evt)
+    assert "Selected" in vars_["encode_selected_input_file_text"].value
 
 
 def test_decode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- support DropTarget/DragTarget file dropping on the Encode tab
- automatically open Helix visualizer after encoding completes
- document drag-and-drop usage
- update GUI feature list
- extend Flet GUI tests for drop zone

## Testing
- `ruff check .`
- `pytest -q tests/test_flet_app_interactions.py tests/test_flet_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68644d491fac8326a113717a5b9725ff