### PR TITLE
Add dashboard API and Playwright tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -238,6 +238,8 @@ jobs:
         cd openai_testing
         npm install
         cd ..
+        npm install --prefix web/helix-ui
+        npm run build --prefix web/helix-ui
 
     - name: Smoke test CUA server
       run: node -e "console.log('cua smoke')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ bchlib = ">=2.1,<3.0"
 raptorq = ">=2.0,<3.0"
 FrameD = "*"
 numba = "*"
+playwright = "*"
 
 [tool.poetry.scripts]
 genecoder = "genecoder.cli.cli:main"

--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -1,0 +1,25 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+from httpx import AsyncClient
+
+import web.main as main
+
+main.API_TOKEN = "test-token"
+
+@pytest.mark.asyncio
+async def test_dashboard_metrics_async() -> None:
+    async with AsyncClient(app=main.app, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/dashboard/metrics",
+            headers={"Authorization": f"Bearer {main.API_TOKEN}"},
+            json={"dna_sequence": "ACGT"},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot"}
+    assert isinstance(data["gc_content"], float)
+    assert isinstance(data["max_homopolymer"], int)
+    assert isinstance(data["error_rate"], float)
+    assert isinstance(data["plot"], str)

--- a/tests/test_frontend_playwright.py
+++ b/tests/test_frontend_playwright.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+
+def _build_ui() -> Path:
+    root = Path(__file__).resolve().parents[1] / "web" / "helix-ui"
+    dist = root / "dist"
+    if not dist.is_dir():
+        subprocess.run(["npm", "install"], cwd=root, check=True)
+        subprocess.run(["npm", "run", "build"], cwd=root, check=True)
+    return dist / "index.html"
+
+
+def test_helix_ui_renders() -> None:
+    page_path = _build_ui()
+    assert page_path.is_file()
+
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:  # Browser may not be installed
+            pytest.skip(str(exc))
+        page = browser.new_page()
+        page.goto(page_path.as_uri())
+        page.wait_for_selector("canvas")
+        browser.close()


### PR DESCRIPTION
## Summary
- add pytest/httpx test for `/dashboard/metrics`
- add Playwright UI smoke test
- include Playwright in dev dependencies
- build web UI in CI before running tests

## Testing
- `pre-commit run ruff --files .github/workflows/python-ci.yml pyproject.toml tests/test_dashboard_httpx.py tests/test_frontend_playwright.py`
- `pre-commit run mypy --files tests/test_dashboard_httpx.py tests/test_frontend_playwright.py pyproject.toml`
- `pytest tests/test_dashboard_httpx.py tests/test_frontend_playwright.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e719c588326aaef4223e9dc4bb6