### PR TITLE
Add checksum verification for plugin registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   if it still violates GC content or homopolymer limits.
 - Added ``--d2sim-options`` and ``GENECODER_D2SIM_OPTIONS`` to customize ``d2sim`` calls.
 - Refactored ``BaseSimulator`` for shared simulator settings.
+- Plugin registry now verifies package checksums before installation.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -5,6 +5,7 @@ from types import ModuleType
 import os
 import sys
 import subprocess
+import tempfile
 import urllib.request
 from urllib.parse import urlparse
 import importlib
@@ -32,12 +33,16 @@ FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, str]] = {}
 
 
-def register_codec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
+def register_codec(
+    name: str, encode: Callable[..., Any], decode: Callable[..., Any]
+) -> None:
     """Register a codec implementation under ``name``."""
     CODEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
 
-def register_fec(name: str, encode: Callable[..., Any], decode: Callable[..., Any]) -> None:
+def register_fec(
+    name: str, encode: Callable[..., Any], decode: Callable[..., Any]
+) -> None:
     """Register a FEC backend under ``name``."""
     FEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
@@ -81,7 +86,9 @@ def _install_registry_plugins(url: str) -> None:
 
     for entry in data.get("packages", []):
         if isinstance(entry, dict):
-            spec = str(entry.get("spec") or entry.get("package") or entry.get("url") or "")
+            spec = str(
+                entry.get("spec") or entry.get("package") or entry.get("url") or ""
+            )
             checksum = str(entry.get("checksum", ""))
         else:
             logger.warning("Missing checksum for plugin entry %s", entry)
@@ -91,14 +98,37 @@ def _install_registry_plugins(url: str) -> None:
             logger.warning("Incomplete plugin entry in registry: %s", entry)
             continue
 
-        if compute_checksum(spec.encode()) != checksum:
-            logger.warning("Checksum mismatch for plugin %s", spec)
+        scheme = urlparse(spec).scheme
+        if scheme not in {"https", "file"}:
+            logger.warning("Insecure plugin URL %s", spec)
             continue
 
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+            with urllib.request.urlopen(spec) as resp:
+                pkg_bytes = resp.read()
+        except Exception as exc:  # pragma: no cover - download error path
+            logger.warning("Failed to download plugin %s: %s", spec, exc)
+            continue
+
+        if compute_checksum(pkg_bytes) != checksum:
+            logger.warning("Checksum mismatch for plugin %s", spec)
+            continue
+
+        tmp_file = None
+        try:
+            suffix = os.path.splitext(urlparse(spec).path)[1]
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                tmp.write(pkg_bytes)
+                tmp_file = tmp.name
+            subprocess.check_call([sys.executable, "-m", "pip", "install", tmp_file])
         except Exception as exc:  # pragma: no cover - install error path
             logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
+        finally:
+            if tmp_file:
+                try:
+                    os.unlink(tmp_file)
+                except Exception:
+                    pass
 
 
 def install_registry_plugins(url: str | None = None) -> None:
