### PR TITLE
Refactor Flet app logic into modules

### DIFF
--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -17,25 +17,21 @@ integrated pipeline and extensible design.
 
 import flet as ft
 import os
-import asyncio  # For asynchronous operations
-import json
 import logging
 import webbrowser
-from typing import Optional, Any
-try:
-    import websockets
-except Exception:  # pragma: no cover - optional dependency
-    websockets = None
+from typing import Optional
+
+from genecoder.flet_ws import ws_clients  # noqa: F401 - start server on import
+from genecoder.flet_handlers import (
+    make_decode_handler,
+    make_encode_handler,
+    decoded_bytes_to_save,
+)
 
 # Project module imports
-from genecoder.options import EncodeOptions
-from genecoder import perform_encoding
 from genecoder.plugins import load_plugins
-from genecoder.manifest import generate_manifest
-from genecoder.flet_helpers import parse_int_input
-from genecoder.app_helpers import perform_decoding
 from genecoder.helix_view import show_helix_ui
-from genecoder.formats import from_fasta, to_fasta
+from genecoder.formats import from_fasta
 from genecoder.cli.encode import reverse_complement
 from genecoder.glossary_tooltips import (
     load_glossary,
@@ -60,33 +56,6 @@ except Exception:
 
 
 encode_fasta_data_to_save_ref: ft.Ref[Optional[str]] = ft.Ref[Optional[str]]()
-decoded_bytes_to_save: bytes = b""
-
-# --- optional WebSocket streaming setup ---
-ws_clients: set[Any] = set()
-if websockets:
-    async def _ws_handler(websocket: Any) -> None:
-        ws_clients.add(websocket)
-        try:
-            async for _ in websocket:
-                pass
-        finally:
-            ws_clients.discard(websocket)
-
-    try:
-        try:
-            loop: asyncio.AbstractEventLoop | None = asyncio.get_event_loop()
-        except RuntimeError:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = None
-        if loop:
-            loop.create_task(websockets.serve(_ws_handler, "localhost", 8765))
-        else:  # pragma: no cover - depends on environment
-            logger.error("No running event loop; WebSocket server not started")
-    except OSError as exc:  # pragma: no cover - depends on environment
-        logger.error("Failed to start WebSocket server: %s", exc)
 
 
 def main(page: ft.Page) -> None:
@@ -262,7 +231,7 @@ def main(page: ft.Page) -> None:
                 ft.Text("Drop file"),
                 width=150,
                 height=80,
-                border=ft.border.all(1, ft.colors.BLUE_GREY_200),
+                border=ft.border.all(1, colors.BLUE_GREY_200),
                 alignment=ft.alignment.center,
             ),
             **drop_kwargs,
@@ -411,215 +380,86 @@ def main(page: ft.Page) -> None:
     # This is a forward declaration of sorts for app_tabs, its full definition with content is later.
     app_tabs: ft.Tabs = ft.Tabs()
 
-    # --- Encode Event Handlers ---
-    async def encode_data(e: ft.ControlEvent) -> None:
-        """
-        Handles the encoding process when the 'Encode' button is clicked.
+    def refresh_helix_view(_: ft.ControlEvent | None = None) -> None:
+        dna_seq = ""
+        if encode_hidden_fasta_content.value:
+            parsed = from_fasta(encode_hidden_fasta_content.value)
+            if parsed:
+                dna_seq = parsed[0][1]
+        rc_seq = reverse_complement(dna_seq) if mirror_checkbox.value else None
+        helix_container.controls.clear()
+        helix_container.controls.append(
+            ft.Row([
+                animate_checkbox,
+                ft.Text("Zoom:"),
+                zoom_slider,
+                ft.Text("FPS:"),
+                fps_slider,
+            ])
+        )
+        colors = {
+            "A": int(helix_color_a.value.lstrip("#"), 16),
+            "C": int(helix_color_c.value.lstrip("#"), 16),
+            "G": int(helix_color_g.value.lstrip("#"), 16),
+            "T": int(helix_color_t.value.lstrip("#"), 16),
+        }
 
-        This asynchronous function performs the following steps:
-        1. Disables UI controls (buttons, progress ring) to prevent concurrent operations.
-        2. Resets UI elements (status texts, image displays).
-        3. Validates user inputs (file selection, parity k-value).
-        4. Reads input file data asynchronously.
-        5. Applies the selected encoding method (Base-4 Direct, Huffman, GC-Balanced)
-           asynchronously using `asyncio.to_thread`.
-        6. Optionally applies Triple-Repeat, Hamming(7,4), or Reed-Solomon FEC if selected,
-           also asynchronously.
-        7. Constructs FASTA header and formats the output.
-        8. Calculates and displays encoding metrics.
-        9. Generates and displays analysis plots (Huffman codeword lengths, nucleotide frequencies)
-           asynchronously if applicable.
-        10. Updates status messages and re-enables UI controls in a `finally` block.
-        """
-        # The encode workflow does not use the decoded bytes buffer
-
-        # Disable buttons and show progress
-        encode_button.disabled = True
-        encode_browse_button.disabled = True
-        encode_progress_ring.visible = True
-
-        encode_status_text.value = "Processing..."
-        encode_orig_size_text.value = "Original size: - bytes"
-        encode_dna_len_text.value = "Encoded DNA length: - nucleotides"
-        encode_comp_ratio_text.value = "Compression ratio: -"
-        encode_bits_per_nt_text.value = "Bits per nucleotide: - bits/nt"
-        encode_actual_gc_value.value = "-"
-        encode_actual_homopolymer_value.value = "-"
-        encode_dna_snippet_text.value = ""
-        fixed_dna_snippet_text.value = ""
-        fixed_metrics_text.value = ""
-        encode_save_button.visible = False
-        encode_manifest_save_button.visible = False
-        encode_hidden_fasta_content.value = ""
-        encode_hidden_manifest_content.value = ""
-
-        codeword_hist_image.src_base64 = None
-        nucleotide_freq_image.src_base64 = None
-        sequence_analysis_plot_image.src_base64 = None  # Clear new plot
-        analysis_status_text.value = "Encode data to view analysis plots."
-        fix_suggestion_text.value = ""
-        if len(app_tabs.tabs) > 2:
-            app_tabs.tabs[2].disabled = True
-
+        helix_container.controls.append(
+            show_helix_ui(
+                dna_seq,
+                strand2_sequence=rc_seq,
+                animate=animate_checkbox.value,
+                zoom=zoom_slider.value,
+                colors=colors,
+                fps=fps_slider.value,
+                ws_url="ws://localhost:8765",
+            )
+        )
         page.update()
 
