### PR TITLE
Handle CloudClient HTTP errors

### DIFF
--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -22,8 +22,16 @@ class CloudClient:
         headers = {}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-        resp = self._client.post("/jobs", json={"type": job_type, "payload": payload}, headers=headers)
-        resp.raise_for_status()
+        import httpx
+
+        try:
+            resp = self._client.post(
+                "/jobs", json={"type": job_type, "payload": payload}, headers=headers
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"Failed to submit job: {exc}") from exc
+
         data = resp.json()
         job_id = data.get("job_id")
         if not isinstance(job_id, str):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,13 +1,16 @@
 import argparse
 import json
+from pathlib import Path
+from typing import cast
 
 import httpx
+import pytest
 
 from genecoder.cloud import CloudClient
 from genecoder.cli import cloud as cloud_cli
 
 
-def test_cloud_client_submit():
+def test_cloud_client_submit() -> None:
     captured: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -26,14 +29,27 @@ def test_cloud_client_submit():
     assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
 
 
-def test_cloud_submit_cli(tmp_path, monkeypatch):
+def test_cloud_client_submit_error() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    transport = httpx.MockTransport(handler)
+    client = CloudClient(
+        "http://s",
+        client=httpx.Client(base_url="http://s", transport=transport),
+    )
+    with pytest.raises(RuntimeError, match="Failed to submit job"):
+        client.submit("bundle", {"a": 1})
+
+
+def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bundle = tmp_path / "b.yaml"
     bundle.write_text("encode:\n  input_files: []\n")
 
     calls: dict[str, object] = {}
 
     class DummyClient:
-        def __init__(self, base_url: str, token: str | None = None, client=None) -> None:
+        def __init__(self, base_url: str, token: str | None = None, client: object | None = None) -> None:
             calls["base_url"] = base_url
             calls["token"] = token
 
@@ -48,13 +64,13 @@ def test_cloud_submit_cli(tmp_path, monkeypatch):
         def __enter__(self) -> "DummyClient":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: BaseException | None, exc: BaseException | None, tb: object | None) -> None:
             pass
 
     monkeypatch.setattr("genecoder.cloud.CloudClient", DummyClient)
     args = argparse.Namespace(bundle=str(bundle), server="http://s", token=None)
     cloud_cli._handle_submit(args)
     assert calls["job_type"] == "bundle"
-    assert "archive" in calls["payload"]
+    assert "archive" in cast(dict[str, object], calls["payload"])
     assert calls["base_url"] == "http://s"
     assert calls["token"] is None


### PR DESCRIPTION
## Summary
- handle HTTP errors in `CloudClient.submit`
- raise `RuntimeError` when POST fails
- test CloudClient HTTP error handling

## Testing
- `ruff check src/genecoder/cloud/__init__.py tests/test_cloud.py`
- `mypy src/genecoder/cloud/__init__.py tests/test_cloud.py`
- `pytest tests/test_cloud.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e0218ba88326ad1026eafd90c637