### PR TITLE
Add cloud submission client

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -1,0 +1,26 @@
+# Cloud Worker Integration
+
+GeneCoder can submit encode/decode jobs to a remote worker via a simple REST API.
+The :class:`genecoder.cloud.CloudClient` provides a minimal wrapper for sending
+jobs to a queue exposed by a web service.
+
+```python
+from genecoder.cloud import CloudClient
+
+with CloudClient("http://worker:8000", token="TOKEN") as client:
+    job = client.submit("bundle", {"archive": "<base64 data>"})
+    print(job)
+```
+
+## CLI Usage
+
+Bundles can be packaged and uploaded using the `genecoder cloud submit` command:
+
+```bash
+genecoder cloud submit bundle.yaml --server http://worker:8000 --token TOKEN
+```
+
+The command creates a ZIP archive containing the bundle file and any input files
+listed under the `encode.input_files` section. The archive is Base64 encoded and
+sent to the remote worker's `/jobs` endpoint. The returned job ID is printed to
+stdout.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - CLI Tutorial: cli_tutorial.md
       - GUI Tutorial: gui_tutorial.md
       - Web API Tutorial: web_api_tutorial.md
+      - Cloud Worker Integration: cloud.md
       - Helix Frontend: helix_frontend.md
   - Archived:
       - Full Development Vision: archived/DEVELOPMENT_VISION.md

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -20,6 +20,7 @@ from .plugins import (
     install_registry_plugins,
 )
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
+from .cloud import CloudClient
 
 
 
@@ -35,6 +36,7 @@ __all__ = [
     "encrypt_data",
     "decrypt_data",
     "compute_checksum",
+    "CloudClient",
 ]
 
 

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -4,7 +4,7 @@ import sys
 
 from genecoder import __version__
 from genecoder.plugins import load_plugins
-from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
+# simulators are imported lazily by subcommands that need them
 from typing import Any
 
 # Delay heavy imports until building the parser to keep --version lightweight
@@ -16,6 +16,7 @@ channel: Any | None = None
 bundle: Any | None = None
 plugin: Any | None = None
 benchmark: Any | None = None
+cloud: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -59,11 +60,12 @@ def build_parser() -> argparse.ArgumentParser:
         report as _report,
         channel as _channel,
         bundle as _bundle,
+        cloud as _cloud,
         plugin as _plugin_mod,
         benchmark as _benchmark,
     )
 
-    global encode, decode, analyze, report, channel, bundle, plugin, benchmark
+    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark
 
     encode = _encode
     decode = _decode
@@ -71,6 +73,7 @@ def build_parser() -> argparse.ArgumentParser:
     report = _report
     channel = _channel
     bundle = _bundle
+    cloud = _cloud
     plugin = _plugin_mod
     benchmark = _benchmark
 
@@ -96,6 +99,7 @@ def build_parser() -> argparse.ArgumentParser:
     report.register_subcommand(subparsers)
     channel.register_subcommand(subparsers)
     bundle.register_subcommand(subparsers)
+    cloud.register_subcommand(subparsers)
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)
 

--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser("cloud", help="Interact with cloud workers")
+    cloud_sub = parser.add_subparsers(dest="cloud_command", required=True)
+    submit = cloud_sub.add_parser("submit", help="Submit a bundle to a remote worker")
+    submit.add_argument("bundle", type=str, help="Path to bundle YAML file")
+    submit.add_argument("--server", type=str, default="http://localhost:8000", help="Worker base URL")
+    submit.add_argument("--token", type=str, help="Bearer token for authentication")
+    submit.set_defaults(func=_handle_submit)
+
+
+def _handle_submit(args: argparse.Namespace) -> None:
+    import yaml
+    from genecoder.cloud import CloudClient
+    bundle_path = Path(args.bundle)
+    with open(bundle_path, "r", encoding="utf-8") as fh:
+        bundle_data = fh.read()
+        cfg = yaml.safe_load(bundle_data) or {}
+    input_files = [Path(p) for p in cfg.get("encode", {}).get("input_files", [])]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = Path(tmpdir) / "bundle.zip"
+        with zipfile.ZipFile(archive_path, "w") as zf:
+            zf.writestr(bundle_path.name, bundle_data)
+            for f in input_files:
+                zf.write(f, arcname=f.name)
+        archive_b64 = base64.b64encode(archive_path.read_bytes()).decode("utf-8")
+
+    with CloudClient(args.server, args.token) as client:
+        job_id = client.submit("bundle", {"archive": archive_b64})
+    print(job_id)

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class CloudClient:
+    """Minimal REST client for submitting jobs to a remote worker."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        client: Any | None = None,
+    ) -> None:
+        import httpx
+
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self._client = client or httpx.Client(base_url=self.base_url)
+
+    def submit(self, job_type: str, payload: dict[str, Any]) -> str:
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        resp = self._client.post("/jobs", json={"type": job_type, "payload": payload}, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        job_id = data.get("job_id")
+        if not isinstance(job_id, str):
+            raise ValueError("Invalid response from server")
+        return job_id
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "CloudClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.close()
+
+__all__ = ["CloudClient"]

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+
+import httpx
+
+from genecoder.cloud import CloudClient
+from genecoder.cli import cloud as cloud_cli
+
+
+def test_cloud_client_submit():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["data"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"job_id": "jid"})
+
+    transport = httpx.MockTransport(handler)
+    client = CloudClient(
+        "http://s",
+        client=httpx.Client(base_url="http://s", transport=transport),
+    )
+    jid = client.submit("bundle", {"a": 1})
+    assert jid == "jid"
+    assert captured["path"] == "/jobs"
+    assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
+
+
+def test_cloud_submit_cli(tmp_path, monkeypatch):
+    bundle = tmp_path / "b.yaml"
+    bundle.write_text("encode:\n  input_files: []\n")
+
+    calls: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self, base_url: str, token: str | None = None, client=None) -> None:
+            calls["base_url"] = base_url
+            calls["token"] = token
+
+        def submit(self, job_type: str, payload: dict[str, object]) -> str:
+            calls["job_type"] = job_type
+            calls["payload"] = payload
+            return "jid"
+
+        def close(self) -> None:
+            pass
+
+        def __enter__(self) -> "DummyClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            pass
+
+    monkeypatch.setattr("genecoder.cloud.CloudClient", DummyClient)
+    args = argparse.Namespace(bundle=str(bundle), server="http://s", token=None)
+    cloud_cli._handle_submit(args)
+    assert calls["job_type"] == "bundle"
+    assert "archive" in calls["payload"]
+    assert calls["base_url"] == "http://s"
+    assert calls["token"] is None


### PR DESCRIPTION
## Summary
- implement a minimal CloudClient for submitting jobs
- add `genecoder cloud submit` CLI wrapper
- document usage in `cloud.md`
- fix lint by removing unused imports

## Testing
- `ruff check . | head -n 20`
- `mypy src/genecoder/cloud src/genecoder/cli/cloud.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68686c30ec4083269e94f43a93d9d208