### PR TITLE
Update cloud CLI default URL and docs

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -7,7 +7,7 @@ jobs to a queue exposed by a web service.
 ```python
 from genecoder.cloud import CloudClient
 
-with CloudClient("http://worker:8000", token="TOKEN") as client:
+with CloudClient("https://worker:8000", token="TOKEN") as client:
     job = client.submit("bundle", {"archive": "<base64 data>"})
     print(job)
 ```
@@ -17,7 +17,7 @@ with CloudClient("http://worker:8000", token="TOKEN") as client:
 Bundles can be packaged and uploaded using the `genecoder cloud submit` command:
 
 ```bash
-genecoder cloud submit bundle.yaml --server http://worker:8000 --token TOKEN
+genecoder cloud submit bundle.yaml --server https://worker:8000 --token TOKEN
 ```
 
 The command creates a ZIP archive containing the bundle file and any input files

--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -13,14 +13,23 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     cloud_sub = parser.add_subparsers(dest="cloud_command", required=True)
     submit = cloud_sub.add_parser("submit", help="Submit a bundle to a remote worker")
     submit.add_argument("bundle", type=str, help="Path to bundle YAML file")
-    submit.add_argument("--server", type=str, default="http://localhost:8000", help="Worker base URL")
+    submit.add_argument(
+        "--server",
+        type=str,
+        default="https://localhost:8000",
+        help="Worker base URL",
+    )
     submit.add_argument("--token", type=str, help="Bearer token for authentication")
     submit.set_defaults(func=_handle_submit)
 
 
 def _handle_submit(args: argparse.Namespace) -> None:
+    import warnings
     import yaml
     from genecoder.cloud import CloudClient
+
+    if not args.server.startswith("https://"):
+        warnings.warn("Using a non-HTTPS server URL", stacklevel=2)
     bundle_path = Path(args.bundle)
     with open(bundle_path, "r", encoding="utf-8") as fh:
         bundle_data = fh.read()

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -20,8 +20,8 @@ def test_cloud_client_submit() -> None:
 
     transport = httpx.MockTransport(handler)
     client = CloudClient(
-        "http://s",
-        client=httpx.Client(base_url="http://s", transport=transport),
+        "https://s",
+        client=httpx.Client(base_url="https://s", transport=transport),
     )
     jid = client.submit("bundle", {"a": 1})
     assert jid == "jid"
@@ -35,8 +35,8 @@ def test_cloud_client_submit_error() -> None:
 
     transport = httpx.MockTransport(handler)
     client = CloudClient(
-        "http://s",
-        client=httpx.Client(base_url="http://s", transport=transport),
+        "https://s",
+        client=httpx.Client(base_url="https://s", transport=transport),
     )
     with pytest.raises(RuntimeError, match="Failed to submit job"):
         client.submit("bundle", {"a": 1})
@@ -68,9 +68,9 @@ def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
             pass
 
     monkeypatch.setattr("genecoder.cloud.CloudClient", DummyClient)
-    args = argparse.Namespace(bundle=str(bundle), server="http://s", token=None)
+    args = argparse.Namespace(bundle=str(bundle), server="https://s", token=None)
     cloud_cli._handle_submit(args)
     assert calls["job_type"] == "bundle"
     assert "archive" in cast(dict[str, object], calls["payload"])
-    assert calls["base_url"] == "http://s"
+    assert calls["base_url"] == "https://s"
     assert calls["token"] is None


### PR DESCRIPTION
## Summary
- change default `--server` to use HTTPS
- warn on insecure server usage
- document new default
- adjust cloud tests for HTTPS

## Testing
- `ruff check src/genecoder/cli/cloud.py tests/test_cloud.py`
- `mypy src/genecoder/cli/cloud.py tests/test_cloud.py`
- `pytest tests/test_cloud.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b24090c5083268b05097860d67034