### PR TITLE
Remove deprecated simulate-errors option

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -81,10 +81,12 @@ sudo make install
 
 ## Command-line usage
 
-Apply simple substitutions with a chosen probability:
+Apply simple substitutions with a chosen probability using the ``channel`` command:
 
 ```bash
-genecoder decode --simulate-errors 0.02 <other options>
+genecoder channel --input-file input.fasta --output-file corrupted.fasta \
+    --sub-prob 0.02
+genecoder decode corrupted.fasta --output-file decoded.bin <other options>
 ```
 
 Invoke the replication or transcription models:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,11 +121,12 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    Streaming operations are **resumable**. Pass `--resume state.json` to
    continue an interrupted encode or decode run.
 
-10. **Decode with simulated channel errors**
+10. **Introduce channel errors before decoding**
 
    ```bash
-   genecoder decode --input-files encoded.fasta \
-       --output-file decoded.bin --simulate-errors 0.02
+   genecoder channel --input-file encoded.fasta --output-file corrupted.fasta \
+       --sub-prob 0.02
+   genecoder decode corrupted.fasta --output-file decoded.bin
    ```
 
    Set the environment variable `GENECODER_SIM_SEED` to an integer to make the

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -4,7 +4,6 @@ import sys
 
 from genecoder import __version__
 from genecoder.plugins import load_plugins
-from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight
@@ -98,8 +97,6 @@ def build_parser() -> argparse.ArgumentParser:
     bundle.register_subcommand(subparsers)
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)
-
-    # deprecated simulate-errors subcommand was removed in favor of channel
 
     return parser
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import random
 import re
 from pathlib import Path
 
@@ -232,17 +231,6 @@ def process_single_decode(
                 f"Applied {args.simulator} simulator before decoding."
             )
 
-        if args.simulate_errors > 0.0:
-            from genecoder.channel_sim import simulate_errors
-
-            seed_env = os.getenv("GENECODER_SIM_SEED")
-            rng = random.Random(int(seed_env)) if seed_env is not None else random.Random()
-            sequence_from_fasta = simulate_errors(
-                sequence_from_fasta, args.simulate_errors, rng=rng
-            )
-            logger.info(
-                f"Applied simulated errors (p={args.simulate_errors}) before decoding."
-            )
 
         options = build_decoding_options(args)
         final_decoded_data = run_decoding_pipeline(
@@ -403,16 +391,6 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--auto-ext",
         action="store_true",
         help="Automatically remove .dna and restore the original extension.",
-    )
-    parser.add_argument(
-        "--simulate-errors",
-        type=float,
-        default=0.0,
-        help=(
-            "Probability of random substitution errors applied before decoding. "
-            "Set the GENECODER_SIM_SEED environment variable to an integer to "
-            "seed the random generator."
-        ),
     )
     sim_choices = list(sorted(SIMULATOR_REGISTRY.keys())) or ["none"]
     parser.add_argument(

--- a/tests/test_cli_roundtrip.py
+++ b/tests/test_cli_roundtrip.py
@@ -285,6 +285,31 @@ def test_decode_sim_errors_deterministic(tmp_path: Path):
     env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
     env["GENECODER_SIM_SEED"] = "7"
 
+    corrupted1 = tmp_path / "c1.fasta"
+    corrupted2 = tmp_path / "c2.fasta"
+
+    channel_args = [
+        "channel",
+        "--input-file",
+        str(fasta_file),
+        "--output-file",
+        str(corrupted1),
+        "--sub-prob",
+        "0.2",
+        "--seed",
+        "7",
+        "--min-length",
+        "1",
+        "--max-homopolymer",
+        "10",
+    ]
+    result1 = run_cli_command(channel_args, env=env)
+    assert result1.returncode == 0, result1.stderr
+
+    channel_args[4] = str(corrupted2)  # update output path
+    result2 = run_cli_command(channel_args, env=env)
+    assert result2.returncode == 0, result2.stderr
+
     out_dir1 = tmp_path / "d1"
     out_dir2 = tmp_path / "d2"
     out_dir1.mkdir()
@@ -293,22 +318,21 @@ def test_decode_sim_errors_deterministic(tmp_path: Path):
     decode_args = [
         "decode",
         "--input-files",
-        str(fasta_file),
+        str(corrupted1),
         "--output-dir",
         str(out_dir1),
         "--method",
         "base4_direct",
-        "--simulate-errors",
-        "0.2",
     ]
     decode_result1 = run_cli_command(decode_args, env=env)
     assert decode_result1.returncode == 0, decode_result1.stderr
 
     decode_args[4] = str(out_dir2)  # update output-dir for second run
+    decode_args[2] = str(corrupted2)
     decode_result2 = run_cli_command(decode_args, env=env)
     assert decode_result2.returncode == 0, decode_result2.stderr
 
-    output_file1 = out_dir1 / "seed.txt_decoded.bin"
-    output_file2 = out_dir2 / "seed.txt_decoded.bin"
+    output_file1 = out_dir1 / "c1_decoded.bin"
+    output_file2 = out_dir2 / "c2_decoded.bin"
     assert output_file1.read_bytes() == output_file2.read_bytes()
 


### PR DESCRIPTION
## Summary
- drop `--simulate-errors` from decode CLI
- update docs to use the new `channel` command
- adjust deterministic error test to use `channel`

## Testing
- `ruff check src/genecoder/cli/decode.py src/genecoder/cli/cli.py tests/test_cli_roundtrip.py docs/simulators.md docs/usage.md`
- `mypy src/genecoder/cli/decode.py src/genecoder/cli/cli.py`
- `pytest -q tests/test_cli_roundtrip.py::test_decode_sim_errors_deterministic`

------
https://chatgpt.com/codex/tasks/task_e_68686c1f76ac8326880818c3eb4a602e