### PR TITLE
Add channel subcommand for combined simulators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: mypy
         args: ["--config-file", "mypy.ini", "src"]
         pass_filenames: false
-        additional_dependencies: ["cryptography"]
+        additional_dependencies: ["cryptography", "types-PyYAML"]
   - repo: local
     hooks:
       - id: pytest

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,7 +174,31 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file decoded.bin --simulator squigulator
    ```
 
-13. **AI-assisted decoding**
+13. **Combine simulators into a channel**
+
+   Apply multiple simulators and enforce synthesis constraints:
+
+   ```bash
+   genecoder channel --input-file encoded.fasta \
+       --output-file channel.fasta --simulator simple --simulator indel
+   ```
+
+   The same configuration can be provided via YAML:
+
+   ```yaml
+   simulators:
+     - simple
+     - indel
+   constraints:
+     max_homopolymer: 5
+   ```
+
+   ```bash
+   genecoder channel --input-file encoded.fasta \
+       --output-file channel.fasta --config config.yml
+   ```
+
+14. **AI-assisted decoding**
 
    Install the optional `dnaformer` extras to enable a machine learning model
    that can recover sequences with high error rates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ packages = [
 python = "^3.11"
 reedsolo = "*"
 cryptography = "^45.0.4"
+pyyaml = "*"
 numpy = {version = ">=2.2,<2.3", optional = true}
 pyldpc = {version = ">=0.7.6,<0.7.7", optional = true}
 pyfinite = {version = ">=1.9,<2.0", optional = true}

--- a/src/genecoder/cli/__init__.py
+++ b/src/genecoder/cli/__init__.py
@@ -10,6 +10,7 @@ from .decode import (
     run_decoding_pipeline,
 )
 from .cli import main
+from .channel import process_channel
 
 __all__ = [
     "EncodingOptions",
@@ -19,5 +20,6 @@ __all__ = [
     "build_decoding_options",
     "run_decoding_pipeline",
     "main",
+    "process_channel",
 ]
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Combine simulators and synthesis constraints into a single channel."""
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+from genecoder.formats import from_fasta, to_fasta
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.synthesis import SynthesisConstraints, validate_sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _load_config(path: str) -> tuple[list[str], dict[str, int]]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Config file must map keys to values")
+    sim = data.get("simulators", [])
+    if not isinstance(sim, Sequence):
+        raise ValueError("'simulators' must be a list")
+    constraints = data.get("constraints", {})
+    if not isinstance(constraints, dict):
+        raise ValueError("'constraints' must be a mapping")
+    return list(sim), {k: int(v) for k, v in constraints.items()}
+
+
+def _apply_simulators(sequence: str, simulators: Sequence[str]) -> str:
+    for name in simulators:
+        if name not in SIMULATOR_REGISTRY:
+            logger.error("Unknown simulator: %s", name)
+            raise SystemExit(1)
+        channel = SIMULATOR_REGISTRY[name]
+        sequence = channel.simulate(sequence)
+        logger.info("Applied %s simulator", name)
+    return sequence
+
+
+def process_channel(
+    input_file: str,
+    output_file: str,
+    simulators: Sequence[str],
+    constraints: dict[str, int],
+) -> None:
+    with open(input_file, "r", encoding="utf-8") as f:
+        fasta_str = f.read()
+    records = from_fasta(fasta_str)
+    if not records:
+        logger.error("No FASTA records found in %s", input_file)
+        raise SystemExit(1)
+    header, seq = records[0]
+
+    seq = _apply_simulators(seq, simulators)
+
+    synth = SynthesisConstraints(**constraints)
+    if not validate_sequence(seq, synth):
+        logger.error("Sequence violates synthesis constraints")
+        raise SystemExit(1)
+    logger.info("Sequence satisfies synthesis constraints")
+
+    fasta_out = to_fasta(seq, header, line_width=80)
+    os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
+    with open(output_file, "w", encoding="utf-8") as f_out:
+        f_out.write(fasta_out)
+
+    manifest = {
+        "file": os.path.basename(Path(input_file).as_posix()),
+        "simulators": list(simulators),
+        "constraints": constraints,
+        "metrics": {"length": len(seq)},
+    }
+    manifest_path = os.path.splitext(output_file)[0] + ".manifest.json"
+    with open(manifest_path, "w", encoding="utf-8") as m_out:
+        json.dump(manifest, m_out, indent=2)
+    logger.info("Manifest written to %s", manifest_path)
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser("channel", help="Combine simulators and synthesis constraints")
+    parser.add_argument("--input-file", required=True, type=str, help="Path to input FASTA")
+    parser.add_argument("--output-file", required=True, type=str, help="Path to output FASTA")
+    parser.add_argument(
+        "--simulator",
+        dest="simulators",
+        action="append",
+        default=[],
+        help="Simulator to apply (can be repeated)",
+    )
+    parser.add_argument("--config", type=str, help="YAML config defining simulators and constraints")
+    parser.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
+    parser.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
+    parser.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
+    parser.set_defaults(func=_handle_command)
+
+
+def _handle_command(args: argparse.Namespace) -> None:
+    simulators = list(args.simulators)
+    constraints = {
+        "min_length": args.min_length,
+        "max_length": args.max_length,
+        "max_homopolymer": args.max_homopolymer,
+    }
+    if args.config:
+        cfg_sim, cfg_con = _load_config(args.config)
+        if cfg_sim:
+            simulators = cfg_sim
+        constraints.update(cfg_con)
+    if not simulators:
+        logger.error("At least one simulator must be specified")
+        raise SystemExit(1)
+    process_channel(args.input_file, args.output_file, simulators, constraints)

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -12,6 +12,7 @@ encode: Any | None = None
 decode: Any | None = None
 analyze: Any | None = None
 report: Any | None = None
+channel: Any | None = None
 
 logger = logging.getLogger(__name__)
 
@@ -47,13 +48,20 @@ def setup_logging(level: int) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    from . import encode as _encode, decode as _decode, analyze as _analyze, report as _report
+    from . import (
+        encode as _encode,
+        decode as _decode,
+        analyze as _analyze,
+        report as _report,
+        channel as _channel,
+    )
 
-    global encode, decode, analyze, report
+    global encode, decode, analyze, report, channel
     encode = _encode
     decode = _decode
     analyze = _analyze
     report = _report
+    channel = _channel
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
     # simulators are available during subcommand registration.
@@ -74,6 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
     decode.register_subcommand(subparsers)
     analyze.register_subcommand(subparsers)
     report.register_subcommand(subparsers)
+    channel.register_subcommand(subparsers)
 
     sim_parser = subparsers.add_parser(
         "simulate-errors", help="Introduce random errors into a FASTA sequence."

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -1,0 +1,72 @@
+import json
+import os
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+
+def create_fasta(path: Path, seq: str = "ACGT", header: str = "seq") -> None:
+    from src.genecoder.formats import to_fasta
+    path.write_text(to_fasta(seq, header))
+
+
+def test_channel_cli_simulator(tmp_path: Path) -> None:
+    input_fasta = tmp_path / "in.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out.fasta"
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "simple",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    manifest = tmp_path / "out.manifest.json"
+    data = json.loads(manifest.read_text())
+    assert data["simulators"] == ["simple"]
+    assert isinstance(data["metrics"].get("length"), int)
+
+
+def test_channel_cli_yaml(tmp_path: Path) -> None:
+    input_fasta = tmp_path / "in.fasta"
+    create_fasta(input_fasta)
+    config = tmp_path / "cfg.yml"
+    config.write_text(
+        """simulators:\n  - simple\nconstraints:\n  min_length: 1\n  max_length: 10\n  max_homopolymer: 5\n"""
+    )
+    output_fasta = tmp_path / "out2.fasta"
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--config",
+            str(config),
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    manifest = tmp_path / "out2.manifest.json"
+    data = json.loads(manifest.read_text())
+    assert data["simulators"] == ["simple"]
+    assert data["constraints"]["max_homopolymer"] == 5
+


### PR DESCRIPTION
## Summary
- add `channel` CLI subcommand for chaining simulators with synthesis constraints
- generate manifest for combined channel
- document usage example
- support YAML config
- test simulator chaining and manifest output
- update mypy pre-commit deps

## Testing
- `pytest -q tests/test_cli_channel.py`
- `ruff check src/genecoder/cli/channel.py`
- `mypy --config-file mypy.ini src/genecoder/cli/channel.py`

------
https://chatgpt.com/codex/tasks/task_e_68649265687883268fc3eb80b70a0558