### PR TITLE
Add plugin registry failure tests

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 import genecoder.plugins as plugins
 
@@ -43,4 +44,43 @@ def test_registry_install(monkeypatch):
         [sys.executable, "-m", "pip", "install", "pkgA>=1.0"],
         [sys.executable, "-m", "pip", "install", "pkgB"],
     ]
+
+
+def test_registry_install_failure(monkeypatch, caplog):
+    """Warnings are logged if installation of a package fails."""
+    def fake_check_call(cmd):
+        raise RuntimeError("boom")
+
+    def fake_urlopen(url):
+        assert url == "https://example.com/plugins.yaml"
+        data = b"packages:\n  - pkgA"
+        return DummyResponse(data)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugins()
+
+    assert "Failed to install plugin pkgA from registry" in caplog.text
+
+
+def test_registry_bad_yaml(monkeypatch, caplog):
+    """Malformed registry YAML triggers a warning and no installation."""
+
+    def fake_urlopen(url):
+        assert url == "https://example.com/plugins.yaml"
+        return DummyResponse(b"not: [yaml")
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugins()
+
+    assert "Failed to fetch plugin registry" in caplog.text
 


### PR DESCRIPTION
## Summary
- test failing installations emit warnings
- test malformed registry YAML

## Testing
- `pre-commit run --files tests/test_plugin_registry.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d93cf86883268b74c0b176a8da89