### PR TITLE
Add ChannelPipeline and refactor CLI commands

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -11,7 +11,8 @@ from typing import Sequence
 
 
 from genecoder.formats import from_fasta, to_fasta
-from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
+from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 
 logger = logging.getLogger(__name__)
@@ -33,14 +34,17 @@ def _load_config(path: str) -> tuple[list[str], dict[str, int]]:
 
 
 def _apply_simulators(sequence: str, simulators: Sequence[str]) -> str:
+    channels: list[BaseChannel] = []
     for name in simulators:
         if name not in SIMULATOR_REGISTRY:
             logger.error("Unknown simulator: %s", name)
             raise SystemExit(1)
-        channel = SIMULATOR_REGISTRY[name]
-        sequence = channel.simulate(sequence)
+        channels.append(SIMULATOR_REGISTRY[name])
+    pipeline = ChannelPipeline(channels)
+    result: str = pipeline.simulate(sequence)
+    for name in simulators:
         logger.info("Applied %s simulator", name)
-    return sequence
+    return result
 
 
 def process_channel(

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -4,7 +4,7 @@ import sys
 
 from genecoder import __version__
 from genecoder.plugins import load_plugins
-from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight
@@ -149,7 +149,8 @@ def _handle_sim_errors(args: argparse.Namespace) -> None:
             read_len = getattr(args, "read_length", None)
             if read_len is not None and hasattr(channel, "read_length"):
                 channel.read_length = read_len
-            corrupted = channel.simulate(seq)
+            pipeline = ChannelPipeline([channel])
+            corrupted = pipeline.simulate(seq)
         else:
             corrupted = introduce_errors(
                 seq,

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Dict
 
 from ..channels.base import BaseChannel
+from .pipeline import ChannelPipeline
 
 SIMULATOR_REGISTRY: Dict[str, BaseChannel] = {}
 
@@ -30,6 +31,7 @@ __all__ = [
     "ReplicationSimulator",
     "TranscriptionSimulator",
     "TranslationSimulator",
+    "ChannelPipeline",
     "simulate_reads",
 ]
 

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from ..channels.base import BaseChannel
+
+__all__ = ["ChannelPipeline"]
+
+
+class ChannelPipeline(BaseChannel):
+    """Apply a sequence of channels to a DNA sequence."""
+
+    def __init__(self, channels: Iterable[BaseChannel] | None = None) -> None:
+        self.channels: List[BaseChannel] = list(channels or [])
+
+    def add_channel(self, channel: BaseChannel) -> None:
+        """Append ``channel`` to the pipeline."""
+        self.channels.append(channel)
+
+    def simulate(self, sequence: str) -> str:
+        for channel in self.channels:
+            sequence = channel.simulate(sequence)
+        return sequence


### PR DESCRIPTION
## Summary
- add `ChannelPipeline` to simulators package
- refactor `simulate-errors` and `channel` CLI commands to use the pipeline

## Testing
- `pytest -q tests/test_cli_channel.py tests/test_cli_simulator_selection.py`
- `pytest -q` *(fails: KeyboardInterrupt after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_686545ea1b848326ad6eb5f3c1e00eb6