### PR TITLE
Add validation tests for dashboard endpoints

### DIFF
--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -11,6 +11,8 @@ main.API_TOKEN = "test-token"
 def _client() -> TestClient:
     return TestClient(main.app)
 
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
 
 def test_dashboard_page() -> None:
     with _client() as client:
@@ -23,7 +25,7 @@ def test_dashboard_metrics() -> None:
     with _client() as client:
         resp = client.post(
             "/dashboard/metrics",
-            headers={"Authorization": f"Bearer {main.API_TOKEN}"},
+            headers=AUTH_HEADERS,
             json={"dna_sequence": "ACGT"},
         )
     assert resp.status_code == 200
@@ -33,3 +35,55 @@ def test_dashboard_metrics() -> None:
     assert isinstance(data["max_homopolymer"], int)
     assert isinstance(data["error_rate"], float)
     assert isinstance(data["plot"], str)
+
+
+def test_dashboard_metrics_invalid_chars() -> None:
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/metrics",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": "ACGTX"},
+        )
+    assert resp.status_code == 400
+
+
+def test_dashboard_metrics_bad_window() -> None:
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/metrics",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": "ACGT", "window_size": 0},
+        )
+    assert resp.status_code == 400
+
+
+def test_dashboard_plot_data_valid() -> None:
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/plot-data",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": "ACGT"},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) == {"gc_positions", "gc_values", "hp_lengths"}
+
+
+def test_dashboard_plot_data_invalid_chars() -> None:
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/plot-data",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": "ACGX"},
+        )
+    assert resp.status_code == 400
+
+
+def test_dashboard_plot_data_bad_window() -> None:
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/plot-data",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": "ACGT", "window_size": 0},
+        )
+    assert resp.status_code == 400

--- a/web/main.py
+++ b/web/main.py
@@ -253,17 +253,24 @@ async def dashboard_metrics(
     _: None = Depends(verify_token),
 ) -> dict[str, object]:
     seq = req.dna_sequence
-    gc = calculate_gc_content(seq)
-    max_hp = get_max_homopolymer_length(seq)
-    gc_data = calculate_windowed_gc_content(seq, req.window_size, req.step_size)
-    hp_regions = identify_homopolymer_regions(seq, req.min_homopolymer_len)
-    buf = generate_sequence_analysis_plot(gc_data, hp_regions, len(seq))
-    plot_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
-    buf.close()
-    orig_bytes, _ = decode_base4_direct(seq)
-    corrupted = introduce_errors(seq, substitution_prob=0.05)
-    dec_bytes, _ = decode_base4_direct(corrupted)
-    ber = bit_error_rate(orig_bytes, dec_bytes)
+    if set(seq.upper()) - {"A", "C", "G", "T"}:
+        raise HTTPException(status_code=400, detail="Invalid characters in sequence")
+    try:
+        gc = calculate_gc_content(seq)
+        max_hp = get_max_homopolymer_length(seq)
+        gc_data = calculate_windowed_gc_content(
+            seq, req.window_size, req.step_size
+        )
+        hp_regions = identify_homopolymer_regions(seq, req.min_homopolymer_len)
+        buf = generate_sequence_analysis_plot(gc_data, hp_regions, len(seq))
+        plot_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        buf.close()
+        orig_bytes, _ = decode_base4_direct(seq)
+        corrupted = introduce_errors(seq, substitution_prob=0.05)
+        dec_bytes, _ = decode_base4_direct(corrupted)
+        ber = bit_error_rate(orig_bytes, dec_bytes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "gc_content": gc,
         "max_homopolymer": max_hp,
@@ -305,10 +312,15 @@ async def dashboard_plot_data(
     """Return windowed GC content and homopolymer lengths."""
 
     seq = req.dna_sequence
-    starts, gc_values = calculate_windowed_gc_content(
-        seq, req.window_size, req.step_size
-    )
-    hp_lengths = _homopolymer_lengths(seq)
+    if set(seq.upper()) - {"A", "C", "G", "T"}:
+        raise HTTPException(status_code=400, detail="Invalid characters in sequence")
+    try:
+        starts, gc_values = calculate_windowed_gc_content(
+            seq, req.window_size, req.step_size
+        )
+        hp_lengths = _homopolymer_lengths(seq)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "gc_positions": starts,
         "gc_values": gc_values,


### PR DESCRIPTION
## Summary
- ensure `/dashboard/metrics` and `/dashboard/plot-data` return 400 for invalid input
- validate DNA characters server-side

## Testing
- `ruff check web/main.py tests/test_dashboard_httpx.py`
- `mypy --config-file pyproject.toml`
- `pytest -q tests/test_dashboard_httpx.py`

------
https://chatgpt.com/codex/tasks/task_e_686698d3d0d48326981f406c9af87c11