### PR TITLE
Update plugin marketplace docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,15 @@ See [docs/plugins.md](docs/plugins.md) for details on writing and registering
 new codecs, FEC back-ends or simulators. Plugins are automatically loaded when
 using the CLI or GUI. When using GeneCoder as a library call
 ``genecoder.plugins.load_plugins()`` first to populate the registries.
+
+Remote plugin sources can be configured via the environment variables
+``GENECODER_PLUGIN_REGISTRY_URL`` and ``GENECODER_PLUGIN_CATALOG_URL``. Set
+``GENECODER_PLUGIN_REGISTRY_URL`` to a YAML file with package names to install
+automatically and ``GENECODER_PLUGIN_CATALOG_URL`` to a JSON or YAML catalog
+used by the ``genecoder plugin`` commands. The catalog URL may be an HTTP(S)
+address or a local file via ``file://``.
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=https://example.com/registry.yaml
+export GENECODER_PLUGIN_CATALOG_URL=https://example.com/catalog.yaml
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -108,8 +108,14 @@ print(CODEC_REGISTRY.keys())
 
 `load_plugins()` can optionally install third‑party plugins from a remote
 registry before discovering entry points. Set the environment variable
-`GENECODER_PLUGIN_REGISTRY_URL` to the location of a YAML file listing plugin
-packages:
+`GENECODER_PLUGIN_REGISTRY_URL` to the URL of a YAML file listing plugin
+packages. Example:
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=https://example.com/registry.yaml
+```
+
+The registry file must contain:
 
 ```yaml
 packages:
@@ -124,7 +130,13 @@ their packages are installed and executed automatically.
 ## Plugin Marketplace
 
 Set ``GENECODER_PLUGIN_CATALOG_URL`` to a JSON or YAML file describing
-available plugins. The format is:
+available plugins. Example:
+
+```bash
+export GENECODER_PLUGIN_CATALOG_URL=https://example.com/catalog.yaml
+```
+
+The file may be JSON or YAML and should follow this structure:
 
 ```yaml
 plugins:
@@ -132,6 +144,18 @@ plugins:
     version: "1.0.0"
     url: myplugin==1.0.0
     description: Example plugin
+```
+
+The URL may use HTTP(S) or point to a local file via ``file://``.
+
+JSON uses the same keys:
+
+```json
+{
+  "plugins": [
+    {"name": "myplugin", "version": "1.0.0", "url": "myplugin==1.0.0", "description": "Example plugin"}
+  ]
+}
 ```
 
 After loading plugins, list available entries:


### PR DESCRIPTION
## Summary
- document `GENECODER_PLUGIN_REGISTRY_URL` and `GENECODER_PLUGIN_CATALOG_URL`
- explain using these variables in README
- note that catalog files can be local

## Testing
- `PYTHONPATH=. mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6865e8d97c7c8326b96d2d1159173757