-        try:
-            input_path = selected_encode_input_file_path.current
-            if not input_path:
-                encode_status_text.value = "Error: Please select an input file first."
-                encode_status_text.color =  colors.RED_ACCENT_700
-                page.update()
-                return
+    animate_checkbox.on_change = refresh_helix_view
+    zoom_slider.on_change = refresh_helix_view
+    fps_slider.on_change = refresh_helix_view
 
-            with open(input_path, "rb") as f_in:
-                input_data = await asyncio.to_thread(f_in.read)
-
-            try:
-                options = EncodeOptions(
-                    method=method_dropdown.value,
-                    add_parity=parity_checkbox.value,
-                    k_value=parse_int_input(k_value_input.value, 7),
-                    fec_method=fec_dropdown.value,
-                    window_size=parse_int_input(window_size_input.value, 50),
-                    step_size=parse_int_input(step_size_input.value, 10),
-                    min_homopolymer_len=parse_int_input(min_homopolymer_input.value, 4),
-                    alphabet=alphabet_dropdown.value,
-                )
-            except ValueError as ex:
-                encode_status_text.value = f"Invalid numeric input: {ex}"
-                encode_status_text.color =  colors.RED_ACCENT_700
-                page.update()
-                return
-
-            try:
-                result = await asyncio.to_thread(perform_encoding, input_data, options)
-            except ValueError as ex:
-                encode_status_text.value = f"Error: {ex}"
-                encode_status_text.color =  colors.RED_ACCENT_700
-                page.update()
-                return
-
-            final_fasta = result.fasta
-            forward_seq = result.encoded_dna
-            if mirror_checkbox.value:
-                rc_seq = reverse_complement(forward_seq)
-                rc_header = result.fasta.splitlines()[0][1:] + " mirror=rc"
-                final_fasta += to_fasta(rc_seq, rc_header, line_width=80)
-            encode_hidden_fasta_content.value = final_fasta
-            encode_hidden_sequence.value = forward_seq
-            encode_dna_snippet_text.value = forward_seq[:200]
-            if ws_clients:
-                async def _stream_bases(seq: str, step: int = 50) -> None:
-                    for i in range(0, len(seq), step):
-                        chunk = seq[i : i + step]
-                        await asyncio.gather(*(c.send(chunk) for c in ws_clients))
-                        await asyncio.sleep(0)
-
-                asyncio.create_task(_stream_bases(forward_seq))
-            encode_save_button.visible = True
-            manifest = generate_manifest(
-                os.path.basename(input_path), options, result.metrics
-            )
-            encode_hidden_manifest_content.value = json.dumps(manifest, indent=2)
-            encode_manifest_save_button.visible = True
-
-            metrics = result.metrics
-            encode_orig_size_text.value = (
-                f"Original size: {metrics['original_size']} bytes"
-            )
-            encode_dna_len_text.value = (
-                f"Encoded DNA length: {metrics['dna_length']} nucleotides"
-            )
-            encode_comp_ratio_text.value = (
-                f"Compression ratio: {metrics['compression_ratio']:.2f}"
-            )
-            encode_bits_per_nt_text.value = (
-                f"Bits per nucleotide: {metrics['bits_per_nt']:.2f} bits/nt"
-            )
-
-            if options.method == "GC-Balanced":
-                encode_actual_gc_value.value = f"{metrics['actual_gc']:.2%}"
-                encode_actual_homopolymer_value.value = f"{metrics['max_homopolymer']}"
-            else:
-                encode_actual_gc_value.value = "N/A"
-                encode_actual_homopolymer_value.value = "N/A"
-
-            codeword_hist_image.src_base64 = result.plots.get("codeword_hist")
-            nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
-            sequence_analysis_plot_image.src_base64 = result.plots.get(
-                "sequence_analysis"
-            )
-
-            # Compute after populating result.plots so checks use a stable value
-            any_plot = any(result.plots.values())
-
-            if any_plot:
-                analysis_status_text.value = (
-                    "All analysis plots generated successfully."
-                )
-                analysis_status_text.color =  colors.GREEN_700
-            else:
-                analysis_status_text.value = "No analysis plots applicable or generated for the selected options."
-                analysis_status_text.color =  colors.ORANGE_ACCENT_700
-            if len(app_tabs.tabs) > 2:
-                app_tabs.tabs[2].disabled = not any_plot
-
-            info_msgs = list(result.info_messages)
-            if options.method == "GC-Balanced" and options.add_parity:
-                info_msgs.insert(
-                    0, "Info: 'Add Parity' not directly used by GC-Balanced."
-                )
-            status_prefix = " ".join(info_msgs)
-            encode_status_text.value = (
-                status_prefix + " " if status_prefix else ""
-            ) + "Encoding successful! Click 'Save Encoded FASTA...' to save."
-            encode_status_text.color =  colors.GREEN_700
-
-            gc_val = calculate_gc_content(forward_seq)
-            hp_len = get_max_homopolymer_length(forward_seq)
-            constraints = SynthesisConstraints()
-            if (
-                gc_val < 0.4
-                or gc_val > 0.6
-                or hp_len > constraints.max_homopolymer
-            ):
-                fixed = fix_sequence(
-                    forward_seq,
-                    target_gc_min=0.4,
-                    target_gc_max=0.6,
-                    max_homopolymer=constraints.max_homopolymer,
-                )
-                fix_gc = calculate_gc_content(fixed)
-                fix_hp = get_max_homopolymer_length(fixed)
-                fix_suggestion_text.value = (
-                    f"Suggested fix GC {fix_gc:.2%}, max HP {fix_hp}."
-                )
-            else:
-                fix_suggestion_text.value = ""
-
-            refresh_helix_view()
-            app_tabs.selected_index = 3
-            page.update()
-
-        except FileNotFoundError:
-            encode_status_text.value = f"Error: Input file '{input_path}' not found."
-            encode_status_text.color =  colors.RED_ACCENT_700
-        except OSError as ex:
-            encode_status_text.value = f"I/O error during encoding: {ex}"
-            encode_status_text.color =  colors.RED_ACCENT_700
-        except Exception as ex:
-            logger.exception("Unexpected error during encoding")
-            encode_status_text.value = f"An unexpected error occurred: {ex}"
-            encode_status_text.color =  colors.RED_ACCENT_700
-            raise
-        finally:
-            # Re-enable buttons and hide progress
-            encode_button.disabled = False
-            encode_browse_button.disabled = False
-            encode_progress_ring.visible = False
-            page.update()
-
-    encode_button.on_click = encode_data
+    # --- Encode Event Handlers ---
+    encode_button.on_click = make_encode_handler(
+        page=page,
+        selected_encode_input_file_path=selected_encode_input_file_path,
+        encode_button=encode_button,
+        encode_browse_button=encode_browse_button,
+        encode_progress_ring=encode_progress_ring,
+        encode_status_text=encode_status_text,
+        encode_orig_size_text=encode_orig_size_text,
+        encode_dna_len_text=encode_dna_len_text,
+        encode_comp_ratio_text=encode_comp_ratio_text,
+        encode_bits_per_nt_text=encode_bits_per_nt_text,
+        encode_actual_gc_value=encode_actual_gc_value,
+        encode_actual_homopolymer_value=encode_actual_homopolymer_value,
+        encode_dna_snippet_text=encode_dna_snippet_text,
+        fixed_dna_snippet_text=fixed_dna_snippet_text,
+        fixed_metrics_text=fixed_metrics_text,
+        encode_save_button=encode_save_button,
+        encode_manifest_save_button=encode_manifest_save_button,
+        encode_hidden_fasta_content=encode_hidden_fasta_content,
+        encode_hidden_manifest_content=encode_hidden_manifest_content,
+        encode_hidden_sequence=encode_hidden_sequence,
+        codeword_hist_image=codeword_hist_image,
+        nucleotide_freq_image=nucleotide_freq_image,
+        sequence_analysis_plot_image=sequence_analysis_plot_image,
+        analysis_status_text=analysis_status_text,
+        fix_suggestion_text=fix_suggestion_text,
+        app_tabs=app_tabs,
+        method_dropdown=method_dropdown,
+        parity_checkbox=parity_checkbox,
+        k_value_input=k_value_input,
+        fec_dropdown=fec_dropdown,
+        window_size_input=window_size_input,
+        step_size_input=step_size_input,
+        min_homopolymer_input=min_homopolymer_input,
+        alphabet_dropdown=alphabet_dropdown,
+        mirror_checkbox=mirror_checkbox,
+        refresh_helix_view=refresh_helix_view,
+    )
 
     async def apply_fix(_: ft.ControlEvent) -> None:
         seq = encode_hidden_sequence.value
