### PR TITLE
Add web API route tests

### DIFF
--- a/tests/test_web_api_analyze_report.py
+++ b/tests/test_web_api_analyze_report.py
@@ -46,3 +46,8 @@ def test_dashboard_metrics_with_token() -> None:
     assert r.status_code == 200
     data = r.json()
     assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot"}
+
+
+def test_report_invalid_request() -> None:
+    r = client.post("/report", json={"data": "bad", "type": "encode"})
+    assert r.status_code == 422

--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -64,3 +64,18 @@ def test_rate_limiter_requires_token(monkeypatch, tmp_path):
     )
     assert r2.status_code == 200
 
+
+
+def test_upload_chunk_missing_field(tmp_path, monkeypatch):
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = None
+    payload = {"offset": 0, "data": base64.b64encode(b"d").decode()}
+    r = client.post("/upload-chunk", json=payload)
+    assert r.status_code == 422
+
+
+def test_download_chunk_not_found(monkeypatch, tmp_path):
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = None
+    r = client.get("/download-chunk", params={"file_id": "missing", "offset": 1})
+    assert r.status_code == 404

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -1,0 +1,46 @@
+import argparse
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+import web.main as main
+import genecoder.plugins as plugins
+from genecoder.cli import plugin as plugin_cli
+
+main.API_TOKEN = "test-token"
+client = TestClient(main.app)
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
+
+def test_plugin_catalog_page() -> None:
+    r = client.get("/plugin-catalog")
+    assert r.status_code == 200
+    assert "<!DOCTYPE html>" in r.text
+
+
+def test_list_plugins() -> None:
+    plugins.PLUGIN_CATALOG.clear()
+    plugins.PLUGIN_CATALOG["demo"] = {"description": "Demo"}
+    r = client.get("/plugins")
+    assert r.status_code == 200
+    assert "demo" in r.json().get("plugins", {})
+
+
+def test_install_plugin() -> None:
+    called = []
+
+    def fake_install(args: argparse.Namespace) -> None:
+        called.append(args.name)
+
+    plugins.PLUGIN_CATALOG["demo"] = {}
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr(plugin_cli, "_handle_install", fake_install)
+        r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "demo"})
+    assert r.status_code == 200
+    assert called == ["demo"]
+
+
+def test_install_requires_token() -> None:
+    r = client.post("/plugins/install", json={"name": "demo"})
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- cover `/report` error handling
- check chunk endpoints 404 and 422 cases
- add plugin catalog API tests

## Testing
- `pytest tests/test_web_api_analyze_report.py tests/test_web_api_chunks.py tests/test_web_api_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6869f070558c83269c4b01c67785283d