### PR TITLE
Add instructions for optional test extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ poetry install --with gui,web,dev --no-interaction
 poetry run pytest -q
 ```
 
+### Optional Test Dependencies
+
+Some integration tests use optional GUI and web components. Install these extras
+with:
+
+```bash
+poetry install --with gui,web --no-interaction
+```
+
 All code changes must pass `pre-commit` and the test suite. These checks are not
 required for documentation-only pull requests.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Install the project in editable mode with development tools:
 poetry install --with gui,web,dev --no-interaction
 ```
 
+You can also run `scripts/setup_test_env.sh` to install the optional GUI and web
+extras used by the test suite.
+
 ## OpenAI Testing Environment
 
 The `openai_testing/` directory bundles the demo from the

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install optional dependencies used by tests
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+echo "Installing GUI and web extras..."
+poetry install --with gui,web --no-interaction


### PR DESCRIPTION
## Summary
- document installing gui and web extras for the test suite
- provide a helper script for setting up those extras
- mention the helper in the development setup docs

## Testing
- `pytest tests/test_cli_version.py::test_cli_version -q`
- `SKIP=pytest pre-commit run --files CONTRIBUTING.md README.md scripts/setup_test_env.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e9506a3a88326a21b088a72b81645