@@ -781,74 +621,17 @@ def main(page: ft.Page) -> None:
         on_click=_open_decode_file_picker,
     )
 
-    async def decode_file_data(e: ft.ControlEvent) -> None:
-        """Decode an input FASTA file using :func:`perform_decoding`."""
-        global decoded_bytes_to_save
-
-        decode_status_text.value = "Processing..."
-        decode_progress_ring.visible = True
-        decode_button.disabled = True
-        decode_browse_button.disabled = True
-        decode_save_button.visible = False
-        decoded_bytes_to_save = b""
-        page.update()
-
-        try:
-            input_path = selected_decode_input_file_path.current
-            if not input_path:
-                decode_status_text.value = (
-                    "Error: Please select an input FASTA file first."
-                )
-                decode_status_text.color =  colors.RED_ACCENT_700
-                page.update()
-                return
-
-            with open(input_path, "r", encoding="utf-8") as f_in:
-                file_content_str = await asyncio.to_thread(f_in.read)
-
-            try:
-                result = await asyncio.to_thread(
-                    perform_decoding, file_content_str, decode_alphabet_dropdown.value
-                )
-            except ValueError as ex:
-                decode_status_text.value = f"Error: {ex}"
-                decode_status_text.color =  colors.RED_ACCENT_700
-                page.update()
-                return
-            except Exception as ex:
-                logger.exception("Unexpected error during decoding")
-                decode_status_text.value = f"Unexpected error: {ex}"
-                decode_status_text.color =  colors.RED_ACCENT_700
-                raise
-
-            decoded_bytes_to_save = result.decoded_bytes
-            decode_status_text.value = result.status_message
-            decode_status_text.color =  colors.GREEN_700
-            if result.fec_info:
-                decode_fec_info_text.value = result.fec_info
-                decode_fec_info_text.color =  colors.GREEN_700
-            else:
-                decode_fec_info_text.value = ""
-            decode_save_button.visible = True
-
-        except FileNotFoundError:
-            decode_status_text.value = f"Error: Input file '{input_path}' not found."
-            decode_status_text.color =  colors.RED_ACCENT_700
-        except OSError as ex:
-            decode_status_text.value = f"I/O error: {ex}"
-            decode_status_text.color =  colors.RED_ACCENT_700
-        except Exception as ex:
-            logger.exception("Unexpected error during decode_file_data")
-            decode_status_text.value = f"Critical error: {ex}"
-            decode_status_text.color =  colors.RED_ACCENT_700
-            raise
-        finally:
-            decode_progress_ring.visible = False
-            decode_button.disabled = False
-            decode_browse_button.disabled = False
-            page.update()
-
-    decode_button.on_click = decode_file_data
+    decode_button.on_click = make_decode_handler(
+        page=page,
+        selected_decode_input_file_path=selected_decode_input_file_path,
+        decode_button=decode_button,
+        decode_browse_button=decode_browse_button,
+        decode_progress_ring=decode_progress_ring,
+        decode_status_text=decode_status_text,
+        decode_fec_info_text=decode_fec_info_text,
+        decode_save_button=decode_save_button,
+        decode_alphabet_dropdown=decode_alphabet_dropdown,
+    )
 
     async def on_save_decoded_file_result(e: ft.FilePickerResultEvent) -> None:  # Made async
         if e.path:
