### PR TITLE
Fix decode_ai auth tests

### DIFF
--- a/tests/test_web_api_decode_ai.py
+++ b/tests/test_web_api_decode_ai.py
@@ -6,10 +6,13 @@ pytest.importorskip("httpx")
 pytest.importorskip("dnaformer")
 from fastapi.testclient import TestClient
 
-from web.main import app
+import web.main as main
 from genecoder.dnaformer_codec import encode_data_dnaformer
 
-client = TestClient(app)
+main.API_TOKEN = "test-token"
+client = TestClient(main.app)
+
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
 
 
 def test_decode_ai_endpoint() -> None:
@@ -19,7 +22,33 @@ def test_decode_ai_endpoint() -> None:
         "encoded": base64.b64encode(encoded).decode(),
         "info": info,
     }
-    r = client.post("/decode/ai", json=payload)
+    r = client.post("/decode/ai", headers=AUTH_HEADERS, json=payload)
     assert r.status_code == 200
     decoded = base64.b64decode(r.json()["decoded_bytes"])
     assert decoded == data
+
+
+def test_decode_ai_requires_token() -> None:
+    data = b"no token"
+    encoded, info = encode_data_dnaformer(data)
+    payload = {
+        "encoded": base64.b64encode(encoded).decode(),
+        "info": info,
+    }
+    r = client.post("/decode/ai", json=payload)
+    assert r.status_code == 401
+
+
+def test_decode_ai_invalid_token() -> None:
+    data = b"bad token"
+    encoded, info = encode_data_dnaformer(data)
+    payload = {
+        "encoded": base64.b64encode(encoded).decode(),
+        "info": info,
+    }
+    r = client.post(
+        "/decode/ai",
+        headers={"Authorization": "Bearer wrong"},
+        json=payload,
+    )
+    assert r.status_code == 401

--- a/web/main.py
+++ b/web/main.py
@@ -210,7 +210,10 @@ async def decode(
 
 
 @app.post("/decode/ai")
-async def decode_ai(req: DecodeAIRequest) -> dict[str, object]:
+async def decode_ai(
+    req: DecodeAIRequest,
+    _: None = Depends(verify_token),
+) -> dict[str, object]:
     """Decode data using the optional DNAformer model."""
 
     try:


### PR DESCRIPTION
## Summary
- protect `/decode/ai` with the same token check used by other endpoints
- add tests to cover missing and invalid auth tokens

## Testing
- `pre-commit run ruff --files web/main.py tests/test_web_api_decode_ai.py`
- `pytest -q tests/test_web_api_decode_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_68685b4adc208326935581da8a0efb1f