@@ -162,9 +192,11 @@ def _load_and_register(
             module = (
                 item
                 if isinstance(item, ModuleType)
-                else item.load()
-                if hasattr(item, "load")
-                else importlib.import_module(name)
+                else (
+                    item.load()
+                    if hasattr(item, "load")
+                    else importlib.import_module(name)
+                )
             )
         except Exception:  # pragma: no cover - error path
             if failures is not None:
@@ -249,4 +281,3 @@ def load_plugins() -> None:
 
     if failures:
         logger.warning("Failed to import plugins: %s", ", ".join(failures))
-

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -26,61 +26,77 @@ def test_registry_install(monkeypatch):
         installs.append(cmd)
 
     def fake_urlopen(url):
-        assert url == "https://example.com/plugins.yaml"
-        c1 = compute_checksum("pkgA>=1.0".encode())
-        c2 = compute_checksum("pkgB".encode())
-        data = (
-            "packages:\n"
-            f"  - spec: pkgA>=1.0\n    checksum: {c1}\n"
-            f"  - spec: pkgB\n    checksum: {c2}"
-        ).encode()
-        return DummyResponse(data)
+        if url == "https://example.com/plugins.yaml":
+            pkg_a = b"AAA"
+            pkg_b = b"BBB"
+            c1 = compute_checksum(pkg_a)
+            c2 = compute_checksum(pkg_b)
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgA.whl\n    checksum: {c1}\n"
+                f"  - spec: https://example.com/pkgB.whl\n    checksum: {c2}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgA.whl":
+            return DummyResponse(b"AAA")
+        elif url == "https://example.com/pkgB.whl":
+            return DummyResponse(b"BBB")
+        raise AssertionError(url)
 
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
     plugins.install_registry_plugins()
 
-    assert installs == [
-        [sys.executable, "-m", "pip", "install", "pkgA>=1.0"],
-        [sys.executable, "-m", "pip", "install", "pkgB"],
+    assert [cmd[:4] for cmd in installs] == [
+        [sys.executable, "-m", "pip", "install"],
+        [sys.executable, "-m", "pip", "install"],
     ]
 
 
 def test_registry_install_failure(monkeypatch, caplog):
-    """Warnings are logged if installation of a package fails."""
     def fake_check_call(cmd):
         raise RuntimeError("boom")
 
     def fake_urlopen(url):
-        assert url == "https://example.com/plugins.yaml"
-        c1 = compute_checksum("pkgA".encode())
-        data = (
-            "packages:\n"
-            f"  - spec: pkgA\n    checksum: {c1}"
-        ).encode()
+        if url == "https://example.com/plugins.yaml":
+            pkg = b"CCC"
+            c1 = compute_checksum(pkg)
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgC.whl\n    checksum: {c1}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgC.whl":
+            return DummyResponse(b"CCC")
+        raise AssertionError(url)
 
-        return DummyResponse(data)
-
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
     with caplog.at_level(logging.WARNING):
         plugins.install_registry_plugins()
 
-    assert "Failed to install plugin pkgA from registry" in caplog.text
+    assert (
+        "Failed to install plugin https://example.com/pkgC.whl from registry"
+        in caplog.text
+    )
 
 
 def test_registry_bad_yaml(monkeypatch, caplog):
-    """Malformed registry YAML triggers a warning and no installation."""
-
     def fake_urlopen(url):
         assert url == "https://example.com/plugins.yaml"
         return DummyResponse(b"not: [yaml")
 
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
@@ -89,3 +105,33 @@ def test_registry_bad_yaml(monkeypatch, caplog):
 
     assert "Failed to fetch plugin registry" in caplog.text
 
+
+def test_registry_checksum_mismatch(monkeypatch, caplog):
+    installs = []
+
+    def fake_check_call(cmd):
+        installs.append(cmd)
+
+    def fake_urlopen(url):
+        if url == "https://example.com/plugins.yaml":
+            wrong = compute_checksum(b"WRONG")
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgD.whl\n    checksum: {wrong}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgD.whl":
+            return DummyResponse(b"DDD")
+        raise AssertionError(url)
+
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING):
+        plugins.install_registry_plugins()
+
+    assert not installs
+    assert "Checksum mismatch for plugin https://example.com/pkgD.whl" in caplog.text


### PR DESCRIPTION
## Summary
- validate plugins from registries by downloading the package file, computing its checksum and comparing to the registry
- skip installs if checksum mismatches or download fails
- test registry checksum validation
- document checksum verification in changelog

## Testing
- `flake8 tests/test_plugin_registry.py src/genecoder/plugins.py`
- `python -m pytest tests/test_plugin_registry.py tests/test_bundle.py::test_bundle_run -q`
- `python -m pytest -q` *(passes: 610 tests, 51 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68685f4a6cdc8326a0e86098d34b0ca7