### PR TITLE
Fix websocket log test

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -20,9 +20,7 @@ from genecoder.utils import get_alphabet_maps
 from ..options import DecodingOptions
 from .common import run_tasks
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-from ..options import DecodingOptions
 from typing import Callable
-from ..options import DecodingOptions
 
 # Delay importing heavy security module until needed
 decrypt_data: Callable[..., bytes] | None = None

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -70,7 +70,7 @@ if websockets:
 
     try:
         try:
-            loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_event_loop()
         except RuntimeError:
             loop = None
         if loop:


### PR DESCRIPTION
## Summary
- switch from `asyncio.get_running_loop()` to `asyncio.get_event_loop()` when starting the websocket server

## Testing
- `ruff check src/genecoder/flet_app.py`
- `ruff check`
- `pytest tests/test_flet_app_websocket.py::test_websocket_start_error_logged -q`
- `pytest -q` *(all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_686492626f188326a03117bdd32453f0