### PR TITLE
Add FEC benchmark link

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -14,3 +14,34 @@ PYTHONPATH=src python benchmarks/fec_bench.py --format csv > results.csv
 Use `--format json` to emit JSON instead of CSV and `--output` to specify an output file.
 
 Results can be plotted using external tools like pandas or matplotlib.
+
+## Quick Tutorial
+
+To quickly test the benchmark script with minimal data run:
+
+```bash
+PYTHONPATH=src python benchmarks/fec_bench.py --size 16 --error-prob 0 --format csv
+```
+
+which prints a CSV table similar to:
+
+```text
+fec,encode_mb_s,decode_mb_s,ber,error
+bch,,,,bchlib is required for BCH encoding. Install it via 'pip install bchlib'.
+fountain,,,,pyfinite is required for Fountain encoding. Install it via 'pip install pyfinite'.
+```
+
+Generating JSON output uses the same flags with `--format json`:
+
+```bash
+PYTHONPATH=src python benchmarks/fec_bench.py --size 16 --error-prob 0 --format json
+```
+
+Example JSON:
+
+```json
+[
+  {"fec": "bch", "error": "bchlib is required for BCH encoding. Install it via 'pip install bchlib'."},
+  {"fec": "fountain", "error": "pyfinite is required for Fountain encoding. Install it via 'pip install pyfinite'."}
+]
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,6 @@ For more details, explore the sections below.
 * [n8n Overview](n8n_overview.md) – Automate workflows with n8n.
 * [Simulators](simulators.md) – Available read simulators and how to install external tools.
 * [Performance Benchmarks](performance.md) – Encoding/decoding throughput numbers.
+* [FEC Benchmarks](benchmarks.md) – Forward error correction examples and results.
 * [Technology Stack](technology_stack.md) – Overview of dependencies and tooling.
 * [Glossary](glossary.md) – Key terms used throughout the docs.

--- a/tests/test_fec_bench_script.py
+++ b/tests/test_fec_bench_script.py
@@ -1,0 +1,30 @@
+import json
+import os
+import subprocess
+import sys
+
+from tests.conftest import PROJECT_ROOT
+
+
+def _run_fec_bench(args: list[str]) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_path = PROJECT_ROOT / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    cmd = [sys.executable, str(PROJECT_ROOT / "benchmarks" / "fec_bench.py")] + args
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=PROJECT_ROOT)
+
+
+def test_fec_bench_json() -> None:
+    result = _run_fec_bench(["--size", "16", "--error-prob", "0", "--format", "json"])
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert all("fec" in item for item in data)
+
+
+def test_fec_bench_csv() -> None:
+    result = _run_fec_bench(["--size", "16", "--error-prob", "0", "--format", "csv"])
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.strip().splitlines() if line]
+    assert lines[0].startswith("fec,")
+    assert len(lines) >= 2


### PR DESCRIPTION
## Summary
- reference FEC tutorial from the docs index
- demonstrate running `fec_bench.py` and validate CSV/JSON output

## Testing
- `pre-commit run ruff --files docs/index.md docs/benchmarks.md tests/test_fec_bench_script.py`
- `pre-commit run mypy --files docs/index.md docs/benchmarks.md tests/test_fec_bench_script.py`
- `python -m pytest tests/test_fec_bench_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68654e72d6648326b5149dfa05e8cfa0