@@ -1039,46 +822,6 @@ def main(page: ft.Page) -> None:
         expand=True,
     )
 
-    def refresh_helix_view(_: ft.ControlEvent | None = None) -> None:
-        dna_seq = ""
-        if encode_hidden_fasta_content.value:
-            parsed = from_fasta(encode_hidden_fasta_content.value)
-            if parsed:
-                dna_seq = parsed[0][1]
-        rc_seq = reverse_complement(dna_seq) if mirror_checkbox.value else None
-        helix_container.controls.clear()
-        helix_container.controls.append(
-            ft.Row([
-                animate_checkbox,
-                ft.Text("Zoom:"),
-                zoom_slider,
-                ft.Text("FPS:"),
-                fps_slider,
-            ])
-        )
-        colors = {
-            "A": int(helix_color_a.value.lstrip("#"), 16),
-            "C": int(helix_color_c.value.lstrip("#"), 16),
-            "G": int(helix_color_g.value.lstrip("#"), 16),
-            "T": int(helix_color_t.value.lstrip("#"), 16),
-        }
-
-        helix_container.controls.append(
-            show_helix_ui(
-                dna_seq,
-                strand2_sequence=rc_seq,
-                animate=animate_checkbox.value,
-                zoom=zoom_slider.value,
-                colors=colors,
-                fps=fps_slider.value,
-                ws_url="ws://localhost:8765",
-            )
-        )
-        page.update()
-
-    animate_checkbox.on_change = refresh_helix_view
-    zoom_slider.on_change = refresh_helix_view
-    fps_slider.on_change = refresh_helix_view
 
     def on_tab_change(e: ft.ControlEvent) -> None:
         if app_tabs.selected_index == 3:

