### PR TITLE
Add notebooks and example dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GeneCoder is an educational toolkit for exploring DNA-based data storage. It pro
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
+Introductory Jupyter notebooks with encoding and decoding examples are available in the [notebooks/](notebooks) directory.
 
 GeneCoder's long-term goal is to provide an integrated research platform that
 bridges encoding algorithms with sequencing and synthesis simulations while

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,4 @@ For more details, explore the sections below.
 * [FEC Benchmarks](benchmarks.md) – Forward error correction examples and results.
 * [Technology Stack](technology_stack.md) – Overview of dependencies and tooling.
 * [Glossary](glossary.md) – Key terms used throughout the docs.
+* [Introductory Notebooks](../notebooks) – Encoding, channel simulation and decoding examples.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,8 @@
 
 See the [Disclaimer](../README.md#disclaimer) before using the toolkit.
 
+For a hands-on introduction check the Jupyter notebooks in the [notebooks/](../notebooks) directory.
+
 GeneCoder operations are performed with the `genecoder` CLI:
 
 ```bash

--- a/notebooks/channel_simulation_example.ipynb
+++ b/notebooks/channel_simulation_example.ipynb
@@ -1,0 +1,28 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3e3899fc",
+   "metadata": {},
+   "source": [
+    "# Channel Simulation Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5e2f547",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from genecoder.channel_sim import simulate_errors\n",
+    "seq = 'ACGTACGT'\n",
+    "noisy = simulate_errors(seq, p_error=0.1)\n",
+    "print(noisy)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/decoding_example.ipynb
+++ b/notebooks/decoding_example.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5ffbe5c",
+   "metadata": {},
+   "source": [
+    "# Decoding Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42aa2baa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from genecoder.encoders import encode_base4_direct, decode_base4_direct\n",
+    "with open('../tests/data/sample.txt', 'rb') as f:\n",
+    "    original = f.read()\n",
+    "dna = encode_base4_direct(original)\n",
+    "decoded, errors = decode_base4_direct(dna)\n",
+    "print(decoded.decode())\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/encoding_example.ipynb
+++ b/notebooks/encoding_example.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "249b698c",
+   "metadata": {},
+   "source": [
+    "# Encoding Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b075e9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from genecoder.encoders import encode_base4_direct\n",
+    "with open('../tests/data/sample.txt', 'rb') as f:\n",
+    "    data = f.read()\n",
+    "dna = encode_base4_direct(data)\n",
+    "print(dna)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/data/sample.txt
+++ b/tests/data/sample.txt
@@ -1,0 +1,1 @@
+Hello GeneCoder


### PR DESCRIPTION
## Summary
- add small sample dataset under `tests/data/`
- add introductory notebooks for encoding, channel simulation and decoding
- link new notebooks from README and documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d939bf3c83269dfdfc1cf2e3222f