### PR TITLE
Add DeepDNA codec plugin

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -48,3 +48,21 @@ webview = show_helix_ui(seq1, seq2)
 
 The `--mirror` flag on the CLI writes both forward and reverse-complement
 records which can be viewed together using `show_helix_ui` as above.
+
+## DeepDNA Codec
+
+GeneCoder includes an optional AI-based FEC backend wrapping the open-source DeepDNA model. Install the extra and use it just like the other FEC methods:
+
+```bash
+pip install "genecoder[deepdna]"
+```
+
+### Example usage
+
+```python
+from genecoder.deepdna_codec import encode_data_deepdna, decode_data_deepdna
+
+data = b"hello world"
+encoded, info = encode_data_deepdna(data)
+decoded, _ = decode_data_deepdna(encoded, info)
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,6 +109,16 @@ poetry install --extras dnaformer --no-interaction
 Once installed, GeneCoder will automatically register the codec when
 imported.
 
+## DeepDNA Plugin
+
+Install the optional DeepDNA model with Poetry's extras support:
+
+```bash
+poetry install --extras deepdna --no-interaction
+```
+
+The codec registers itself automatically when imported.
+
 ## FrameD FEC Backend
 
 The optional FrameD plugin wraps optimized C++ kernels using CFFI to provide additional

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -209,6 +209,14 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --method ai
    ```
 
+   Or install the alternative `deepdna` extras:
+
+   ```bash
+   poetry install --extras deepdna --no-interaction
+   genecoder decode --input-files noisy.fasta --output-file out.bin \
+       --method ai
+   ```
+
 ### Manifest files
 
 Each encoded file produces a companion JSON manifest capturing the encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ flet-webview = {version = "*", optional = true}
 fastapi = {version = ">=0.110", optional = true}
 uvicorn = { version = "*", extras = ["standard"], optional = true }
 httpx = {version = "<0.28", optional = true}
+deepdna = {version = "*", optional = true}
 
 [tool.poetry.group.gui.dependencies]
 flet = ">=0.28,<0.29"
@@ -79,6 +80,7 @@ bch = "genecoder.bch_codec"
 raptorq = "genecoder.raptorq_codec"
 framed = "genecoder.fec.framed"
 dnaformer = "genecoder.dnaformer_codec"
+deepdna = "genecoder.deepdna_codec"
 
 [tool.poetry.plugins."genecoder.simulators"]
 nanopore = "genecoder.nanopore_sim"
@@ -97,6 +99,7 @@ ldpc = ["pyldpc", "numpy"]
 fountain = ["pyfinite"]
 raptorq = ["raptorq", "numpy"]
 bch = ["bchlib"]
+deepdna = ["deepdna", "torch"]
 
 gui = ["flet", "matplotlib", "flet-webview"]
 web = ["fastapi", "uvicorn", "httpx"]

--- a/src/genecoder/deepdna_codec.py
+++ b/src/genecoder/deepdna_codec.py
@@ -1,0 +1,51 @@
+"""DeepDNA error correction codec using optional :mod:`deepdna`."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple, TYPE_CHECKING
+
+_HAS_DEEPDNA = False
+
+if TYPE_CHECKING:
+    import deepdna
+else:  # pragma: no cover - optional dependency
+    try:
+        import deepdna  # type: ignore
+        _HAS_DEEPDNA = True
+    except Exception:  # pragma: no cover - missing optional dependency
+        deepdna = None  # type: ignore
+        _HAS_DEEPDNA = False
+
+
+def _require_deepdna() -> None:  # pragma: no cover - helper
+    """Ensure :mod:`deepdna` is installed."""
+    if not _HAS_DEEPDNA:
+        raise ImportError(
+            "deepdna is required for DeepDNA encoding. Install it via 'pip install deepdna'."
+        )
+
+
+def encode_data_deepdna(data: bytes, model_name: str = "deepdna-small") -> Tuple[bytes, Any]:
+    """Encode ``data`` using the DeepDNA model."""
+    _require_deepdna()
+    assert deepdna is not None
+    model = deepdna.DeepDNA(model_name)
+    encoded = model.encode(data)
+    return encoded, {"model_name": model_name}
+
+
+def decode_data_deepdna(encoded: bytes, info: Any) -> Tuple[bytes, int]:
+    """Decode DeepDNA encoded ``encoded`` bytes using ``info`` from encoding."""
+    _require_deepdna()
+    assert deepdna is not None
+    model = deepdna.DeepDNA(info["model_name"])
+    decoded = model.decode(encoded)
+    return decoded, 0
+
+
+from typing import Callable
+
+
+def register(register_fec: Callable[[str, Callable[[bytes], Tuple[bytes, Any]], Callable[[bytes, Any], Tuple[bytes, int]]], None]) -> None:
+    """Register this module's FEC backend."""
+    register_fec("deepdna", encode_data_deepdna, decode_data_deepdna)

--- a/tests/test_deepdna_codec.py
+++ b/tests/test_deepdna_codec.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _install_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = types.ModuleType("deepdna")
+
+    class DeepDNA:
+        def __init__(self, model_name: str):
+            self.model_name = model_name
+
+        def encode(self, data: bytes) -> bytes:  # type: ignore[override]
+            return data[::-1]
+
+        def decode(self, encoded: bytes) -> bytes:  # type: ignore[override]
+            return encoded[::-1]
+
+    mod.DeepDNA = DeepDNA
+    monkeypatch.setitem(sys.modules, "deepdna", mod)
+
+
+def test_deepdna_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_stub(monkeypatch)
+    import genecoder.deepdna_codec as deepdna_codec
+
+    importlib.reload(deepdna_codec)
+
+    data = b"deepdna test"
+    encoded, info = deepdna_codec.encode_data_deepdna(data)
+    decoded, corrected = deepdna_codec.decode_data_deepdna(encoded, info)
+    assert decoded == data
+    assert corrected == 0


### PR DESCRIPTION
## Summary
- add new DeepDNA FEC plugin
- expose the plugin via entry point and extras
- document the codec in features docs
- document how to install/use the DeepDNA plugin
- test DeepDNA codec with a stub model

## Testing
- `ruff check src tests docs`
- `pytest tests/test_deepdna_codec.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e6a67148326b81355495869b342