### PR TITLE
Unify CLI error simulation

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -4,7 +4,7 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 
 ## Built-in simulators
 
-- **simple** — random substitution errors. Use `--simulate-errors` on the CLI or
+- **simple** — random substitution errors. Use `genecoder channel --sub-prob` or
   `--simulator simple`.
 - **indel** — introduces insertions and deletions in addition to substitutions.
 - **none** — disable simulation (the default).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,7 @@ A quick sanity check is to run the command and ensure the usage header appears.
 
 ```bash
 $ genecoder --help | head -n 5
-Usage: genecoder [-h] [--version] {encode,decode,analyze,simulate-errors} ...
+Usage: genecoder [-h] [--version] {encode,decode,analyze,channel} ...
 GeneCoder: Encode and decode data into simulated DNA sequences.
 ...
 ```
@@ -136,8 +136,8 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    ```bash
    genecoder encode --input-files hello.jpg --output-dir encoded \
        --method base4_direct --auto-ext
-   genecoder simulate-errors encoded/hello.jpg.dna --sub-rate 0.01 \
-       --output-file corrupted.dna
+   genecoder channel --input-file encoded/hello.jpg.dna --output-file corrupted.dna \
+       --sub-prob 0.01
    genecoder decode corrupted.dna --output-dir decoded --auto-ext
    ```
 

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -20,7 +20,7 @@ def _get_allowed(command: str) -> set[str]:
             a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
         )
         _ALLOWED_CACHE = {}
