### PR TITLE
Implement shared bit_error_rate utility

### DIFF
--- a/benchmarks/fec_bench.py
+++ b/benchmarks/fec_bench.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 from genecoder import FEC_REGISTRY, load_plugins
+from genecoder.utils import bit_error_rate
 
 REDUNDANCY_ARGS = {
     "bch": "t",
@@ -24,18 +25,6 @@ REDUNDANCY_ARGS = {
 
 DATA_SIZE = 1_000_000  # 1 MB of random bytes
 ERROR_PROB = 0.01  # probability of flipping each bit
-
-
-def bit_error_rate(original: bytes, recovered: bytes) -> float:
-    """Return the bit error rate between two byte strings."""
-    total_bits = len(original) * 8
-    min_len = min(len(original), len(recovered))
-    errors = 0
-    for o, r in zip(original[:min_len], recovered[:min_len]):
-        errors += (o ^ r).bit_count()
-    if len(recovered) < len(original):
-        errors += (len(original) - len(recovered)) * 8
-    return errors / total_bits if total_bits else 0.0
 
 
 def introduce_bit_errors(data: bytes, prob: float, rng: random.Random | None = None) -> bytes:

--- a/src/genecoder/utils.py
+++ b/src/genecoder/utils.py
@@ -78,3 +78,15 @@ def check_homopolymer_length(dna_sequence: str, max_len: int) -> bool:
     """Checks if any homopolymer in the DNA sequence exceeds a maximum length."""
     return get_max_homopolymer_length(dna_sequence) > max_len
 
+
+def bit_error_rate(original: bytes, recovered: bytes) -> float:
+    """Return the bit error rate between two byte strings."""
+    total_bits = len(original) * 8
+    min_len = min(len(original), len(recovered))
+    errors = 0
+    for o, r in zip(original[:min_len], recovered[:min_len]):
+        errors += (o ^ r).bit_count()
+    if len(recovered) < len(original):
+        errors += (len(original) - len(recovered)) * 8
+    return errors / total_bits if total_bits else 0.0
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from genecoder.utils import get_temp_dir
+from genecoder.utils import get_temp_dir, bit_error_rate
 
 
 def test_get_temp_dir_env_override(monkeypatch):
@@ -26,3 +26,13 @@ def test_mkdtemp_respects_env(monkeypatch):
             assert Path(path).parent == Path(base)
         finally:
             os.rmdir(path)
+
+
+def test_bit_error_rate_identical() -> None:
+    assert bit_error_rate(b"abc", b"abc") == 0.0
+
+
+def test_bit_error_rate_basic() -> None:
+    original = b"\x00"
+    recovered = b"\x01"
+    assert bit_error_rate(original, recovered) == 1 / 8

--- a/web/main.py
+++ b/web/main.py
@@ -22,7 +22,7 @@ from genecoder.cli import plugin as plugin_cli
 import argparse
 from genecoder.formats import from_fasta
 from genecoder.encoders import calculate_gc_content, decode_base4_direct
-from genecoder.utils import get_max_homopolymer_length, get_temp_dir
+from genecoder.utils import get_max_homopolymer_length, get_temp_dir, bit_error_rate
 from genecoder.plotting import (
     calculate_windowed_gc_content,
     identify_homopolymer_regions,
@@ -44,18 +44,6 @@ import redis.asyncio as redis
 
 DNA_RE = re.compile(r"^[ACGT]+$")
 FILE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
-
-
-def bit_error_rate(original: bytes, recovered: bytes) -> float:
-    """Return the bit error rate between two byte strings."""
-    total_bits = len(original) * 8
-    min_len = min(len(original), len(recovered))
-    errors = 0
-    for o, r in zip(original[:min_len], recovered[:min_len]):
-        errors += (o ^ r).bit_count()
-    if len(recovered) < len(original):
-        errors += (len(original) - len(recovered)) * 8
-    return errors / total_bits if total_bits else 0.0
 
 API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")


### PR DESCRIPTION
## Summary
- add `bit_error_rate` helper to `genecoder.utils`
- use the new helper in `fec_bench.py` benchmark
- use the new helper in `web/main.py`
- test the new utility

## Testing
- `ruff check benchmarks/fec_bench.py src/genecoder/utils.py web/main.py tests/test_utils.py`
- `mypy --config-file pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fadcbcdc83268ca57dab64165f51