### PR TITLE
Add plugin ratings API and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Several environment variables control optional behaviour of the FastAPI server:
 - `GENECODER_RATINGS_PATH` – file path for storing plugin rating information.
   Ratings submitted via the `/plugins/rate` endpoint are loaded from and written
   back to this JSON file on server shutdown, letting ratings persist between
-  restarts.
+  restarts. Ratings can be fetched with `GET /plugins/rate`.
 - `GENECODER_CORS_ORIGINS` – comma-separated list of allowed origins for
   Cross-Origin Resource Sharing (CORS). The default `*` permits requests from any
   origin. Restrict this variable to limit which web clients may call the API.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -200,6 +200,18 @@ curl -X POST -H "Content-Type: application/json" \
 
 The response includes the updated average star count for the plugin.
 
+Ratings can also be retrieved via ``GET /plugins/rate``:
+
+```bash
+curl 'http://localhost:8000/plugins/rate?name=myplugin'
+```
+
+For convenience the CLI exposes a ``rate`` command:
+
+```bash
+genecoder plugin rate myplugin 5 --server https://localhost:8000
+```
+
 Always verify that catalog entries originate from reputable sources or trusted
 registries. A matching checksum only proves the downloaded file has not been
 corrupted or tampered with; it does not guarantee that the plugin's code is

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -66,6 +66,20 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     )
     reg_parser.set_defaults(func=_handle_install_registry)
 
+    rate_parser = plugin_sub.add_parser(
+        "rate", help="Submit a star rating for a plugin"
+    )
+    rate_parser.add_argument("name", help="Plugin name to rate")
+    rate_parser.add_argument("rating", type=int, help="Rating from 1-5")
+    rate_parser.add_argument(
+        "--server",
+        type=str,
+        default="https://localhost:8000",
+        help="GeneCoder web server URL",
+    )
+    rate_parser.add_argument("--token", type=str, help="Bearer token for authentication")
+    rate_parser.set_defaults(func=_handle_rate)
+
 
 def _handle_list(args: argparse.Namespace) -> None:
     if not plugins.PLUGIN_CATALOG:
@@ -142,4 +156,28 @@ def _handle_install(args: argparse.Namespace) -> None:
 
 def _handle_install_registry(args: argparse.Namespace) -> None:
     plugins.install_registry_plugins(args.url)
+
+
+def _handle_rate(args: argparse.Namespace) -> None:
+    import warnings
+    import httpx
+
+    if not 1 <= args.rating <= 5:
+        logger.error("Rating must be 1-5")
+        raise SystemExit(1)
+    if not args.server.startswith("https://"):
+        warnings.warn("Using a non-HTTPS server URL", stacklevel=2)
+    url = args.server.rstrip("/") + "/plugins/rate"
+    headers = {"Content-Type": "application/json"}
+    if args.token:
+        headers["Authorization"] = f"Bearer {args.token}"
+    try:
+        resp = httpx.post(url, json={"name": args.name, "rating": args.rating}, headers=headers)
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network error path
+        logger.error("Failed to submit rating: %s", exc)
+        raise SystemExit(1)
+    avg = resp.json().get("average")
+    if avg is not None:
+        print(avg)
 

--- a/tests/test_plugin_cli_rate.py
+++ b/tests/test_plugin_cli_rate.py
@@ -1,0 +1,34 @@
+import argparse
+import pytest
+import sys
+from types import SimpleNamespace
+from genecoder.cli import plugin as plugin_cli
+
+
+def test_plugin_rate_cli(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    called = {}
+
+    class DummyResp:
+        def __init__(self) -> None:
+            self.status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, float]:
+            return {"average": 4.0}
+
+    def fake_post(url: str, *, json: dict[str, object], headers: dict[str, str]):
+        called["url"] = url
+        called["json"] = json
+        called["headers"] = headers
+        return DummyResp()
+
+    dummy = SimpleNamespace(post=fake_post)
+    monkeypatch.setitem(sys.modules, "httpx", dummy)
+    args = argparse.Namespace(name="demo", rating=5, server="https://s", token=None)
+    plugin_cli._handle_rate(args)
+    assert called["url"] == "https://s/plugins/rate"
+    assert called["json"] == {"name": "demo", "rating": 5}
+    out = capsys.readouterr().out.strip()
+    assert out == "4.0"

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -168,6 +168,16 @@ def test_rate_plugin() -> None:
     assert r.json()['average'] == 3
 
 
+def test_get_plugin_rating() -> None:
+    main.PLUGIN_RATINGS.clear()
+    main.PLUGIN_RATINGS['demo'] = [3, 5]
+    r = client.get('/plugins/rate', params={'name': 'demo'})
+    assert r.status_code == 200
+    assert r.json()['average'] == 4
+    r = client.get('/plugins/rate', params={'name': 'missing'})
+    assert r.status_code == 404
+
+
 def test_catalog_fetch_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """Failed catalog downloads return an empty list."""
 

--- a/web/main.py
+++ b/web/main.py
@@ -568,6 +568,16 @@ async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
     return {"average": avg}
 
 
+@app.get("/plugins/rate")
+async def get_plugin_rating(name: str) -> dict[str, float]:
+    """Return the current average rating for ``name``."""
+    ratings = PLUGIN_RATINGS.get(name)
+    if not ratings:
+        raise HTTPException(status_code=404, detail="No ratings found")
+    avg = sum(ratings) / len(ratings)
+    return {"average": avg}
+
+
 @app.get("/metrics")
 async def metrics() -> dict[str, int]:
     """Return encode and bundle usage metrics."""


### PR DESCRIPTION
## Summary
- add GET endpoint for plugin ratings
- implement `genecoder plugin rate` command
- document rating CLI and API usage
- test rating API and CLI

## Testing
- `ruff check web/main.py src/genecoder/cli/plugin.py tests/test_plugin_cli_rate.py tests/test_web_api_plugins.py`
- `pytest tests/test_plugin_cli_rate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686daafd162c83268e403150e127c610