### PR TITLE
Add dashboard plot-data and constraint fixer tests

### DIFF
--- a/tests/test_constraint_fixer.py
+++ b/tests/test_constraint_fixer.py
@@ -26,3 +26,31 @@ def test_fix_sequence_no_change_needed():
     fixed = fix_sequence(seq, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3)
     assert fixed == seq
 
+
+def test_fix_sequence_enforces_gc_and_homopolymer_limits_low_gc() -> None:
+    seq = "A" * 12
+    fixed = fix_sequence(
+        seq,
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=3,
+        rng=random.Random(0),
+    )
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 3
+    assert len(fixed) == len(seq)
+
+
+def test_fix_sequence_enforces_gc_and_homopolymer_limits_high_gc() -> None:
+    seq = "G" * 10
+    fixed = fix_sequence(
+        seq,
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=2,
+        rng=random.Random(0),
+    )
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 2
+    assert len(fixed) == len(seq)
+

--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -58,3 +58,20 @@ def test_dashboard_plot_data_invalid_chars() -> None:
     assert resp.status_code == 400
     assert "Invalid" in resp.json()["detail"]
 
+
+def test_dashboard_plot_data_valid_sequence() -> None:
+    seq = "ACGT" * 25
+    with _client() as client:
+        resp = client.post(
+            "/dashboard/plot-data",
+            headers=AUTH_HEADERS,
+            json={"dna_sequence": seq},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) >= {"gc_positions", "gc_values", "hp_lengths"}
+    assert data["gc_positions"] == [0, 10, 20, 30, 40, 50]
+    assert all(value == 0.5 for value in data["gc_values"])
+    assert len(data["hp_lengths"]) == len(seq)
+    assert all(length == 1 for length in data["hp_lengths"])
+


### PR DESCRIPTION
## Summary
- extend `dashboard_httpx` tests to validate successful plot-data response
- add new `fix_sequence` edge case tests ensuring GC balance and homopolymer limits
- keep linter and tests passing

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c357dc08326a248661a60fc90ca