### PR TITLE
Add plugin rating and worker job tests

### DIFF
--- a/tests/test_cli_plugin_catalog.py
+++ b/tests/test_cli_plugin_catalog.py
@@ -1,0 +1,92 @@
+import os
+from pathlib import Path
+
+import pytest
+from genecoder.security import compute_checksum
+
+from tests.test_cli import run_cli_command
+
+
+class DummyResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_cli_catalog_list_and_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    catalog = (
+        "plugins:\n  - name: plug\n    version: '0.1'\n    url: https://example.com/pkg.whl\n    description: Example\n    checksum: "
+        + checksum
+    ).encode()
+
+    patch_dir = tmp_path / "patch"
+    patch_dir.mkdir()
+    installed = tmp_path / "installed"
+    site_py = patch_dir / "sitecustomize.py"
+    site_py.write_text(
+        f"""
+import sys
+from pathlib import Path
+import genecoder.plugins as plugins
+import genecoder.cli.plugin as plugin_cli
+
+pkg = {pkg!r}
+catalog = {catalog!r}
+
+class _R:
+    def __init__(self, data):
+        self._data = data
+    def __enter__(self):
+        return self
+    def __exit__(self, *exc):
+        return False
+    def read(self):
+        return self._data
+
+def fake_urlopen(url):
+    if url == 'https://example.com/catalog.yaml':
+        return _R(catalog)
+    if url == 'https://example.com/pkg.whl':
+        return _R(pkg)
+    raise AssertionError(url)
+plugins.urllib.request.urlopen = fake_urlopen
+
+def fake_check_call(cmd):
+    if cmd[:4] == [sys.executable, '-m', 'pip', 'download']:
+        dest = cmd[cmd.index('-d') + 1]
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / 'plug.whl').write_bytes(pkg)
+    elif cmd[:4] == [sys.executable, '-m', 'pip', 'install']:
+        Path('{installed}',).write_text('ok')
+    else:
+        raise AssertionError(cmd)
+plugin_cli.subprocess.check_call = fake_check_call
+plugin_cli.plugins.entry_points = lambda group=None: []
+"""
+    )
+
+    env = os.environ.copy()
+    env["GENECODER_PLUGIN_CATALOG_URL"] = "https://example.com/catalog.yaml"
+    root = Path(__file__).resolve().parents[1]
+    src = root / "src"
+    env["PYTHONPATH"] = (
+        f"{patch_dir}{os.pathsep}{src}" + os.pathsep + env.get("PYTHONPATH", "")
+    )
+
+    result = run_cli_command(["plugin", "list"], env=env)
+    assert "plug" in result.stdout
+
+    result = run_cli_command(["plugin", "install", "plug"], env=env)
+    assert result.returncode == 0
+    assert (tmp_path / "installed").is_file()

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -136,6 +136,7 @@ def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert calls["token"] is None
 
 fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
 from genecoder.cloud import worker
 
 
@@ -210,4 +211,79 @@ def test_worker_integration_async(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         assert Path(called["config"]).name == "b.yaml"
 
     asyncio.run(_run())
+
+
+def test_worker_submit_requires_token(tmp_path: Path) -> None:
+    """Job submissions without a token are rejected."""
+
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+    r = client.post("/jobs", json={"type": "bundle", "payload": {"archive": archive_b64}})
+    assert r.status_code == 401
+
+
+def test_worker_submit_invalid_type() -> None:
+    """Unsupported job types return 400."""
+
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bogus", "payload": {}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_submit_missing_archive() -> None:
+    """Missing archive field returns 400."""
+
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_submit_invalid_archive() -> None:
+    """Invalid archive data returns 400."""
+
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": "foo"}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_submit_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Valid job submissions invoke the bundle handler."""
+
+    worker.API_TOKEN = "tok"
+    called: dict[str, object] = {}
+
+    def dummy(args: argparse.Namespace) -> None:
+        called["config"] = args.config
+
+    monkeypatch.setattr(worker.bundle_cli, "_handle_run", dummy)
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+    client = TestClient(worker.app)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 200
+    assert Path(called["config"]).name == "b.yaml"
+    assert r.json()["job_id"]
 

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -1,9 +1,11 @@
 import argparse
 import base64
+import json
 import sys
 from pathlib import Path
 import pytest
 httpx = pytest.importorskip("httpx")
+pytest.importorskip("fastapi_limiter")
 
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
@@ -252,3 +254,33 @@ def test_install_invalid_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         m.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key_path))
         r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "signed"})
     assert r.status_code == 400
+
+
+def test_rate_plugin_invalid() -> None:
+    """Ratings outside 1-5 are rejected."""
+
+    r = client.post("/plugins/rate", json={"name": "demo", "rating": 0})
+    assert r.status_code == 400
+    r = client.post("/plugins/rate", json={"name": "demo", "rating": 6})
+    assert r.status_code == 400
+
+
+def test_rate_plugin_persistence(tmp_path: Path) -> None:
+    """Ratings are persisted and update the catalog."""
+
+    main.PLUGIN_RATINGS.clear()
+    path = tmp_path / "ratings.json"
+    main.RATINGS_PATH = str(path)
+    plugins.PLUGIN_CATALOG["demo"] = {}
+    r = client.post("/plugins/rate", json={"name": "demo", "rating": 5})
+    assert r.status_code == 200
+    assert r.json()["average"] == 5
+    data = json.loads(path.read_text())
+    assert data == {"demo": [5]}
+    assert plugins.PLUGIN_CATALOG["demo"]["stars"] == 5
+    r = client.post("/plugins/rate", json={"name": "demo", "rating": 3})
+    assert r.status_code == 200
+    assert r.json()["average"] == 4
+    data = json.loads(path.read_text())
+    assert data == {"demo": [5, 3]}
+    assert plugins.PLUGIN_CATALOG["demo"]["stars"] == 4


### PR DESCRIPTION
## Summary
- extend `/plugins/rate` API test coverage
- test worker job submission errors and success paths
- add CLI tests for plugin list/install with catalog

## Testing
- `ruff check tests/test_web_api_plugins.py tests/test_cloud.py tests/test_cli_plugin_catalog.py`
- `pytest tests/test_cli_plugin_catalog.py tests/test_web_api_plugins.py tests/test_cloud.py -k "rate_plugin_invalid or rate_plugin_persistence or worker_submit or cli_catalog" -q`

------
https://chatgpt.com/codex/tasks/task_e_686daafe7a3c8326bf7ed31704760088