### PR TITLE
Add FEC benchmark

### DIFF
--- a/benchmarks/fec_bench.py
+++ b/benchmarks/fec_bench.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""Benchmark forward error correction back-ends."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+from genecoder import FEC_REGISTRY, load_plugins
+
+
+DATA_SIZE = 1_000_000  # 1 MB of random bytes
+ERROR_PROB = 0.01  # probability of flipping each bit
+
+
+def bit_error_rate(original: bytes, recovered: bytes) -> float:
+    """Return the bit error rate between two byte strings."""
+    total_bits = len(original) * 8
+    min_len = min(len(original), len(recovered))
+    errors = 0
+    for o, r in zip(original[:min_len], recovered[:min_len]):
+        errors += (o ^ r).bit_count()
+    if len(recovered) < len(original):
+        errors += (len(original) - len(recovered)) * 8
+    return errors / total_bits if total_bits else 0.0
+
+
+def introduce_bit_errors(data: bytes, prob: float, rng: random.Random | None = None) -> bytes:
+    """Flip bits in ``data`` with probability ``prob``."""
+    rng = rng or random.Random()
+    arr = bytearray(data)
+    for i in range(len(arr)):
+        for b in range(8):
+            if rng.random() < prob:
+                arr[i] ^= 1 << b
+    return bytes(arr)
+
+
+def bench_backend(name: str, encode, decode, data: bytes, prob: float) -> dict[str, float | str]:
+    start = time.perf_counter()
+    try:
+        encoded, info = encode(data)
+    except Exception as exc:  # pragma: no cover - optional deps
+        return {"fec": name, "error": str(exc)}
+    enc_time = time.perf_counter() - start
+
+    noisy = introduce_bit_errors(encoded, prob)
+    start = time.perf_counter()
+    try:
+        decoded, _ = decode(noisy, info)
+    except Exception as exc:  # pragma: no cover - error path
+        return {
+            "fec": name,
+            "encode_mb_s": len(data) / (1024 * 1024) / enc_time,
+            "error": str(exc),
+        }
+    dec_time = time.perf_counter() - start
+    ber = bit_error_rate(data, decoded)
+    return {
+        "fec": name,
+        "encode_mb_s": len(data) / (1024 * 1024) / enc_time,
+        "decode_mb_s": len(data) / (1024 * 1024) / dec_time,
+        "ber": ber,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark FEC back-ends")
+    parser.add_argument("--format", choices=["csv", "json"], default="csv")
+    parser.add_argument("--output", "-o", type=Path, help="Write results to file")
+    parser.add_argument("--size", type=int, default=DATA_SIZE, help="Data size in bytes")
+    parser.add_argument(
+        "--error-prob",
+        type=float,
+        default=ERROR_PROB,
+        help="Bit flip probability",
+    )
+    args = parser.parse_args()
+
+    load_plugins()
+    data = os.urandom(args.size)
+
+    results: list[dict[str, float | str]] = []
+    for name in sorted(FEC_REGISTRY):
+        funcs = FEC_REGISTRY[name]
+        result = bench_backend(name, funcs["encode"], funcs["decode"], data, args.error_prob)
+        results.append(result)
+
+    out = open(args.output, "w", newline="") if args.output else sys.stdout
+    if args.format == "csv":
+        fieldnames = ["fec", "encode_mb_s", "decode_mb_s", "ber", "error"]
+        writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+    else:
+        json.dump(results, out, indent=2)
+        if out is not sys.stdout:
+            out.write("\n")
+    if out is not sys.stdout:
+        out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,16 @@
+# FEC Benchmarks
+
+GeneCoder ships with `benchmarks/fec_bench.py` for evaluating forward error correction implementations.
+
+The script automatically loads FEC plugins via `FEC_REGISTRY`, encodes sample data,
+introduces random bit flips and reports encode/decode throughput along with the residual bit error rate.
+
+Run with default settings (1&nbsp;MB input, 1% bit flip probability):
+
+```bash
+PYTHONPATH=src python benchmarks/fec_bench.py --format csv > results.csv
+```
+
+Use `--format json` to emit JSON instead of CSV and `--output` to specify an output file.
+
+Results can be plotted using external tools like pandas or matplotlib.

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -72,7 +72,10 @@ if websockets:
         try:
             loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
         except RuntimeError:
-            loop = None
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = None
         if loop:
             loop.create_task(websockets.serve(_ws_handler, "localhost", 8765))
         else:  # pragma: no cover - depends on environment


### PR DESCRIPTION
## Summary
- add benchmark script to measure FEC implementations
- document how to run the benchmark
- handle websocket startup when only an event loop is returned

## Testing
- `pre-commit run --files benchmarks/fec_bench.py docs/benchmarks.md src/genecoder/flet_app.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864926648a08326ad356f96808a420a