### PR TITLE
Add DropTarget visualizer test

### DIFF
--- a/tests/test_flet_gui.py
+++ b/tests/test_flet_gui.py
@@ -1,4 +1,7 @@
 import pytest
+import json
+from pathlib import Path
+from flet.core.control_event import ControlEvent
 
 ft = pytest.importorskip("flet")
 ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
@@ -73,3 +76,46 @@ def test_glossary_modal_text_opens_dialog() -> None:
     assert page.dialog.open is True
     assert page.dialog.title.value == "GC content"
     assert page.dialog.content.value == "long definition"
+
+
+def test_drop_target_invokes_visualizer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
+    ft.colors = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
+
+    page = _DummyPage()
+    monkeypatch.setattr(ft, "app", lambda *, target, view=ft.AppView.FLET_APP, **__: target(page))
+
+    captured_slider: dict[str, ft.Slider] = {}
+    orig_slider = ft.Slider
+
+    def capture_slider(*args, **kwargs):
+        slider = orig_slider(*args, **kwargs)
+        if kwargs.get("divisions") == 15 and kwargs.get("max") == 2.0:
+            captured_slider["zoom"] = slider
+        return slider
+
+    monkeypatch.setattr(ft, "Slider", capture_slider)
+    monkeypatch.setattr("genecoder.flet_app.show_helix_ui", lambda *_, **__: calls.append(True))
+    from genecoder import flet_app
+    calls: list[bool] = []
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    picker: ft.FilePicker = page.overlay[0]
+    picker_vars = {n: c.cell_contents for n, c in zip(picker.on_result.__code__.co_freevars, picker.on_result.__closure__)}
+
+    refresh_fn = captured_slider["zoom"].on_change
+    refresh_vars = {n: c.cell_contents for n, c in zip(refresh_fn.__code__.co_freevars, refresh_fn.__closure__)}
+
+    fasta = tmp_path / "seq.fasta"
+    fasta.write_text(">seq\nACGT")
+    data = json.dumps({"files": [{"name": fasta.name, "path": str(fasta), "size": fasta.stat().st_size, "id": 1}]})
+    event = ft.FilePickerResultEvent(ControlEvent("x", "y", data, picker, page))
+    picker.on_result(event)
+
+    assert picker_vars["encode_selected_input_file_text"].value.startswith("Selected: ")
+
+    refresh_vars["encode_hidden_fasta_content"].value = fasta.read_text()
+    refresh_fn(None)
+
+    assert calls


### PR DESCRIPTION
## Summary
- extend `test_flet_gui` with DropTarget simulation
- verify the selected file text updates and the helix UI is shown

## Testing
- `ruff check tests/test_flet_gui.py`
- `pytest -q tests/test_flet_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_68644d4d7f50832694dd2199a8994979