### PR TITLE
Fix legacy XOR decrypt handling

### DIFF
--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -30,6 +30,7 @@ def encrypt_data(data: bytes, key: bytes) -> bytes:
 def decrypt_data(data: bytes, key: bytes) -> bytes:
     """Decrypt data produced by :func:`encrypt_data` or legacy XOR."""
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
     if data.startswith(_AES_HEADER):
         aes_key = hashlib.sha256(key).digest()
         nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
@@ -37,12 +38,7 @@ def decrypt_data(data: bytes, key: bytes) -> bytes:
         dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
         return dec
 
-
-    aes_key = hashlib.sha256(key).digest()
-    nonce = data[len(_AES_HEADER) : len(_AES_HEADER) + 12]
-    ciphertext = data[len(_AES_HEADER) + 12 :]
-    dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
-    return dec
+    return _xor_cipher(data, key)
 
 
 def compute_checksum(data: bytes) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -40,6 +40,13 @@ def test_decrypt_legacy_format_fails() -> None:
     assert decrypt_data(legacy_enc, key=legacy_key) == data
 
 
+def test_decrypt_xor_cipher_roundtrip() -> None:
+    data = b"old-data"
+    key = b"legacy-key"
+    enc = _legacy_xor_encrypt(data, key)
+    assert decrypt_data(enc, key=key) == data
+
+
 def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:
     src = tmp_path / "msg.txt"
     src.write_text("secure message")


### PR DESCRIPTION
## Summary
- handle missing AES header in `decrypt_data`
- test XOR path explicitly

## Testing
- `pre-commit run --files src/genecoder/security.py tests/test_security.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685aeed1648326b99c3ee7cdad6b75