### PR TITLE
Update API token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ poetry install --with web --no-interaction
 poetry run uvicorn web.main:app --reload
 ```
 
+Set the `GENECODER_API_TOKEN` environment variable to supply the bearer token
+required by the API. If the variable is not set, a random token is generated and
+printed at startup.
+
 See [docs/installation.md](docs/installation.md) for detailed setup and testing instructions, including the [mamba-based setup](docs/installation.md#mamba-based-setup) and the [Windows Quick Start](docs/installation.md#windows-quick-start).
 - For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
 - For working inside the VS Code Dev Container see [docs/installation.md#using-the-dev-container](docs/installation.md#using-the-dev-container).

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -29,9 +29,10 @@ You can add your own endpoints to expose encoding and decoding features.
 The server enables [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 so that browser-based clients on other origins can call the API. Set
 `GENECODER_CORS_ORIGINS` to a comma-separated list of allowed origins (default
-`*`). Write endpoints also use a simple bearer token for authentication.
-
-Set the token before starting the server:
+`*`). Write endpoints also use a bearer token for authentication. Set
+`GENECODER_API_TOKEN` before starting the server to supply your own token. If the
+variable is unset, a random token is generated at startup and printed to the
+console.
 
 ```bash
 export GENECODER_API_TOKEN=secret

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -6,7 +6,6 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-import yaml  # type: ignore
 
 from . import cli as cli_module
 
@@ -57,6 +56,8 @@ def _run_cli(args_list: list[str]) -> None:
 
 
 def _handle_run(args: argparse.Namespace) -> None:
+    import yaml
+
     with open(args.config, "r", encoding="utf-8") as fh:
         config = yaml.safe_load(fh) or {}
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -9,7 +9,6 @@ import os
 from pathlib import Path
 from typing import Sequence
 
-import yaml
 
 from genecoder.formats import from_fasta, to_fasta
 from genecoder.simulators import SIMULATOR_REGISTRY
@@ -19,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def _load_config(path: str) -> tuple[list[str], dict[str, int]]:
+    import yaml
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     if not isinstance(data, dict):

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -13,6 +13,7 @@ decode: Any | None = None
 analyze: Any | None = None
 report: Any | None = None
 channel: Any | None = None
+bundle: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -55,15 +56,17 @@ def build_parser() -> argparse.ArgumentParser:
         analyze as _analyze,
         report as _report,
         channel as _channel,
+        bundle as _bundle,
     )
 
-    global encode, decode, analyze, report, channel
+    global encode, decode, analyze, report, channel, bundle
 
     encode = _encode
     decode = _decode
     analyze = _analyze
     report = _report
     channel = _channel
+    bundle = _bundle
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -86,6 +89,7 @@ def build_parser() -> argparse.ArgumentParser:
     analyze.register_subcommand(subparsers)
     report.register_subcommand(subparsers)
     channel.register_subcommand(subparsers)
+    bundle.register_subcommand(subparsers)
 
 
     sim_parser = subparsers.add_parser(

--- a/web/main.py
+++ b/web/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 import hashlib
+import secrets
 from fastapi import FastAPI, HTTPException, Depends, Request, Response
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -47,7 +48,7 @@ def bit_error_rate(original: bytes, recovered: bytes) -> float:
         errors += (len(original) - len(recovered)) * 8
     return errors / total_bits if total_bits else 0.0
 
-API_TOKEN = os.getenv("GENECODER_API_TOKEN", "change-me")
+API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")
 security = HTTPBearer(auto_error=False)
 
@@ -66,6 +67,10 @@ REDIS_URL = os.getenv("GENECODER_REDIS_URL")
 
 @app.on_event("startup")
 async def _startup() -> None:
+    global API_TOKEN
+    if API_TOKEN is None:
+        API_TOKEN = secrets.token_urlsafe(16)
+        print(f"Generated API token: {API_TOKEN}")
     if REDIS_URL:
         r = redis.from_url(REDIS_URL, encoding="utf-8", decode_responses=True)
         await FastAPILimiter.init(r)


### PR DESCRIPTION
## Summary
- make `GENECODER_API_TOKEN` optional and generate a token on startup
- update docs about the token requirement
- mention API token env var in README
- register CLI bundle command and defer YAML imports

## Testing
- `pre-commit run --files web/main.py docs/web_api_tutorial.md README.md src/genecoder/cli/bundle.py src/genecoder/cli/cli.py src/genecoder/cli/channel.py`

------
https://chatgpt.com/codex/tasks/task_e_68652f16fc208326b519b75462f9ee3f