### PR TITLE
Add portable vertical slice script

### DIFF
--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -48,6 +48,19 @@ INFO:     Uvicorn running on http://127.0.0.1:8000
 
 Open that address in your browser to confirm the server is reachable.
 
+### Automated Shell Script
+
+For Linux, macOS and other Unix-like systems a portable shell version of the
+demo script is provided:
+
+```bash
+bash scripts/vertical_slice.sh
+```
+
+It performs the same actions as the Windows script: upgrading ``pip``,
+installing optional extras, running the smoke tests, launching the Flet GUI and
+then starting the FastAPI server.
+
 ## CLI Smoke Test
 
 Ensure the command line interface is available and the test suite passes. On

--- a/scripts/vertical_slice.sh
+++ b/scripts/vertical_slice.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Portable script for the GeneCoder vertical slice demo
+# Mirrors scripts/windows_vertical_slice.ps1
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+echo "Installing dependencies with optional extras..."
+echo "Upgrading pip..."
+python -m pip install --upgrade pip
+poetry install --with gui,web,dnaformer --no-interaction
+
+echo "Running CLI smoke test..."
+genecoder --version
+poetry run pytest -q
+
+echo "Launching the Flet GUI..."
+python -m genecoder.flet_app
+
+echo "Starting the FastAPI server..."
+poetry run uvicorn web.main:app --reload


### PR DESCRIPTION
## Summary
- add `scripts/vertical_slice.sh` to replicate Windows demo steps on Unix
- document the new script in `docs/vertical_slice.md`

## Testing
- `pre-commit run --files scripts/vertical_slice.sh docs/vertical_slice.md`

------
https://chatgpt.com/codex/tasks/task_e_686d1791dbcc832682156ffbd9d326d4