### PR TITLE
Add vertical slice bundle demo

### DIFF
--- a/configs/vertical_slice_demo.yaml
+++ b/configs/vertical_slice_demo.yaml
@@ -1,0 +1,10 @@
+encode:
+  input_files:
+    - tests/data/vertical_slice.txt
+  method: base4_direct
+  fec: hamming_7_4
+simulate:
+  simulators:
+    - adv_nanopore
+decode:
+  method: base4_direct

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -71,6 +71,18 @@ genecoder --version
 poetry run pytest -q
 ```
 
+## Bundle Workflow
+
+An example configuration file at `configs/vertical_slice_demo.yaml` demonstrates
+using a simulator and Hamming FEC. Run the bundle with:
+
+```bash
+genecoder bundle run configs/vertical_slice_demo.yaml --cache-dir runs
+```
+
+The `scripts/vertical_slice.sh` helper executes the same command automatically
+as part of the demo.
+
 ## Launch the GUI
 
 ```bash

--- a/scripts/vertical_slice.sh
+++ b/scripts/vertical_slice.sh
@@ -16,6 +16,9 @@ echo "Running CLI smoke test..."
 genecoder --version
 poetry run pytest -q
 
+echo "Running bundle workflow..."
+genecoder bundle run configs/vertical_slice_demo.yaml --cache-dir runs
+
 echo "Launching the Flet GUI..."
 python -m genecoder.flet_app
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -72,7 +72,11 @@ def _install_registry_plugins(url: str) -> None:
     """Install plugin packages listed in a YAML registry at ``url``."""
 
     if yaml is None:  # pragma: no cover - optional dependency missing
-        logger.warning("YAML support unavailable, skipping plugin registry %s", url)
+        logger.warning(
+            "YAML support unavailable, skipping plugin registry %s. "
+            "Install PyYAML to enable plugin catalogs.",
+            url,
+        )
         return
 
     key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
@@ -189,7 +193,11 @@ def _fetch_catalog(url: str) -> None:
     """Fetch plugin catalogue from ``url`` and store in ``PLUGIN_CATALOG``."""
 
     if yaml is None:  # pragma: no cover - optional dependency missing
-        logger.warning("YAML support unavailable, skipping plugin catalog %s", url)
+        logger.warning(
+            "YAML support unavailable, skipping plugin catalog %s. "
+            "Install PyYAML to enable plugin catalogs.",
+            url,
+        )
         return
 
     try:

--- a/tests/data/vertical_slice.txt
+++ b/tests/data/vertical_slice.txt
@@ -1,0 +1,1 @@
+Vertical slice demo


### PR DESCRIPTION
## Summary
- add `vertical_slice_demo.yaml` showing a workflow with Hamming FEC and a simulator
- include a small demo input file
- run the bundle from `vertical_slice.sh`
- document the bundle workflow in `vertical_slice.md`
- clarify log message when PyYAML is missing

## Testing
- `ruff check .`
- `pytest tests/test_cli_plugin_catalog.py tests/test_plugin_cli_registry.py tests/test_plugin_marketplace.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7f382a348326be887830e9823719