### PR TITLE
Extend FEC benchmark script

### DIFF
--- a/benchmarks/fec_bench.py
+++ b/benchmarks/fec_bench.py
@@ -14,6 +14,13 @@ from pathlib import Path
 
 from genecoder import FEC_REGISTRY, load_plugins
 
+REDUNDANCY_ARGS = {
+    "bch": "t",
+    "reed_solomon": "nsym",
+    "fountain": "chunk_size",
+    "raptorq": "symbol_size",
+}
+
 
 DATA_SIZE = 1_000_000  # 1 MB of random bytes
 ERROR_PROB = 0.01  # probability of flipping each bit
@@ -42,10 +49,23 @@ def introduce_bit_errors(data: bytes, prob: float, rng: random.Random | None = N
     return bytes(arr)
 
 
-def bench_backend(name: str, encode, decode, data: bytes, prob: float) -> dict[str, float | str]:
+def bench_backend(
+    name: str,
+    encode,
+    decode,
+    data: bytes,
+    prob: float,
+    redundancy: int | None = None,
+    param: str | None = None,
+) -> dict[str, float | str]:
     start = time.perf_counter()
     try:
-        encoded, info = encode(data)
+        if redundancy is not None and param:
+            encoded, info = encode(data, **{param: redundancy})
+        elif redundancy is not None:
+            encoded, info = encode(data, redundancy)
+        else:
+            encoded, info = encode(data)
     except Exception as exc:  # pragma: no cover - optional deps
         return {"fec": name, "error": str(exc)}
     enc_time = time.perf_counter() - start
@@ -62,8 +82,10 @@ def bench_backend(name: str, encode, decode, data: bytes, prob: float) -> dict[s
         }
     dec_time = time.perf_counter() - start
     ber = bit_error_rate(data, decoded)
+    redundancy_ratio = len(encoded) / len(data) if len(data) else 0.0
     return {
         "fec": name,
+        "redundancy": redundancy_ratio,
         "encode_mb_s": len(data) / (1024 * 1024) / enc_time,
         "decode_mb_s": len(data) / (1024 * 1024) / dec_time,
         "ber": ber,
@@ -81,6 +103,13 @@ def main() -> None:
         default=ERROR_PROB,
         help="Bit flip probability",
     )
+    parser.add_argument(
+        "--redundancy",
+        type=int,
+        action="append",
+        default=[0],
+        help="Redundancy levels to test",
+    )
     args = parser.parse_args()
 
     load_plugins()
@@ -89,12 +118,31 @@ def main() -> None:
     results: list[dict[str, float | str]] = []
     for name in sorted(FEC_REGISTRY):
         funcs = FEC_REGISTRY[name]
-        result = bench_backend(name, funcs["encode"], funcs["decode"], data, args.error_prob)
-        results.append(result)
+        param = REDUNDANCY_ARGS.get(name)
+        for r in args.redundancy:
+            result = bench_backend(
+                name,
+                funcs["encode"],
+                funcs["decode"],
+                data,
+                args.error_prob,
+                r,
+                param,
+            )
+            result["redundancy_param"] = r
+            results.append(result)
 
     out = open(args.output, "w", newline="") if args.output else sys.stdout
     if args.format == "csv":
-        fieldnames = ["fec", "encode_mb_s", "decode_mb_s", "ber", "error"]
+        fieldnames = [
+            "fec",
+            "redundancy_param",
+            "redundancy",
+            "encode_mb_s",
+            "decode_mb_s",
+            "ber",
+            "error",
+        ]
         writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         for row in results:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -13,6 +13,15 @@ python -m genecoder.cli benchmark fec --format csv > results.csv
 Use `--format json` to emit JSON instead of CSV, `--output` to write to a file and
 `--plot` to save a PNG chart of the results generated with `genecoder.report`.
 
+To explore how redundancy affects error correction pass one or more `--redundancy`
+values. The benchmark will run each FEC backend for every level and report the
+resulting bit error rate.
+
+```bash
+python -m genecoder.cli benchmark fec --size 1024 --error-prob 0.05 \
+    --format json --redundancy 4 8 12
+```
+
 ## Quick Tutorial
 
 To quickly test the benchmark script with minimal data run:

--- a/src/genecoder/cli/benchmark.py
+++ b/src/genecoder/cli/benchmark.py
@@ -28,6 +28,13 @@ def register_subcommand(
     fec_parser.add_argument("--output", "-o", type=Path)
     fec_parser.add_argument("--size", type=int, default=_DATA_SIZE)
     fec_parser.add_argument("--error-prob", type=float, default=_ERROR_PROB)
+    fec_parser.add_argument(
+        "--redundancy",
+        type=int,
+        nargs="+",
+        default=[0],
+        help="Redundancy levels to test",
+    )
     fec_parser.add_argument("--plot", type=Path, help="Write PNG plot of results")
     fec_parser.set_defaults(func=_handle_fec)
 
@@ -51,6 +58,8 @@ def _handle_fec(args: argparse.Namespace) -> None:
         "--error-prob",
         str(args.error_prob),
     ]
+    for r in args.redundancy:
+        cmd.extend(["--redundancy", str(r)])
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)
@@ -58,7 +67,10 @@ def _handle_fec(args: argparse.Namespace) -> None:
     results_text = proc.stdout
     if args.plot:
         results = _parse_results(results_text, args.format)
