### PR TITLE
Deprecate XOR decryption

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,5 @@
+# Security Notes
+
+GeneCoder encrypts data using AES-GCM with a random nonce. Previous releases also allowed XOR-based encryption for legacy reasons. The XOR branch is now deprecated.
+
+Using data that is not prefixed with the `AESGCM1` header triggers a `DeprecationWarning` and will be removed in a future release. Ensure all encrypted files use AES-GCM.

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import warnings
 
 
 _AES_HEADER = b"AESGCM1"
@@ -38,6 +39,11 @@ def decrypt_data(data: bytes, key: bytes) -> bytes:
         dec: bytes = AESGCM(aes_key).decrypt(nonce, ciphertext, None)
         return dec
 
+    warnings.warn(
+        "XOR decryption is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _xor_cipher(data, key)
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -33,19 +33,27 @@ def _legacy_xor_encrypt(data: bytes, key: bytes) -> bytes:
     return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
 
 
-@pytest.mark.parametrize("encryptor", [encrypt_data, _legacy_xor_encrypt])
-def test_decrypt_aes_and_xor(encryptor) -> None:
+def test_decrypt_aes_roundtrip() -> None:
     data = b"legacy"
     key = b"GeneCoder"
-    enc = encryptor(data, key)
+    enc = encrypt_data(data, key)
     assert decrypt_data(enc, key=key) == data
+
+
+def test_xor_decryption_emits_warning() -> None:
+    data = b"legacy"
+    key = b"GeneCoder"
+    enc = _legacy_xor_encrypt(data, key)
+    with pytest.warns(DeprecationWarning):
+        assert decrypt_data(enc, key=key) == data
 
 
 def test_decrypt_xor_cipher_roundtrip() -> None:
     data = b"old-data"
     key = b"legacy-key"
     enc = _legacy_xor_encrypt(data, key)
-    assert decrypt_data(enc, key=key) == data
+    with pytest.warns(DeprecationWarning):
+        assert decrypt_data(enc, key=key) == data
 
 
 def test_cli_encrypt_checksum_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- emit `DeprecationWarning` when decrypting legacy XOR data
- document AES-only support and deprecation notes in `security.md`
- update unit tests to expect the warning when XOR data is decrypted

## Testing
- `ruff check src/genecoder/security.py tests/test_security.py`
- `mypy src/genecoder/security.py`
- `pytest tests/test_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f886ce1083269b67bba1a0bfba0c