### PR TITLE
Verify plugin download checksum

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -4,6 +4,8 @@ import argparse
 import logging
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 from genecoder import plugins
 
@@ -59,10 +61,36 @@ def _handle_install(args: argparse.Namespace) -> None:
     if version and not meta.get("url"):
         spec = f"{name}=={version}"
     checksum = meta.get("checksum")
-    if checksum and plugins.compute_checksum(spec.encode()) != checksum:
-        logger.warning("Checksum mismatch for plugin %s", name)
-        raise SystemExit(1)
-    subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "--no-deps",
+                "-d",
+                tmp_dir,
+                spec,
+            ]
+        )
+        files = list(Path(tmp_dir).iterdir())
+        if not files:
+            logger.error("No package downloaded for plugin %s", name)
+            raise SystemExit(1)
+        pkg_path = files[0]
+        pkg_bytes = pkg_path.read_bytes()
+        if checksum and plugins.compute_checksum(pkg_bytes) != checksum:
+            logger.warning("Checksum mismatch for plugin %s", name)
+            raise SystemExit(1)
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            str(pkg_path),
+        ])
 
 
 def _handle_install_registry(args: argparse.Namespace) -> None:

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -1,5 +1,7 @@
 import sys
 import argparse
+from pathlib import Path
+import pytest
 
 
 import genecoder.plugins as plugins
@@ -22,7 +24,8 @@ class DummyResponse:
 
 
 def test_catalog_list_and_install(monkeypatch, capsys):
-    h = compute_checksum("plug==0.1".encode())
+    pkg = b"PKG"
+    h = compute_checksum(pkg)
     catalog = (
         "plugins:\n  - name: plug\n    version: '0.1'\n    url: plug==0.1\n    description: Example\n    checksum: "
         + h
@@ -33,13 +36,26 @@ def test_catalog_list_and_install(monkeypatch, capsys):
         return DummyResponse(catalog)
 
     installs = []
+    calls = []
 
     def fake_check_call(cmd):
-        installs.append(cmd)
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "plug.whl").write_bytes(pkg)
+        elif cmd[:4] == [sys.executable, "-m", "pip", "install"]:
+            installs.append(cmd)
+        else:
+            raise AssertionError(cmd)
+
+    def fake_compute_checksum(data: bytes) -> str:
+        calls.append(data)
+        return compute_checksum(data)
 
     monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute_checksum)
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
 
     plugins.load_plugins()
@@ -50,7 +66,46 @@ def test_catalog_list_and_install(monkeypatch, capsys):
     assert "plug" in captured
 
     plugin_cli._handle_install(argparse.Namespace(name="plug"))
-    assert installs == [[sys.executable, "-m", "pip", "install", "plug==0.1"]]
+    assert installs and installs[0][:4] == [sys.executable, "-m", "pip", "install"]
+    assert calls == [pkg]
+
+
+def test_install_checksum_mismatch(monkeypatch, caplog):
+    pkg = b"PKG"
+    wrong = compute_checksum(b"WRONG")
+    catalog = (
+        "plugins:\n  - name: plug\n    version: '0.1'\n    url: plug==0.1\n    checksum: "
+        + wrong
+    ).encode()
+
+    def fake_urlopen(url):
+        assert url == "https://example.com/catalog.yaml"
+        return DummyResponse(catalog)
+
+    installs = []
+
+    def fake_check_call(cmd):
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "plug.whl").write_bytes(pkg)
+        elif cmd[:4] == [sys.executable, "-m", "pip", "install"]:
+            installs.append(cmd)
+        else:
+            raise AssertionError(cmd)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    plugins.load_plugins()
+
+    with caplog.at_level("WARNING"), pytest.raises(SystemExit):
+        plugin_cli._handle_install(argparse.Namespace(name="plug"))
+
+    assert not installs
+    assert "Checksum mismatch for plugin plug" in caplog.text
 
 
 def test_catalog_network_error(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- verify downloaded plugin files by checksum before installing
- test the checksum validation logic for the plugin marketplace

## Testing
- `ruff check src/genecoder/cli/plugin.py tests/test_plugin_marketplace.py`
- `pytest -q tests/test_plugin_marketplace.py`


------
https://chatgpt.com/codex/tasks/task_e_6869e020e470832689b9142ba8ad0056