### PR TITLE
Add signature and checksum verification for plugin installs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -139,7 +139,9 @@ Set ``GENECODER_PLUGIN_PUBLIC_KEY`` to the path of the PEM encoded public key
 used to verify these signatures. Registry entries without a valid ``signature``
 field are ignored. Only HTTPS URLs (or ``file://`` for local testing) are
 accepted. Each package is installed only if the signature verifies and the
-checksum matches; otherwise installation is aborted and a warning is logged. The
+checksum matches; installation uses ``pip install --require-hashes`` so the
+downloaded file must match the expected SHA256 digest; otherwise installation
+is aborted and a warning is logged. The
 checksum check merely confirms that the package was not altered in transit; it
 does **not** guarantee the plugin is safe. Always use registries from trusted
 sources and review plugins before installing them.

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -136,9 +136,10 @@ def _handle_install(args: argparse.Namespace) -> None:
             raise SystemExit(1)
         pkg_path = files[0]
         pkg_bytes = pkg_path.read_bytes()
+        digest = None
         if signature_b64 and pubkey is not None:
             try:
-                plugins.compute_checksum(
+                digest = plugins.compute_checksum(
                     pkg_bytes,
                     signature=base64.b64decode(signature_b64),
                     public_key=pubkey,
@@ -148,10 +149,17 @@ def _handle_install(args: argparse.Namespace) -> None:
                     "Signature verification failed for plugin %s: %s", name, exc
                 )
                 raise SystemExit(1)
-        if checksum and plugins.compute_checksum(pkg_bytes) != checksum:
+        else:
+            digest = plugins.compute_checksum(pkg_bytes)
+        if checksum and digest != checksum:
             logger.error("Checksum mismatch for plugin %s", name)
             raise SystemExit(1)
-        _run_pip(["install", str(pkg_path)], "pip install")
+        req_file = Path(tmp_dir) / "req.txt"
+        req_file.write_text(f"{pkg_path} --hash=sha256:{digest}\n")
+        _run_pip(
+            ["install", "--require-hashes", "-r", str(req_file)],
+            "pip install",
+        )
 
 
 def _handle_install_registry(args: argparse.Namespace) -> None:

--- a/src/genecoder/plugins.py
+++ b/src/genecoder/plugins.py
@@ -143,20 +143,37 @@ def _install_registry_plugins(url: str) -> None:
             continue
 
         tmp_file = None
+        req_file = None
         try:
             suffix = os.path.splitext(urlparse(spec).path)[1]
             with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
                 tmp.write(pkg_bytes)
                 tmp_file = tmp.name
-            subprocess.check_call([sys.executable, "-m", "pip", "install", tmp_file])
+
+            with tempfile.NamedTemporaryFile("w", delete=False) as req:
+                req.write(f"{tmp_file} --hash=sha256:{digest}\n")
+                req_file = req.name
+
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--require-hashes",
+                    "-r",
+                    req_file,
+                ]
+            )
         except Exception as exc:  # pragma: no cover - install error path
             logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
         finally:
-            if tmp_file:
-                try:
-                    os.unlink(tmp_file)
-                except Exception:
-                    pass
+            for path in (tmp_file, req_file):
+                if path:
+                    try:
+                        os.unlink(path)
+                    except Exception:
+                        pass
 
 
 def install_registry_plugins(url: str | None = None) -> None:

--- a/tests/test_plugin_cli_registry.py
+++ b/tests/test_plugin_cli_registry.py
@@ -58,11 +58,12 @@ def test_cli_registry_install(monkeypatch: pytest.MonkeyPatch) -> None:
         argparse.Namespace(url="https://example.com/plugins.yaml")
     )
 
-    assert installs and installs[0][:4] == [
+    assert installs and installs[0][:5] == [
         sys.executable,
         "-m",
         "pip",
         "install",
+        "--require-hashes",
     ]
 
 
@@ -105,3 +106,50 @@ def test_cli_registry_install_failure(
         )
 
     assert "Failed to install plugin https://example.com/pkg.whl from registry" in caplog.text
+
+
+def test_cli_registry_signature_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+    ) -> str:
+        if signature is not None:
+            raise ValueError("bad sig")
+        return compute_checksum(data)
+
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+
+    with caplog.at_level(logging.WARNING):
+        plugin_cli._handle_install_registry(
+            argparse.Namespace(url="https://example.com/plugins.yaml")
+        )
+
+    assert not installs
+    assert "Invalid signature for plugin https://example.com/pkg.whl" in caplog.text

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -27,6 +27,7 @@ class DummyResponse:
 
 
 def test_registry_install(monkeypatch):
+
     installs = []
 
     def fake_check_call(cmd):
@@ -73,9 +74,9 @@ def test_registry_install(monkeypatch):
 
     plugins.install_registry_plugins()
 
-    assert [cmd[:4] for cmd in installs] == [
-        [sys.executable, "-m", "pip", "install"],
-        [sys.executable, "-m", "pip", "install"],
+    assert [cmd[:5] for cmd in installs] == [
+        [sys.executable, "-m", "pip", "install", "--require-hashes"],
+        [sys.executable, "-m", "pip", "install", "--require-hashes"],
     ]
 
 
@@ -175,6 +176,50 @@ def test_registry_checksum_mismatch(monkeypatch, caplog):
 
     assert not installs
     assert "Checksum mismatch for plugin https://example.com/pkgD.whl" in caplog.text
+
+
+def test_registry_signature_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    pkg = b"FFF"
+    checksum = compute_checksum(pkg)
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            sig = base64.b64encode(b"sig").decode()
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgF.whl\n    checksum: {checksum}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgF.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+    ) -> str:
+        if signature is not None:
+            raise ValueError("bad sig")
+        return compute_checksum(data)
+
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+
+    with caplog.at_level(logging.WARNING):
+        plugins.install_registry_plugins()
+
+    assert not installs
+    assert "Invalid signature for plugin https://example.com/pkgF.whl" in caplog.text
 
 
 def test_registry_checksum_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- verify plugin signatures in CLI and registry install logic
- enforce SHA256 hashes via `pip install --require-hashes`
- test hash and signature failures for registry installs
- document use of pip's hash check when installing from registries

## Testing
- `ruff check --fix src/genecoder/cli/plugin.py src/genecoder/plugins.py tests/test_plugin_cli_registry.py tests/test_plugin_registry.py`
- `pytest tests/test_plugin_registry.py tests/test_plugin_cli_registry.py tests/test_plugin_marketplace.py tests/test_cli_plugin_catalog.py tests/test_web_api_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686db7fa48b4832695b716ae9dd5d0d3