### PR TITLE
Update plugin security docs and encryption warning

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -169,3 +169,15 @@ Install a plugin from the catalog:
 ```bash
 genecoder plugin install myplugin
 ```
+
+## Third-Party Plugin Risks and Verification
+
+GeneCoder automatically imports any packages that expose the appropriate entry
+points or are listed in a plugin registry. These plugins execute arbitrary
+Python code with the privileges of the current user. Malicious or poorly
+written plugins could therefore compromise your system or corrupt data.
+
+GeneCoder itself does not verify the authenticity of third-party packages. When
+using a registry or catalog, ensure the listed sources are trustworthy and, if
+possible, manually inspect the plugin code or compare checksums before
+installation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,8 +262,8 @@ genecoder encode --input-files msg.txt \
 ```
 ### Security Options
 
-Use `--encrypt` to XOR-encrypt the input bytes with a built-in key before
-encoding. Provide `--key <file>` to read custom key bytes from a file. The
+Use `--encrypt` to XOR-encrypt the input bytes. You **must** provide your own
+key via `--key <file>` as GeneCoder does not include a secure default. The
 `--checksum` flag stores a SHA256 checksum of the plaintext in the FASTA header
 which is validated during decoding.
 


### PR DESCRIPTION
## Summary
- document security considerations for third-party plugins
- clarify that encryption requires providing your own key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686698d5ee8083268c40ed183d505f8e