### PR TITLE
Add plugin catalog interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ ffield.lut.*
 # Generated requirements files
 requirements.txt
 requirements.lock
+
+# Node.js artifacts
+web/helix-ui/node_modules/
+web/helix-ui/package-lock.json

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -4,7 +4,6 @@ import sys
 
 from genecoder import __version__
 from genecoder.plugins import load_plugins
-from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -1,7 +1,6 @@
 import sys
 import argparse
-import logging
-import pytest
+
 
 import genecoder.plugins as plugins
 from genecoder.cli import plugin as plugin_cli

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -1,0 +1,39 @@
+import argparse
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+import web.main as main
+import genecoder.plugins as plugins
+from genecoder.cli import plugin as plugin_cli
+
+main.API_TOKEN = "test-token"
+client = TestClient(main.app)
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
+
+def test_list_plugins(monkeypatch):
+    plugins.PLUGIN_CATALOG.clear()
+    plugins.PLUGIN_CATALOG["demo"] = {"description": "Demo"}
+    r = client.get("/plugins")
+    assert r.status_code == 200
+    assert "demo" in r.json().get("plugins", {})
+
+
+def test_install_plugin(monkeypatch):
+    called = []
+
+    def fake_install(args: argparse.Namespace) -> None:
+        called.append(args.name)
+
+    monkeypatch.setattr(plugin_cli, "_handle_install", fake_install)
+    plugins.PLUGIN_CATALOG["demo"] = {}
+    r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "demo"})
+    assert r.status_code == 200
+    assert called == ["demo"]
+
+
+def test_install_requires_token():
+    r = client.post("/plugins/install", json={"name": "demo"})
+    assert r.status_code == 401

--- a/web/helix-ui/package.json
+++ b/web/helix-ui/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -13,7 +14,11 @@
     "three": "^0.164.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
+    "jsdom": "^26.1.0",
+    "vite": "^5.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/web/helix-ui/plugins.html
+++ b/web/helix-ui/plugins.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plugin Catalog</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/plugins_main.jsx"></script>
+  </body>
+</html>

--- a/web/helix-ui/src/PluginCatalog.jsx
+++ b/web/helix-ui/src/PluginCatalog.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+
+export default function PluginCatalog() {
+  const [plugins, setPlugins] = useState(null);
+  const [installing, setInstalling] = useState({});
+
+  useEffect(() => {
+    fetch('/plugins')
+      .then((r) => r.json())
+      .then((data) => setPlugins(data.plugins || {}));
+  }, []);
+
+  const install = async (name) => {
+    setInstalling((s) => ({ ...s, [name]: true }));
+    await fetch('/plugins/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setInstalling((s) => ({ ...s, [name]: false }));
+  };
+
+  if (!plugins) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Plugin Catalog</h1>
+      <ul>
+        {Object.entries(plugins).map(([name, meta]) => (
+          <li key={name}>
+            <strong>{name}</strong>
+            {meta.description ? ` - ${meta.description}` : ''}
+            <button onClick={() => install(name)} disabled={installing[name]}>
+              {installing[name] ? 'Installing...' : 'Install'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/helix-ui/src/PluginCatalog.test.jsx
+++ b/web/helix-ui/src/PluginCatalog.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import PluginCatalog from './PluginCatalog.jsx';
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ plugins: { demo: { description: 'Demo' } } }) })
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('renders plugins and installs', async () => {
+  render(<PluginCatalog />);
+  expect(await screen.findByText(/Demo/)).toBeInTheDocument();
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  const btn = screen.getByRole('button', { name: /install/i });
+  fireEvent.click(btn);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+});

--- a/web/helix-ui/src/plugins_main.jsx
+++ b/web/helix-ui/src/plugins_main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import PluginCatalog from './PluginCatalog.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <PluginCatalog />
+  </React.StrictMode>
+);

--- a/web/helix-ui/vite.config.js
+++ b/web/helix-ui/vite.config.js
@@ -10,4 +10,7 @@ export default defineConfig({
       '@docs': resolve(__dirname, '../../docs'),
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 });

--- a/web/main.py
+++ b/web/main.py
@@ -17,6 +17,9 @@ import re
 from genecoder.options import EncodeOptions
 from genecoder import perform_encoding, perform_decoding
 from genecoder.plugins import load_plugins
+from genecoder import plugins
+from genecoder.cli import plugin as plugin_cli
+import argparse
 from genecoder.formats import from_fasta
 from genecoder.encoders import calculate_gc_content, decode_base4_direct
 from genecoder.utils import get_max_homopolymer_length, get_temp_dir
@@ -117,6 +120,10 @@ dashboard_index_path = helix_ui_dir / "dist" / "dashboard.html"
 if not dashboard_index_path.is_file():
     dashboard_index_path = helix_ui_dir / "dashboard.html"
 
+plugin_index_path = helix_ui_dir / "dist" / "plugins.html"
+if not plugin_index_path.is_file():
+    plugin_index_path = helix_ui_dir / "plugins.html"
+
 @app.get("/", response_class=HTMLResponse)
 async def index() -> str:
     return index_path.read_text(encoding="utf-8")
@@ -132,6 +139,12 @@ async def helix() -> str:
 async def dashboard() -> str:
     """Return the React-based dashboard interface."""
     return dashboard_index_path.read_text(encoding="utf-8")
+
+
+@app.get("/plugin-catalog", response_class=HTMLResponse)
+async def plugin_catalog_page() -> str:
+    """Return the React-based plugin catalog interface."""
+    return plugin_index_path.read_text(encoding="utf-8")
 
 
 class EncodeOptionsModel(BaseModel):
@@ -398,3 +411,26 @@ async def download_chunk(
         raise HTTPException(status_code=404, detail="Chunk not found")
     data = chunk_path.read_bytes()
     return {"offset": str(offset), "data": base64.b64encode(data).decode("utf-8")}
+
+
+class PluginInstallRequest(BaseModel):
+    name: str
+
+
+@app.get("/plugins")
+async def list_plugins() -> dict[str, object]:
+    """Return the plugin catalog."""
+    return {"plugins": plugins.PLUGIN_CATALOG}
+
+
+@app.post("/plugins/install")
+async def install_plugin(
+    req: PluginInstallRequest,
+    _: None = Depends(verify_token),
+) -> dict[str, str]:
+    args = argparse.Namespace(name=req.name)
+    try:
+        await asyncio.to_thread(plugin_cli._handle_install, args)
+    except SystemExit as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- serve a new plugin catalog page from `web/helix-ui`
- expose `/plugins` and `/plugins/install` API endpoints
- ignore dashboard UI node_modules in git
- implement React component to show catalog entries and install buttons
- add unit tests for plugin APIs and React component
- fix lint errors in CLI and tests

## Testing
- `ruff check`
- `pytest tests/test_plugins_api.py -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68686c31d48883269b66a3d493ae69b3