### PR TITLE
Verify registry plugin signatures

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -129,15 +129,20 @@ The registry file must contain:
 packages:
   - spec: genecoder-fancy-plugin>=1.0
     checksum: abcdef123456...
+    signature: BASE64_SIG
   - spec: git+https://example.com/user/custom.git
     checksum: 0123456789ab...
+    signature: ANOTHER_SIG
 ```
 
-Only HTTPS URLs (or ``file://`` for local testing) are accepted. Each package is
-installed only if the checksum matches; otherwise installation is aborted and a
-warning is logged. The checksum check merely confirms that the package was not
-altered in transit; it does **not** guarantee the plugin is safe. Always use
-registries from trusted sources and review plugins before installing them.
+Set ``GENECODER_PLUGIN_PUBLIC_KEY`` to the path of the PEM encoded public key
+used to verify these signatures. Registry entries without a valid ``signature``
+field are ignored. Only HTTPS URLs (or ``file://`` for local testing) are
+accepted. Each package is installed only if the signature verifies and the
+checksum matches; otherwise installation is aborted and a warning is logged. The
+checksum check merely confirms that the package was not altered in transit; it
+does **not** guarantee the plugin is safe. Always use registries from trusted
+sources and review plugins before installing them.
 
 ## Plugin Marketplace
 

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -10,6 +10,8 @@ import urllib.request
 from urllib.parse import urlparse
 import importlib
 import hashlib
+import base64
+from pathlib import Path
 
 _yaml: Any
 try:  # pragma: no cover - import is trivial
@@ -73,6 +75,15 @@ def _install_registry_plugins(url: str) -> None:
         logger.warning("YAML support unavailable, skipping plugin registry %s", url)
         return
 
+    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
+    pubkey: bytes | None = None
+    if key_path:
+        try:
+            pubkey = Path(key_path).read_bytes()
+        except Exception:  # pragma: no cover - filesystem error path
+            logger.warning("Failed to read public key %s", key_path)
+            pubkey = None
+
     if urlparse(url).scheme != "https":
         logger.warning("Insecure plugin registry URL %s", url)
         return
@@ -90,6 +101,15 @@ def _install_registry_plugins(url: str) -> None:
                 entry.get("spec") or entry.get("package") or entry.get("url") or ""
             )
             checksum = str(entry.get("checksum", ""))
+            sig_b64 = entry.get("signature")
+            if not isinstance(sig_b64, str):
+                logger.warning("Missing signature for plugin entry %s", entry)
+                continue
+            try:
+                signature = base64.b64decode(sig_b64)
+            except Exception:
+                logger.warning("Invalid signature for plugin entry %s", entry)
+                continue
         else:
             logger.warning("Missing checksum for plugin entry %s", entry)
             continue
@@ -110,7 +130,15 @@ def _install_registry_plugins(url: str) -> None:
             logger.warning("Failed to download plugin %s: %s", spec, exc)
             continue
 
-        if compute_checksum(pkg_bytes) != checksum:
+        if pubkey is None:
+            logger.warning("No public key configured for signed plugin %s", spec)
+            continue
+        try:
+            digest = compute_checksum(pkg_bytes, signature=signature, public_key=pubkey)
+        except Exception as exc:
+            logger.warning("Invalid signature for plugin %s: %s", spec, exc)
+            continue
+        if digest != checksum:
             logger.warning("Checksum mismatch for plugin %s", spec)
             continue
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -8,6 +8,8 @@ httpx = pytest.importorskip("httpx")
 
 import genecoder.plugins as plugins
 from genecoder.security import compute_checksum
+import base64
+from pathlib import Path
 
 
 class DummyResponse:
@@ -36,10 +38,11 @@ def test_registry_install(monkeypatch):
             pkg_b = b"BBB"
             c1 = compute_checksum(pkg_a)
             c2 = compute_checksum(pkg_b)
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgA.whl\n    checksum: {c1}\n"
-                f"  - spec: https://example.com/pkgB.whl\n    checksum: {c2}"
+                f"  - spec: https://example.com/pkgA.whl\n    checksum: {c1}\n    signature: {sig}\n"
+                f"  - spec: https://example.com/pkgB.whl\n    checksum: {c2}\n    signature: {sig}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgA.whl":
@@ -48,11 +51,25 @@ def test_registry_install(monkeypatch):
             return DummyResponse(b"BBB")
         raise AssertionError(url)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    orig_compute = plugins.compute_checksum
+
+    def fake_compute(
+        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
+    ) -> str:
+        if signature is not None:
+            assert signature == b"sig"
+            assert public_key == b"PUB"
+        return orig_compute(data)
+
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
 
     plugins.install_registry_plugins()
 
@@ -70,20 +87,29 @@ def test_registry_install_failure(monkeypatch, caplog):
         if url == "https://example.com/plugins.yaml":
             pkg = b"CCC"
             c1 = compute_checksum(pkg)
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgC.whl\n    checksum: {c1}"
+                f"  - spec: https://example.com/pkgC.whl\n    checksum: {c1}\n    signature: {sig}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgC.whl":
             return DummyResponse(b"CCC")
         raise AssertionError(url)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
 
     with caplog.at_level(logging.WARNING):
         plugins.install_registry_plugins()
@@ -120,20 +146,29 @@ def test_registry_checksum_mismatch(monkeypatch, caplog):
     def fake_urlopen(url):
         if url == "https://example.com/plugins.yaml":
             wrong = compute_checksum(b"WRONG")
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgD.whl\n    checksum: {wrong}"
+                f"  - spec: https://example.com/pkgD.whl\n    checksum: {wrong}\n    signature: {sig}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgD.whl":
             return DummyResponse(b"DDD")
         raise AssertionError(url)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
 
     with caplog.at_level(logging.WARNING):
         plugins.install_registry_plugins()
@@ -156,21 +191,29 @@ def test_registry_checksum_validation(monkeypatch):
 
     def fake_urlopen(url):
         if url == "https://example.com/plugins.yaml":
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgE.whl\n    checksum: {expected}"
+                f"  - spec: https://example.com/pkgE.whl\n    checksum: {expected}\n    signature: {sig}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgE.whl":
             return DummyResponse(pkg)
         raise AssertionError(url)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(plugins, "compute_checksum", fake_compute_checksum)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: fake_compute_checksum(d),
+    )
 
     plugins.install_registry_plugins()
 
@@ -195,9 +238,10 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/plugins.yaml":
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
             )
             return httpx.Response(200, text=data)
         elif request.url.path == "/pkg.whl":
@@ -207,13 +251,21 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
     client = httpx.Client(transport=httpx.MockTransport(handler))
     installs: list[list[str]] = []
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(
         plugins.urllib.request, "urlopen", _urlopen_via_httpx(client)
     )
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
 
     plugins.install_registry_plugins()
 
@@ -235,9 +287,10 @@ def test_registry_install_via_httpx_checksum_mismatch(
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/plugins.yaml":
+            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong}"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong}\n    signature: {sig}"
             )
             return httpx.Response(200, text=data)
         elif request.url.path == "/pkg.whl":
@@ -247,13 +300,21 @@ def test_registry_install_via_httpx_checksum_mismatch(
     client = httpx.Client(transport=httpx.MockTransport(handler))
     installs: list[list[str]] = []
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
     monkeypatch.setenv(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(
         plugins.urllib.request, "urlopen", _urlopen_via_httpx(client)
     )
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
 
     with caplog.at_level(logging.WARNING):
         plugins.install_registry_plugins()


### PR DESCRIPTION
## Summary
- verify plugin registry packages using the public key in `GENECODER_PLUGIN_PUBLIC_KEY`
- require `signature` in registry entries
- document registry signature requirement
- update registry plugin tests

## Testing
- `ruff check .`
- `pytest tests/test_plugin_registry.py tests/test_web_api_plugins.py::test_install_signature_success -q`

------
https://chatgpt.com/codex/tasks/task_e_686c81e24b6c8326b4131f68abfabb91