-        buf = report_module.plot_fec_benchmark(results)
+        if any("redundancy" in r for r in results):
+            buf = report_module.plot_fec_success(results)
+        else:
+            buf = report_module.plot_fec_benchmark(results)
         with open(args.plot, "wb") as fh:
             fh.write(buf.getvalue())
         buf.close()

--- a/src/genecoder/report.py
+++ b/src/genecoder/report.py
@@ -14,6 +14,7 @@ __all__ = [
     "encode_to_html",
     "decode_to_html",
     "plot_fec_benchmark",
+    "plot_fec_success",
 ]
 
 
@@ -100,6 +101,38 @@ def plot_fec_benchmark(results: List[Dict[str, float | str]]) -> io.BytesIO:
     ax.set_title("FEC Benchmark")
     ax.set_xticks(x)
     ax.set_xticklabels(names)
+    ax.legend()
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    try:
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+    finally:
+        plt.close(fig)
+    return buf
+
+
+def plot_fec_success(results: List[Dict[str, float | str]]) -> io.BytesIO:
+    """Return a success-rate vs redundancy plot for FEC benchmarks."""
+    if not _MATPLOTLIB_AVAILABLE:
+        return _dummy_png()
+
+    names = sorted({r.get("fec", "") for r in results})
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for name in names:
+        subset = [r for r in results if r.get("fec") == name and "redundancy" in r]
+        if not subset:
+            continue
+        subset.sort(key=lambda d: float(d.get("redundancy_param", d.get("redundancy", 0))))
+        xs = [float(r.get("redundancy_param", r.get("redundancy", 0))) for r in subset]
+        ys = [1.0 - float(r.get("ber", 1.0)) for r in subset]
+        ax.plot(xs, ys, marker="o", label=name)
+
+    ax.set_xlabel("redundancy")
+    ax.set_ylabel("success rate")
+    ax.set_title("FEC Success Rate")
+    ax.set_ylim(0, 1)
     ax.legend()
     plt.tight_layout()
 

--- a/tests/test_fec_bench_script.py
+++ b/tests/test_fec_bench_script.py
@@ -28,3 +28,19 @@ def test_fec_bench_csv() -> None:
     lines = [line for line in result.stdout.strip().splitlines() if line]
     assert lines[0].startswith("fec,")
     assert len(lines) >= 2
+
+
+def test_fec_bench_redundancy_json() -> None:
+    result = _run_fec_bench([
+        "--size",
+        "16",
+        "--error-prob",
+        "0",
+        "--format",
+        "json",
+        "--redundancy",
+        "2",
+    ])
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert all("redundancy_param" in item for item in data)


### PR DESCRIPTION
## Summary
- vary redundancy values in `fec_bench.py`
- update CLI to pass redundancy list and choose plotting function
- add `plot_fec_success` helper
- document redundancy benchmarking
- test JSON output of `fec_bench.py`

## Testing
- `pre-commit run ruff --files benchmarks/fec_bench.py src/genecoder/cli/benchmark.py src/genecoder/report.py tests/test_fec_bench_script.py`
- `pre-commit run mypy --files benchmarks/fec_bench.py src/genecoder/cli/benchmark.py src/genecoder/report.py tests/test_fec_bench_script.py`
- `pytest tests/test_fec_bench_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f06edb2c8326b0df8c89285b9275