### PR TITLE
Add file locking when saving plugin ratings

### DIFF
--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -2,6 +2,7 @@ import argparse
 import base64
 import json
 import sys
+import concurrent.futures
 from pathlib import Path
 import pytest
 httpx = pytest.importorskip("httpx")
@@ -294,3 +295,24 @@ def test_rate_plugin_persistence(tmp_path: Path) -> None:
     data = json.loads(path.read_text())
     assert data == {"demo": [5, 3]}
     assert plugins.PLUGIN_CATALOG["demo"]["stars"] == 4
+
+
+def test_concurrent_plugin_ratings(tmp_path: Path) -> None:
+    """Concurrent rating requests produce a valid JSON file."""
+
+    main.PLUGIN_RATINGS.clear()
+    path = tmp_path / "ratings.json"
+    main.RATINGS_PATH = str(path)
+    plugins.PLUGIN_CATALOG["demo"] = {}
+
+    def post_rating() -> None:
+        r = client.post("/plugins/rate", json={"name": "demo", "rating": 5})
+        assert r.status_code == 200
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
+        futures = [ex.submit(post_rating) for _ in range(20)]
+        for f in futures:
+            f.result()
+
+    data = json.loads(path.read_text())
+    assert data == {"demo": [5] * 20}

--- a/web/main.py
+++ b/web/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 import hashlib
+import fcntl
 import secrets
 from fastapi import FastAPI, HTTPException, Depends, Request, Response
 from fastapi.responses import HTMLResponse
@@ -77,7 +78,15 @@ def _save_plugin_ratings() -> None:
         return
     path = Path(RATINGS_PATH)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(PLUGIN_RATINGS), encoding="utf-8")
+    data = json.dumps(PLUGIN_RATINGS)
+    with path.open("w", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
 
 def verify_token(


### PR DESCRIPTION
## Summary
- prevent corrupted ratings by locking ratings.json
- test concurrent rating writes

## Testing
- `ruff check web/main.py tests/test_web_api_plugins.py`
- `pytest tests/test_web_api_plugins.py -k "concurrent_plugin_ratings" -q`

------
https://chatgpt.com/codex/tasks/task_e_686db7fb2888832690c57fdfd36bf75a