### PR TITLE
Add regression tests and enforce Ruff failures

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -131,6 +131,9 @@ jobs:
         assert "example" in plugins.SIMULATOR_REGISTRY, "simulator not registered"
         PY
 
+    - name: Run ruff lint
+      run: ruff check --exit-non-zero-on-fix .
+
     - name: Restore pre-commit cache
       id: precommit-cache
       uses: actions/cache/restore@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.4.4
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--exit-non-zero-on-fix"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.1
     hooks:

--- a/tests/test_benchmark_modules.py
+++ b/tests/test_benchmark_modules.py
@@ -1,0 +1,22 @@
+import re
+import benchmarks.error_rate as error_rate
+import benchmarks.throughput as throughput
+
+
+def test_error_rate_main(monkeypatch, capsys):
+    monkeypatch.setattr(error_rate, "DATA_SIZE", 10)
+    monkeypatch.setattr(error_rate, "encode_base4_direct", lambda d: "A" * (len(d) * 4))
+    monkeypatch.setattr(error_rate, "decode_base4_direct", lambda s: (b"\x00" * (len(s) // 4), None))
+    monkeypatch.setattr(error_rate, "introduce_errors", lambda s, substitution_prob=0.0: s)
+    error_rate.main()
+    out = capsys.readouterr().out
+    assert re.search(r"BER:", out)
+
+
+def test_throughput_main(monkeypatch, capsys):
+    monkeypatch.setattr(throughput, "DATA_SIZE", 10)
+    monkeypatch.setattr(throughput, "encode_base4_direct", lambda d: "A" * (len(d) * 4))
+    monkeypatch.setattr(throughput, "decode_base4_direct", lambda s: b"" )
+    throughput.main()
+    out = capsys.readouterr().out
+    assert "encode:" in out and "decode:" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,6 +396,36 @@ def test_simulate_errors_command(temp_dir: Path, small_fasta_file: Path):
     assert new_seq != original_seq
 
 
+def test_simulate_errors_missing_input(temp_dir: Path) -> None:
+    out_file = temp_dir / "corrupted.fasta"
+    cmd_args = [
+        "simulate-errors",
+        "--input-file",
+        str(temp_dir / "nofile.fasta"),
+        "--output-file",
+        str(out_file),
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode != 0
+    assert "not found" in result.stderr.lower()
+
+
+def test_simulate_errors_unknown_simulator(temp_dir: Path, small_fasta_file: Path) -> None:
+    out_file = temp_dir / "corrupt.fasta"
+    cmd_args = [
+        "simulate-errors",
+        "--input-file",
+        str(small_fasta_file),
+        "--output-file",
+        str(out_file),
+        "--simulator",
+        "bogus",
+    ]
+    result = run_cli_command(cmd_args)
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr.lower()
+
+
 def test_invalid_fec_none_choice(temp_dir: Path):
     """Passing '--fec None' should result in an argparse error."""
     input_file = temp_dir / "invalid.txt"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -60,3 +60,45 @@ def test_decode_html_report(tmp_path: Path) -> None:
     ])
     assert result.returncode == 0
     assert "<h1>Decoding Report</h1>" in out_file.read_text()
+
+
+def test_cli_report_encode_stdout(tmp_path: Path) -> None:
+    enc = EncodeResult(
+        fasta=">seq\nACGT\n",
+        encoded_dna="ACGT",
+        metrics={"gc": 0.5},
+        info_messages=["ok"],
+    )
+    json_path = tmp_path / "enc.json"
+    json_path.write_text(json.dumps(enc.__dict__))
+    result = run_cli_command([
+        "report",
+        "--input-json",
+        str(json_path),
+        "--type",
+        "encode",
+    ])
+    assert result.returncode == 0
+    assert "# Encoding Report" in result.stdout
+
+
+def test_cli_report_decode_stdout(tmp_path: Path) -> None:
+    dec = DecodeResult(decoded_bytes=b"abc", status_message="ok", fec_info="none")
+    dec_dict = {
+        "decoded_bytes": base64.b64encode(dec.decoded_bytes).decode(),
+        "status_message": dec.status_message,
+        "fec_info": dec.fec_info,
+    }
+    json_path = tmp_path / "dec.json"
+    json_path.write_text(json.dumps(dec_dict))
+    result = run_cli_command([
+        "report",
+        "--input-json",
+        str(json_path),
+        "--type",
+        "decode",
+        "--format",
+        "html",
+    ])
+    assert result.returncode == 0
+    assert "<h1>Decoding Report</h1>" in result.stdout

--- a/tests/test_simulators_additional.py
+++ b/tests/test_simulators_additional.py
@@ -52,3 +52,37 @@ def test_replication_identity(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "3")
     channel = ReplicationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
     assert channel.simulate("GGCC") == "GGCC"
+
+
+def test_replication_all_deleted(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "4")
+    channel = ReplicationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=1.0)
+    assert channel.simulate("ATGC") == ""
+
+
+def test_replication_empty_input() -> None:
+    channel = ReplicationSimulator()
+    assert channel.simulate("") == ""
+
+
+def test_transcription_all_insertions(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "5")
+    channel = TranscriptionSimulator(substitution_rate=0.0, insertion_rate=1.0, deletion_rate=0.0)
+    result = channel.simulate("AT")
+    assert len(result) == 4
+    assert result.startswith("A")
+
+
+def test_transcription_empty_sequence() -> None:
+    channel = TranscriptionSimulator()
+    assert channel.simulate("") == ""
+
+
+def test_translation_incomplete_codon() -> None:
+    channel = TranslationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)
+    assert channel.simulate("AUGGC") == "M"
+
+
+def test_translation_all_deleted() -> None:
+    channel = TranslationSimulator(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=1.0)
+    assert channel.simulate("AUGGCU") == ""


### PR DESCRIPTION
## Summary
- make Ruff lint step fail on fixes in CI
- enforce Ruff fix failures in pre-commit
- add CLI regression tests
- add benchmark module tests
- cover edge cases for replication, transcription and translation simulators

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml .pre-commit-config.yaml tests/test_cli.py tests/test_reports.py tests/test_simulators_additional.py tests/test_benchmark_modules.py`
- `pytest tests/test_cli.py::test_simulate_errors_missing_input tests/test_cli.py::test_simulate_errors_unknown_simulator tests/test_reports.py::test_cli_report_encode_stdout tests/test_reports.py::test_cli_report_decode_stdout tests/test_benchmark_modules.py tests/test_simulators_additional.py::test_replication_all_deleted tests/test_simulators_additional.py::test_replication_empty_input tests/test_simulators_additional.py::test_transcription_all_insertions tests/test_simulators_additional.py::test_transcription_empty_sequence tests/test_simulators_additional.py::test_translation_incomplete_codon tests/test_simulators_additional.py::test_translation_all_deleted -q`

------
https://chatgpt.com/codex/tasks/task_e_6864927d9fdc832697999c9b7808cecc