### PR TITLE
Add minimal cloud worker

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -24,3 +24,16 @@ The command creates a ZIP archive containing the bundle file and any input files
 listed under the `encode.input_files` section. The archive is Base64 encoded and
 sent to the remote worker's `/jobs` endpoint. The returned job ID is printed to
 stdout.
+
+## Running the Worker
+
+The worker application is located at `genecoder.cloud.worker`. It exposes a `/jobs` endpoint that accepts the archive produced by `genecoder cloud submit` and executes the bundle locally.
+
+A convenient way to start the worker is using Docker:
+
+```bash
+docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN ghcr.io/d0ttino/genecoder \
+    python -m genecoder.cloud.worker
+```
+
+Replace `TOKEN` with a secret value and use the same token when submitting jobs.

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import os
+import secrets
+import tempfile
+import uuid
+import zipfile
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from genecoder.cli import bundle as bundle_cli
+from genecoder.plugins import load_plugins
+
+API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
+security = HTTPBearer(auto_error=False)
+app = FastAPI(title="GeneCoder Worker")
+
+
+def verify_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> None:
+    if credentials is None or credentials.credentials != API_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    global API_TOKEN
+    load_plugins()
+    if API_TOKEN is None:
+        API_TOKEN = secrets.token_urlsafe(16)
+        print(f"Generated API token: {API_TOKEN}")
+
+
+@app.post("/jobs")
+def submit_job(payload: dict, _token: None = Depends(verify_token)) -> dict[str, str]:
+    if payload.get("type") != "bundle":
+        raise HTTPException(status_code=400, detail="Unsupported job type")
+    body = payload.get("payload")
+    if not isinstance(body, dict) or "archive" not in body:
+        raise HTTPException(status_code=400, detail="Missing archive")
+    archive_b64 = body["archive"]
+    if not isinstance(archive_b64, str):
+        raise HTTPException(status_code=400, detail="Invalid archive")
+    try:
+        data = base64.b64decode(archive_b64)
+    except Exception as exc:  # pragma: no cover - invalid base64
+        raise HTTPException(status_code=400, detail="Invalid archive") from exc
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            zf.extractall(tmpdir)
+        tmp_path = Path(tmpdir)
+        yaml_files = [p for p in tmp_path.iterdir() if p.suffix in {".yaml", ".yml"}]
+        if not yaml_files:
+            raise HTTPException(status_code=400, detail="Bundle file not found")
+        args = argparse.Namespace(
+            config=str(yaml_files[0]), cache_dir="bundle_runs", export_archive=None
+        )
+        bundle_cli._handle_run(args)
+
+    return {"job_id": str(uuid.uuid4())}
+
+
+def main() -> None:  # pragma: no cover - manual launch
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import tempfile
 from pathlib import Path
 from typing import cast
 
@@ -133,3 +134,80 @@ def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert "archive" in cast(dict[str, object], calls["payload"])
     assert calls["base_url"] == "https://s"
     assert calls["token"] is None
+
+fastapi = pytest.importorskip("fastapi")
+from genecoder.cloud import worker
+
+
+def _build_archive(bundle_path: Path) -> str:
+    import base64
+    import zipfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive = Path(tmpdir) / "bundle.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.write(bundle_path, arcname=bundle_path.name)
+        return base64.b64encode(archive.read_bytes()).decode()
+
+
+def test_worker_integration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    worker.API_TOKEN = "tok"
+    called: dict[str, object] = {}
+
+    def dummy(args: argparse.Namespace) -> None:
+        called["config"] = args.config
+
+    monkeypatch.setattr(worker.bundle_cli, "_handle_run", dummy)
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        transport = httpx.ASGITransport(app=worker.app)
+
+        async def _call() -> httpx.Response:
+            async with httpx.AsyncClient(transport=transport, base_url="http://worker") as ac:
+                resp = await ac.request(
+                    request.method,
+                    request.url.path,
+                    headers=request.headers,
+                    content=request.content,
+                )
+            return resp
+
+        resp = asyncio.run(_call())
+        return httpx.Response(
+            resp.status_code, headers=resp.headers, content=resp.content
+        )
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.Client(transport=transport, base_url="http://worker")
+    client = CloudClient("http://worker", token="tok", client=http_client)
+    jid = client.submit("bundle", {"archive": archive_b64})
+    http_client.close()
+    assert jid
+    assert Path(called["config"]).name == "b.yaml"
+
+
+def test_worker_integration_async(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    worker.API_TOKEN = "tok"
+    called: dict[str, object] = {}
+
+    def dummy(args: argparse.Namespace) -> None:
+        called["config"] = args.config
+
+    monkeypatch.setattr(worker.bundle_cli, "_handle_run", dummy)
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+
+    async def _run() -> None:
+        transport = httpx.ASGITransport(app=worker.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://worker") as ac_client:
+            async with AsyncCloudClient("http://worker", token="tok", client=ac_client) as ac:
+                jid = await ac.submit("bundle", {"archive": archive_b64})
+                assert jid
+        assert Path(called["config"]).name == "b.yaml"
+
+    asyncio.run(_run())
+


### PR DESCRIPTION
## Summary
- add `worker` FastAPI app exposing `/jobs`
- document running the worker in the cloud guide
- test new worker via httpx in cloud tests

## Testing
- `pytest tests/test_cloud.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2bf608c88326bfcd5393ad28ca22