### PR TITLE
Fix plugin key check

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -67,7 +67,10 @@ def _handle_install(args: argparse.Namespace) -> None:
     pubkey: bytes | None = None
 
     key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
-    if signature_b64 and key_path:
+    if signature_b64:
+        if not key_path:
+            logger.error("Missing public key for signed plugin %s", name)
+            raise SystemExit(1)
         try:
             pubkey = Path(key_path).read_bytes()
         except Exception:  # pragma: no cover - filesystem error path

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -49,6 +49,25 @@ def test_install_requires_token() -> None:
     assert r.status_code == 401
 
 
+def test_install_signature_missing_key() -> None:
+    pkg = b"PKG"
+    checksum = plugins.compute_checksum(pkg)
+    sig_b64 = base64.b64encode(b"sig").decode()
+    plugins.PLUGIN_CATALOG["signed"] = {"checksum": checksum, "signature": sig_b64}
+
+    def fake_check_call(cmd):
+        raise AssertionError("pip should not run")
+
+    def fake_compute(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("compute_checksum should not run")
+
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr(plugin_cli.subprocess, "check_call", fake_check_call)
+        m.setattr(plugin_cli.plugins, "compute_checksum", fake_compute)
+        r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "signed"})
+    assert r.status_code == 400
+
+
 def test_install_signature_failure() -> None:
     pkg = b"PKG"
     checksum = plugins.compute_checksum(pkg)


### PR DESCRIPTION
## Summary
- fail fast if a plugin signature is provided without a key
- test that web plugin install fails when key is missing

## Testing
- `ruff check src/genecoder/cli/plugin.py tests/test_web_api_plugins.py`
- `pre-commit run mypy --files src/genecoder/cli/plugin.py tests/test_web_api_plugins.py`
- `pytest tests/test_web_api_plugins.py -k test_install_signature_missing_key -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2407a8d08326839479585b143209