### PR TITLE
Async file I/O in web API

### DIFF
--- a/tests/test_web_api_chunks.py
+++ b/tests/test_web_api_chunks.py
@@ -1,17 +1,23 @@
 import base64
+import asyncio
 import hashlib
 import json
 import pytest
+httpx = pytest.importorskip("httpx")
 
 pytest.importorskip("fastapi_limiter")
 
 fastapi = pytest.importorskip("fastapi")
-pytest.importorskip("httpx")
-from fastapi.testclient import TestClient
 
 import web.main as main
 
-client = TestClient(main.app)
+def _request(method: str, url: str, **kwargs: object) -> httpx.Response:
+    async def _call() -> httpx.Response:
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            return await ac.request(method, url, **kwargs)
+
+    return asyncio.run(_call())
 
 
 from pathlib import Path
@@ -27,7 +33,7 @@ def test_chunk_upload_and_download(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         "offset": 1,
         "data": base64.b64encode(data).decode(),
     }
-    r = client.post("/upload-chunk", json=payload)
+    r = _request("POST", "/upload-chunk", json=payload)
     assert r.status_code == 200
     expected_hash = hashlib.sha256(data).hexdigest()
     assert r.json()["hash"] == expected_hash
@@ -40,7 +46,7 @@ def test_chunk_upload_and_download(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     manifest = manifest_path.read_text().splitlines()
     assert manifest == [json.dumps({"offset": 1, "hash": expected_hash})]
 
-    r2 = client.get("/download-chunk", params={"file_id": "file1", "offset": 1})
+    r2 = _request("GET", "/download-chunk", params={"file_id": "file1", "offset": 1})
     assert r2.status_code == 200
     assert base64.b64decode(r2.json()["data"]) == data
 
@@ -60,10 +66,11 @@ def test_rate_limiter_requires_token(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         "offset": 0,
         "data": base64.b64encode(b"data").decode(),
     }
-    r = client.post("/upload-chunk", json=payload)
+    r = _request("POST", "/upload-chunk", json=payload)
     assert r.status_code == 401
 
-    r2 = client.post(
+    r2 = _request(
+        "POST",
         "/upload-chunk",
         json=payload,
         headers={"Authorization": "Bearer t"},
@@ -76,14 +83,14 @@ def test_upload_chunk_missing_field(tmp_path, monkeypatch):
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
     main.FastAPILimiter.redis = None
     payload = {"offset": 0, "data": base64.b64encode(b"d").decode()}
-    r = client.post("/upload-chunk", json=payload)
+    r = _request("POST", "/upload-chunk", json=payload)
     assert r.status_code == 422
 
 
 def test_download_chunk_not_found(monkeypatch, tmp_path):
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
     main.FastAPILimiter.redis = None
-    r = client.get("/download-chunk", params={"file_id": "missing", "offset": 1})
+    r = _request("GET", "/download-chunk", params={"file_id": "missing", "offset": 1})
     assert r.status_code == 404
 
 
@@ -108,7 +115,7 @@ def test_invalid_file_ids_rejected_upload(monkeypatch: pytest.MonkeyPatch, tmp_p
         "offset": 0,
         "data": base64.b64encode(b"x").decode(),
     }
-    r = client.post("/upload-chunk", json=payload)
+    r = _request("POST", "/upload-chunk", json=payload)
     assert r.status_code == 400
 
 
@@ -128,5 +135,5 @@ def test_invalid_file_ids_rejected_upload(monkeypatch: pytest.MonkeyPatch, tmp_p
 def test_invalid_file_ids_rejected_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad_id: str) -> None:
     monkeypatch.setenv("GENECODER_TMP", str(tmp_path))
     main.FastAPILimiter.redis = None
-    r = client.get("/download-chunk", params={"file_id": bad_id, "offset": 0})
+    r = _request("GET", "/download-chunk", params={"file_id": bad_id, "offset": 0})
     assert r.status_code == 400

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -15,6 +15,7 @@ pytest.importorskip("fastapi_limiter")
 
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
+import asyncio
 
 import web.main as main
 from web import plugin_catalog
@@ -24,6 +25,15 @@ from genecoder.cli import plugin as plugin_cli
 main.API_TOKEN = "test-token"
 client = TestClient(main.app)
 AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
+
+def _request(method: str, url: str, **kwargs: object) -> httpx.Response:
+    async def _call() -> httpx.Response:
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            return await ac.request(method, url, **kwargs)
+
+    return asyncio.run(_call())
 
 
 class DummyResponse:
@@ -169,10 +179,10 @@ def test_install_signature_success(tmp_path: Path) -> None:
 
 def test_rate_plugin() -> None:
     main.PLUGIN_RATINGS.clear()
-    r = client.post('/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 4})
+    r = _request('POST', '/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 4})
     assert r.status_code == 200
     assert r.json()['average'] == 4
-    r = client.post('/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 2})
+    r = _request('POST', '/plugins/rate', headers=AUTH_HEADERS, json={'name': 'demo', 'rating': 2})
     assert r.status_code == 200
     assert r.json()['average'] == 3
 
@@ -180,10 +190,10 @@ def test_rate_plugin() -> None:
 def test_get_plugin_rating() -> None:
     main.PLUGIN_RATINGS.clear()
     main.PLUGIN_RATINGS['demo'] = [3, 5]
-    r = client.get('/plugins/rate', headers=AUTH_HEADERS, params={'name': 'demo'})
+    r = _request('GET', '/plugins/rate', headers=AUTH_HEADERS, params={'name': 'demo'})
     assert r.status_code == 200
     assert r.json()['average'] == 4
-    r = client.get('/plugins/rate', headers=AUTH_HEADERS, params={'name': 'missing'})
+    r = _request('GET', '/plugins/rate', headers=AUTH_HEADERS, params={'name': 'missing'})
     assert r.status_code == 404
 
 
@@ -276,9 +286,9 @@ def test_install_invalid_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 def test_rate_plugin_invalid() -> None:
     """Ratings outside 1-5 are rejected."""
 
-    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 0})
+    r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 0})
     assert r.status_code == 400
-    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 6})
+    r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 6})
     assert r.status_code == 400
 
 
