### PR TITLE
Update docs for optional test extras

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ with:
 poetry install --with gui,web --no-interaction
 ```
 
+You can also run `scripts/setup_test_env.sh` to install the same extras.
+
 All code changes must pass `pre-commit` and the test suite. These checks are not
 required for documentation-only pull requests.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,12 @@ Install the project in editable mode with development tools:
 poetry install --with gui,web,dev --no-interaction
 ```
 
-You can also run `scripts/setup_test_env.sh` to install the optional GUI and web
-extras used by the test suite.
+You can also run the helper script to install the optional GUI and web extras
+required by the test suite:
+
+```bash
+scripts/setup_test_env.sh
+```
 
 ## OpenAI Testing Environment
 


### PR DESCRIPTION
## Summary
- explain optional test dependencies in CONTRIBUTING.md
- show a helper script usage example in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ed393261c832693ad211f81946867