### PR TITLE
Validate chunk ID regex

### DIFF
--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -85,3 +85,24 @@ def test_download_chunk_not_found(monkeypatch, tmp_path):
     main.FastAPILimiter.redis = None
     r = client.get("/download-chunk", params={"file_id": "missing", "offset": 1})
     assert r.status_code == 404
+
+
+@pytest.mark.parametrize("bad_id", ["../bad", "foo/../bar", "..", "foo/bar"])
+def test_invalid_file_ids_rejected_upload(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_id: str) -> None:
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = None
+    payload = {
+        "file_id": bad_id,
+        "offset": 0,
+        "data": base64.b64encode(b"x").decode(),
+    }
+    r = client.post("/upload-chunk", json=payload)
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize("bad_id", ["../bad", "foo/../bar", "..", "foo/bar"])
+def test_invalid_file_ids_rejected_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_id: str) -> None:
+    monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
+    main.FastAPILimiter.redis = None
+    r = client.get("/download-chunk", params={"file_id": bad_id, "offset": 0})
+    assert r.status_code == 400

--- a/web/main.py
+++ b/web/main.py
@@ -43,6 +43,7 @@ from fastapi_limiter.depends import RateLimiter
 import redis.asyncio as redis
 
 DNA_RE = re.compile(r"^[ACGT]+$")
+FILE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def bit_error_rate(original: bytes, recovered: bytes) -> float:
@@ -438,6 +439,8 @@ async def upload_chunk(
 ) -> dict[str, str]:
     if FastAPILimiter.redis:
         await rate_limit(request, response)
+    if not FILE_ID_RE.fullmatch(req.file_id):
+        raise HTTPException(status_code=400, detail="Invalid file ID")
     base_dir = get_temp_dir() / "chunks" / req.file_id
     base_dir.mkdir(parents=True, exist_ok=True)
     chunk_bytes = base64.b64decode(req.data.encode("utf-8"), validate=True)
@@ -460,6 +463,8 @@ async def download_chunk(
 ) -> dict[str, str]:
     if FastAPILimiter.redis:
         await rate_limit(request, response)
+    if not FILE_ID_RE.fullmatch(file_id):
+        raise HTTPException(status_code=400, detail="Invalid file ID")
     chunk_path = get_temp_dir() / "chunks" / file_id / f"{offset}.chunk"
     if not chunk_path.is_file():
         raise HTTPException(status_code=404, detail="Chunk not found")


### PR DESCRIPTION
## Summary
- validate chunk IDs and reject traversal
- test invalid chunk ID cases

## Testing
- `ruff check web/main.py tests/test_web_api_chunks.py`
- `pytest -q tests/test_web_api_chunks.py`

------
https://chatgpt.com/codex/tasks/task_e_6869f887ee808326bc3f05a900f87e57