### PR TITLE
Fix fastapi import in metrics tests

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from tests.test_cli import run_cli_command
 
-fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 


### PR DESCRIPTION
## Summary
- ensure `fastapi` is optional for metrics tests by calling `pytest.importorskip` directly before importing `TestClient`

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d88819380832689ddf953cc2e11bf