### PR TITLE
Add markdown link check ignore config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,20 +1,22 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'src/**'
-      - 'web/**'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'src/**'
-      - 'web/**'
+    push:
+      branches: [ main ]
+      paths:
+        - 'docs/**'
+        - 'mkdocs.yml'
+        - 'README.md'
+        - 'src/**'
+        - 'web/**'
+    pull_request:
+      branches: [ main ]
+      paths:
+        - 'docs/**'
+        - 'mkdocs.yml'
+        - 'README.md'
+        - 'src/**'
+        - 'web/**'
   workflow_dispatch: {}
 
 concurrency:
@@ -41,6 +43,10 @@ jobs:
           key: ${{ hashFiles('docs/requirements.txt') }}
       - name: Install documentation requirements
         run: pip install -r docs/requirements.txt
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Check Markdown links
+        run: pre-commit run markdown-link-check --files README.md $(git ls-files "docs/**/*.md")
       - name: Build docs
         run: mkdocs build --strict
       - name: Upload PDF

--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    {"pattern": "https://d0ttino.github.io/GeneCoder/"}
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
         args: ["--config-file", "pyproject.toml"]
         pass_filenames: false
         additional_dependencies: ["cryptography", "types-PyYAML"]
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.13.7
+    hooks:
+      - id: markdown-link-check
+        files: '^(docs/.*\.md|README\.md)$'
+        args: ['-c', '.mlc.config.json']
   - repo: local
     hooks:
       - id: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ The hook also runs automatically on each commit if installed.
 An additional `check-glossary-terms` hook verifies that every term in
 `docs/glossary.json` appears in at least one Markdown file. The commit
 will fail if any terms are missing.
+The `markdown-link-check` hook scans `README.md` and all Markdown files
+in `docs/` to verify that hyperlinks are still valid.
 The `python-ci` workflow also runs this script in a dedicated job after linting
 to catch missing terms in pull requests.
 


### PR DESCRIPTION
## Summary
- configure markdown-link-check to ignore docs link
- pass custom config via pre-commit hook

## Testing
- `ruff check .pre-commit-config.yaml CONTRIBUTING.md .github/workflows/docs.yml .mlc.config.json`
- `mypy`
- `pytest tests/test_cloud.py tests/test_flet_handlers.py -q`
- `npx markdown-link-check -c .mlc.config.json README.md`


------
https://chatgpt.com/codex/tasks/task_e_6869fe561f3883268f02c80677b55b5e