### PR TITLE
Fix decrypt_data to handle XOR fallback

### DIFF
--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -37,12 +37,7 @@ def decrypt_data(data: bytes, key: bytes) -> bytes:
         dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
         return dec
 
-
-    aes_key = hashlib.sha256(key).digest()
-    nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
-    ciphertext = data[len(_AES_HEADER) + 12 :]
-    dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
-    return dec
+    return _xor_cipher(data, key)
 
 
 def compute_checksum(data: bytes) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -33,11 +33,12 @@ def _legacy_xor_encrypt(data: bytes, key: bytes) -> bytes:
     return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
 
 
-def test_decrypt_legacy_format_fails() -> None:
+@pytest.mark.parametrize("encryptor", [encrypt_data, _legacy_xor_encrypt])
+def test_decrypt_aes_and_xor(encryptor) -> None:
     data = b"legacy"
-    legacy_key = b"GeneCoder"
-    legacy_enc = _legacy_xor_encrypt(data, legacy_key)
-    assert decrypt_data(legacy_enc, key=legacy_key) == data
+    key = b"GeneCoder"
+    enc = encryptor(data, key)
+    assert decrypt_data(enc, key=key) == data
 
 
 def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- fix decrypt_data so data without AES header uses XOR
- verify decrypt_data works for AES and XOR ciphertexts

## Testing
- `ruff check src/genecoder/security.py tests/test_security.py`
- `pytest tests/test_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68685b4c26b88326a1682fb65f61e01e