### PR TITLE
Add type hints to selected tests

### DIFF
--- a/tests/test_streaming_paths.py
+++ b/tests/test_streaming_paths.py
@@ -1,7 +1,7 @@
-from genecoder.encoders import encode_base4_direct, decode_base4_direct
+from genecoder.encoders import decode_base4_direct, encode_base4_direct
 
 
-def test_encode_decode_stream_roundtrip():
+def test_encode_decode_stream_roundtrip() -> None:
     chunks = [b"hello", b"world"]
     encoded_iter = encode_base4_direct(chunks, stream=True)
     dna_chunks = list(encoded_iter)
@@ -10,13 +10,13 @@ def test_encode_decode_stream_roundtrip():
     assert decoded == b"helloworld"
 
 
-def test_encode_stream_single_bytes():
+def test_encode_stream_single_bytes() -> None:
     data = b"abc"
     encoded_iter = encode_base4_direct(data, stream=True)
     assert list(encoded_iter) == [encode_base4_direct(data)]
 
 
-def test_decode_stream_single_string():
+def test_decode_stream_single_string() -> None:
     dna = encode_base4_direct(b"xy")
     decoded_iter = decode_base4_direct(dna, stream=True)
     result = b"".join(part for part, _ in decoded_iter)

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -12,7 +12,7 @@ from pathlib import Path as SysPath
 PROJECT_ROOT = SysPath(__file__).parent.parent
 
 
-def run_cli_command(command_args: list[str], env=None) -> subprocess.CompletedProcess:
+def run_cli_command(command_args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     if env is None:
         env = os.environ.copy()
         src_path = PROJECT_ROOT / "src"
@@ -21,22 +21,22 @@ def run_cli_command(command_args: list[str], env=None) -> subprocess.CompletedPr
     return subprocess.run(full_command, capture_output=True, text=True, env=env, cwd=PROJECT_ROOT)
 
 
-def test_validate_sequence_pass():
+def test_validate_sequence_pass() -> None:
     constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
     assert validate_sequence("ACGTAC", constraints)
 
 
-def test_validate_sequence_fail_length():
+def test_validate_sequence_fail_length() -> None:
     constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
     assert not validate_sequence("AC", constraints)
 
 
-def test_validate_sequence_fail_homopolymer():
+def test_validate_sequence_fail_homopolymer() -> None:
     constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
     assert not validate_sequence("AAACCC", constraints)
 
 
-def test_export_csv_and_analysis_warnings(tmp_path: Path):
+def test_export_csv_and_analysis_warnings(tmp_path: Path) -> None:
     # Create input files
     f1 = tmp_path / "a.txt"
     f1.write_text("hello")


### PR DESCRIPTION
## Summary
- add missing argument and return type annotations to tests
- ensure tests and type checking run cleanly
- use builtin generics for CLI test helper

## Testing
- `poetry run mypy tests/test_synthesis.py tests/test_streaming_paths.py`
- `poetry run ruff check tests/test_synthesis.py tests/test_streaming_paths.py`
- `poetry run pytest -q tests/test_synthesis.py tests/test_streaming_paths.py`


------
https://chatgpt.com/codex/tasks/task_e_686daafe89948326b366fe9a964aa3bc