--- a/src/genecoder/flet_handlers.py
+++ b/src/genecoder/flet_handlers.py
@@ -1,0 +1,341 @@
+"""Event handler helpers for the Flet GUI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Callable, Awaitable, Optional
+
+import flet as ft
+
+# Compatibility alias for color constants across Flet versions
+COLORS = getattr(ft, "colors", getattr(ft, "Colors", None)) or ft.Colors
+
+from .app_helpers import perform_decoding
+from .constraint_fixer import fix_sequence
+from .flet_helpers import parse_int_input
+from .gc_constrained_encoder import calculate_gc_content
+from .manifest import generate_manifest
+from .options import EncodeOptions
+from .utils import get_max_homopolymer_length
+from .synthesis import SynthesisConstraints
+from .cli.encode import reverse_complement
+from .formats import to_fasta
+from . import perform_encoding
+from .flet_ws import ws_clients
+
+logger = logging.getLogger(__name__)
+
+
+decoded_bytes_to_save: bytes = b""
+
+
+def make_encode_handler(
+    *,
+    page: ft.Page,
+    selected_encode_input_file_path: ft.Ref[Optional[str]],
+    encode_button: ft.ElevatedButton,
+    encode_browse_button: ft.ElevatedButton,
+    encode_progress_ring: ft.ProgressRing,
+    encode_status_text: ft.Text,
+    encode_orig_size_text: ft.Text,
+    encode_dna_len_text: ft.Text,
+    encode_comp_ratio_text: ft.Text,
+    encode_bits_per_nt_text: ft.Text,
+    encode_actual_gc_value: ft.Text,
+    encode_actual_homopolymer_value: ft.Text,
+    encode_dna_snippet_text: ft.Text,
+    fixed_dna_snippet_text: ft.Text,
+    fixed_metrics_text: ft.Text,
+    encode_save_button: ft.ElevatedButton,
+    encode_manifest_save_button: ft.ElevatedButton,
+    encode_hidden_fasta_content: ft.Text,
+    encode_hidden_manifest_content: ft.Text,
+    encode_hidden_sequence: ft.Text,
+    codeword_hist_image: ft.Image,
+    nucleotide_freq_image: ft.Image,
+    sequence_analysis_plot_image: ft.Image,
+    analysis_status_text: ft.Text,
+    fix_suggestion_text: ft.Text,
+    app_tabs: ft.Tabs,
+    method_dropdown: ft.Dropdown,
+    parity_checkbox: ft.Checkbox,
+    k_value_input: ft.TextField,
+    fec_dropdown: ft.Dropdown,
+    window_size_input: ft.TextField,
+    step_size_input: ft.TextField,
+    min_homopolymer_input: ft.TextField,
+    alphabet_dropdown: ft.Dropdown,
+    mirror_checkbox: ft.Checkbox,
+    refresh_helix_view: Callable[[], None],
+) -> Callable[[ft.ControlEvent], Awaitable[None]]:
+    """Create the asynchronous encode event handler."""
+
+    async def encode_data(e: ft.ControlEvent) -> None:
+        # Disable buttons and show progress
+        encode_button.disabled = True
+        encode_browse_button.disabled = True
+        encode_progress_ring.visible = True
+
+        encode_status_text.value = "Processing..."
+        encode_orig_size_text.value = "Original size: - bytes"
+        encode_dna_len_text.value = "Encoded DNA length: - nucleotides"
+        encode_comp_ratio_text.value = "Compression ratio: -"
+        encode_bits_per_nt_text.value = "Bits per nucleotide: - bits/nt"
+        encode_actual_gc_value.value = "-"
+        encode_actual_homopolymer_value.value = "-"
+        encode_dna_snippet_text.value = ""
+        fixed_dna_snippet_text.value = ""
+        fixed_metrics_text.value = ""
+        encode_save_button.visible = False
+        encode_manifest_save_button.visible = False
+        encode_hidden_fasta_content.value = ""
+        encode_hidden_manifest_content.value = ""
+
+        codeword_hist_image.src_base64 = None
+        nucleotide_freq_image.src_base64 = None
+        sequence_analysis_plot_image.src_base64 = None
+        analysis_status_text.value = "Encode data to view analysis plots."
+        fix_suggestion_text.value = ""
+        if len(app_tabs.tabs) > 2:
+            app_tabs.tabs[2].disabled = True
+
+        page.update()
+
+        try:
+            input_path = selected_encode_input_file_path.current
+            if not input_path:
+                encode_status_text.value = "Error: Please select an input file first."
+                encode_status_text.color = COLORS.RED_ACCENT_700
+                page.update()
+                return
+
+            with open(input_path, "rb") as f_in:
+                input_data = await asyncio.to_thread(f_in.read)
+
+            try:
+                options = EncodeOptions(
+                    method=method_dropdown.value,
+                    add_parity=parity_checkbox.value,
+                    k_value=parse_int_input(k_value_input.value, 7),
+                    fec_method=fec_dropdown.value,
+                    window_size=parse_int_input(window_size_input.value, 50),
+                    step_size=parse_int_input(step_size_input.value, 10),
+                    min_homopolymer_len=parse_int_input(min_homopolymer_input.value, 4),
+                    alphabet=alphabet_dropdown.value,
+                )
+            except ValueError as ex:
+                encode_status_text.value = f"Invalid numeric input: {ex}"
+                encode_status_text.color = COLORS.RED_ACCENT_700
+                page.update()
+                return
+
+            try:
+                result = await asyncio.to_thread(perform_encoding, input_data, options)
+            except ValueError as ex:
+                encode_status_text.value = f"Error: {ex}"
+                encode_status_text.color = COLORS.RED_ACCENT_700
+                page.update()
+                return
+
+            final_fasta = result.fasta
+            forward_seq = result.encoded_dna
+            if mirror_checkbox.value:
+                rc_seq = reverse_complement(forward_seq)
+                rc_header = result.fasta.splitlines()[0][1:] + " mirror=rc"
+                final_fasta += to_fasta(rc_seq, rc_header, line_width=80)
+            encode_hidden_fasta_content.value = final_fasta
+            encode_hidden_sequence.value = forward_seq
+            encode_dna_snippet_text.value = forward_seq[:200]
+            if ws_clients:
+                async def _stream_bases(seq: str, step: int = 50) -> None:
+                    for i in range(0, len(seq), step):
+                        chunk = seq[i : i + step]
+                        await asyncio.gather(*(c.send(chunk) for c in ws_clients))
+                        await asyncio.sleep(0)
+
+                asyncio.create_task(_stream_bases(forward_seq))
+            encode_save_button.visible = True
+            manifest = generate_manifest(
+                os.path.basename(input_path), options, result.metrics
+            )
+            encode_hidden_manifest_content.value = json.dumps(manifest, indent=2)
+            encode_manifest_save_button.visible = True
+
+            metrics = result.metrics
+            encode_orig_size_text.value = (
+                f"Original size: {metrics['original_size']} bytes"
+            )
+            encode_dna_len_text.value = (
+                f"Encoded DNA length: {metrics['dna_length']} nucleotides"
+            )
+            encode_comp_ratio_text.value = (
+                f"Compression ratio: {metrics['compression_ratio']:.2f}"
+            )
+            encode_bits_per_nt_text.value = (
+                f"Bits per nucleotide: {metrics['bits_per_nt']:.2f} bits/nt"
+            )
+
+            if options.method == "GC-Balanced":
+                encode_actual_gc_value.value = f"{metrics['actual_gc']:.2%}"
+                encode_actual_homopolymer_value.value = f"{metrics['max_homopolymer']}"
+            else:
+                encode_actual_gc_value.value = "N/A"
+                encode_actual_homopolymer_value.value = "N/A"
+
+            codeword_hist_image.src_base64 = result.plots.get("codeword_hist")
+            nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
+            sequence_analysis_plot_image.src_base64 = result.plots.get(
+                "sequence_analysis"
+            )
+
+            any_plot = any(result.plots.values())
+
+            if any_plot:
+                analysis_status_text.value = (
+                    "All analysis plots generated successfully."
+                )
+                analysis_status_text.color = COLORS.GREEN_700
+            else:
+                analysis_status_text.value = (
+                    "No analysis plots applicable or generated for the selected options."
+                )
+                analysis_status_text.color = COLORS.ORANGE_ACCENT_700
+            if len(app_tabs.tabs) > 2:
+                app_tabs.tabs[2].disabled = not any_plot
+
+            info_msgs = list(result.info_messages)
+            if options.method == "GC-Balanced" and options.add_parity:
+                info_msgs.insert(0, "Info: 'Add Parity' not directly used by GC-Balanced.")
+            status_prefix = " ".join(info_msgs)
+            encode_status_text.value = (
+                status_prefix + " " if status_prefix else ""
+            ) + "Encoding successful! Click 'Save Encoded FASTA...' to save."
+            encode_status_text.color = COLORS.GREEN_700
+
+            gc_val = calculate_gc_content(forward_seq)
+            hp_len = get_max_homopolymer_length(forward_seq)
+            constraints = SynthesisConstraints()
+            if (
+                gc_val < 0.4
+                or gc_val > 0.6
+                or hp_len > constraints.max_homopolymer
+            ):
+                fixed = fix_sequence(
+                    forward_seq,
+                    target_gc_min=0.4,
+                    target_gc_max=0.6,
+                    max_homopolymer=constraints.max_homopolymer,
+                )
+                fix_gc = calculate_gc_content(fixed)
+                fix_hp = get_max_homopolymer_length(fixed)
+                fix_suggestion_text.value = (
+                    f"Suggested fix GC {fix_gc:.2%}, max HP {fix_hp}."
+                )
+            else:
+                fix_suggestion_text.value = ""
+
+            refresh_helix_view()
+            app_tabs.selected_index = 3
+            page.update()
+
+        except FileNotFoundError:
+            encode_status_text.value = f"Error: Input file '{input_path}' not found."
+            encode_status_text.color = COLORS.RED_ACCENT_700
+        except OSError as ex:
+            encode_status_text.value = f"I/O error during encoding: {ex}"
+            encode_status_text.color = COLORS.RED_ACCENT_700
+        except Exception as ex:  # pragma: no cover - unexpected
+            logger.exception("Unexpected error during encoding")
+            encode_status_text.value = f"An unexpected error occurred: {ex}"
+            encode_status_text.color = COLORS.RED_ACCENT_700
+            raise
+        finally:
+            encode_button.disabled = False
+            encode_browse_button.disabled = False
+            encode_progress_ring.visible = False
+            page.update()
+
+    return encode_data
+
+
+def make_decode_handler(
+    *,
+    page: ft.Page,
+    selected_decode_input_file_path: ft.Ref[Optional[str]],
+    decode_button: ft.ElevatedButton,
+    decode_browse_button: ft.ElevatedButton,
+    decode_progress_ring: ft.ProgressRing,
+    decode_status_text: ft.Text,
+    decode_fec_info_text: ft.Text,
+    decode_save_button: ft.ElevatedButton,
+    decode_alphabet_dropdown: ft.Dropdown,
+) -> Callable[[ft.ControlEvent], Awaitable[None]]:
+    """Create the asynchronous decode event handler."""
+
+    async def decode_file_data(e: ft.ControlEvent) -> None:
+        global decoded_bytes_to_save
+        decode_status_text.value = "Processing..."
+        decode_progress_ring.visible = True
+        decode_button.disabled = True
+        decode_browse_button.disabled = True
+        decode_save_button.visible = False
+        decoded_bytes_to_save = b""
+        page.update()
+
+        try:
+            input_path = selected_decode_input_file_path.current
+            if not input_path:
+                decode_status_text.value = "Error: Please select an input FASTA file first."
+                decode_status_text.color = COLORS.RED_ACCENT_700
+                page.update()
+                return
+
+            with open(input_path, "r", encoding="utf-8") as f_in:
+                file_content_str = await asyncio.to_thread(f_in.read)
+
+            try:
+                result = await asyncio.to_thread(
+                    perform_decoding, file_content_str, decode_alphabet_dropdown.value
+                )
+            except ValueError as ex:
+                decode_status_text.value = f"Error: {ex}"
+                decode_status_text.color = COLORS.RED_ACCENT_700
+                page.update()
+                return
+            except Exception as ex:
+                logger.exception("Unexpected error during decoding")
+                decode_status_text.value = f"Unexpected error: {ex}"
+                decode_status_text.color = COLORS.RED_ACCENT_700
+                raise
+
+            decoded_bytes_to_save = result.decoded_bytes
+            decode_status_text.value = result.status_message
+            decode_status_text.color = COLORS.GREEN_700
+            if result.fec_info:
+                decode_fec_info_text.value = result.fec_info
+                decode_fec_info_text.color = COLORS.GREEN_700
+            else:
+                decode_fec_info_text.value = ""
+            decode_save_button.visible = True
+
+        except FileNotFoundError:
+            decode_status_text.value = f"Error: Input file '{input_path}' not found."
+            decode_status_text.color = COLORS.RED_ACCENT_700
+        except OSError as ex:
+            decode_status_text.value = f"I/O error: {ex}"
+            decode_status_text.color = COLORS.RED_ACCENT_700
+        except Exception as ex:  # pragma: no cover - unexpected
+            logger.exception("Unexpected error during decode_file_data")
+            decode_status_text.value = f"Critical error: {ex}"
+            decode_status_text.color = COLORS.RED_ACCENT_700
+            raise
+        finally:
+            decode_progress_ring.visible = False
+            decode_button.disabled = False
+            decode_browse_button.disabled = False
+            page.update()
+
+    return decode_file_data

--- a/src/genecoder/flet_ws.py
+++ b/src/genecoder/flet_ws.py
@@ -1,0 +1,46 @@
+import asyncio
+import logging
+from typing import Any
+
+try:
+    import websockets
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None
+
+logger = logging.getLogger(__name__)
+
+ws_clients: set[Any] = set()
+
+
+def start_server() -> None:
+    """Start the local WebSocket server if possible."""
+
+    if not websockets:
+        return
+
+    async def _ws_handler(websocket: Any) -> None:
+        ws_clients.add(websocket)
+        try:
+            async for _ in websocket:
+                pass
+        finally:
+            ws_clients.discard(websocket)
+
+    try:
+        try:
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_event_loop()
+        except RuntimeError:
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = None
+        if loop:
+            loop.create_task(websockets.serve(_ws_handler, "localhost", 8765))
+        else:  # pragma: no cover - depends on environment
+            logger.error("No running event loop; WebSocket server not started")
+    except OSError as exc:  # pragma: no cover - depends on environment
+        logger.error("Failed to start WebSocket server: %s", exc)
+
+
+# Start server on import for backwards compatibility
+start_server()

--- a/tests/test_flet_app_interactions.py
+++ b/tests/test_flet_app_interactions.py
@@ -120,7 +120,7 @@ def test_encode_unexpected_error_propagates(tmp_path: Path, monkeypatch: pytest.
     def boom(*_a, **_k):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(flet_app, "perform_encoding", boom)
+    monkeypatch.setattr("genecoder.flet_handlers.perform_encoding", boom)
 
     ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
 
@@ -142,7 +142,7 @@ def test_decode_unexpected_error_propagates(tmp_path: Path, monkeypatch: pytest.
     def boom(*_a, **_k):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(flet_app, "perform_decoding", boom)
+    monkeypatch.setattr("genecoder.flet_handlers.perform_decoding", boom)
 
     ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
 
@@ -164,7 +164,7 @@ def test_encode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     def bad(*_a, **_k):
         raise ValueError("bad input")
 
-    monkeypatch.setattr(flet_app, "perform_encoding", bad)
+    monkeypatch.setattr("genecoder.flet_handlers.perform_encoding", bad)
 
     ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
 
@@ -208,7 +208,7 @@ def test_decode_value_error_handled(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     def bad(*_a, **_k):
         raise ValueError("bad fasta")
 
-    monkeypatch.setattr(flet_app, "perform_decoding", bad)
+    monkeypatch.setattr("genecoder.flet_handlers.perform_decoding", bad)
 
     ft.app(target=flet_app.main, view=ft.AppView.FLET_APP_HIDDEN, port=0)
 

--- a/tests/test_flet_app_websocket.py
+++ b/tests/test_flet_app_websocket.py
@@ -18,11 +18,11 @@ def test_websocket_start_error_logged(monkeypatch, caplog):
     loop = asyncio.new_event_loop()
     monkeypatch.setattr(asyncio, "get_event_loop", lambda: loop)
 
-    if "genecoder.flet_app" in sys.modules:
-        del sys.modules["genecoder.flet_app"]
+    if "genecoder.flet_ws" in sys.modules:
+        del sys.modules["genecoder.flet_ws"]
 
     with caplog.at_level(logging.ERROR):
-        importlib.import_module("genecoder.flet_app")
+        importlib.import_module("genecoder.flet_ws")
 
     assert any(
         "Failed to start WebSocket server" in rec.message for rec in caplog.records

--- a/tests/test_flet_handlers.py
+++ b/tests/test_flet_handlers.py
@@ -1,0 +1,119 @@
+import asyncio
+import types
+
+import pytest
+
+from genecoder.flet_handlers import (
+    make_encode_handler,
+    make_decode_handler,
+)
+
+ft = pytest.importorskip("flet")
+
+
+class DummyPage:
+    def update(self) -> None:  # noqa: D401 - minimal stub
+        pass
+
+
+def control(**kwargs):
+    return types.SimpleNamespace(**kwargs)
+
+
+def test_make_encode_handler_calls_perform_encoding(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def fake_perform_encoding(data: bytes, opts: object) -> object:
+        called["data"] = data
+        return types.SimpleNamespace(
+            fasta=">seq\nAC",
+            encoded_dna="AC",
+            plots={},
+            metrics={
+                "original_size": len(data),
+                "dna_length": 2,
+                "compression_ratio": 1.0,
+                "bits_per_nt": 2.0,
+                "actual_gc": 0.5,
+                "max_homopolymer": 1,
+            },
+            info_messages=[],
+        )
+
+    monkeypatch.setattr("genecoder.flet_handlers.perform_encoding", fake_perform_encoding)
+    monkeypatch.setattr("genecoder.flet_handlers.generate_manifest", lambda *a, **k: {})
+
+    inp = tmp_path / "data.bin"
+    inp.write_bytes(b"x")
+
+    handler = make_encode_handler(
+        page=DummyPage(),
+        selected_encode_input_file_path=types.SimpleNamespace(current=str(inp)),
+        encode_button=control(disabled=False),
+        encode_browse_button=control(disabled=False),
+        encode_progress_ring=control(visible=False),
+        encode_status_text=control(value="", color=""),
+        encode_orig_size_text=control(value=""),
+        encode_dna_len_text=control(value=""),
+        encode_comp_ratio_text=control(value=""),
+        encode_bits_per_nt_text=control(value=""),
+        encode_actual_gc_value=control(value=""),
+        encode_actual_homopolymer_value=control(value=""),
+        encode_dna_snippet_text=control(value=""),
+        fixed_dna_snippet_text=control(value=""),
+        fixed_metrics_text=control(value=""),
+        encode_save_button=control(visible=False),
+        encode_manifest_save_button=control(visible=False),
+        encode_hidden_fasta_content=control(value=""),
+        encode_hidden_manifest_content=control(value=""),
+        encode_hidden_sequence=control(value=""),
+        codeword_hist_image=control(src_base64=None),
+        nucleotide_freq_image=control(src_base64=None),
+        sequence_analysis_plot_image=control(src_base64=None),
+        analysis_status_text=control(value="", color=""),
+        fix_suggestion_text=control(value=""),
+        app_tabs=types.SimpleNamespace(
+            tabs=[types.SimpleNamespace(disabled=False) for _ in range(3)],
+            selected_index=0,
+        ),
+        method_dropdown=types.SimpleNamespace(value="Base-4 Direct"),
+        parity_checkbox=types.SimpleNamespace(value=False),
+        k_value_input=types.SimpleNamespace(value="7"),
+        fec_dropdown=types.SimpleNamespace(value="None"),
+        window_size_input=types.SimpleNamespace(value="50"),
+        step_size_input=types.SimpleNamespace(value="10"),
+        min_homopolymer_input=types.SimpleNamespace(value="4"),
+        alphabet_dropdown=types.SimpleNamespace(value="base4"),
+        mirror_checkbox=types.SimpleNamespace(value=False),
+        refresh_helix_view=lambda: None,
+    )
+
+    asyncio.run(handler(None))
+    assert called["data"] == b"x"
+
+
+def test_make_decode_handler_sets_global(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_perform_decoding(fasta: str, alphabet: str) -> object:
+        return types.SimpleNamespace(decoded_bytes=b"out", status_message="ok", fec_info="")
+
+    monkeypatch.setattr("genecoder.flet_handlers.perform_decoding", fake_perform_decoding)
+
+    fasta = tmp_path / "seq.fa"
+    fasta.write_text(">s\nAC")
+
+    handler = make_decode_handler(
+        page=DummyPage(),
+        selected_decode_input_file_path=types.SimpleNamespace(current=str(fasta)),
+        decode_button=control(disabled=False),
+        decode_browse_button=control(disabled=False),
+        decode_progress_ring=control(visible=False),
+        decode_status_text=control(value="", color=""),
+        decode_fec_info_text=control(value="", color=""),
+        decode_save_button=control(visible=False),
+        decode_alphabet_dropdown=types.SimpleNamespace(value="base4"),
+    )
+
+    asyncio.run(handler(None))
+    from genecoder import flet_handlers
+
+    assert flet_handlers.decoded_bytes_to_save == b"out"


### PR DESCRIPTION
## Summary
- extract websocket server to `flet_ws.py`
- move encoding/decoding handlers to `flet_handlers.py`
- simplify `flet_app.py` to focus on UI setup
- adjust existing tests and add new tests for handlers
- fix color constants for Flet compatibility

## Testing
- `ruff check .`
- `mypy src/genecoder/flet_app.py src/genecoder/flet_handlers.py src/genecoder/flet_ws.py`
- `pytest -q` *(625 passed, 42 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_6869e44984288326898b08c83f4160f3