@@ -289,13 +299,13 @@ def test_rate_plugin_persistence(tmp_path: Path) -> None:
     path = tmp_path / "ratings.json"
     main.RATINGS_PATH = str(path)
     plugins.PLUGIN_CATALOG["demo"] = {}
-    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
+    r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
     assert r.status_code == 200
     assert r.json()["average"] == 5
     data = json.loads(path.read_text())
     assert data == {"demo": [5]}
     assert plugins.PLUGIN_CATALOG["demo"]["stars"] == 5
-    r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 3})
+    r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 3})
     assert r.status_code == 200
     assert r.json()["average"] == 4
     data = json.loads(path.read_text())
@@ -312,7 +322,7 @@ def test_concurrent_plugin_ratings(tmp_path: Path) -> None:
     plugins.PLUGIN_CATALOG["demo"] = {}
 
     def post_rating() -> None:
-        r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
+        r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 5})
         assert r.status_code == 200
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
@@ -334,7 +344,7 @@ def test_concurrent_ratings_file_valid(tmp_path: Path) -> None:
     plugins.PLUGIN_CATALOG["demo"] = {}
 
     def post_rating() -> None:
-        r = client.post("/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 4})
+        r = _request("POST", "/plugins/rate", headers=AUTH_HEADERS, json={"name": "demo", "rating": 4})
         assert r.status_code == 200
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as ex:

--- a/web/main.py
+++ b/web/main.py
@@ -73,19 +73,23 @@ def _load_plugin_ratings() -> None:
         }
 
 
-def _save_plugin_ratings() -> None:
+async def _save_plugin_ratings() -> None:
     """Persist plugin ratings to ``RATINGS_PATH`` if configured."""
     if not RATINGS_PATH:
         return
     path = Path(RATINGS_PATH)
     path.parent.mkdir(parents=True, exist_ok=True)
     data = json.dumps(PLUGIN_RATINGS)
-    with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as fh:
-        fh.seek(0)
-        fh.truncate(0)
-        fh.write(data)
-        fh.flush()
-        os.fsync(fh.fileno())
+
+    def _write() -> None:
+        with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as fh:
+            fh.seek(0)
+            fh.truncate(0)
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    await asyncio.to_thread(_write)
 
 
 def verify_token(
@@ -117,7 +121,7 @@ async def _startup() -> None:
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
-    _save_plugin_ratings()
+    await _save_plugin_ratings()
     if FastAPILimiter.redis:
         await FastAPILimiter.close()
 
@@ -511,12 +515,14 @@ async def upload_chunk(
     base_dir.mkdir(parents=True, exist_ok=True)
     chunk_bytes = base64.b64decode(req.data.encode("utf-8"), validate=True)
     chunk_path = base_dir / f"{req.offset}.chunk"
-    with open(chunk_path, "wb") as f:
-        f.write(chunk_bytes)
+    await asyncio.to_thread(chunk_path.write_bytes, chunk_bytes)
     manifest_path = base_dir / "upload.manifest"
     h = hashlib.sha256(chunk_bytes).hexdigest()
-    with open(manifest_path, "a", encoding="utf-8") as mf:
-        mf.write(json.dumps({"offset": req.offset, "hash": h}) + "\n")
+    async def _append() -> None:
+        with open(manifest_path, "a", encoding="utf-8") as mf:
+            mf.write(json.dumps({"offset": req.offset, "hash": h}) + "\n")
+
+    await asyncio.to_thread(_append)
     return {"status": "ok", "hash": h}
 
 
@@ -534,7 +540,7 @@ async def download_chunk(
     chunk_path = get_temp_dir() / "chunks" / file_id / f"{offset}.chunk"
     if not chunk_path.is_file():
         raise HTTPException(status_code=404, detail="Chunk not found")
-    data = chunk_path.read_bytes()
+    data = await asyncio.to_thread(chunk_path.read_bytes)
     return {"offset": str(offset), "data": base64.b64encode(data).decode("utf-8")}
 
 
@@ -578,7 +584,7 @@ async def rate_plugin(
     ratings.append(req.rating)
     avg = sum(ratings) / len(ratings)
     plugins.PLUGIN_CATALOG.setdefault(req.name, {}).update({"stars": avg})
-    _save_plugin_ratings()
+    await _save_plugin_ratings()
     return {"average": avg}
 
 


### PR DESCRIPTION
## Summary
- use `asyncio.to_thread` to handle plugin rating persistence asynchronously
- await plugin rating saves on shutdown and rating requests
- use `asyncio.to_thread` for chunk file operations
- adapt chunk and plugin API tests to make async requests

## Testing
- `ruff check . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f08d27d108326a4a890462077996f