### PR TITLE
Add plugin examples to mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        args: ["--config-file", "mypy.ini", "src"]
+        args: ["--config-file", "pyproject.toml"]
         pass_filenames: false
         additional_dependencies: ["cryptography", "types-PyYAML"]
   - repo: local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ Or restrict it to specific files:
 pre-commit run --files path/to/file.py
 ```
 
+When developing plugins in `plugins-examples/`, include the package path so Ruff
+and mypy lint those files as well:
+
+```bash
+pre-commit run --files plugins-examples/example_codec/example_codec/__init__.py
+```
+
 The hook also runs automatically on each commit if installed.
 
 An additional `check-glossary-terms` hook verifies that every term in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,20 @@ line-length = 88
   extend-select = []
   extend-ignore = ["E402"]
 
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+strict = true
+explicit_package_bases = true
+files = [
+    "src",
+    "plugins-examples/example_codec/example_codec",
+    "plugins-examples/example_fec/example_fec",
+    "plugins-examples/example_simulator/example_simulator",
+    "plugins-examples/example_package_plugin/example_plugin",
+    "plugins-examples/advanced_fec/advanced_fec",
+]
+
 
 [tool.poetry]
 name = "GeneCoder"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -63,6 +63,7 @@ def test_registry_install_failure(monkeypatch, caplog):
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(builtins, "input", lambda _: "y")
 
     with caplog.at_level(logging.WARNING):
         plugins.load_plugins()


### PR DESCRIPTION
## Summary
- run mypy on plugin example packages
- update pre-commit hook to read pyproject configuration
- document linting the example plugins
- patch registry test to mock input

## Testing
- `ruff check plugins-examples`
- `mypy --config-file pyproject.toml`
- `pytest tests/test_plugin_registry.py::test_registry_install_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e8e6b76483268e5053b9dfb6a0fe