### PR TITLE
Add plugin registry support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -103,3 +103,20 @@ from genecoder.plugins import CODEC_REGISTRY
 genecoder.plugins.load_plugins()
 print(CODEC_REGISTRY.keys())
 ```
+
+## Plugin Registries
+
+`load_plugins()` can optionally install third‑party plugins from a remote
+registry before discovering entry points. Set the environment variable
+`GENECODER_PLUGIN_REGISTRY_URL` to the location of a YAML file listing plugin
+packages:
+
+```yaml
+packages:
+  - genecoder-fancy-plugin>=1.0
+  - git+https://example.com/user/custom.git
+```
+
+The URL may use HTTP(S) or point to a local file via ``file://``. Each entry is
+passed directly to ``pip install``. Only use registries from trusted sources as
+their packages are installed and executed automatically.

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Callable, Dict, Any, Iterable
 from types import ModuleType
+import os
+import sys
+import subprocess
+import urllib.request
+import yaml
 
 from .channels.base import BaseChannel
 from importlib.metadata import entry_points, EntryPoints
@@ -30,6 +35,23 @@ def register_fec(name: str, encode: Callable[..., Any], decode: Callable[..., An
 def register_simulator(name: str, channel: BaseChannel) -> None:
     """Register a read simulator under ``name``."""
     _register_simulator(name, channel)
+
+
+def _install_registry_plugins(url: str) -> None:
+    """Install plugin packages listed in a YAML registry at ``url``."""
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = yaml.safe_load(response.read()) or {}
+    except Exception as exc:  # pragma: no cover - network error path
+        logger.warning("Failed to fetch plugin registry %s: %s", url, exc)
+        return
+
+    for spec in data.get("packages", []):
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+        except Exception as exc:  # pragma: no cover - install error path
+            logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
 
 
 def _load_and_register(
@@ -72,6 +94,10 @@ def load_plugins() -> None:
     builtin = importlib.import_module("genecoder.builtin_plugins")
     if hasattr(builtin, "register_builtin_plugins"):
         builtin.register_builtin_plugins()
+
+    registry_url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
+    if registry_url:
+        _install_registry_plugins(registry_url)
 
     failures: list[str] = []
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,46 @@
+import sys
+
+import genecoder.plugins as plugins
+
+
+class DummyResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def test_registry_install(monkeypatch):
+    installs = []
+
+    def fake_check_call(cmd):
+        installs.append(cmd)
+
+    def fake_urlopen(url):
+        assert url == "https://example.com/plugins.yaml"
+        data = b"packages:\n  - pkgA>=1.0\n  - pkgB"
+        return DummyResponse(data)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert installs == [
+        [sys.executable, "-m", "pip", "install", "pkgA>=1.0"],
+        [sys.executable, "-m", "pip", "install", "pkgB"],
+    ]
+


### PR DESCRIPTION
## Summary
- enable remote plugin registry via `GENECODER_PLUGIN_REGISTRY_URL`
- document plugin registries and security notes
- test plugin registry installation logic

## Testing
- `pre-commit run ruff --files docs/plugins.md src/genecoder/plugins.py tests/test_plugin_registry.py`
- `pre-commit run mypy --files src/genecoder/plugins.py`
- `pytest -q tests/test_plugin_registry.py`

------
https://chatgpt.com/codex/tasks/task_e_686545ea1e848326acf6eb200cdbbeb3