### PR TITLE
Handle multi-record FASTA in channel CLI

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -76,32 +76,37 @@ def process_channel(
     if not records:
         logger.error("No FASTA records found in %s", input_file)
         raise SystemExit(1)
-    header, seq = records[0]
-
-    seq = _apply_simulators(
-        seq,
-        simulators,
-        parallel=parallel,
-        threads=threads,
-        processes=processes,
-    )
 
     synth = SynthesisConstraints(**constraints)
-    if not validate_sequence(seq, synth):
-        logger.error("Sequence violates synthesis constraints")
-        raise SystemExit(1)
-    logger.info("Sequence satisfies synthesis constraints")
+    processed_records: list[tuple[str, str]] = []
+    for header, seq in records:
+        seq = _apply_simulators(
+            seq,
+            simulators,
+            parallel=parallel,
+            threads=threads,
+            processes=processes,
+        )
 
-    fasta_out = to_fasta(seq, header, line_width=80)
+        if not validate_sequence(seq, synth):
+            logger.error("Sequence violates synthesis constraints")
+            raise SystemExit(1)
+        logger.info("Sequence satisfies synthesis constraints")
+        processed_records.append((header, seq))
+
+    fasta_out = "".join(
+        to_fasta(seq, header, line_width=80) for header, seq in processed_records
+    )
     os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
     with open(output_file, "w", encoding="utf-8") as f_out:
         f_out.write(fasta_out)
 
+    total_len = sum(len(seq) for _, seq in processed_records)
     manifest = {
         "file": os.path.basename(Path(input_file).as_posix()),
         "simulators": list(simulators),
         "constraints": constraints,
-        "metrics": {"length": len(seq)},
+        "metrics": {"length": total_len},
     }
     manifest_path = os.path.splitext(output_file)[0] + ".manifest.json"
     with open(manifest_path, "w", encoding="utf-8") as m_out:

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -9,6 +9,11 @@ def create_fasta(path: Path, seq: str = "ACGT", header: str = "seq") -> None:
     path.write_text(to_fasta(seq, header))
 
 
+def create_multi_fasta(path: Path, records: list[tuple[str, str]]) -> None:
+    from src.genecoder.formats import to_fasta
+    path.write_text("".join(to_fasta(seq, hdr) for seq, hdr in records))
+
+
 def test_channel_cli_simulator(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)
@@ -69,4 +74,33 @@ def test_channel_cli_yaml(tmp_path: Path) -> None:
     data = json.loads(manifest.read_text())
     assert data["simulators"] == ["simple"]
     assert data["constraints"]["max_homopolymer"] == 5
+
+
+def test_channel_cli_multi_record(tmp_path: Path) -> None:
+    input_fasta = tmp_path / "in_multi.fasta"
+    create_multi_fasta(input_fasta, [("AAAA", "seq1"), ("TTTT", "seq2")])
+    output_fasta = tmp_path / "out_multi.fasta"
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "simple",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    from src.genecoder.formats import from_fasta
+    parsed = from_fasta(output_fasta.read_text())
+    assert [hdr for hdr, _ in parsed] == ["seq1", "seq2"]
 


### PR DESCRIPTION
## Summary
- iterate through all input FASTA records in `process_channel`
- preserve headers when writing the output FASTA
- note total length for manifest
- add support for multi-record inputs in `tests/test_cli_channel.py`

## Testing
- `ruff check tests/test_cli_channel.py src/genecoder/cli/channel.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866986f22048326a42a9808c82f4286