### PR TITLE
Add fix sequence button in GUI

### DIFF
--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -32,3 +32,7 @@ input file.
 ![GUI screenshot](https://flet.dev/docs/images/screenshot.png)
 
 Use the buttons at the bottom of each tab to start the selected operation.
+
+After encoding completes, GC and homopolymer metrics are shown. If they fall outside recommended ranges, a **Fix Sequence** button allows automatic adjustment. Clicking it displays the fixed DNA snippet and updated metrics.
+
+Example: encode any file, then click **Fix Sequence** when the suggestion text appears to view the corrected sequence.

--- a/notebooks/lessons/4_analyzing_results.ipynb
+++ b/notebooks/lessons/4_analyzing_results.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "# imagine loading results\n",
     "print('analysis placeholder')"
    ]

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -339,6 +339,16 @@ def main(page: ft.Page) -> None:
 
     encode_status_text: ft.Text = ft.Text("", selectable=True)
     fix_suggestion_text: ft.Text = ft.Text("", selectable=True)
+    fix_button: ft.ElevatedButton = ft.ElevatedButton("Fix Sequence")
+    fixed_dna_snippet_text: ft.TextField = ft.TextField(
+        label="Fixed DNA Snippet (first 200 chars)",
+        read_only=True,
+        multiline=True,
+        max_lines=3,
+        value="",
+        width=500,
+    )
+    fixed_metrics_text: ft.Text = ft.Text("", selectable=True)
     encode_orig_size_text: ft.Text = ft.Text("Original size: - bytes")
     encode_dna_len_text: ft.Text = ft.Text("Encoded DNA length: - nucleotides")
     encode_comp_ratio_text: ft.Text = ft.Text("Compression ratio: -")
@@ -436,6 +446,8 @@ def main(page: ft.Page) -> None:
         encode_actual_gc_value.value = "-"
         encode_actual_homopolymer_value.value = "-"
         encode_dna_snippet_text.value = ""
+        fixed_dna_snippet_text.value = ""
+        fixed_metrics_text.value = ""
         encode_save_button.visible = False
         encode_manifest_save_button.visible = False
         encode_hidden_fasta_content.value = ""
@@ -608,6 +620,28 @@ def main(page: ft.Page) -> None:
             page.update()
 
     encode_button.on_click = encode_data
+
+    async def apply_fix(_: ft.ControlEvent) -> None:
+        seq = encode_hidden_sequence.value
+        if not seq:
+            fixed_metrics_text.value = "No sequence available to fix."
+            fixed_dna_snippet_text.value = ""
+            page.update()
+            return
+        constraints = SynthesisConstraints()
+        fixed = fix_sequence(
+            seq,
+            target_gc_min=0.4,
+            target_gc_max=0.6,
+            max_homopolymer=constraints.max_homopolymer,
+        )
+        fixed_dna_snippet_text.value = fixed[:200]
+        gc_val = calculate_gc_content(fixed)
+        hp_len = get_max_homopolymer_length(fixed)
+        fixed_metrics_text.value = f"Fixed GC {gc_val:.2%}, max HP {hp_len}"
+        page.update()
+
+    fix_button.on_click = apply_fix
 
     async def on_encode_save_file_result(e: ft.FilePickerResultEvent) -> None:  # Made async for consistency, though not strictly needed here
 
@@ -964,6 +998,9 @@ def main(page: ft.Page) -> None:
                             encode_manifest_save_button,
                             encode_status_text,
                             fix_suggestion_text,
+                            fix_button,
+                            fixed_metrics_text,
+                            fixed_dna_snippet_text,
                             encode_hidden_fasta_content,
                             encode_hidden_manifest_content,
                             encode_hidden_sequence,

--- a/tests/test_flet_app_interactions.py
+++ b/tests/test_flet_app_interactions.py
@@ -43,6 +43,8 @@ def _setup_flet(monkeypatch: pytest.MonkeyPatch):
             captured["encode"] = btn
         elif args and args[0] == "Decode":
             captured["decode"] = btn
+        elif args and args[0] == "Fix Sequence":
+            captured["fix"] = btn
         return btn
 
     monkeypatch.setattr(ft, "ElevatedButton", capture_button)
@@ -219,3 +221,26 @@ def test_decode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
     asyncio.run(decode_cb(None))
     assert "bad fasta" in dec_vars["decode_status_text"].value
+
+
+def test_fix_sequence_button(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, _ = _setup_flet(monkeypatch)
+    from genecoder import flet_app
+
+    ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
+
+    encode_cb = captured["encode"].on_click
+    fix_cb = captured["fix"].on_click
+
+    enc_vars = {n: c.cell_contents for n, c in zip(encode_cb.__code__.co_freevars, encode_cb.__closure__)}
+    fix_vars = {n: c.cell_contents for n, c in zip(fix_cb.__code__.co_freevars, fix_cb.__closure__)}
+
+    input_path = tmp_path / "data.bin"
+    input_path.write_bytes(b"A" * 100)
+    enc_vars["selected_encode_input_file_path"].current = str(input_path)
+
+    asyncio.run(encode_cb(None))
+    asyncio.run(fix_cb(None))
+
+    assert fix_vars["fixed_dna_snippet_text"].value
+    assert "Fixed GC" in fix_vars["fixed_metrics_text"].value


### PR DESCRIPTION
## Summary
- add a button to apply `fix_sequence` in `flet_app` and show results
- document the new feature in the GUI tutorial
- test the fix button in `test_flet_app_interactions`
- fix ruff warning in analyzing results notebook

## Testing
- `ruff check . --fix`
- `mypy --config-file pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686698ce6e6083268cd6e27bb1fcb321