### PR TITLE
Add design interface endpoints

### DIFF
--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -85,6 +85,30 @@ The JSON response includes the sequence length,
 [GC content](glossary.md#gc-content) and the longest
 [homopolymer](glossary.md#homopolymer) run.
 
+## Sequence Design
+
+Open `/design` in the browser to launch a simple React interface for
+validating and fixing DNA sequences.
+
+The validation endpoint returns basic sequence metrics:
+
+```json
+POST /design/validate
+{ "sequence": "ACGT" }
+```
+
+The response reports whether the sequence falls within the supplied GC
+and homopolymer limits.
+
+To automatically adjust a sequence, call `/design/fix`:
+
+```json
+POST /design/fix
+{ "sequence": "AAAAAA", "gc_min": 0.4, "gc_max": 0.6, "max_homopolymer": 3 }
+```
+
+The fixed sequence and its metrics are returned in the JSON response.
+
 ## Generating Reports
 
 Use `/report` to convert an encoding or decoding result into Markdown or HTML

--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -1,6 +1,8 @@
 import argparse
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
@@ -13,7 +15,7 @@ client = TestClient(main.app)
 AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
 
 
-def test_list_plugins(monkeypatch):
+def test_list_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
     plugins.PLUGIN_CATALOG.clear()
     plugins.PLUGIN_CATALOG["demo"] = {"description": "Demo"}
     r = client.get("/plugins")
@@ -21,7 +23,7 @@ def test_list_plugins(monkeypatch):
     assert "demo" in r.json().get("plugins", {})
 
 
-def test_install_plugin(monkeypatch):
+def test_install_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
     called = []
 
     def fake_install(args: argparse.Namespace) -> None:
@@ -34,6 +36,6 @@ def test_install_plugin(monkeypatch):
     assert called == ["demo"]
 
 
-def test_install_requires_token():
+def test_install_requires_token() -> None:
     r = client.post("/plugins/install", json={"name": "demo"})
     assert r.status_code == 401

--- a/tests/test_web_api_analyze_report.py
+++ b/tests/test_web_api_analyze_report.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient

--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -3,6 +3,8 @@ import hashlib
 import json
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
@@ -12,9 +14,13 @@ import web.main as main
 client = TestClient(main.app)
 
 
-def test_chunk_upload_and_download(tmp_path, monkeypatch):
+from pathlib import Path
+from fastapi import Request
+
+
+def test_chunk_upload_and_download(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
-    main.FastAPILimiter.redis = None
+    main.FastAPILimiter.redis = None  # type: ignore[attr-defined]
     data = b"chunk data"
     payload = {
         "file_id": "file1",
@@ -39,13 +45,13 @@ def test_chunk_upload_and_download(tmp_path, monkeypatch):
     assert base64.b64decode(r2.json()["data"]) == data
 
 
-def test_rate_limiter_requires_token(monkeypatch, tmp_path):
+def test_rate_limiter_requires_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
-    main.FastAPILimiter.redis = object()
+    main.FastAPILimiter.redis = object()  # type: ignore[attr-defined]
 
-    async def fake_rate_limit(request, _response):
+    async def fake_rate_limit(request: Request, _response: object) -> None:
         if "authorization" not in request.headers:
-            raise main.HTTPException(status_code=401, detail="missing token")
+            raise main.HTTPException(status_code=401, detail="missing token")  # type: ignore[attr-defined]
 
     monkeypatch.setattr(main, "rate_limit", fake_rate_limit)
 

--- a/tests/test_web_api_decode_ai.py
+++ b/tests/test_web_api_decode_ai.py
@@ -1,6 +1,8 @@
 import base64
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 pytest.importorskip("dnaformer")

--- a/tests/test_web_api_encode_decode.py
+++ b/tests/test_web_api_encode_decode.py
@@ -1,6 +1,8 @@
 import base64
 import pytest
 
+pytest.importorskip("fastapi_limiter")
+
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient

--- a/tests/test_web_api_no_redis.py
+++ b/tests/test_web_api_no_redis.py
@@ -1,5 +1,8 @@
 import base64
+from pathlib import Path
 import pytest
+
+pytest.importorskip("fastapi_limiter")
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
@@ -10,8 +13,8 @@ import web.main as main
 client = TestClient(main.app)
 
 
-def test_chunk_endpoints_without_redis(tmp_path):
-    main.FastAPILimiter.redis = None
+def test_chunk_endpoints_without_redis(tmp_path: Path) -> None:
+    main.FastAPILimiter.redis = None  # type: ignore[attr-defined]
     data = b"no redis"
     payload = {
         "file_id": "file",

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -3,6 +3,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
+from genecoder.utils import get_max_homopolymer_length
 
 import base64
 
@@ -12,6 +13,7 @@ main.API_TOKEN = "test-token"
 app = main.app
 index_path = main.index_path
 helix_index_path = main.helix_index_path
+design_index_path = main.design_index_path
 client = TestClient(app)
 
 AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
@@ -97,3 +99,26 @@ def test_report_endpoint() -> None:
     r = client.post("/report", json={"data": enc, "type": "encode", "format": "html"})
     assert r.status_code == 200
     assert "<h1>Encoding Report</h1>" in r.json()["report"]
+
+
+def test_design_page() -> None:
+    response = client.get("/design")
+    assert response.status_code == 200
+    assert response.text == design_index_path.read_text(encoding="utf-8")
+
+
+def test_design_validate_endpoint() -> None:
+    payload = {"sequence": "ACGT"}
+    r = client.post("/design/validate", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data) >= {"valid", "gc_content", "max_homopolymer"}
+
+
+def test_design_fix_endpoint() -> None:
+    payload = {"sequence": "AAAA", "max_homopolymer": 2}
+    r = client.post("/design/fix", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert "sequence" in data
+    assert get_max_homopolymer_length(data["sequence"]) <= 2

--- a/web/helix-ui/design.html
+++ b/web/helix-ui/design.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sequence Designer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/design_main.jsx"></script>
+  </body>
+</html>

--- a/web/helix-ui/src/Design.jsx
+++ b/web/helix-ui/src/Design.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+export default function Design() {
+  const [sequence, setSequence] = useState('ACGT');
+  const [result, setResult] = useState(null);
+
+  const validate = async () => {
+    const r = await fetch('/design/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sequence })
+    });
+    setResult(await r.json());
+  };
+
+  const fix = async () => {
+    const r = await fetch('/design/fix', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sequence })
+    });
+    const data = await r.json();
+    setSequence(data.sequence);
+    setResult(data);
+  };
+
+  return (
+    <div>
+      <textarea value={sequence} onChange={e => setSequence(e.target.value)} />
+      <div>
+        <button onClick={validate}>Validate</button>
+        <button onClick={fix}>Fix</button>
+      </div>
+      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/web/helix-ui/src/design_main.jsx
+++ b/web/helix-ui/src/design_main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Design from './Design.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Design />
+  </React.StrictMode>
+);

--- a/web/main.py
+++ b/web/main.py
@@ -29,6 +29,7 @@ from genecoder.plotting import (
     generate_sequence_analysis_plot,
 )
 from genecoder.error_simulation import introduce_errors
+from genecoder import constraint_fixer
 from genecoder.app_helpers import EncodeResult, DecodeResult
 from genecoder.report import (
     encode_to_markdown,
@@ -124,6 +125,10 @@ plugin_index_path = helix_ui_dir / "dist" / "plugins.html"
 if not plugin_index_path.is_file():
     plugin_index_path = helix_ui_dir / "plugins.html"
 
+design_index_path = helix_ui_dir / "dist" / "design.html"
+if not design_index_path.is_file():
+    design_index_path = helix_ui_dir / "design.html"
+
 @app.get("/", response_class=HTMLResponse)
 async def index() -> str:
     return index_path.read_text(encoding="utf-8")
@@ -145,6 +150,12 @@ async def dashboard() -> str:
 async def plugin_catalog_page() -> str:
     """Return the React-based plugin catalog interface."""
     return plugin_index_path.read_text(encoding="utf-8")
+
+
+@app.get("/design", response_class=HTMLResponse)
+async def design_page() -> str:
+    """Return the React-based sequence design interface."""
+    return design_index_path.read_text(encoding="utf-8")
 
 
 class EncodeOptionsModel(BaseModel):
@@ -345,6 +356,49 @@ async def dashboard_plot_data(
         "gc_positions": starts,
         "gc_values": gc_values,
         "hp_lengths": hp_lengths,
+    }
+
+
+class DesignRequest(BaseModel):
+    """Request model for sequence design tools."""
+
+    sequence: str
+    gc_min: float = 0.4
+    gc_max: float = 0.6
+    max_homopolymer: int = 4
+
+
+@app.post("/design/validate")
+async def design_validate(req: DesignRequest) -> dict[str, object]:
+    """Validate a sequence against GC and homopolymer constraints."""
+
+    seq = req.sequence.upper()
+    gc_val = calculate_gc_content(seq)
+    max_hp = get_max_homopolymer_length(seq)
+    valid = req.gc_min <= gc_val <= req.gc_max and max_hp <= req.max_homopolymer
+    return {
+        "valid": valid,
+        "gc_content": gc_val,
+        "max_homopolymer": max_hp,
+    }
+
+
+@app.post("/design/fix")
+async def design_fix(req: DesignRequest) -> dict[str, object]:
+    """Return a sequence adjusted to satisfy constraints."""
+
+    fixed = constraint_fixer.fix_sequence(
+        req.sequence,
+        target_gc_min=req.gc_min,
+        target_gc_max=req.gc_max,
+        max_homopolymer=req.max_homopolymer,
+    )
+    gc_val = calculate_gc_content(fixed)
+    max_hp = get_max_homopolymer_length(fixed)
+    return {
+        "sequence": fixed,
+        "gc_content": gc_val,
+        "max_homopolymer": max_hp,
     }
 
 


### PR DESCRIPTION
## Summary
- serve a new React page at `/design`
- add `/design/validate` and `/design/fix` API endpoints
- document sequence design endpoints in the web API tutorial
- add unit tests for the new endpoints
- skip web API tests if `fastapi_limiter` is missing

## Testing
- `ruff check web/main.py tests/test_dashboard_httpx.py tests/test_plugins_api.py tests/test_web_api_chunks.py tests/test_web_api_decode_ai.py tests/test_web_api_encode_decode.py tests/test_web_api_analyze_report.py tests/test_web_api_no_redis.py tests/test_web_app.py`
- `mypy --config-file pyproject.toml web/main.py tests/test_dashboard_httpx.py tests/test_plugins_api.py tests/test_web_api_chunks.py tests/test_web_api_decode_ai.py tests/test_web_api_encode_decode.py tests/test_web_api_analyze_report.py tests/test_web_api_no_redis.py tests/test_web_app.py`
- `pytest tests/test_dashboard_httpx.py tests/test_plugins_api.py tests/test_web_api_chunks.py tests/test_web_api_decode_ai.py tests/test_web_api_encode_decode.py tests/test_web_api_analyze_report.py tests/test_web_api_no_redis.py tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6869f06fa25c83268c1ae44cc134117c