### PR TITLE
Add FastAPI chunk endpoint tests

### DIFF
--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -1,0 +1,66 @@
+import base64
+import hashlib
+import json
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+import web.main as main
+
+client = TestClient(main.app)
+
+
+def test_chunk_upload_and_download(tmp_path, monkeypatch):
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = None
+    data = b"chunk data"
+    payload = {
+        "file_id": "file1",
+        "offset": 1,
+        "data": base64.b64encode(data).decode(),
+    }
+    r = client.post("/upload-chunk", json=payload)
+    assert r.status_code == 200
+    expected_hash = hashlib.sha256(data).hexdigest()
+    assert r.json()["hash"] == expected_hash
+    chunk_dir = tmp_path / "chunks" / "file1"
+    chunk_path = chunk_dir / "1.chunk"
+    assert chunk_path.is_file()
+    assert chunk_path.read_bytes() == data
+    manifest_path = chunk_dir / "upload.manifest"
+    assert manifest_path.is_file()
+    manifest = manifest_path.read_text().splitlines()
+    assert manifest == [json.dumps({"offset": 1, "hash": expected_hash})]
+
+    r2 = client.get("/download-chunk", params={"file_id": "file1", "offset": 1})
+    assert r2.status_code == 200
+    assert base64.b64decode(r2.json()["data"]) == data
+
+
+def test_rate_limiter_requires_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = object()
+
+    async def fake_rate_limit(request, _response):
+        if "authorization" not in request.headers:
+            raise main.HTTPException(status_code=401, detail="missing token")
+
+    monkeypatch.setattr(main, "rate_limit", fake_rate_limit)
+
+    payload = {
+        "file_id": "file2",
+        "offset": 0,
+        "data": base64.b64encode(b"data").decode(),
+    }
+    r = client.post("/upload-chunk", json=payload)
+    assert r.status_code == 401
+
+    r2 = client.post(
+        "/upload-chunk",
+        json=payload,
+        headers={"Authorization": "Bearer t"},
+    )
+    assert r2.status_code == 200
+


### PR DESCRIPTION
## Summary
- test upload/download chunk endpoints
- verify rate limiting behavior with mock

## Testing
- `ruff check tests/test_web_api_chunks.py`
- `mypy --config-file mypy.ini src`
- `pytest -q tests/test_web_api_chunks.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e8e585648326be328903356d2972