### PR TITLE
Improve bundle config validation

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -9,6 +9,27 @@ from pathlib import Path
 
 from . import cli as cli_module
 
+_ALLOWED_CACHE: dict[str, set[str]] | None = None
+
+
+def _get_allowed(command: str) -> set[str]:
+    global _ALLOWED_CACHE
+    if _ALLOWED_CACHE is None:
+        parser = cli_module.build_parser()
+        subparsers = next(
+            a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+        )
+        _ALLOWED_CACHE = {}
+        for name in ("encode", "simulate-errors", "decode"):
+            sub = subparsers.choices[name]
+            allowed = {
+                act.dest
+                for act in sub._actions
+                if act.option_strings and act.dest != "help"
+            }
+            _ALLOWED_CACHE[name] = allowed
+    return _ALLOWED_CACHE[command]
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,6 +52,14 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _normalize_args(prefix: str, opts: dict[str, object]) -> list[str]:
+    if not isinstance(opts, dict):
+        raise TypeError(f"{prefix} section must be a mapping")
+
+    allowed = _get_allowed(prefix)
+    unknown = set(opts) - allowed
+    if unknown:
+        raise ValueError(f"Unknown {prefix} options: {', '.join(sorted(unknown))}")
+
     args = [prefix]
     for key, value in opts.items():
         if value is None:
@@ -42,8 +71,12 @@ def _normalize_args(prefix: str, opts: dict[str, object]) -> list[str]:
         elif isinstance(value, list):
             args.append(opt)
             args.extend([str(v) for v in value])
-        else:
+        elif isinstance(value, (int, float, str)):
             args.extend([opt, str(value)])
+        else:
+            raise TypeError(
+                f"Invalid type for {prefix}.{key}: {type(value).__name__}"
+            )
     return args
 
 
@@ -60,6 +93,16 @@ def _handle_run(args: argparse.Namespace) -> None:
 
     with open(args.config, "r", encoding="utf-8") as fh:
         config = yaml.safe_load(fh) or {}
+
+    if not isinstance(config, dict):
+        raise TypeError("Top level YAML must be a mapping")
+
+    allowed_sections = {"encode", "simulate", "decode"}
+    unknown_sections = set(config) - allowed_sections
+    if unknown_sections:
+        raise ValueError(
+            f"Unknown top-level keys: {', '.join(sorted(unknown_sections))}"
+        )
 
     config_hash = hashlib.sha256(
         json.dumps(config, sort_keys=True).encode()
@@ -78,13 +121,17 @@ def _handle_run(args: argparse.Namespace) -> None:
     decoded_dir.mkdir(parents=True, exist_ok=True)
 
     enc_cfg = config.get("encode", {})
+    if not isinstance(enc_cfg, dict):
+        raise TypeError("encode section must be a mapping")
     enc_args = _normalize_args("encode", enc_cfg)
     enc_args += ["--output-dir", str(encoded_dir)]
     _run_cli(enc_args)
 
     input_files = [encoded_dir / (Path(p).name + ".fasta") for p in enc_cfg.get("input_files", [])]
 
-    sim_cfg = config.get("simulator")
+    sim_cfg = config.get("simulate")
+    if sim_cfg is not None and not isinstance(sim_cfg, dict):
+        raise TypeError("simulate section must be a mapping")
     if sim_cfg:
         simulated_dir.mkdir(parents=True, exist_ok=True)
         sim_args_common = _normalize_args("simulate-errors", sim_cfg)
@@ -97,6 +144,8 @@ def _handle_run(args: argparse.Namespace) -> None:
         input_files = new_inputs
 
     dec_cfg = config.get("decode")
+    if dec_cfg is not None and not isinstance(dec_cfg, dict):
+        raise TypeError("decode section must be a mapping")
     if dec_cfg:
         dec_args = _normalize_args("decode", dec_cfg)
         dec_args += ["--input-files"] + [str(p) for p in input_files]

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -30,3 +30,39 @@ def test_bundle_run(tmp_path: Path) -> None:
     decoded = run_dir / "decoded" / "message.txt_decoded.bin"
     assert encoded.exists()
     assert decoded.exists()
+
+
+def test_bundle_unknown_section(tmp_path: Path) -> None:
+    cfg = {"encode": {}, "decode": {}, "bogus": {}}
+    cfg_path = tmp_path / "b.yml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    res = run_cli_command(["bundle", "run", str(cfg_path), "--cache-dir", str(tmp_path / "runs")])
+    assert res.returncode != 0
+    assert "Unknown top-level keys" in res.stderr
+
+
+def test_bundle_bad_section_type(tmp_path: Path) -> None:
+    cfg = {"encode": "nope", "decode": {}}
+    path = tmp_path / "c.yml"
+    path.write_text(yaml.safe_dump(cfg))
+    res = run_cli_command(["bundle", "run", str(path), "--cache-dir", str(tmp_path / "runs")])
+    assert res.returncode != 0
+    assert "encode section must be a mapping" in res.stderr
+
+
+def test_bundle_unknown_encode_option(tmp_path: Path) -> None:
+    inp = tmp_path / "f.txt"
+    inp.write_text("x")
+    cfg = {
+        "encode": {
+            "input_files": [str(inp)],
+            "method": "base4_direct",
+            "bogus": 1,
+        },
+        "decode": {"method": "base4_direct"},
+    }
+    p = tmp_path / "d.yml"
+    p.write_text(yaml.safe_dump(cfg))
+    res = run_cli_command(["bundle", "run", str(p), "--cache-dir", str(tmp_path / "runs")])
+    assert res.returncode != 0
+    assert "Unknown encode options" in res.stderr


### PR DESCRIPTION
## Summary
- validate allowable option keys when running bundle workflows
- handle malformed bundle sections
- test malformed YAML cases

## Testing
- `ruff check src/genecoder/cli/bundle.py tests/test_bundle.py`
- `mypy src/genecoder/cli/bundle.py`
- `pytest tests/test_bundle.py::test_bundle_run tests/test_bundle.py::test_bundle_unknown_section tests/test_bundle.py::test_bundle_bad_section_type tests/test_bundle.py::test_bundle_unknown_encode_option -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d9183f08832692a4c6d170081b66