### PR TITLE
Add auth for plugin ratings

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -193,10 +193,12 @@ genecoder plugin install myplugin
 
 The ``/plugin-catalog`` web page lets you search and sort available plugins by
 name, description or rating. To submit feedback programmatically send a rating
-to the API:
+to the API. Both rating endpoints require an API token supplied in the
+``Authorization`` header:
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <TOKEN>" \
   -d '{"name": "myplugin", "rating": 5}' http://localhost:8000/plugins/rate
 ```
 
@@ -205,7 +207,8 @@ The response includes the updated average star count for the plugin.
 Ratings can also be retrieved via ``GET /plugins/rate``:
 
 ```bash
-curl 'http://localhost:8000/plugins/rate?name=myplugin'
+curl -H "Authorization: Bearer <TOKEN>" \
+  'http://localhost:8000/plugins/rate?name=myplugin'
 ```
 
 For convenience the CLI exposes a ``rate`` command:

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -4,8 +4,13 @@ import json
 import sys
 import concurrent.futures
 from pathlib import Path
+from typing import Callable, Literal
 import pytest
 httpx = pytest.importorskip("httpx")
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from httpx import Request, Response
 pytest.importorskip("fastapi_limiter")
 
 fastapi = pytest.importorskip("fastapi")
@@ -28,7 +33,7 @@ class DummyResponse:
     def __enter__(self) -> "DummyResponse":
         return self
 
-    def __exit__(self, *exc: object) -> bool:
+    def __exit__(self, *exc: object) -> Literal[False]:
         return False
 
     def read(self) -> bytes:
@@ -74,10 +79,10 @@ def test_install_signature_missing_key() -> None:
     sig_b64 = base64.b64encode(b"sig").decode()
     plugins.PLUGIN_CATALOG["signed"] = {"checksum": checksum, "signature": sig_b64}
 
-    def fake_check_call(cmd):
+    def fake_check_call(cmd: list[str]) -> None:
         raise AssertionError("pip should not run")
 
-    def fake_compute(*args, **kwargs):  # pragma: no cover - should not be called
+    def fake_compute(*args: object, **kwargs: object) -> str:  # pragma: no cover - should not be called
         raise AssertionError("compute_checksum should not run")
 
     with pytest.MonkeyPatch().context() as m:
@@ -93,7 +98,7 @@ def test_install_signature_failure() -> None:
     sig_b64 = base64.b64encode(b"sig").decode()
     plugins.PLUGIN_CATALOG["signed"] = {"checksum": checksum, "signature": sig_b64}
 
-    def fake_check_call(cmd):
+    def fake_check_call(cmd: list[str]) -> None:
         if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
             dest = cmd[cmd.index("-d") + 1]
             Path(dest).mkdir(parents=True, exist_ok=True)
@@ -103,7 +108,7 @@ def test_install_signature_failure() -> None:
         else:
             raise AssertionError(cmd)
 
-    orig_compute = plugins.compute_checksum
+    orig_compute: Callable[[bytes], str] = plugins.compute_checksum
 
     def fake_compute(
         data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
@@ -122,7 +127,7 @@ def test_install_signature_failure() -> None:
     assert r.status_code == 400
 
 
-def test_install_signature_success(tmp_path) -> None:
+def test_install_signature_success(tmp_path: Path) -> None:
     pkg = b"PKG"
     checksum = plugins.compute_checksum(pkg)
     sig = base64.b64encode(b"valid").decode()
@@ -133,7 +138,7 @@ def test_install_signature_success(tmp_path) -> None:
 
     installs = []
 
-    def fake_check_call(cmd):
+    def fake_check_call(cmd: list[str]) -> None:
         if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
             dest = cmd[cmd.index("-d") + 1]
             Path(dest).mkdir(parents=True, exist_ok=True)
@@ -143,7 +148,7 @@ def test_install_signature_success(tmp_path) -> None:
         else:
             raise AssertionError(cmd)
 
-    orig_compute = plugins.compute_checksum
+    orig_compute: Callable[[bytes], str] = plugins.compute_checksum
 
     def fake_compute(
         data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
@@ -164,10 +169,10 @@ def test_install_signature_success(tmp_path) -> None:
 
 def test_rate_plugin() -> None:
     main.PLUGIN_RATINGS.clear()
-    r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 4})
+    r = client.post('/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 4})
     assert r.status_code == 200
     assert r.json()['average'] == 4
-    r = client.post('/plugins/rate', json={'name': 'demo', 'rating': 2})
+    r = client.post('/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 2})
     assert r.status_code == 200
     assert r.json()['average'] == 3
 
@@ -175,23 +180,23 @@ def test_rate_plugin() -> None:
 def test_get_plugin_rating() -> None:
     main.PLUGIN_RATINGS.clear()
     main.PLUGIN_RATINGS['demo'] = [3, 5]
-    r = client.get('/plugins/rate', params={'name': 'demo'})
+    r = client.get('/plugins/rate', headers=AUTH_HEADERS, params={'name': 'demo'})
     assert r.status_code == 200
     assert r.json()['average'] == 4
-    r = client.get('/plugins/rate', params={'name': 'missing'})
+    r = client.get('/plugins/rate', headers=AUTH_HEADERS, params={'name': 'missing'})
     assert r.status_code == 404
 
 
 def test_catalog_fetch_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """Failed catalog downloads return an empty list."""
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: Request) -> Response:
         raise httpx.ConnectError("offline", request=request)
 
     transport = httpx.MockTransport(handler)
 
     def fake_urlopen(url: str) -> DummyResponse:
-        request = httpx.Request("GET", url)
+        request = Request("GET", url)
         transport.handle_request(request)
         raise AssertionError("unreachable")
 
@@ -248,7 +253,7 @@ def test_install_invalid_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         else:
             raise AssertionError(cmd)
 
-    orig_compute = plugins.compute_checksum
+    orig_compute: Callable[[bytes], str] = plugins.compute_checksum
 
     def fake_compute(
         data: bytes,
@@ -271,9 +276,9 @@ def test_install_invalid_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 def test_rate_plugin_invalid() -> None:
     """Ratings outside 1-5 are rejected."""
 
-    r = client.post("/plugins/rate", json={"name": "demo", "rating": 0})
+    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 0})
     assert r.status_code == 400
-    r = client.post("/plugins/rate", json={"name": "demo", "rating": 6})
+    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 6})
     assert r.status_code == 400
 
 
@@ -284,13 +289,13 @@ def test_rate_plugin_persistence(tmp_path: Path) -> None:
     path = tmp_path / "ratings.json"
     main.RATINGS_PATH = str(path)
     plugins.PLUGIN_CATALOG["demo"] = {}
-    r = client.post("/plugins/rate", json={"name": "demo", "rating": 5})
+    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
     assert r.status_code == 200
     assert r.json()["average"] == 5
     data = json.loads(path.read_text())
     assert data == {"demo": [5]}
     assert plugins.PLUGIN_CATALOG["demo"]["stars"] == 5
-    r = client.post("/plugins/rate", json={"name": "demo", "rating": 3})
+    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 3})
     assert r.status_code == 200
     assert r.json()["average"] == 4
     data = json.loads(path.read_text())
@@ -307,7 +312,7 @@ def test_concurrent_plugin_ratings(tmp_path: Path) -> None:
     plugins.PLUGIN_CATALOG["demo"] = {}
 
     def post_rating() -> None:
-        r = client.post("/plugins/rate", json={"name": "demo", "rating": 5})
+        r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
         assert r.status_code == 200
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
@@ -329,7 +334,7 @@ def test_concurrent_ratings_file_valid(tmp_path: Path) -> None:
     plugins.PLUGIN_CATALOG["demo"] = {}
 
     def post_rating() -> None:
-        r = client.post("/plugins/rate", json={"name": "demo", "rating": 4})
+        r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 4})
         assert r.status_code == 200
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as ex:

--- a/web/main.py
+++ b/web/main.py
@@ -567,7 +567,10 @@ async def install_plugin(
 
 
 @app.post("/plugins/rate")
-async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
+async def rate_plugin(
+    req: PluginRatingRequest,
+    _: None = Depends(verify_token),
+) -> dict[str, float]:
     """Submit a rating for a plugin and return the new average."""
     if req.rating < 1 or req.rating > 5:
         raise HTTPException(status_code=400, detail="rating must be 1-5")
@@ -580,7 +583,10 @@ async def rate_plugin(req: PluginRatingRequest) -> dict[str, float]:
 
 
 @app.get("/plugins/rate")
-async def get_plugin_rating(name: str) -> dict[str, float]:
+async def get_plugin_rating(
+    name: str,
+    _: None = Depends(verify_token),
+) -> dict[str, float]:
     """Return the current average rating for ``name``."""
     ratings = PLUGIN_RATINGS.get(name)
     if not ratings:
@@ -592,4 +598,5 @@ async def get_plugin_rating(name: str) -> dict[str, float]:
 @app.get("/metrics")
 async def metrics() -> dict[str, int]:
     """Return encode, bundle and simulation usage metrics."""
-    return get_metrics()
+    data: dict[str, int] = get_metrics()
+    return data


### PR DESCRIPTION
## Summary
- secure plugin rating APIs with auth token
- adjust tests for auth requirement and satisfy mypy
- document auth header when rating plugins

## Testing
- `ruff check web/main.py tests/test_web_api_plugins.py`
- `mypy --config-file pyproject.toml web/main.py tests/test_web_api_plugins.py`
- `pytest tests/test_web_api_plugins.py::test_rate_plugin -q`
- `pytest tests/test_web_api_plugins.py::test_get_plugin_rating tests/test_web_api_plugins.py::test_rate_plugin_invalid tests/test_web_api_plugins.py::test_rate_plugin_persistence tests/test_web_api_plugins.py::test_concurrent_plugin_ratings tests/test_web_api_plugins.py::test_concurrent_ratings_file_valid -q`


------
https://chatgpt.com/codex/tasks/task_e_686e9505ee648326a7d59b6091b517df