### PR TITLE
Add env option safety checks

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -31,12 +31,22 @@ from .formats import from_fasta, to_fasta
 
 
 def _parse_env_options(command: str) -> list[str]:
-    """Return additional options for ``command`` parsed from the environment."""
+    """Return additional options for ``command`` parsed from the environment.
+
+    The environment variable ``GENECODER_<CMD>_OPTIONS`` allows forwarding extra
+    command line arguments to the external simulators.  For security reasons
+    only a limited set of characters is permitted.  If ``raw`` contains
+    potentially dangerous characters a ``ValueError`` is raised.
+    """
 
     env_var = f"GENECODER_{command.upper()}_OPTIONS"
     raw = os.getenv(env_var)
     if not raw:
         return []
+
+    if any(c in raw for c in ";&|`$<>\\\n\r") or not raw.isprintable():
+        raise ValueError(f"Unsafe characters in {env_var}")
+
     import shlex
 
     try:
@@ -87,6 +97,10 @@ def _simulate_adapter(
                 cmd_list += ["-e", str(error_rate)]
             cmd_list += _parse_env_options(command)
             return _run_external(cmd_list, sequence)
+        except ValueError as exc:  # pragma: no cover - invalid options
+            raise ValueError(
+                f"Invalid GENECODER_{command.upper()}_OPTIONS: {exc}"
+            ) from exc
         except (RuntimeError, subprocess.CalledProcessError) as exc:  # pragma: no cover - error path
             logger.warning(
                 "%s failed: %s; falling back to simple error model",

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -68,6 +68,28 @@ def test_parse_options_invalid(monkeypatch, caplog):
     assert any("Invalid" in r.message for r in caplog.records)
 
 
+def test_parse_options_unsafe(monkeypatch):
+    monkeypatch.setenv("GENECODER_D2SIM_OPTIONS", "foo;bar")
+    with pytest.raises(ValueError):
+        nanopore_sim._parse_env_options("d2sim")
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_adapters_invalid_env_options(monkeypatch, name):
+    func, cmd = ADAPTERS[name]
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: "/usr/bin/" + t)
+    run_called = []
+    monkeypatch.setattr(
+        nanopore_sim,
+        "_run_external",
+        lambda *_: run_called.append(True) or "ok",
+    )
+    monkeypatch.setenv(f"GENECODER_{cmd.upper()}_OPTIONS", "foo;bar")
+    with pytest.raises(ValueError):
+        func("ACGT")
+    assert not run_called
+
+
 @pytest.mark.parametrize("name", ADAPTERS.keys())
 def test_adapters_fall_back(monkeypatch, name):
     func, cmd = ADAPTERS[name]


### PR DESCRIPTION
## Summary
- reject unsafe chars in simulator option env vars
- bubble up ValueError from `_simulate_adapter`
- test invalid env options in nanopore sim module

## Testing
- `ruff check src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py`
- `mypy --config-file mypy.ini src/genecoder/nanopore_sim.py`
- `pytest tests/test_nanopore_sim.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68652f17db788326bb7a8cdf460e5a27