### PR TITLE
Introduce shared CLI option helpers

### DIFF
--- a/src/genecoder/cli/__init__.py
+++ b/src/genecoder/cli/__init__.py
@@ -1,19 +1,21 @@
 """CLI submodules for GeneCoder."""
 
 from ..options import EncodingOptions, DecodingOptions
-from .encode import (
+from .options import (
     build_encoding_options,
-    run_encoding_pipeline,
-)
-from .decode import (
     build_decoding_options,
-    run_decoding_pipeline,
+    ChannelOptions,
+    build_channel_options,
 )
+from .encode import run_encoding_pipeline
+from .decode import run_decoding_pipeline
 from .cli import main
 from .channel import process_channel
 
 __all__ = [
     "EncodingOptions",
+    "ChannelOptions",
+    "build_channel_options",
     "build_encoding_options",
     "run_encoding_pipeline",
     "DecodingOptions",

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -16,6 +16,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
+from .options import ChannelOptions, build_channel_options
 
 logger = logging.getLogger(__name__)
 
@@ -165,37 +166,22 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(args: argparse.Namespace) -> None:
-    simulators = list(args.simulators)
-    constraints = {
-        "min_length": args.min_length,
-        "max_length": args.max_length,
-        "max_homopolymer": args.max_homopolymer,
-    }
-    if args.config:
-        cfg_sim, cfg_con = _load_config(args.config)
-        if cfg_sim:
-            simulators = cfg_sim
-        constraints.update(cfg_con)
-    prob_specified = any([args.sub_prob, args.ins_prob, args.del_prob])
-    if simulators and prob_specified:
-        logger.error("Probability options cannot be combined with --simulator or --config")
+    try:
+        opts: ChannelOptions = build_channel_options(args)
+    except ValueError as exc:
+        logger.error(str(exc))
         raise SystemExit(1)
-    if not simulators and not prob_specified:
-        logger.error("At least one simulator or probability option must be specified")
-        raise SystemExit(1)
-    if args.threads is not None and args.processes is not None:
-        logger.error("Cannot specify both --threads and --processes")
-        raise SystemExit(1)
+
     process_channel(
         args.input_file,
         args.output_file,
-        simulators,
-        constraints,
-        sub_prob=args.sub_prob,
-        ins_prob=args.ins_prob,
-        del_prob=args.del_prob,
-        seed=args.seed,
-        parallel=args.parallel,
-        threads=args.threads,
-        processes=args.processes,
+        opts.simulators,
+        opts.constraints,
+        sub_prob=opts.sub_prob,
+        ins_prob=opts.ins_prob,
+        del_prob=opts.del_prob,
+        seed=opts.seed,
+        parallel=opts.parallel,
+        threads=opts.threads,
+        processes=opts.processes,
     )

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -18,6 +18,7 @@ from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from ..options import DecodingOptions
 from .common import run_tasks
+from .options import build_decoding_options
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from typing import Callable, Tuple, cast
 
@@ -48,18 +49,6 @@ def _get_header_filename(file_path: str) -> str | None:
     except OSError:
         logger.debug("Could not read header from %s", file_path)
     return None
-
-
-
-def build_decoding_options(args: argparse.Namespace) -> DecodingOptions:
-    return DecodingOptions(
-        method=args.method,
-        check_parity=args.check_parity,
-        k_value=args.k_value,
-        parity_rule=args.parity_rule,
-        alphabet=getattr(args, "alphabet", "base4"),
-    )
-
 
 def run_decoding_pipeline(
     sequence: str, header: str, options: DecodingOptions, input_file_name: str

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -9,6 +9,7 @@ import logging
 import os
 from ..options import EncodingOptions
 from pathlib import Path
+from .options import build_encoding_options
 from genecoder.metrics import increment as increment_metric
 
 from genecoder.manifest import generate_manifest
@@ -49,27 +50,6 @@ def _ensure_security_loaded() -> None:
         compute_checksum = _chk
 
 logger = logging.getLogger(__name__)
-
-
-
-def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
-    if not 0 <= args.gc_min <= 1 or not 0 <= args.gc_max <= 1:
-        raise ValueError("gc_min and gc_max must be between 0 and 1")
-    if args.gc_min > args.gc_max:
-        raise ValueError("gc_min cannot be greater than gc_max")
-
-    return EncodingOptions(
-        method=args.method,
-        add_parity=args.add_parity,
-        k_value=args.k_value,
-        parity_rule=args.parity_rule,
-        fec=args.fec,
-        gc_min=args.gc_min,
-        gc_max=args.gc_max,
-        max_homopolymer=args.max_homopolymer,
-        alphabet=getattr(args, "alphabet", "base4"),
-    )
-
 
 def run_encoding_pipeline(
     data: bytes, options: EncodingOptions, input_file_name: str

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -1,0 +1,96 @@
+"""Helper functions and dataclasses for CLI argument handling."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Dict
+
+from genecoder.options import EncodingOptions, DecodingOptions
+
+
+@dataclass
+class ChannelOptions:
+    """Options for the ``channel`` subcommand."""
+
+    simulators: List[str]
+    constraints: Dict[str, int]
+    sub_prob: float = 0.0
+    ins_prob: float = 0.0
+    del_prob: float = 0.0
+    seed: int | None = None
+    parallel: bool = False
+    threads: int | None = None
+    processes: int | None = None
+
+
+def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
+    """Create :class:`EncodingOptions` from parsed CLI arguments."""
+
+    if not 0 <= args.gc_min <= 1 or not 0 <= args.gc_max <= 1:
+        raise ValueError("gc_min and gc_max must be between 0 and 1")
+    if args.gc_min > args.gc_max:
+        raise ValueError("gc_min cannot be greater than gc_max")
+
+    return EncodingOptions(
+        method=args.method,
+        add_parity=args.add_parity,
+        k_value=args.k_value,
+        parity_rule=args.parity_rule,
+        fec=args.fec,
+        gc_min=args.gc_min,
+        gc_max=args.gc_max,
+        max_homopolymer=args.max_homopolymer,
+        alphabet=getattr(args, "alphabet", "base4"),
+    )
+
+
+def build_decoding_options(args: argparse.Namespace) -> DecodingOptions:
+    """Create :class:`DecodingOptions` from parsed CLI arguments."""
+
+    return DecodingOptions(
+        method=args.method,
+        check_parity=args.check_parity,
+        k_value=args.k_value,
+        parity_rule=args.parity_rule,
+        alphabet=getattr(args, "alphabet", "base4"),
+    )
+
+
+def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
+    """Create :class:`ChannelOptions` from parsed CLI arguments."""
+
+    from .channel import _load_config  # Local import to avoid heavy deps at import time
+
+    simulators = list(args.simulators)
+    constraints = {
+        "min_length": args.min_length,
+        "max_length": args.max_length,
+        "max_homopolymer": args.max_homopolymer,
+    }
+
+    if args.config:
+        cfg_sim, cfg_con = _load_config(args.config)
+        if cfg_sim:
+            simulators = cfg_sim
+        constraints.update(cfg_con)
+
+    prob_specified = any([args.sub_prob, args.ins_prob, args.del_prob])
+    if simulators and prob_specified:
+        raise ValueError("Probability options cannot be combined with --simulator or --config")
+    if not simulators and not prob_specified:
+        raise ValueError("At least one simulator or probability option must be specified")
+    if args.threads is not None and args.processes is not None:
+        raise ValueError("Cannot specify both --threads and --processes")
+
+    return ChannelOptions(
+        simulators=simulators,
+        constraints=constraints,
+        sub_prob=args.sub_prob,
+        ins_prob=args.ins_prob,
+        del_prob=args.del_prob,
+        seed=args.seed,
+        parallel=args.parallel,
+        threads=args.threads,
+        processes=args.processes,
+    )

--- a/tests/test_cli_additional.py
+++ b/tests/test_cli_additional.py
@@ -1,11 +1,7 @@
 import argparse
 import logging
-from genecoder.cli import (
-    build_encoding_options,
-    build_decoding_options,
-    run_encoding_pipeline,
-    run_decoding_pipeline,
-)
+from genecoder.cli.options import build_encoding_options, build_decoding_options
+from genecoder.cli import run_encoding_pipeline, run_decoding_pipeline
 
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -6,12 +6,8 @@ import pytest
 from pathlib import Path
 from tests.test_cli import run_cli_command
 
-from genecoder.cli import (
-    build_encoding_options,
-    build_decoding_options,
-    run_encoding_pipeline,
-    run_decoding_pipeline,
-)
+from genecoder.cli.options import build_encoding_options, build_decoding_options
+from genecoder.cli import run_encoding_pipeline, run_decoding_pipeline
 from genecoder.encoders import encode_base4_direct
 from genecoder.formats import to_fasta
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -2,12 +2,8 @@ import argparse
 import pytest
 from pathlib import Path
 from genecoder.formats import to_fasta, from_fasta
-from genecoder.cli import (
-    build_encoding_options,
-    build_decoding_options,
-    run_encoding_pipeline,
-    run_decoding_pipeline,
-)
+from genecoder.cli.options import build_encoding_options, build_decoding_options
+from genecoder.cli import run_encoding_pipeline, run_decoding_pipeline
 from genecoder.reed_solomon_codec import _HAS_REEDSOLO
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 

--- a/tests/test_header_sanitization.py
+++ b/tests/test_header_sanitization.py
@@ -1,5 +1,6 @@
 import argparse
-from genecoder.cli.encode import run_encoding_pipeline, build_encoding_options
+from genecoder.cli.encode import run_encoding_pipeline
+from genecoder.cli.options import build_encoding_options
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 
 


### PR DESCRIPTION
## Summary
- add `genecoder.cli.options` with helper dataclasses and builders
- refactor encode/decode/channel modules to use shared helpers
- re-export helpers in `genecoder.cli`
- update tests for new import paths

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9bb6879c8326847df4e187844d69