### PR TITLE
Add signature checks to plugin installs

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -136,8 +136,10 @@ def _handle_install(args: argparse.Namespace) -> None:
             raise SystemExit(1)
         pkg_path = files[0]
         pkg_bytes = pkg_path.read_bytes()
-        digest = None
-        if signature_b64 and pubkey is not None:
+        if signature_b64:
+            if pubkey is None:
+                logger.error("Missing public key for signed plugin %s", name)
+                raise SystemExit(1)
             try:
                 digest = plugins.compute_checksum(
                     pkg_bytes,

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -130,14 +130,18 @@ def _install_registry_plugins(url: str) -> None:
             logger.warning("Failed to download plugin %s: %s", spec, exc)
             continue
 
-        if pubkey is None:
-            logger.warning("No public key configured for signed plugin %s", spec)
-            continue
-        try:
-            digest = compute_checksum(pkg_bytes, signature=signature, public_key=pubkey)
-        except Exception as exc:
-            logger.warning("Invalid signature for plugin %s: %s", spec, exc)
-            continue
+        if signature is not None:
+            if pubkey is None:
+                logger.warning("No public key configured for signed plugin %s", spec)
+                continue
+            try:
+                digest = compute_checksum(pkg_bytes, signature=signature, public_key=pubkey)
+            except Exception as exc:
+                logger.warning("Invalid signature for plugin %s: %s", spec, exc)
+                continue
+        else:
+            digest = compute_checksum(pkg_bytes)
+
         if digest != checksum:
             logger.warning("Checksum mismatch for plugin %s", spec)
             continue
@@ -220,6 +224,7 @@ def _fetch_catalog(url: str) -> None:
             "url": str(entry.get("url", "")),
             "description": str(entry.get("description", "")),
             "checksum": str(entry.get("checksum", "")),
+            "signature": str(entry.get("signature", "")),
             "author": str(entry.get("author", "")),
             "stars": entry.get("stars", 0),
         }

--- a/tests/test_plugin_cli_registry.py
+++ b/tests/test_plugin_cli_registry.py
@@ -153,3 +153,41 @@ def test_cli_registry_signature_failure(
 
     assert not installs
     assert "Invalid signature for plugin https://example.com/pkg.whl" in caplog.text
+
+
+def test_cli_registry_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    pkg = b"PKG"
+    wrong = compute_checksum(b"WRONG")
+    sig = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+
+    with caplog.at_level(logging.WARNING):
+        plugin_cli._handle_install_registry(
+            argparse.Namespace(url="https://example.com/plugins.yaml")
+        )
+
+    assert not installs
+    assert "Checksum mismatch for plugin https://example.com/pkg.whl" in caplog.text

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -1,6 +1,8 @@
 import sys
 import argparse
 from pathlib import Path
+import logging
+import base64
 import pytest
 
 
@@ -106,6 +108,66 @@ def test_install_checksum_mismatch(monkeypatch, caplog):
 
     assert not installs
     assert "Checksum mismatch for plugin plug" in caplog.text
+
+
+def test_install_signature_mismatch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
+
+    catalog = (
+        "plugins:\n"
+        "  - name: plug\n"
+        "    version: '0.1'\n"
+        "    url: plug==0.1\n"
+        f"    checksum: {checksum}\n"
+        f"    signature: {sig}"
+    ).encode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        assert url == "https://example.com/catalog.yaml"
+        return DummyResponse(catalog)
+
+    installs: list[list[str]] = []
+
+    def fake_check_call(cmd: list[str]) -> None:
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "plug.whl").write_bytes(pkg)
+        elif cmd[:4] == [sys.executable, "-m", "pip", "install"]:
+            installs.append(cmd)
+        else:  # pragma: no cover - unexpected command
+            raise AssertionError(cmd)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+    ) -> str:
+        if signature is not None:
+            raise ValueError("bad sig")
+        return compute_checksum(data)
+
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+
+    plugins.load_plugins()
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit):
+        plugin_cli._handle_install(argparse.Namespace(name="plug"))
+
+    assert not installs
+    assert "Signature verification failed for plugin plug" in caplog.text
 
 
 def test_catalog_network_error(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- verify plugin signatures in CLI before running pip
- verify registry plugin signatures before pip execution
- store catalog signatures for later verification
- test checksum and signature mismatch handling in plugin CLI registry and marketplace

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/cli/plugin.py src/genecoder/plugin_manager.py tests/test_plugin_cli_registry.py tests/test_plugin_registry.py tests/test_plugin_marketplace.py`
- `pytest tests/test_plugin_cli_registry.py::test_cli_registry_checksum_mismatch tests/test_plugin_registry.py::test_registry_checksum_mismatch tests/test_plugin_marketplace.py::test_install_signature_mismatch -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7897e2848326b11238713c58ade7