### PR TITLE
Fix test optional deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ to catch missing terms in pull requests.
 Unit tests use `pytest`. Install the pinned dependencies and run:
 
 ```bash
-poetry install --with gui,web --no-interaction
+poetry install --with gui,web,dev --no-interaction
 poetry run pytest -q
 ```
 

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -98,7 +98,7 @@ def _handle_install(args: argparse.Namespace) -> None:
         pkg_bytes = pkg_path.read_bytes()
         if signature_b64 and pubkey is not None:
             try:
-                plugins.compute_checksum(  # type: ignore[attr-defined]
+                plugins.compute_checksum(
                     pkg_bytes,
                     signature=base64.b64decode(signature_b64),
                     public_key=pubkey,
@@ -106,7 +106,7 @@ def _handle_install(args: argparse.Namespace) -> None:
             except Exception:
                 logger.warning("Signature verification failed for plugin %s", name)
                 raise SystemExit(1)
-        if checksum and plugins.compute_checksum(pkg_bytes) != checksum:  # type: ignore[attr-defined]
+        if checksum and plugins.compute_checksum(pkg_bytes) != checksum:
             logger.warning("Checksum mismatch for plugin %s", name)
             raise SystemExit(1)
         subprocess.check_call([

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -10,6 +10,8 @@ import uuid
 import zipfile
 from pathlib import Path
 
+from typing import Any
+
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
@@ -28,7 +30,7 @@ def verify_token(
         raise HTTPException(status_code=401, detail="Invalid or missing token")
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 def _startup() -> None:
     global API_TOKEN
     load_plugins()
@@ -37,8 +39,8 @@ def _startup() -> None:
         print(f"Generated API token: {API_TOKEN}")
 
 
-@app.post("/jobs")
-def submit_job(payload: dict, _token: None = Depends(verify_token)) -> dict[str, str]:
+@app.post("/jobs")  # type: ignore[misc]
+def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) -> dict[str, str]:
     if payload.get("type") != "bundle":
         raise HTTPException(status_code=400, detail="Unsupported job type")
     body = payload.get("payload")

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -2,7 +2,9 @@ import json
 import hashlib
 from pathlib import Path
 from tests.test_cli import run_cli_command
-import yaml
+import pytest
+
+yaml = pytest.importorskip("yaml")
 
 
 def test_bundle_run(tmp_path: Path) -> None:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -3,8 +3,8 @@ import logging
 
 from typing import Callable
 
-import httpx
 import pytest
+httpx = pytest.importorskip("httpx")
 
 import genecoder.plugins as plugins
 from genecoder.security import compute_checksum

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -1,10 +1,9 @@
 import argparse
 import base64
 import sys
-import json
 from pathlib import Path
 import pytest
-import httpx
+httpx = pytest.importorskip("httpx")
 
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary
- skip tests if optional modules are missing
- document installing dev dependencies before running tests
- silence mypy warnings and adjust FastAPI worker types

## Testing
- `pre-commit run ruff --files tests/test_bundle.py tests/test_plugin_registry.py tests/test_web_api_plugins.py src/genecoder/cli/plugin.py src/genecoder/cloud/worker.py`
- `pre-commit run mypy --files src/genecoder/cli/plugin.py src/genecoder/cloud/worker.py tests/test_bundle.py tests/test_plugin_registry.py tests/test_web_api_plugins.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c74c8416c8326b3506e9a0059b0cf