### PR TITLE
Add plugin catalog search and rating API

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -156,6 +156,8 @@ plugins:
     version: "1.0.0"
     url: myplugin==1.0.0
     description: Example plugin
+    author: Example Author
+    stars: 4.5
 ```
 
 The URL may use HTTP(S) or point to a local file via ``file://``.
@@ -165,7 +167,7 @@ JSON uses the same keys:
 ```json
 {
   "plugins": [
-    {"name": "myplugin", "version": "1.0.0", "url": "myplugin==1.0.0", "description": "Example plugin"}
+    {"name": "myplugin", "version": "1.0.0", "url": "myplugin==1.0.0", "description": "Example plugin", "author": "Example Author", "stars": 4.5}
   ]
 }
 ```
@@ -181,6 +183,17 @@ Install a plugin from the catalog:
 ```bash
 genecoder plugin install myplugin
 ```
+
+The ``/plugin-catalog`` web page lets you search and sort available plugins by
+name, description or rating. To submit feedback programmatically send a rating
+to the API:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"name": "myplugin", "rating": 5}' http://localhost:8000/plugins/rate
+```
+
+The response includes the updated average star count for the plugin.
 
 Always verify that catalog entries originate from reputable sources or trusted
 registries. A matching checksum only proves the downloaded file has not been

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-PLUGIN_CATALOG: Dict[str, Dict[str, str]] = {}
+PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 
 def register_codec(
@@ -175,6 +175,8 @@ def _fetch_catalog(url: str) -> None:
             "url": str(entry.get("url", "")),
             "description": str(entry.get("description", "")),
             "checksum": str(entry.get("checksum", "")),
+            "author": str(entry.get("author", "")),
+            "stars": entry.get("stars", 0),
         }
 
 

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -122,3 +122,13 @@ def test_install_signature_success(tmp_path) -> None:
         r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "signed"})
     assert r.status_code == 200
     assert installs
+
+
+def test_rate_plugin() -> None:
+    main.PLUGIN_RATINGS.clear()
+    r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 4})
+    assert r.status_code == 200
+    assert r.json()['average'] == 4
+    r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 2})
+    assert r.status_code == 200
+    assert r.json()['average'] == 3

--- a/web/helix-ui/src/PluginCatalog.jsx
+++ b/web/helix-ui/src/PluginCatalog.jsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState } from 'react';
 export default function PluginCatalog() {
   const [plugins, setPlugins] = useState(null);
   const [installing, setInstalling] = useState({});
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState('name');
 
   useEffect(() => {
     fetch('/plugins')
@@ -24,14 +26,44 @@ export default function PluginCatalog() {
     return <div>Loading...</div>;
   }
 
+  const filtered = Object.entries(plugins).filter(([name, meta]) =>
+    name.toLowerCase().includes(search.toLowerCase()) ||
+    (meta.description || '').toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === 'stars') {
+      return (b[1].stars || 0) - (a[1].stars || 0);
+    }
+    return a[0].localeCompare(b[0]);
+  });
+
   return (
     <div style={{ padding: 20 }}>
       <h1>Plugin Catalog</h1>
+      <div style={{ marginBottom: 10 }}>
+        <input
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <label style={{ marginLeft: 10 }}>
+          Sort:
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+            <option value="name">Name</option>
+            <option value="stars">Stars</option>
+          </select>
+        </label>
+      </div>
       <ul>
-        {Object.entries(plugins).map(([name, meta]) => (
+        {sorted.map(([name, meta]) => (
           <li key={name}>
             <strong>{name}</strong>
+            {meta.author ? ` by ${meta.author}` : ''}
             {meta.description ? ` - ${meta.description}` : ''}
+            {typeof meta.stars === 'number' && (
+              <span> ⭐{meta.stars.toFixed(1)}</span>
+            )}
             <button onClick={() => install(name)} disabled={installing[name]}>
               {installing[name] ? 'Installing...' : 'Install'}
             </button>

--- a/web/helix-ui/src/PluginCatalog.test.jsx
+++ b/web/helix-ui/src/PluginCatalog.test.jsx
@@ -4,7 +4,15 @@ import '@testing-library/jest-dom/vitest';
 import PluginCatalog from './PluginCatalog.jsx';
 
 global.fetch = vi.fn(() =>
-  Promise.resolve({ json: () => Promise.resolve({ plugins: { demo: { description: 'Demo' } } }) })
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        plugins: {
+          a: { description: 'A plugin', stars: 2 },
+          b: { description: 'B plugin', stars: 5 },
+        },
+      }),
+  })
 );
 
 afterEach(() => {
@@ -13,9 +21,19 @@ afterEach(() => {
 
 test('renders plugins and installs', async () => {
   render(<PluginCatalog />);
-  expect(await screen.findByText(/Demo/)).toBeInTheDocument();
+  expect(await screen.findByText(/A plugin/)).toBeInTheDocument();
+
+  const searchBox = screen.getByPlaceholderText(/search/i);
+  fireEvent.change(searchBox, { target: { value: 'b' } });
+  expect(screen.queryByText(/A plugin/)).not.toBeInTheDocument();
+
+  const sortSelect = screen.getByLabelText(/sort/i);
+  fireEvent.change(sortSelect, { target: { value: 'stars' } });
+  const items = screen.getAllByRole('listitem');
+  expect(items[0]).toHaveTextContent('b');
+
   fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
-  const btn = screen.getByRole('button', { name: /install/i });
+  const btn = screen.getAllByRole('button', { name: /install/i })[0];
   fireEvent.click(btn);
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
 });

--- a/web/main.py
+++ b/web/main.py
@@ -48,6 +48,7 @@ FILE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")
 security = HTTPBearer(auto_error=False)
+PLUGIN_RATINGS: dict[str, list[int]] = {}
 
 
 def verify_token(
@@ -464,6 +465,11 @@ class PluginInstallRequest(BaseModel):
     name: str
 
 
+class PluginRatingRequest(BaseModel):
+    name: str
+    rating: int
+
+
 @app.get("/plugins")
 async def list_plugins() -> dict[str, object]:
     """Return the plugin catalog."""
@@ -481,3 +487,15 @@ async def install_plugin(
     except SystemExit as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}
+
+
+@app.post("/plugins/rate")
+async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
+    """Submit a rating for a plugin and return the new average."""
+    if req.rating < 1 or req.rating > 5:
+        raise HTTPException(status_code=400, detail="rating must be 1-5")
+    ratings = PLUGIN_RATINGS.setdefault(req.name, [])
+    ratings.append(req.rating)
+    avg = sum(ratings) / len(ratings)
+    plugins.PLUGIN_CATALOG.setdefault(req.name, {}).update({"stars": avg})
+    return {"average": avg}


### PR DESCRIPTION
## Summary
- allow author & stars metadata in plugin catalog
- expose `/plugins/rate` API for submitting plugin ratings
- add search & sorting UI to `PluginCatalog.jsx`
- test the rating endpoint and updated UI
- document catalog fields, searching and rating

## Testing
- `ruff check .`
- `pytest -q tests/test_web_api_plugins.py`
- `npm test --prefix web/helix-ui`

------
https://chatgpt.com/codex/tasks/task_e_6869fe4f89a88326b910f79a148ab038