### PR TITLE
Update docs for plugin marketplace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,3 +95,10 @@ Follow these steps to publish a new version:
 
 5. Create a GitHub release pointing at the same tag.
 
+## Publishing Plugins to the Marketplace
+
+Plugins intended for distribution must be signed using the helper scripts in
+`plugins-examples/signing/`. Once signed, submit the package through the new
+marketplace process described in `docs/plugins.md`. Marketplace reviewers verify
+the signature before the plugin is listed.
+

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -11,6 +11,7 @@
    - Provide automated reports summarizing encoding accuracy and efficiency.
 4. **Phase 4: Ecosystem & Automation**
    - Publish a plugin repository enabling community codecs and FEC modules.
+   - Require digital signatures for plugins submitted to the new marketplace.
    - Offer workflow templates powered by n8n for routine processing tasks.
    - Package the toolkit for easy container deployment in research pipelines.
 5. **Long-Term Vision**

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -213,3 +213,7 @@ warning.
 
 Signed packages help detect tampering, but they do not make untrusted code safe.
 Always audit plugins and obtain public keys from verified sources.
+
+## Submitting to the Marketplace
+
+Signed plugin packages can be shared publicly by submitting them to the GeneCoder marketplace. After building a wheel and generating the detached signature, visit the marketplace dashboard and upload both files. The system verifies the signature and runs automated checks before listing the plugin in the public catalog.


### PR DESCRIPTION
## Summary
- document plugin signing and mention the new marketplace process in CONTRIBUTING
- add roadmap entry for upcoming plugin marketplace features
- outline how to submit signed plugins to the marketplace in docs/plugins.md

## Testing
- `python scripts/check_glossary_terms.py`
- `pytest -q --maxfail=1`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6869fe553378832694e3059bc8e28ce1