### PR TITLE
Add auth to dashboard metrics

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-import yaml  # type: ignore
+import yaml
 
 from . import cli as cli_module
 

--- a/tests/test_flet_gui.py
+++ b/tests/test_flet_gui.py
@@ -1,9 +1,9 @@
 import pytest
 import json
 from pathlib import Path
-from flet.core.control_event import ControlEvent
 
 ft = pytest.importorskip("flet")
+from flet.core.control_event import ControlEvent
 ft.icons = getattr(ft, "icons", getattr(ft, "Icons", None)) or ft.Icons
 ft.colors = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
 

--- a/tests/test_web_api_analyze_report.py
+++ b/tests/test_web_api_analyze_report.py
@@ -4,9 +4,12 @@ fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
-from web.main import app
+import web.main as main
 
-client = TestClient(app)
+main.API_TOKEN = "test-token"
+client = TestClient(main.app)
+
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
 
 
 def test_analyze_endpoint() -> None:
@@ -29,3 +32,17 @@ def test_report_endpoint() -> None:
     r = client.post("/report", json={"data": enc, "type": "encode", "format": "html"})
     assert r.status_code == 200
     assert "<h1>Encoding Report</h1>" in r.json()["report"]
+
+
+def test_dashboard_metrics_requires_token() -> None:
+    payload = {"dna_sequence": "ACGT"}
+    r = client.post("/dashboard/metrics", json=payload)
+    assert r.status_code == 401
+
+
+def test_dashboard_metrics_with_token() -> None:
+    payload = {"dna_sequence": "ACGT"}
+    r = client.post("/dashboard/metrics", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot"}

--- a/web/main.py
+++ b/web/main.py
@@ -64,14 +64,14 @@ origins = [origin.strip() for origin in CORS_ORIGINS.split(",") if origin.strip(
 REDIS_URL = os.getenv("GENECODER_REDIS_URL")
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 async def _startup() -> None:
     if REDIS_URL:
         r = redis.from_url(REDIS_URL, encoding="utf-8", decode_responses=True)
         await FastAPILimiter.init(r)
 
 
-@app.on_event("shutdown")
+@app.on_event("shutdown")  # type: ignore[misc]
 async def _shutdown() -> None:
     if FastAPILimiter.redis:
         await FastAPILimiter.close()
@@ -243,7 +243,10 @@ async def analyze(req: AnalyzeRequest) -> dict[str, object]:
 
 
 @app.post("/dashboard/metrics")  # type: ignore[misc]
-async def dashboard_metrics(req: DashboardMetricsRequest) -> dict[str, object]:
+async def dashboard_metrics(
+    req: DashboardMetricsRequest,
+    _: None = Depends(verify_token),
+) -> dict[str, object]:
     seq = req.dna_sequence
     gc = calculate_gc_content(seq)
     max_hp = get_max_homopolymer_length(seq)


### PR DESCRIPTION
## Summary
- secure `/dashboard/metrics` with `verify_token`
- test token requirement for dashboard metrics
- fix flakey GUI test
- silence mypy errors in event handlers

## Testing
- `ruff check web/main.py tests/test_web_api_analyze_report.py tests/test_flet_gui.py src/genecoder/cli/bundle.py`
- `mypy --config-file mypy.ini web/main.py src/genecoder/cli/bundle.py`
- `pytest tests/test_web_api_analyze_report.py tests/test_flet_gui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68652f188750832693e8ce7f4178f64a