### PR TITLE
Add plugin catalog service

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -246,6 +246,29 @@ warning.
 Signed packages help detect tampering, but they do not make untrusted code safe.
 Always audit plugins and obtain public keys from verified sources.
 
+## Running the Plugin Catalog Service
+
+The web server exposes a small REST API for hosting plugin metadata. Set
+``GENECODER_CATALOG_PATH`` to the location of a JSON file before starting the
+FastAPI application:
+
+```bash
+export GENECODER_CATALOG_PATH=/tmp/catalog.json
+uvicorn web.main:app
+```
+
+Upload a plugin entry with a POST request including the name, version, checksum
+and optional signature:
+
+```bash
+curl -X POST -H "Authorization: Bearer <TOKEN>" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "demo", "version": "1.0", "checksum": "abc", "signature": "sig"}' \
+     http://localhost:8000/catalog/plugins
+```
+
+List registered entries via ``GET /catalog/plugins``.
+
 ## Submitting to the Marketplace
 
 Signed plugin packages can be shared publicly by submitting them to the GeneCoder marketplace. After building a wheel and generating the detached signature, visit the marketplace dashboard and upload both files. The system verifies the signature and runs automated checks before listing the plugin in the public catalog.

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -12,6 +12,7 @@ fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 import web.main as main
+from web import plugin_catalog
 import genecoder.plugin_manager as plugins
 from genecoder.cli import plugin as plugin_cli
 
@@ -340,3 +341,26 @@ def test_concurrent_ratings_file_valid(tmp_path: Path) -> None:
     data = json.loads(path.read_text())
     assert isinstance(data, dict)
     assert "demo" in data
+
+
+def test_plugin_catalog_crud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Uploading and listing catalog entries works and requires a token."""
+
+    monkeypatch.setattr(plugin_catalog, "CATALOG_PATH", str(tmp_path / "cat.json"), raising=False)
+    plugin_catalog.CATALOG.clear()
+
+    r = client.get("/catalog/plugins")
+    assert r.status_code == 200
+    assert r.json() == {"plugins": []}
+
+    payload = {"name": "demo", "version": "1.0", "checksum": "abc", "signature": "sig"}
+    r = client.post("/catalog/plugins", json=payload)
+    assert r.status_code == 401
+
+    r = client.post("/catalog/plugins", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+    r2 = client.get("/catalog/plugins")
+    assert r2.status_code == 200
+    assert r2.json()["plugins"] == [payload]

--- a/web/main.py
+++ b/web/main.py
@@ -43,6 +43,7 @@ from typing import Any, cast
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 import redis.asyncio as redis
+from . import plugin_catalog
 
 DNA_RE = re.compile(r"^[ACGT]+$")
 FILE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -139,6 +140,9 @@ app.mount("/static", StaticFiles(directory=static_dir), name="static")
 # Mount the React-based helix viewer as a static directory
 helix_ui_dir = Path(__file__).parent / "helix-ui"
 app.mount("/helix-ui", StaticFiles(directory=helix_ui_dir), name="helix-ui")
+
+# REST API for managing plugin catalog entries
+app.include_router(plugin_catalog.router, prefix="/catalog")
 
 index_path = static_dir / "index.html"
 helix_index_path = helix_ui_dir / "dist" / "index.html"

--- a/web/plugin_catalog.py
+++ b/web/plugin_catalog.py
@@ -1,0 +1,98 @@
+import os
+import json
+from pathlib import Path
+from typing import List, Dict, Optional
+
+import portalocker
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+
+import web.main as main
+
+router = APIRouter()
+security = HTTPBearer(auto_error=False)
+
+CATALOG_PATH = os.getenv("GENECODER_CATALOG_PATH")
+CATALOG: List[Dict[str, Optional[str]]] = []
+
+
+class PluginMetadata(BaseModel):
+    name: str
+    version: str
+    checksum: str
+    signature: Optional[str] = None
+
+
+def _load_catalog() -> None:
+    global CATALOG
+    if not CATALOG_PATH:
+        return
+    path = Path(CATALOG_PATH)
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    items = data.get("plugins", [])
+    if isinstance(items, list):
+        CATALOG = [
+            {
+                "name": str(item.get("name", "")),
+                "version": str(item.get("version", "")),
+                "checksum": str(item.get("checksum", "")),
+                "signature": item.get("signature"),
+            }
+            for item in items
+            if item.get("name")
+        ]
+
+
+def _save_catalog() -> None:
+    if not CATALOG_PATH:
+        return
+    path = Path(CATALOG_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps({"plugins": CATALOG})
+    with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as fh:
+        fh.seek(0)
+        fh.truncate(0)
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+@router.on_event("startup")
+def _startup() -> None:
+    _load_catalog()
+
+
+@router.on_event("shutdown")
+def _shutdown() -> None:
+    _save_catalog()
+
+
+def _verify_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> None:
+    if credentials is None or credentials.credentials != main.API_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+
+
+@router.get("/plugins")
+def list_plugins() -> Dict[str, List[Dict[str, Optional[str]]]]:
+    return {"plugins": CATALOG}
+
+
+@router.post("/plugins")
+def add_plugin(
+    meta: PluginMetadata,
+    _: None = Depends(_verify_token),
+) -> Dict[str, str]:
+    for item in CATALOG:
+        if item["name"] == meta.name and item["version"] == meta.version:
+            raise HTTPException(status_code=409, detail="Plugin already exists")
+    CATALOG.append(meta.dict())
+    _save_catalog()
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- expose a new REST API `/catalog` for managing plugin metadata
- mount the catalog service in the main web app
- document running the service and uploading plugins
- test catalog CRUD operations

## Testing
- `pre-commit run --files web/plugin_catalog.py web/main.py docs/plugins.md tests/test_web_api_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_686e7f38699c8326beb0f9d5a0475562