### PR TITLE
Add usage metrics tracking

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 from . import cli as cli_module
+from genecoder.metrics import increment as increment_metric
 
 _ALLOWED_CACHE: dict[str, set[str]] | None = None
 
@@ -181,3 +182,5 @@ def _handle_run(args: argparse.Namespace) -> None:
     logger.info("Bundle output written to %s", run_dir)
     if args.export_archive:
         _create_archive(run_dir, Path(args.export_archive), config_hash)
+
+    increment_metric("bundle_runs")

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -19,6 +19,7 @@ plugin: Any | None = None
 benchmark: Any | None = None
 cloud: Any | None = None
 decode_ai: Any | None = None
+stats: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -66,9 +67,10 @@ def build_parser() -> argparse.ArgumentParser:
         decode_ai as _decode_ai,
         plugin as _plugin_mod,
         benchmark as _benchmark,
+        stats as _stats,
     )
 
-    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai
+    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai, stats
 
     encode = _encode
     decode = _decode
@@ -80,6 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
     decode_ai = _decode_ai
     plugin = _plugin_mod
     benchmark = _benchmark
+    stats = _stats
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -107,6 +110,7 @@ def build_parser() -> argparse.ArgumentParser:
     cloud.register_subcommand(subparsers)
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)
+    stats.register_subcommand(subparsers)
 
     return parser
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -9,6 +9,7 @@ import logging
 import os
 from ..options import EncodingOptions
 from pathlib import Path
+from genecoder.metrics import increment as increment_metric
 
 from genecoder.manifest import generate_manifest
 from genecoder.encoders import (
@@ -629,4 +630,6 @@ def _handle_command(args: argparse.Namespace) -> None:
             writer.writerow(["Name", "Sequence"])
             writer.writerows(csv_rows)
         logger.info(f"CSV order file written to {args.export_csv}")
+
+    increment_metric("encode_runs")
 

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import argparse
+
+from genecoder.metrics import get_metrics
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser("stats", help="Show usage metrics")
+    parser.set_defaults(func=_handle_command)
+
+
+def _handle_command(_: argparse.Namespace) -> None:
+    metrics = get_metrics()
+    for k, v in metrics.items():
+        print(f"{k}: {v}")

--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -1,0 +1,40 @@
+import json
+import os
+from pathlib import Path
+
+__all__ = ["increment", "get_metrics"]
+
+
+def _get_metrics_path() -> Path:
+    env = os.getenv("GENECODER_METRICS_PATH")
+    if env:
+        return Path(env)
+    return Path.home() / ".genecoder" / "metrics.json"
+
+
+def _load() -> dict[str, int]:
+    path = _get_metrics_path()
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return {k: int(v) for k, v in data.items()}
+        except Exception:
+            pass
+    return {}
+
+
+def _save(metrics: dict[str, int]) -> None:
+    path = _get_metrics_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metrics), encoding="utf-8")
+
+
+def increment(key: str) -> None:
+    metrics = _load()
+    metrics[key] = metrics.get(key, 0) + 1
+    _save(metrics)
+
+
+def get_metrics() -> dict[str, int]:
+    return _load()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+import pytest
+from tests.test_cli import run_cli_command
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+
+def test_encode_increments_metrics(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "m.json"
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    inp = tmp_path / "f.txt"
+    inp.write_text("x")
+    res = run_cli_command(["encode", "--input-files", str(inp), "--output-dir", str(tmp_path)])
+    assert res.returncode == 0, res.stderr
+    data = json.loads(metrics_path.read_text())
+    assert data["encode_runs"] == 1
+
+
+def test_stats_cli(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "s.json"
+    metrics_path.write_text(json.dumps({"encode_runs": 2, "bundle_runs": 1}))
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    res = run_cli_command(["stats"])
+    assert res.returncode == 0
+    out = res.stdout.strip().splitlines()
+    assert "encode_runs: 2" in out
+    assert "bundle_runs: 1" in out
+
+
+def test_metrics_endpoint(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "web.json"
+    metrics_path.write_text(json.dumps({"bundle_runs": 5}))
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    import importlib
+    main = importlib.import_module("web.main")
+    importlib.reload(main)
+    main.API_TOKEN = "test-token"
+    client = TestClient(main.app)
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    assert r.json()["bundle_runs"] == 5

--- a/web/main.py
+++ b/web/main.py
@@ -38,6 +38,7 @@ from genecoder.report import (
     encode_to_html,
     decode_to_html,
 )
+from genecoder.metrics import get_metrics
 from typing import cast
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
@@ -560,3 +561,9 @@ async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
     plugins.PLUGIN_CATALOG.setdefault(req.name, {}).update({"stars": avg})
     _save_plugin_ratings()
     return {"average": avg}
+
+
+@app.get("/metrics")
+async def metrics() -> dict[str, int]:
+    """Return encode and bundle usage metrics."""
+    return get_metrics()


### PR DESCRIPTION
## Summary
- increment counters for encode/bundle operations
- persist counts to ~/.genecoder/metrics.json and expose CLI `stats` command
- add `/metrics` endpoint on the web server
- include tests for metrics functionality and ensure API token remains stable during reloads

## Testing
- `ruff check src tests --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c81e1da84832681acc80af764004f