-        for name in ("encode", "simulate-errors", "decode"):
+        for name in ("encode", "channel", "decode"):
             sub = subparsers.choices[name]
             allowed = {
                 act.dest
@@ -134,7 +134,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         raise TypeError("simulate section must be a mapping")
     if sim_cfg:
         simulated_dir.mkdir(parents=True, exist_ok=True)
-        sim_args_common = _normalize_args("simulate-errors", sim_cfg)
+        sim_args_common = _normalize_args("channel", sim_cfg)
         new_inputs = []
         for f in input_files:
             out_f = simulated_dir / f.name

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 import os
+import random
 from pathlib import Path
 from typing import Sequence
 
@@ -14,6 +15,7 @@ from genecoder.formats import from_fasta, to_fasta
 from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
+from genecoder.error_simulation import introduce_errors
 
 logger = logging.getLogger(__name__)
 
@@ -66,12 +68,20 @@ def process_channel(
     simulators: Sequence[str],
     constraints: dict[str, int],
     *,
+    sub_prob: float = 0.0,
+    ins_prob: float = 0.0,
+    del_prob: float = 0.0,
+    seed: int | None = None,
     parallel: bool = False,
     threads: int | None = None,
     processes: int | None = None,
 ) -> None:
-    with open(input_file, "r", encoding="utf-8") as f:
-        fasta_str = f.read()
+    try:
+        with open(input_file, "r", encoding="utf-8") as f:
+            fasta_str = f.read()
+    except FileNotFoundError:
+        logger.error("Error: Input file %s not found.", input_file)
+        raise SystemExit(1)
     records = from_fasta(fasta_str)
     if not records:
         logger.error("No FASTA records found in %s", input_file)
@@ -80,13 +90,23 @@ def process_channel(
     synth = SynthesisConstraints(**constraints)
     processed_records: list[tuple[str, str]] = []
     for header, seq in records:
-        seq = _apply_simulators(
-            seq,
-            simulators,
-            parallel=parallel,
-            threads=threads,
-            processes=processes,
-        )
+        if simulators:
+            seq = _apply_simulators(
+                seq,
+                simulators,
+                parallel=parallel,
+                threads=threads,
+                processes=processes,
+            )
+        else:
+            rng = random.Random(seed)
+            seq = introduce_errors(
+                seq,
+                substitution_prob=sub_prob,
+                insertion_prob=ins_prob,
+                deletion_prob=del_prob,
+                rng=rng,
+            )
 
         if not validate_sequence(seq, synth):
             logger.error("Sequence violates synthesis constraints")
@@ -105,6 +125,11 @@ def process_channel(
     manifest = {
         "file": os.path.basename(Path(input_file).as_posix()),
         "simulators": list(simulators),
+        "probabilities": {
+            "sub_prob": sub_prob,
+            "ins_prob": ins_prob,
+            "del_prob": del_prob,
+        },
         "constraints": constraints,
         "metrics": {"length": total_len},
     }
@@ -126,6 +151,10 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Simulator to apply (can be repeated)",
     )
     parser.add_argument("--config", type=str, help="YAML config defining simulators and constraints")
+    parser.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
+    parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
+    parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
     parser.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
     parser.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
     parser.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
@@ -147,14 +176,22 @@ def _handle_command(args: argparse.Namespace) -> None:
         if cfg_sim:
             simulators = cfg_sim
         constraints.update(cfg_con)
-    if not simulators:
-        logger.error("At least one simulator must be specified")
+    prob_specified = any([args.sub_prob, args.ins_prob, args.del_prob])
+    if simulators and prob_specified:
+        logger.error("Probability options cannot be combined with --simulator or --config")
+        raise SystemExit(1)
+    if not simulators and not prob_specified:
+        logger.error("At least one simulator or probability option must be specified")
         raise SystemExit(1)
     process_channel(
         args.input_file,
         args.output_file,
         simulators,
         constraints,
+        sub_prob=args.sub_prob,
+        ins_prob=args.ins_prob,
+        del_prob=args.del_prob,
+        seed=args.seed,
         parallel=args.parallel,
         threads=args.threads,
         processes=args.processes,

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -99,86 +99,11 @@ def build_parser() -> argparse.ArgumentParser:
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)
 
-
-    sim_parser = subparsers.add_parser(
-        "simulate-errors", help="Introduce random errors into a FASTA sequence."
-    )
-    sim_parser.add_argument("--input-file", type=str, required=True, help="Path to the input FASTA file.")
-    sim_parser.add_argument("--output-file", type=str, required=True, help="Path to save the corrupted FASTA file.")
-    sim_parser.add_argument("--sub-prob", type=float, default=0.01, help="Substitution probability per nucleotide.")
-    sim_parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide.")
-    sim_parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide.")
-    sim_choices = list(sorted(SIMULATOR_REGISTRY.keys())) or ["none"]
-    sim_parser.add_argument(
-        "--simulator",
-        type=str,
-        choices=sim_choices,
-        help="Use a named simulator instead of simple probabilities.",
-    )
-    sim_parser.add_argument(
-        "--read-length",
-        type=int,
-        help="Override read length when using a simulator.",
-    )
-    sim_parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output.")
-    sim_parser.set_defaults(func=_handle_sim_errors)
+    # deprecated simulate-errors subcommand was removed in favor of channel
 
     return parser
 
 
-def _handle_sim_errors(args: argparse.Namespace) -> None:
-    from genecoder.formats import to_fasta, from_fasta
-    from genecoder.error_simulation import introduce_errors
-    from genecoder.simulators import SIMULATOR_REGISTRY
-    import os
-    import random
-
-    try:
-        with open(args.input_file, "r", encoding="utf-8") as f_in:
-            fasta_str = f_in.read()
-        records = from_fasta(fasta_str)
-        if not records:
-            logger.error(f"Error: No FASTA records found in {args.input_file}.")
-            raise SystemExit(1)
-        header, seq = records[0]
-        rng = random.Random(args.seed)
-        sim_name = getattr(args, "simulator", None)
-        if sim_name:
-            if sim_name not in SIMULATOR_REGISTRY:
-                logger.error("Unknown simulator: %s", sim_name)
-                raise SystemExit(1)
-            channel = SIMULATOR_REGISTRY[sim_name]
-            if hasattr(channel, "substitution_rate"):
-                channel.substitution_rate = args.sub_prob
-            if hasattr(channel, "insertion_rate"):
-                channel.insertion_rate = args.ins_prob
-            if hasattr(channel, "deletion_rate"):
-                channel.deletion_rate = args.del_prob
-            read_len = getattr(args, "read_length", None)
-            if read_len is not None and hasattr(channel, "read_length"):
-                channel.read_length = read_len
-            pipeline = ChannelPipeline([channel])
-            corrupted = pipeline.simulate(seq)
-        else:
-            corrupted = introduce_errors(
-                seq,
-                substitution_prob=args.sub_prob,
-                insertion_prob=args.ins_prob,
-                deletion_prob=args.del_prob,
-                rng=rng,
-            )
-        new_header = f"{header} sub_prob={args.sub_prob} ins_prob={args.ins_prob} del_prob={args.del_prob}"
-        fasta_out = to_fasta(corrupted, new_header, line_width=80)
-        os.makedirs(os.path.dirname(args.output_file) or ".", exist_ok=True)
-        with open(args.output_file, "w", encoding="utf-8") as f_out:
-            f_out.write(fasta_out)
-        logger.info(f"Corrupted FASTA sequence written to {args.output_file}")
-    except FileNotFoundError:
-        logger.error(f"Error: Input file {args.input_file} not found.")
-        raise SystemExit(1)
-    except ValueError as exc:
-        logger.error("Error during simulate-errors: %s", exc)
-        raise SystemExit(1)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -381,24 +381,24 @@ def test_analyze_suggest_fix(temp_dir: Path):
     assert "Suggested fix" in result.stdout
 
 
-def test_simulate_errors_command(temp_dir: Path, small_fasta_file: Path):
-    """CLI simulate-errors should output a corrupted FASTA file."""
+def test_channel_command_probabilities(temp_dir: Path, small_fasta_file: Path) -> None:
+    """CLI channel with probabilities should output a corrupted FASTA file."""
     out_file = temp_dir / "corrupted.fasta"
     cmd_args = [
-        "simulate-errors",
+        "channel",
         "--input-file",
         str(small_fasta_file),
         "--output-file",
         str(out_file),
-        "--simulator",
-        "illumina_profile",
         "--sub-prob",
         "0.5",
         "--seed",
         "1",
+        "--min-length",
+        "1",
     ]
     result = run_cli_command(cmd_args)
-    assert result.returncode == 0, f"simulate-errors failed: {result.stderr}"
+    assert result.returncode == 0, f"channel failed: {result.stderr}"
     assert out_file.exists()
 
     original_seq = from_fasta(small_fasta_file.read_text())[0][1]
@@ -406,34 +406,40 @@ def test_simulate_errors_command(temp_dir: Path, small_fasta_file: Path):
     assert new_seq != original_seq
 
 
-def test_simulate_errors_missing_input(temp_dir: Path) -> None:
+def test_channel_missing_input(temp_dir: Path) -> None:
     out_file = temp_dir / "corrupted.fasta"
     cmd_args = [
-        "simulate-errors",
+        "channel",
         "--input-file",
         str(temp_dir / "nofile.fasta"),
         "--output-file",
         str(out_file),
+        "--sub-prob",
+        "0.1",
+        "--min-length",
+        "1",
     ]
     result = run_cli_command(cmd_args)
     assert result.returncode != 0
     assert "not found" in result.stderr.lower()
 
 
-def test_simulate_errors_unknown_simulator(temp_dir: Path, small_fasta_file: Path) -> None:
+def test_channel_unknown_simulator(temp_dir: Path, small_fasta_file: Path) -> None:
     out_file = temp_dir / "corrupt.fasta"
     cmd_args = [
-        "simulate-errors",
+        "channel",
         "--input-file",
         str(small_fasta_file),
         "--output-file",
         str(out_file),
         "--simulator",
         "bogus",
+        "--min-length",
+        "1",
     ]
     result = run_cli_command(cmd_args)
     assert result.returncode != 0
-    assert "invalid choice" in result.stderr.lower()
+    assert "unknown simulator" in result.stderr.lower()
 
 
 def test_invalid_fec_none_choice(temp_dir: Path):

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -4,7 +4,7 @@ import pytest
 
 from genecoder.cli.analyze import process_single_analyze
 from genecoder.cli.decode import process_single_decode
-from genecoder.cli.cli import _handle_sim_errors
+from genecoder.cli.channel import process_channel
 from genecoder.formats import to_fasta
 
 
@@ -34,10 +34,15 @@ def _sim_args(input_file: Path, output_file: Path) -> argparse.Namespace:
     return argparse.Namespace(
         input_file=str(input_file),
         output_file=str(output_file),
+        simulators=[],
+        constraints={"min_length": 0, "max_length": 1000, "max_homopolymer": 4},
         sub_prob=0.1,
         ins_prob=0.0,
         del_prob=0.0,
         seed=None,
+        parallel=False,
+        threads=None,
+        processes=None,
     )
 
 
@@ -76,6 +81,15 @@ def test_handle_sim_errors_unexpected_error(monkeypatch, tmp_path: Path) -> None
     def boom(*_a, **_k):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("genecoder.error_simulation.introduce_errors", boom)
+    monkeypatch.setattr("genecoder.cli.channel.introduce_errors", boom)
     with pytest.raises(RuntimeError):
-        _handle_sim_errors(args)
+        process_channel(
+            args.input_file,
+            args.output_file,
+            args.simulators,
+            args.constraints,
+            sub_prob=args.sub_prob,
+            ins_prob=args.ins_prob,
+            del_prob=args.del_prob,
+            seed=args.seed,
+        )


### PR DESCRIPTION
## Summary
- merge `simulate-errors` behavior into the `channel` subcommand
- update documentation for the new interface
- adjust bundle handling
- refactor tests for the consolidated command

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685f4a21a0832689c93ec7261c2ef3