### PR TITLE
Add plugin signature verification

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -199,3 +199,17 @@ GeneCoder itself does not verify the authenticity of third-party packages. When
 using a registry or catalog, ensure the listed sources are trustworthy and, if
 possible, manually inspect the plugin code or compare checksums before
 installation.
+
+## Signed Plugin Packages
+
+For higher assurance you may sign plugin distributions with an RSA or ECDSA
+private key and publish the detached signature alongside the package. The
+catalog or registry entry should include the base64 encoded signature under the
+``signature`` field. Set the ``GENECODER_PLUGIN_PUBLIC_KEY`` environment
+variable to the path of the corresponding PEM encoded public key. During
+installation GeneCoder verifies the signature before falling back to the regular
+checksum check. A failed signature verification aborts the install and logs a
+warning.
+
+Signed packages help detect tampering, but they do not make untrusted code safe.
+Always audit plugins and obtain public keys from verified sources.

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -61,6 +63,16 @@ def _handle_install(args: argparse.Namespace) -> None:
     if version and not meta.get("url"):
         spec = f"{name}=={version}"
     checksum = meta.get("checksum")
+    signature_b64 = meta.get("signature")
+    pubkey: bytes | None = None
+
+    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
+    if signature_b64 and key_path:
+        try:
+            pubkey = Path(key_path).read_bytes()
+        except Exception:  # pragma: no cover - filesystem error path
+            logger.warning("Failed to read public key %s", key_path)
+            pubkey = None
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         subprocess.check_call(
@@ -81,6 +93,16 @@ def _handle_install(args: argparse.Namespace) -> None:
             raise SystemExit(1)
         pkg_path = files[0]
         pkg_bytes = pkg_path.read_bytes()
+        if signature_b64 and pubkey is not None:
+            try:
+                plugins.compute_checksum(
+                    pkg_bytes,
+                    signature=base64.b64decode(signature_b64),
+                    public_key=pubkey,
+                )
+            except Exception:
+                logger.warning("Signature verification failed for plugin %s", name)
+                raise SystemExit(1)
         if checksum and plugins.compute_checksum(pkg_bytes) != checksum:
             logger.warning("Checksum mismatch for plugin %s", name)
             raise SystemExit(1)

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -41,6 +41,35 @@ def decrypt_data(data: bytes, key: bytes) -> bytes:
     return _xor_cipher(data, key)
 
 
-def compute_checksum(data: bytes) -> str:
-    """Return a hexadecimal SHA256 checksum for ``data``."""
-    return hashlib.sha256(data).hexdigest()
+def compute_checksum(
+    data: bytes,
+    *,
+    signature: bytes | None = None,
+    public_key: bytes | None = None,
+) -> str:
+    """Return a hexadecimal SHA256 checksum for ``data``.
+
+    If ``signature`` and ``public_key`` are provided, verify that the signature
+    matches ``data`` using RSA or ECDSA with a SHA256 hash. ``InvalidSignature``
+    or ``ValueError`` is raised on failure.
+    """
+
+    digest = hashlib.sha256(data).hexdigest()
+
+    if signature is not None:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding, ec, rsa
+
+        if public_key is None:
+            raise ValueError("public_key required when verifying a signature")
+
+        key = serialization.load_pem_public_key(public_key)
+        if isinstance(key, rsa.RSAPublicKey):
+            key.verify(signature, data, padding.PKCS1v15(), hashes.SHA256())
+        elif isinstance(key, ec.EllipticCurvePublicKey):
+            key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
+        else:  # pragma: no cover - unsupported key type
+            raise InvalidSignature("Unsupported key type")
+
+    return digest

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -1,4 +1,7 @@
 import argparse
+import base64
+import sys
+from pathlib import Path
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
@@ -44,3 +47,78 @@ def test_install_plugin() -> None:
 def test_install_requires_token() -> None:
     r = client.post("/plugins/install", json={"name": "demo"})
     assert r.status_code == 401
+
+
+def test_install_signature_failure() -> None:
+    pkg = b"PKG"
+    checksum = plugins.compute_checksum(pkg)
+    sig_b64 = base64.b64encode(b"sig").decode()
+    plugins.PLUGIN_CATALOG["signed"] = {"checksum": checksum, "signature": sig_b64}
+
+    def fake_check_call(cmd):
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "pkg.whl").write_bytes(pkg)
+        elif cmd[:4] == [sys.executable, "-m", "pip", "install"]:
+            raise AssertionError("install should not run")
+        else:
+            raise AssertionError(cmd)
+
+    orig_compute = plugins.compute_checksum
+
+    def fake_compute(
+        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
+    ) -> str:
+        if signature is not None:
+            raise ValueError("bad sig")
+        return orig_compute(data)
+
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr(plugin_cli.subprocess, "check_call", fake_check_call)
+        m.setattr(plugin_cli.plugins, "compute_checksum", fake_compute)
+        key = Path("/tmp/pub.pem")
+        key.write_text("PUB")
+        m.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+        r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "signed"})
+    assert r.status_code == 400
+
+
+def test_install_signature_success(tmp_path) -> None:
+    pkg = b"PKG"
+    checksum = plugins.compute_checksum(pkg)
+    sig = base64.b64encode(b"valid").decode()
+    plugins.PLUGIN_CATALOG["signed"] = {"checksum": checksum, "signature": sig}
+
+    pubkey_path = tmp_path / "pub.pem"
+    pubkey_path.write_text("PUB")
+
+    installs = []
+
+    def fake_check_call(cmd):
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "pkg.whl").write_bytes(pkg)
+        elif cmd[:4] == [sys.executable, "-m", "pip", "install"]:
+            installs.append(cmd)
+        else:
+            raise AssertionError(cmd)
+
+    orig_compute = plugins.compute_checksum
+
+    def fake_compute(
+        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
+    ) -> str:
+        if signature is not None:
+            assert signature == b"valid"
+            assert public_key == b"PUB"
+        return orig_compute(data)
+
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr(plugin_cli.subprocess, "check_call", fake_check_call)
+        m.setattr(plugin_cli.plugins, "compute_checksum", fake_compute)
+        m.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(pubkey_path))
+        r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "signed"})
+    assert r.status_code == 200
+    assert installs


### PR DESCRIPTION
## Summary
- document signed plugin workflow
- verify detached signatures for plugins using RSA/ECDSA
- validate signatures before pip install
- test web API plugin signature handling

## Testing
- `ruff check src/genecoder/security.py src/genecoder/cli/plugin.py tests/test_web_api_plugins.py`
- `pre-commit run mypy --files src/genecoder/security.py src/genecoder/cli/plugin.py tests/test_web_api_plugins.py`
- `pytest -q tests/test_web_api_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_6869f886d20c83268f5e6133a22500f0