### PR TITLE
Remove XOR encryption mode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,7 +262,7 @@ genecoder encode --input-files msg.txt \
 ```
 ### Security Options
 
-Use `--encrypt` to XOR-encrypt the input bytes with a built-in key before
+Use `--encrypt` to AES-GCM encrypt the input bytes with a built-in key before
 encoding. Provide `--key <file>` to read custom key bytes from a file. The
 `--checksum` flag stores a SHA256 checksum of the plaintext in the FASTA header
 which is validated during decoding.

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -13,13 +13,8 @@ _AES_HEADER = b"AESGCM1"
 _DEFAULT_KEY = b"GeneCoder"
 
 
-def _xor_cipher(data: bytes, key: bytes) -> bytes:
-    """Return ``data`` XORed with ``key``."""
-    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
-
-
 def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
-    """Encrypt ``data`` using AES-GCM with a random nonce."""
+    """Return ``data`` encrypted using AES-GCM with a random nonce."""
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
     key = key or _DEFAULT_KEY
@@ -31,22 +26,35 @@ def encrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
     return _AES_HEADER + nonce + enc
 
 
-
-
 def decrypt_data(data: bytes, key: Optional[bytes] = None) -> bytes:
-    """Decrypt data produced by :func:`encrypt_data` or legacy XOR."""
+    """Decrypt bytes produced by :func:`encrypt_data`.
+
+    Parameters
+    ----------
+    data:
+        Bytes previously returned by :func:`encrypt_data`.
+    key:
+        Optional secret key used during encryption. If omitted, a built-in
+        default is used.
+
+    Raises
+    ------
+    ValueError
+        If ``data`` does not appear to be AES encrypted.
+    cryptography.exceptions.InvalidTag
+        If decryption fails because the key or ciphertext is invalid.
+    """
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
     key = key or _DEFAULT_KEY
-    if data.startswith(_AES_HEADER):
-        aes_key = hashlib.sha256(key).digest()
-        nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
-        ciphertext = data[len(_AES_HEADER) + 12 :]
-        dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
-        return dec
+    if not data.startswith(_AES_HEADER):
+        raise ValueError("Data is not AES encrypted")
 
-
-    return _xor_cipher(data, key)
+    aes_key = hashlib.sha256(key).digest()
+    nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
+    ciphertext = data[len(_AES_HEADER) + 12 :]
+    dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
+    return dec
 
 
 def compute_checksum(data: bytes) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -34,10 +34,16 @@ def _legacy_xor_encrypt(data: bytes, key: bytes) -> bytes:
     return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
 
 
-def test_decrypt_legacy_format() -> None:
+def test_decrypt_legacy_format_fails() -> None:
     data = b"legacy"
     legacy_enc = _legacy_xor_encrypt(data, _DEFAULT_KEY)
-    assert decrypt_data(legacy_enc) == data
+    with pytest.raises(ValueError):
+        decrypt_data(legacy_enc)
+
+
+def test_decrypt_unencrypted_bytes() -> None:
+    with pytest.raises(ValueError):
+        decrypt_data(b"not encrypted")
 
 
 def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- deprecate XOR encryption
- clarify docs and type hints for encrypt/decrypt helpers
- update security docs
- test failure cases for decrypting non-AES data

## Testing
- `ruff check src/genecoder/security.py tests/test_security.py`
- `pytest tests/test_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686698cc9dc083268ee8630ec8a8c0aa