### PR TITLE
Refactor CLI threadpool handling

### DIFF
--- a/src/genecoder/cli/common.py
+++ b/src/genecoder/cli/common.py
@@ -1,0 +1,55 @@
+"""Helper utilities shared across CLI modules."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import logging
+import os
+from typing import Callable, Sequence, TypeVar
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+def run_tasks(
+    tasks: Sequence[tuple[str, str, argparse.Namespace]],
+    worker: Callable[[str, str, argparse.Namespace], T],
+    *,
+    description: str,
+    collect_results: bool = False,
+) -> list[T]:
+    """Execute tasks concurrently when there are multiple inputs."""
+
+    results: list[T] = []
+    num_tasks = len(tasks)
+    if num_tasks > 1:
+        logger.info(
+            "Starting batch %s for %d files using ThreadPoolExecutor...",
+            description,
+            num_tasks,
+        )
+        cpu_count = os.cpu_count() or 1
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(8, cpu_count + 4)
+        ) as executor:
+            future_to_task = {
+                executor.submit(worker, t[0], t[1], t[2]): t for t in tasks
+            }
+            for future in concurrent.futures.as_completed(future_to_task):
+                try:
+                    res = future.result()
+                    if collect_results:
+                        results.append(res)
+                except Exception:
+                    logger.exception(
+                        "A file %s task generated an exception", description
+                    )
+        logger.info("\nBatch %s finished.", description)
+    else:
+        if tasks:
+            res = worker(tasks[0][0], tasks[0][1], tasks[0][2])
+            if collect_results:
+                results.append(res)
+    return results

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
 import logging
 import os
 import random
@@ -18,6 +17,8 @@ from genecoder.plugins import FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
+from ..options import DecodingOptions
+from .common import run_tasks
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from typing import Callable
 
@@ -509,23 +510,5 @@ def _handle_command(args: argparse.Namespace) -> None:
         existing_outputs.add(output_file_path)
         tasks.append((input_file_path, output_file_path, args))
 
-    if num_input_files > 1:
-        logger.info(
-            f"Starting batch decoding for {num_input_files} files using ThreadPoolExecutor..."
-        )
-        cpu_count = os.cpu_count() or 1
-        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, cpu_count + 4)) as executor:
-            futures_list = [
-                executor.submit(process_single_decode, task[0], task[1], task[2])
-                for task in tasks
-            ]
-            for decode_future in concurrent.futures.as_completed(futures_list):
-                try:
-                    decode_future.result()
-                except Exception:
-                    logger.exception("A file decoding task generated an exception")
-        logger.info("\nBatch decoding finished.")
-    else:
-        if tasks:
-            process_single_decode(tasks[0][0], tasks[0][1], tasks[0][2])
+    run_tasks(tasks, process_single_decode, description="decoding")
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
 import csv
 import json
 import logging
@@ -25,6 +24,7 @@ from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
+from .common import run_tasks
 from typing import Callable
 
 _COMPLEMENT_MAP = str.maketrans("ACGTacgt", "TGCAtgca")
@@ -611,24 +611,9 @@ def _handle_command(args: argparse.Namespace) -> None:
             continue
         tasks.append((input_file_path, output_file_path, args))
 
-    if num_input_files > 1:
-        logger.info(f"Starting batch encoding for {num_input_files} files using ThreadPoolExecutor...")
-        cpu_count = os.cpu_count() or 1
-        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, cpu_count + 4)) as executor:
-            future_to_file = {executor.submit(process_single_encode, t[0], t[1], t[2]): t[0] for t in tasks}
-            for future in concurrent.futures.as_completed(future_to_file):
-                try:
-                    res = future.result()
-                    if args.export_csv and res:
-                        csv_rows.append(res)
-                except Exception:
-                    logger.exception("A file processing task generated an exception")
-        logger.info("\nBatch encoding finished.")
-    else:
-        if tasks:
-            res = process_single_encode(tasks[0][0], tasks[0][1], tasks[0][2])
-            if args.export_csv and res:
-                csv_rows.append(res)
+    results = run_tasks(tasks, process_single_encode, description="encoding", collect_results=True)
+    if args.export_csv:
+        csv_rows.extend([res for res in results if res])
 
     if args.export_csv and csv_rows:
         os.makedirs(os.path.dirname(args.export_csv) or ".", exist_ok=True)


### PR DESCRIPTION
## Summary
- centralize ThreadPoolExecutor logic for CLI commands
- use new helper in encode/decode modules

## Testing
- `ruff check src/genecoder/cli/common.py src/genecoder/cli/encode.py src/genecoder/cli/decode.py`
- `pytest -q tests/test_cli_encode.py tests/test_cli_decode.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68644d3c0f0c83268d56f61653aa95e2