### PR TITLE
Add env option safety tests

### DIFF
--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -68,10 +68,12 @@ def test_parse_options_invalid(monkeypatch, caplog):
     assert any("Invalid" in r.message for r in caplog.records)
 
 
-def test_parse_options_unsafe(monkeypatch):
-    monkeypatch.setenv("GENECODER_D2SIM_OPTIONS", "foo;bar")
+@pytest.mark.parametrize("command", ["d2sim", "dnarsim", "squigulator"])
+def test_parse_options_unsafe(monkeypatch, command):
+    env_var = f"GENECODER_{command.upper()}_OPTIONS"
+    monkeypatch.setenv(env_var, "foo;bar")
     with pytest.raises(ValueError):
-        nanopore_sim._parse_env_options("d2sim")
+        nanopore_sim._parse_env_options(command)
 
 
 @pytest.mark.parametrize("name", ADAPTERS.keys())


### PR DESCRIPTION
## Summary
- cover `dnarsim` and `squigulator` in the unsafe env option test

## Testing
- `ruff check tests/test_nanopore_sim.py`
- `mypy --config-file pyproject.toml`
- `pytest tests/test_nanopore_sim.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7f3912c08326b4631f2e0105c5f5