### PR TITLE
Add benchmark fec CLI command

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,26 +1,24 @@
 # FEC Benchmarks
 
-GeneCoder ships with `benchmarks/fec_bench.py` for evaluating forward error correction implementations.
-
-The script automatically loads FEC plugins via `FEC_REGISTRY`, encodes sample data,
+GeneCoder provides a CLI subcommand to benchmark forward error correction implementations.
+Internally it reuses `benchmarks/fec_bench.py` which loads FEC plugins, encodes sample data,
 introduces random bit flips and reports encode/decode throughput along with the residual bit error rate.
 
 Run with default settings (1&nbsp;MB input, 1% bit flip probability):
 
 ```bash
-PYTHONPATH=src python benchmarks/fec_bench.py --format csv > results.csv
+python -m genecoder.cli benchmark fec --format csv > results.csv
 ```
 
-Use `--format json` to emit JSON instead of CSV and `--output` to specify an output file.
-
-Results can be plotted using external tools like pandas or matplotlib.
+Use `--format json` to emit JSON instead of CSV, `--output` to write to a file and
+`--plot` to save a PNG chart of the results generated with `genecoder.report`.
 
 ## Quick Tutorial
 
 To quickly test the benchmark script with minimal data run:
 
 ```bash
-PYTHONPATH=src python benchmarks/fec_bench.py --size 16 --error-prob 0 --format csv
+python -m genecoder.cli benchmark fec --size 16 --error-prob 0 --format csv
 ```
 
 which prints a CSV table similar to:
@@ -34,7 +32,7 @@ fountain,,,,pyfinite is required for Fountain encoding. Install it via 'pip inst
 Generating JSON output uses the same flags with `--format json`:
 
 ```bash
-PYTHONPATH=src python benchmarks/fec_bench.py --size 16 --error-prob 0 --format json
+python -m genecoder.cli benchmark fec --size 16 --error-prob 0 --format json
 ```
 
 Example JSON:

--- a/src/genecoder/cli/benchmark.py
+++ b/src/genecoder/cli/benchmark.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Dict, cast
+
+from genecoder import report as report_module
+
+
+_DATA_SIZE = 1_000_000
+_ERROR_PROB = 0.01
+
+
+def register_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser("benchmark", help="Run benchmark suites")
+    bench_sub = parser.add_subparsers(dest="benchmark_cmd", required=True)
+    fec_parser = bench_sub.add_parser(
+        "fec", help="Benchmark forward error correction back-ends"
+    )
+    fec_parser.add_argument("--format", choices=["csv", "json"], default="csv")
+    fec_parser.add_argument("--output", "-o", type=Path)
+    fec_parser.add_argument("--size", type=int, default=_DATA_SIZE)
+    fec_parser.add_argument("--error-prob", type=float, default=_ERROR_PROB)
+    fec_parser.add_argument("--plot", type=Path, help="Write PNG plot of results")
+    fec_parser.set_defaults(func=_handle_fec)
+
+
+def _parse_results(text: str, fmt: str) -> list[dict[str, float | str]]:
+    if fmt == "json":
+        return cast(List[Dict[str, float | str]], json.loads(text))
+    reader = csv.DictReader(io.StringIO(text))
+    return [dict(row) for row in reader]
+
+
+def _handle_fec(args: argparse.Namespace) -> None:
+    script = Path(__file__).resolve().parents[3] / "benchmarks" / "fec_bench.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--format",
+        args.format,
+        "--size",
+        str(args.size),
+        "--error-prob",
+        str(args.error_prob),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    results_text = proc.stdout
+    if args.plot:
+        results = _parse_results(results_text, args.format)
+        buf = report_module.plot_fec_benchmark(results)
+        with open(args.plot, "wb") as fh:
+            fh.write(buf.getvalue())
+        buf.close()
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(results_text)
+    else:
+        sys.stdout.write(results_text)

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -15,6 +15,7 @@ report: Any | None = None
 channel: Any | None = None
 bundle: Any | None = None
 plugin: Any | None = None
