### PR TITLE
Add plugin failure tests

### DIFF
--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -6,11 +6,17 @@ import os
 import sys
 import subprocess
 import urllib.request
-import yaml
+import importlib
+
+_yaml: Any
+try:  # pragma: no cover - import is trivial
+    _yaml = importlib.import_module("yaml")
+except Exception:  # pragma: no cover - optional dependency
+    _yaml = None
+yaml: Any | None = _yaml
 
 from .channels.base import BaseChannel
 from importlib.metadata import entry_points, EntryPoints
-import importlib
 import logging
 import pkgutil
 
@@ -39,6 +45,10 @@ def register_simulator(name: str, channel: BaseChannel) -> None:
 
 def _install_registry_plugins(url: str) -> None:
     """Install plugin packages listed in a YAML registry at ``url``."""
+
+    if yaml is None:  # pragma: no cover - optional dependency missing
+        logger.warning("YAML support unavailable, skipping plugin registry %s", url)
+        return
 
     try:
         with urllib.request.urlopen(url) as response:

--- a/tests/test_plugin_failures.py
+++ b/tests/test_plugin_failures.py
@@ -1,0 +1,104 @@
+import logging
+from importlib.metadata import EntryPoint
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import genecoder.plugins as plugins
+
+
+def _make_entry_points(mode: str, entries: list[EntryPoint | object]) -> Callable[..., object]:
+    def func(*, group: str | None = None) -> object:
+        if mode == "group":
+            assert group is not None
+            return [e for e in entries if getattr(e, "group", None) == group]
+        if group is not None:
+            raise TypeError
+        if mode == "select":
+            class Obj:
+                def select(self, *, group: str) -> list[EntryPoint | object]:
+                    return [e for e in entries if getattr(e, "group", None) == group]
+            return Obj()
+        if mode == "dict":
+            d: dict[str, list[EntryPoint | object]] = {}
+            for e in entries:
+                d.setdefault(getattr(e, "group", ""), []).append(e)
+            return d
+        return entries
+    return func
+
+
+@pytest.mark.parametrize("mode", ["group", "select", "dict", "list"])
+def test_missing_module(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, mode: str) -> None:
+    ep = EntryPoint(name="missing", value="no_such_module", group="genecoder.plugins")
+    monkeypatch.setattr(plugins, "entry_points", _make_entry_points(mode, [ep]))
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugins()
+    assert any("codec:no_such_module" in rec.message for rec in caplog.records)
+    assert "missing" not in plugins.CODEC_REGISTRY
+
+
+class BadEntryPoint:
+    def __init__(self, name: str, group: str) -> None:
+        self.name = name
+        self.group = group
+        self.value = name
+
+    def load(self) -> object:
+        raise ImportError("bad")
+
+
+@pytest.mark.parametrize("mode", ["group", "select", "dict", "list"])
+def test_bad_entry_point(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, mode: str) -> None:
+    ep = BadEntryPoint("bad", "genecoder.plugins")
+    monkeypatch.setattr(plugins, "entry_points", _make_entry_points(mode, [ep]))
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugins()
+    assert any("codec:bad" in rec.message for rec in caplog.records)
+    assert "bad" not in plugins.CODEC_REGISTRY
+
+
+@pytest.mark.parametrize("mode", ["group", "select", "dict", "list"])
+def test_duplicate_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mode: str) -> None:
+    mod1 = tmp_path / "m1.py"
+    mod1.write_text(
+        """
+from typing import Callable
+
+def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]) -> None:
+    def encode(data: bytes) -> str:
+        return "one"
+    def decode(text: str) -> bytes:
+        return b"one"
+    register_codec("dup", encode, decode)
+"""
+    )
+    mod2 = tmp_path / "m2.py"
+    mod2.write_text(
+        """
+from typing import Callable
+
+def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]) -> None:
+    def encode(data: bytes) -> str:
+        return "two"
+    def decode(text: str) -> bytes:
+        return b"two"
+    register_codec("dup", encode, decode)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep1 = EntryPoint(name="one", value="m1", group="genecoder.plugins")
+    ep2 = EntryPoint(name="two", value="m2", group="genecoder.plugins")
+    monkeypatch.setattr(plugins, "entry_points", _make_entry_points(mode, [ep1, ep2]))
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.load_plugins()
+    assert plugins.CODEC_REGISTRY["dup"]["encode"](b"") == "two"


### PR DESCRIPTION
## Summary
- add tests for plugin loading failure cases
- allow optional YAML dependency for plugin registry

## Testing
- `ruff check tests/test_plugin_failures.py src/genecoder/plugins.py`
- `mypy --config-file mypy.ini src/genecoder/plugins.py tests/test_plugin_failures.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e727e3c8326ae9571962e6640c4