### PR TITLE
Add security tests and path traversal cases

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -8,6 +8,9 @@ from genecoder.security import (
     decrypt_data,
     compute_checksum,
 )
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.exceptions import InvalidSignature
 from tests.test_cli import run_cli_command
 
 
@@ -255,4 +258,21 @@ def test_cli_encrypt_key_file_wrong_key(tmp_path: Path) -> None:
         ]
     )
     assert dec_res.returncode != 0
+
+
+def test_compute_checksum_missing_public_key() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    signature = key.sign(b"data", padding.PKCS1v15(), hashes.SHA256())
+    with pytest.raises(ValueError):
+        compute_checksum(b"data", signature=signature)
+
+
+def test_compute_checksum_invalid_signature() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    bad_sig = key.sign(b"other", padding.PKCS1v15(), hashes.SHA256())
+    with pytest.raises(InvalidSignature):
+        compute_checksum(b"data", signature=bad_sig, public_key=pub)
 

--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -87,7 +87,19 @@ def test_download_chunk_not_found(monkeypatch, tmp_path):
     assert r.status_code == 404
 
 
-@pytest.mark.parametrize("bad_id", ["../bad", "foo/../bar", "..", "foo/bar"])
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../bad",
+        "foo/../bar",
+        "..",
+        "foo/bar",
+        "..%2fetc",
+        "..%2f..%2fsecret",
+        "..\\evil",
+        "..%5c..%5cwin",
+    ],
+)
 def test_invalid_file_ids_rejected_upload(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_id: str) -> None:
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
     main.FastAPILimiter.redis = None
@@ -100,7 +112,19 @@ def test_invalid_file_ids_rejected_upload(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert r.status_code == 400
 
 
-@pytest.mark.parametrize("bad_id", ["../bad", "foo/../bar", "..", "foo/bar"])
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../bad",
+        "foo/../bar",
+        "..",
+        "foo/bar",
+        "..%2fetc",
+        "..%2f..%2fsecret",
+        "..\\evil",
+        "..%5c..%5cwin",
+    ],
+)
 def test_invalid_file_ids_rejected_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_id: str) -> None:
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
     main.FastAPILimiter.redis = None


### PR DESCRIPTION
## Summary
- expand invalid file ID tests to include more path traversal attempts
- check plugin checksum verification on missing or bad signatures

## Testing
- `ruff check tests/test_web_api_chunks.py tests/test_security.py`
- `mypy --config-file mypy.ini --show-error-codes --no-error-summary`
- `pytest tests/test_web_api_chunks.py tests/test_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fe55533c8326a72c7b3c713090e4