### PR TITLE
Add AsyncCloudClient and async CLI option

### DIFF
--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -20,13 +20,20 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Worker base URL",
     )
     submit.add_argument("--token", type=str, help="Bearer token for authentication")
+    submit.add_argument(
+        "--async",
+        dest="use_async",
+        action="store_true",
+        help="Use asynchronous submission",
+    )
     submit.set_defaults(func=_handle_submit)
 
 
 def _handle_submit(args: argparse.Namespace) -> None:
     import warnings
     import yaml
-    from genecoder.cloud import CloudClient
+    import asyncio
+    from genecoder.cloud import CloudClient, AsyncCloudClient
 
     if not args.server.startswith("https://"):
         warnings.warn("Using a non-HTTPS server URL", stacklevel=2)
@@ -44,6 +51,14 @@ def _handle_submit(args: argparse.Namespace) -> None:
                 zf.write(f, arcname=f.name)
         archive_b64 = base64.b64encode(archive_path.read_bytes()).decode("utf-8")
 
-    with CloudClient(args.server, args.token) as client:
-        job_id = client.submit("bundle", {"archive": archive_b64})
-    print(job_id)
+    if getattr(args, "use_async", False):
+        async def _run() -> None:
+            async with AsyncCloudClient(args.server, args.token) as client:
+                jid = await client.submit("bundle", {"archive": archive_b64})
+                print(jid)
+
+        asyncio.run(_run())
+    else:
+        with CloudClient(args.server, args.token) as client:
+            job_id = client.submit("bundle", {"archive": archive_b64})
+        print(job_id)

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -52,4 +52,54 @@ class CloudClient:
     ) -> None:
         self.close()
 
-__all__ = ["CloudClient"]
+class AsyncCloudClient:
+    """Asynchronous REST client for submitting jobs to a remote worker."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        client: Any | None = None,
+    ) -> None:
+        import httpx
+
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self._client = client or httpx.AsyncClient(base_url=self.base_url)
+
+    async def submit(self, job_type: str, payload: dict[str, Any]) -> str:
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        import httpx
+
+        try:
+            resp = await self._client.post(
+                "/jobs", json={"type": job_type, "payload": payload}, headers=headers
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"Failed to submit job: {exc}") from exc
+
+        data = resp.json()
+        job_id = data.get("job_id")
+        if not isinstance(job_id, str):
+            raise ValueError("Invalid response from server")
+        return job_id
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncCloudClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        await self.close()
+
+
+__all__ = ["CloudClient", "AsyncCloudClient"]

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from typing import cast
 
 import httpx
+import asyncio
 import pytest
 
-from genecoder.cloud import CloudClient
+from genecoder.cloud import CloudClient, AsyncCloudClient
 from genecoder.cli import cloud as cloud_cli
 
 
@@ -27,6 +28,30 @@ def test_cloud_client_submit() -> None:
     assert jid == "jid"
     assert captured["path"] == "/jobs"
     assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
+
+
+def test_async_cloud_client_submit() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["data"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"job_id": "jid"})
+
+    transport = httpx.MockTransport(handler)
+
+    async def _run() -> None:
+        client = AsyncCloudClient(
+            "https://s",
+            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+        )
+        jid = await client.submit("bundle", {"a": 1})
+        assert jid == "jid"
+        assert captured["path"] == "/jobs"
+        assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
+        await client.close()
+
+    asyncio.run(_run())
 
 
 def test_cloud_client_submit_error() -> None:
@@ -69,6 +94,40 @@ def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr("genecoder.cloud.CloudClient", DummyClient)
     args = argparse.Namespace(bundle=str(bundle), server="https://s", token=None)
+    cloud_cli._handle_submit(args)
+    assert calls["job_type"] == "bundle"
+    assert "archive" in cast(dict[str, object], calls["payload"])
+    assert calls["base_url"] == "https://s"
+    assert calls["token"] is None
+
+
+def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle = tmp_path / "b.yaml"
+    bundle.write_text("encode:\n  input_files: []\n")
+
+    calls: dict[str, object] = {}
+
+    class DummyAsyncClient:
+        def __init__(self, base_url: str, token: str | None = None, client: object | None = None) -> None:
+            calls["base_url"] = base_url
+            calls["token"] = token
+
+        async def submit(self, job_type: str, payload: dict[str, object]) -> str:
+            calls["job_type"] = job_type
+            calls["payload"] = payload
+            return "jid"
+
+        async def close(self) -> None:
+            pass
+
+        async def __aenter__(self) -> "DummyAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: BaseException | None, exc: BaseException | None, tb: object | None) -> None:
+            pass
+
+    monkeypatch.setattr("genecoder.cloud.AsyncCloudClient", DummyAsyncClient)
+    args = argparse.Namespace(bundle=str(bundle), server="https://s", token=None, use_async=True)
     cloud_cli._handle_submit(args)
     assert calls["job_type"] == "bundle"
     assert "archive" in cast(dict[str, object], calls["payload"])


### PR DESCRIPTION
## Summary
- introduce `AsyncCloudClient` using `httpx.AsyncClient`
- enable `--async` option for cloud CLI
- support async submissions
- add tests for asynchronous client and CLI

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini --show-error-codes --no-error-summary`
- `pytest tests/test_cloud.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b286446348326bef7c2be27e9e62f