### PR TITLE
Add oligos_simulated metric

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,5 +22,6 @@ For more details, explore the sections below.
 * [FEC Benchmarks](benchmarks.md) – Forward error correction examples and results.
 * [Technology Stack](technology_stack.md) – Overview of dependencies and tooling.
 * [Glossary](glossary.md) – Key terms used throughout the docs.
+* [Usage Metrics](metrics.md) – Track encode and simulation counts.
 * [Introductory Notebooks](../notebooks) – Encoding, channel simulation and decoding examples.
 * [Lesson Notebooks](../notebooks/lessons) – Step-by-step guides for encoding basics, FEC, simulation and analysis.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,9 @@
+# Usage Metrics
+
+GeneCoder records basic usage statistics in a `metrics.json` file located in `~/.genecoder/` by default. The following counters are tracked:
+
+- `encode_runs` – times the `encode` command has been executed.
+- `bundle_runs` – number of `bundle run` workflows executed.
+- `oligos_simulated` – total sequences processed by channel simulations.
+
+Display these values with `genecoder stats` or via the `/metrics` web API endpoint. Set the `GENECODER_METRICS_PATH` environment variable to use a custom file location.

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -16,6 +16,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
+from genecoder.metrics import increment as increment_metric
 from .options import ChannelOptions, build_channel_options
 
 logger = logging.getLogger(__name__)
@@ -108,6 +109,7 @@ def process_channel(
                 deletion_prob=del_prob,
                 rng=rng,
             )
+            increment_metric("oligos_simulated")
 
         if not validate_sequence(seq, synth):
             logger.error("Sequence violates synthesis constraints")

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -6,7 +6,7 @@ from genecoder.metrics import get_metrics
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    parser = subparsers.add_parser("stats", help="Show usage metrics")
+    parser = subparsers.add_parser("stats", help="Show usage metrics including simulation counts")
     parser.set_defaults(func=_handle_command)
 
 

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import os
 
 from ..channels.base import BaseChannel
+from ..metrics import increment as increment_metric
 
 __all__ = ["ChannelPipeline"]
 
@@ -32,6 +33,7 @@ class ChannelPipeline(BaseChannel):
         if not parallel or len(self.channels) <= 1:
             for channel in self.channels:
                 sequence = channel.simulate(sequence)
+            increment_metric("oligos_simulated")
             return sequence
 
         if workers is None:
@@ -47,4 +49,5 @@ class ChannelPipeline(BaseChannel):
         with executor_cls(max_workers=workers) as executor:
             for channel in self.channels:
                 current = executor.submit(channel.simulate, current).result()
+        increment_metric("oligos_simulated")
         return current

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -21,18 +22,23 @@ def test_encode_increments_metrics(tmp_path: Path, monkeypatch) -> None:
 
 def test_stats_cli(tmp_path: Path, monkeypatch) -> None:
     metrics_path = tmp_path / "s.json"
-    metrics_path.write_text(json.dumps({"encode_runs": 2, "bundle_runs": 1}))
+    metrics_path.write_text(
+        json.dumps({"encode_runs": 2, "bundle_runs": 1, "oligos_simulated": 3})
+    )
     monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
     res = run_cli_command(["stats"])
     assert res.returncode == 0
     out = res.stdout.strip().splitlines()
     assert "encode_runs: 2" in out
     assert "bundle_runs: 1" in out
+    assert "oligos_simulated: 3" in out
 
 
 def test_metrics_endpoint(tmp_path: Path, monkeypatch) -> None:
     metrics_path = tmp_path / "web.json"
-    metrics_path.write_text(json.dumps({"bundle_runs": 5}))
+    metrics_path.write_text(
+        json.dumps({"bundle_runs": 5, "oligos_simulated": 2})
+    )
     monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
     import importlib
     main = importlib.import_module("web.main")
@@ -42,3 +48,46 @@ def test_metrics_endpoint(tmp_path: Path, monkeypatch) -> None:
     r = client.get("/metrics")
     assert r.status_code == 200
     assert r.json()["bundle_runs"] == 5
+    assert r.json()["oligos_simulated"] == 2
+
+
+def test_pipeline_increments_metric(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "p.json"
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    from src.genecoder.channel_sim import Channel
+    from src.genecoder.simulators.pipeline import ChannelPipeline
+
+    pipeline = ChannelPipeline([Channel(0.0)])
+    pipeline.simulate("ACGT")
+    data = json.loads(metrics_path.read_text())
+    assert data["oligos_simulated"] == 1
+
+
+def test_channel_cli_increments_metric(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "c.json"
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+    fasta = tmp_path / "i.fasta"
+    fasta.write_text(">a\nAAAA\n>b\nTTTT\n")
+    out = tmp_path / "o.fasta"
+    res = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(fasta),
+            "--output-file",
+            str(out),
+            "--sub-prob",
+            "0.1",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert res.returncode == 0, res.stderr
+    data = json.loads(metrics_path.read_text())
+    assert data["oligos_simulated"] == 2

--- a/web/main.py
+++ b/web/main.py
@@ -589,5 +589,5 @@ async def get_plugin_rating(name: str) -> dict[str, float]:
 
 @app.get("/metrics")
 async def metrics() -> dict[str, int]:
-    """Return encode and bundle usage metrics."""
+    """Return encode, bundle and simulation usage metrics."""
     return get_metrics()


### PR DESCRIPTION
## Summary
- count sequences processed by ChannelPipeline or CLI channel
- expose the value in stats CLI and web API
- document metrics
- test new metric functionality
- document environment variable to override metrics path

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dbc0cd7d4832684aa02e238c2c8e2