### PR TITLE
Persist plugin ratings

### DIFF
--- a/src/genecoder/flet_ws.py
+++ b/src/genecoder/flet_ws.py
@@ -28,16 +28,11 @@ def start_server() -> None:
 
     try:
         try:
-            loop: asyncio.AbstractEventLoop | None = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
         except RuntimeError:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = None
-        if loop:
-            loop.create_task(websockets.serve(_ws_handler, "localhost", 8765))
-        else:  # pragma: no cover - depends on environment
             logger.error("No running event loop; WebSocket server not started")
+            return
+        loop.create_task(websockets.serve(_ws_handler, "localhost", 8765))
     except OSError as exc:  # pragma: no cover - depends on environment
         logger.error("Failed to start WebSocket server: %s", exc)
 

--- a/tests/test_flet_app_websocket.py
+++ b/tests/test_flet_app_websocket.py
@@ -25,5 +25,5 @@ def test_websocket_start_error_logged(monkeypatch, caplog):
         importlib.import_module("genecoder.flet_ws")
 
     assert any(
-        "Failed to start WebSocket server" in rec.message for rec in caplog.records
+        "No running event loop" in rec.message for rec in caplog.records
     )

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -1,6 +1,7 @@
 import argparse
 import base64
 import sys
+import json
 from pathlib import Path
 import pytest
 
@@ -151,3 +152,18 @@ def test_rate_plugin() -> None:
     r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 2})
     assert r.status_code == 200
     assert r.json()['average'] == 3
+
+
+def test_rate_plugin_persists(tmp_path: Path) -> None:
+    ratings_file = tmp_path / "ratings.json"
+    with pytest.MonkeyPatch().context() as m:
+        m.setenv("GENECODER_RATINGS_PATH", str(ratings_file))
+        main.RATINGS_PATH = str(ratings_file)
+        main.PLUGIN_RATINGS.clear()
+        r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 5})
+        assert r.status_code == 200
+        data = json.loads(ratings_file.read_text())
+        assert data == {"demo": [5]}
+        main.PLUGIN_RATINGS.clear()
+        main._load_plugin_ratings()
+        assert main.PLUGIN_RATINGS == {"demo": [5]}

--- a/web/main.py
+++ b/web/main.py
@@ -50,6 +50,34 @@ API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")
 security = HTTPBearer(auto_error=False)
 PLUGIN_RATINGS: dict[str, list[int]] = {}
+RATINGS_PATH = os.getenv("GENECODER_RATINGS_PATH")
+
+
+def _load_plugin_ratings() -> None:
+    """Load plugin ratings from ``RATINGS_PATH`` if configured."""
+    global PLUGIN_RATINGS
+    if not RATINGS_PATH:
+        return
+    path = Path(RATINGS_PATH)
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover - corrupt file
+        return
+    if isinstance(data, dict):
+        PLUGIN_RATINGS = {
+            k: [int(x) for x in v] for k, v in data.items() if isinstance(v, list)
+        }
+
+
+def _save_plugin_ratings() -> None:
+    """Persist plugin ratings to ``RATINGS_PATH`` if configured."""
+    if not RATINGS_PATH:
+        return
+    path = Path(RATINGS_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(PLUGIN_RATINGS), encoding="utf-8")
 
 
 def verify_token(
@@ -68,6 +96,7 @@ REDIS_URL = os.getenv("GENECODER_REDIS_URL")
 async def _startup() -> None:
     global API_TOKEN
     load_plugins()
+    _load_plugin_ratings()
     if API_TOKEN is None:
         API_TOKEN = secrets.token_urlsafe(16)
         print(f"Generated API token: {API_TOKEN}")
@@ -80,6 +109,7 @@ async def _startup() -> None:
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
+    _save_plugin_ratings()
     if FastAPILimiter.redis:
         await FastAPILimiter.close()
 
@@ -528,4 +558,5 @@ async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
     ratings.append(req.rating)
     avg = sum(ratings) / len(ratings)
     plugins.PLUGIN_CATALOG.setdefault(req.name, {}).update({"stars": avg})
+    _save_plugin_ratings()
     return {"average": avg}


### PR DESCRIPTION
## Summary
- add plugin ratings load/save helpers
- persist ratings at startup, shutdown, and rating updates
- support GENECODER_RATINGS_PATH environment variable
- extend plugin API tests to verify persistence
- fix websocket server startup when no event loop is running
- update websocket test to check for new log message

## Testing
- `ruff check .`
- `pytest -q tests/test_web_api_plugins.py::test_rate_plugin_persists`
- `pytest -q tests/test_flet_app_websocket.py::test_websocket_start_error_logged`


------
https://chatgpt.com/codex/tasks/task_e_686b28662c4883269b710069fb30133e