### PR TITLE
Add confirmation prompt for plugin registry installs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -120,3 +120,11 @@ packages:
 The URL may use HTTP(S) or point to a local file via ``file://``. Each entry is
 passed directly to ``pip install``. Only use registries from trusted sources as
 their packages are installed and executed automatically.
+
+### Security Considerations
+
+When ``GENECODER_PLUGIN_REGISTRY_URL`` is set, GeneCoder will prompt for
+confirmation before installing each package from the registry. Review the list
+of packages carefully and only accept installations from sources you trust.
+Consider verifying a digital signature for the registry file or each package
+before proceeding.

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -58,6 +58,10 @@ def _install_registry_plugins(url: str) -> None:
         return
 
     for spec in data.get("packages", []):
+        confirm = input(f"Install plugin package {spec}? [y/N]: ")
+        if confirm.strip().lower() not in {"y", "yes"}:
+            logger.info("Skipping plugin %s", spec)
+            continue
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
         except Exception as exc:  # pragma: no cover - install error path

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,5 +1,6 @@
 import sys
 
+import builtins
 import genecoder.plugins as plugins
 
 
@@ -32,6 +33,7 @@ def test_registry_install(monkeypatch):
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(builtins, "input", lambda _: "y")
 
     plugins.CODEC_REGISTRY.clear()
     plugins.FEC_REGISTRY.clear()
@@ -43,4 +45,30 @@ def test_registry_install(monkeypatch):
         [sys.executable, "-m", "pip", "install", "pkgA>=1.0"],
         [sys.executable, "-m", "pip", "install", "pkgB"],
     ]
+
+
+def test_registry_install_decline(monkeypatch):
+    installs = []
+
+    def fake_check_call(cmd):
+        installs.append(cmd)
+
+    def fake_urlopen(url):
+        assert url == "https://example.com/plugins.yaml"
+        data = b"packages:\n  - pkgA>=1.0\n  - pkgB"
+        return DummyResponse(data)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(builtins, "input", lambda _: "n")
+
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert installs == []
 


### PR DESCRIPTION
## Summary
- prompt before each pip install when loading registry plugins
- document security considerations around `GENECODER_PLUGIN_REGISTRY_URL`
- test that declined installs are skipped

## Testing
- `ruff check .`
- `pytest tests/test_plugin_registry.py -q`
- `pytest -q` *(partial output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6865d915dcb4832686d202d377998b29