+benchmark: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -59,9 +60,10 @@ def build_parser() -> argparse.ArgumentParser:
         channel as _channel,
         bundle as _bundle,
         plugin as _plugin_mod,
+        benchmark as _benchmark,
     )
 
-    global encode, decode, analyze, report, channel, bundle, plugin
+    global encode, decode, analyze, report, channel, bundle, plugin, benchmark
 
     encode = _encode
     decode = _decode
@@ -70,6 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
     channel = _channel
     bundle = _bundle
     plugin = _plugin_mod
+    benchmark = _benchmark
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -94,6 +97,7 @@ def build_parser() -> argparse.ArgumentParser:
     channel.register_subcommand(subparsers)
     bundle.register_subcommand(subparsers)
     plugin.register_subcommand(subparsers)
+    benchmark.register_subcommand(subparsers)
 
 
     sim_parser = subparsers.add_parser(

--- a/src/genecoder/report.py
+++ b/src/genecoder/report.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from html import escape
-from typing import Iterable
+from typing import Iterable, List, Dict
+import io
+
+from .plotting import plt, _MATPLOTLIB_AVAILABLE, _dummy_png
 
 from .app_helpers import EncodeResult, DecodeResult
 
@@ -10,6 +13,7 @@ __all__ = [
     "decode_to_markdown",
     "encode_to_html",
     "decode_to_html",
+    "plot_fec_benchmark",
 ]
 
 
@@ -75,3 +79,34 @@ def _markdown_to_html(markdown: str) -> str:
     if in_ul:
         html_lines.append("</ul>")
     return "\n".join(html_lines)
+
+
+def plot_fec_benchmark(results: List[Dict[str, float | str]]) -> io.BytesIO:
+    """Return a bar plot of encode/decode throughput for FEC benchmarks."""
+    if not _MATPLOTLIB_AVAILABLE:
+        return _dummy_png()
+
+    names = [r.get("fec", "") for r in results]
+    enc = [float(r.get("encode_mb_s", 0)) for r in results]
+    dec = [float(r.get("decode_mb_s", 0)) for r in results]
+
+    x = list(range(len(names)))
+    width = 0.35
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.bar([i - width / 2 for i in x], enc, width, label="encode MB/s")
+    ax.bar([i + width / 2 for i in x], dec, width, label="decode MB/s")
+    ax.set_ylabel("MB/s")
+    ax.set_title("FEC Benchmark")
+    ax.set_xticks(x)
+    ax.set_xticklabels(names)
+    ax.legend()
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    try:
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+    finally:
+        plt.close(fig)
+    return buf

--- a/tests/test_cli_benchmark.py
+++ b/tests/test_cli_benchmark.py
@@ -1,0 +1,36 @@
+import json
+from tests.test_cli import run_cli_command
+
+
+def test_cli_benchmark_fec_json() -> None:
+    result = run_cli_command([
+        "benchmark",
+        "fec",
+        "--size",
+        "16",
+        "--error-prob",
+        "0",
+        "--format",
+        "json",
+    ])
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert all("fec" in item for item in data)
+
+
+def test_cli_benchmark_fec_csv() -> None:
+    result = run_cli_command([
+        "benchmark",
+        "fec",
+        "--size",
+        "16",
+        "--error-prob",
+        "0",
+        "--format",
+        "csv",
+    ])
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line]
+    assert lines[0].startswith("fec,")
+    assert len(lines) >= 2


### PR DESCRIPTION
## Summary
- add `benchmark fec` subcommand
- support plotting benchmark results via `genecoder.report`
- document benchmark subcommand usage
- test new CLI command

## Testing
- `ruff check src/genecoder/cli/benchmark.py src/genecoder/report.py src/genecoder/cli/cli.py docs/benchmarks.md tests/test_cli_benchmark.py`
- `mypy -p genecoder.cli.benchmark -p genecoder.report -p genecoder.cli.cli`
- `pytest tests/test_cli_benchmark.py tests/test_fec_bench_script.py tests/test_reports.py tests/test_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686698ce279c8326a1410a8fc534e6d0