### PR TITLE
Add optional MPI execution mode

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -44,6 +44,8 @@ def _apply_simulators(
     parallel: bool = False,
     threads: int | None = None,
     processes: int | None = None,
+    mpi: bool = False,
+    mpi_workers: int | None = None,
 ) -> str:
     channels: list[BaseChannel] = []
     for name in simulators:
@@ -52,12 +54,13 @@ def _apply_simulators(
             raise SystemExit(1)
         channels.append(SIMULATOR_REGISTRY[name])
     pipeline = ChannelPipeline(channels)
-    workers = processes or threads
+    workers = mpi_workers or processes or threads
     result: str = pipeline.simulate(
         sequence,
-        parallel=parallel,
+        parallel=parallel or mpi,
         workers=workers,
         use_process_pool=processes is not None,
+        use_mpi=mpi,
     )
     for name in simulators:
         logger.info("Applied %s simulator", name)
@@ -77,6 +80,8 @@ def process_channel(
     parallel: bool = False,
     threads: int | None = None,
     processes: int | None = None,
+    mpi: bool = False,
+    mpi_workers: int | None = None,
 ) -> None:
     try:
         with open(input_file, "r", encoding="utf-8") as f:
@@ -99,6 +104,8 @@ def process_channel(
                 parallel=parallel,
                 threads=threads,
                 processes=processes,
+                mpi=mpi,
+                mpi_workers=mpi_workers,
             )
         else:
             rng = random.Random(seed)
@@ -164,6 +171,8 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.add_argument("--parallel", action="store_true", help="Run channel steps in parallel")
     parser.add_argument("--threads", type=int, default=None, help="Number of worker threads")
     parser.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
+    parser.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
+    parser.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
     parser.set_defaults(func=_handle_command)
 
 
@@ -186,4 +195,6 @@ def _handle_command(args: argparse.Namespace) -> None:
         parallel=opts.parallel,
         threads=opts.threads,
         processes=opts.processes,
+        mpi=opts.mpi,
+        mpi_workers=opts.mpi_workers,
     )

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -22,6 +22,8 @@ class ChannelOptions:
     parallel: bool = False
     threads: int | None = None
     processes: int | None = None
+    mpi: bool = False
+    mpi_workers: int | None = None
 
 
 def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
@@ -82,6 +84,10 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("At least one simulator or probability option must be specified")
     if args.threads is not None and args.processes is not None:
         raise ValueError("Cannot specify both --threads and --processes")
+    if args.mpi and (args.threads is not None or args.processes is not None):
+        raise ValueError("Cannot combine MPI with threads or processes")
+    if args.mpi_workers is not None and not args.mpi:
+        raise ValueError("--mpi-workers requires --mpi")
 
     return ChannelOptions(
         simulators=simulators,
@@ -93,4 +99,6 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         parallel=args.parallel,
         threads=args.threads,
         processes=args.processes,
+        mpi=args.mpi,
+        mpi_workers=args.mpi_workers,
     )

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -30,7 +30,7 @@ def verify_token(
         raise HTTPException(status_code=401, detail="Invalid or missing token")
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 def _startup() -> None:
     global API_TOKEN
     load_plugins()
@@ -39,7 +39,7 @@ def _startup() -> None:
         print(f"Generated API token: {API_TOKEN}")
 
 
-@app.post("/jobs")
+@app.post("/jobs")  # type: ignore[misc]
 def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) -> dict[str, str]:
     if payload.get("type") != "bundle":
         raise HTTPException(status_code=400, detail="Unsupported job type")

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -27,8 +27,12 @@ class ChannelPipeline(BaseChannel):
         parallel: bool = False,
         workers: int | None = None,
         use_process_pool: bool = False,
+        use_mpi: bool = False,
     ) -> str:
         """Return ``sequence`` processed by each channel."""
+
+        if use_mpi:
+            parallel = True
 
         if not parallel or len(self.channels) <= 1:
             for channel in self.channels:
@@ -39,11 +43,18 @@ class ChannelPipeline(BaseChannel):
         if workers is None:
             workers = min(len(self.channels), os.cpu_count() or 1)
 
-        executor_cls = (
-            concurrent.futures.ProcessPoolExecutor
-            if use_process_pool
-            else concurrent.futures.ThreadPoolExecutor
-        )
+        if use_mpi:
+            try:
+                from mpi4py.futures import MPIPoolExecutor
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError("mpi4py is required for MPI execution") from exc
+            executor_cls = MPIPoolExecutor
+        else:
+            executor_cls = (
+                concurrent.futures.ProcessPoolExecutor
+                if use_process_pool
+                else concurrent.futures.ThreadPoolExecutor
+            )
 
         current = sequence
         with executor_cls(max_workers=workers) as executor:

--- a/tests/test_cli_channel_mpi.py
+++ b/tests/test_cli_channel_mpi.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from tests.test_cli import run_cli_command
+
+pytest.importorskip("mpi4py")
+if shutil.which("mpiexec") is None:
+    pytest.skip("mpiexec not available", allow_module_level=True)
+
+
+def create_fasta(path: Path, seq: str = "ACGT", header: str = "seq") -> None:
+    from src.genecoder.formats import to_fasta
+    path.write_text(to_fasta(seq, header))
+
+
+def test_channel_cli_mpi(tmp_path: Path) -> None:
+    input_fasta = tmp_path / "in.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out.fasta"
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "simple",
+            "--min-length",
+            "1",
+            "--mpi",
+            "--mpi-workers",
+            "2",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_mpi_pipeline.py
+++ b/tests/test_mpi_pipeline.py
@@ -1,0 +1,23 @@
+import pytest
+from genecoder.channel_sim import Channel
+from genecoder.simulators.pipeline import ChannelPipeline
+
+pytest.importorskip("mpi4py")
+import shutil
+
+if shutil.which("mpiexec") is None:
+    pytest.skip("mpiexec not available", allow_module_level=True)
+
+
+def test_mpi_pipeline_deterministic(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    pipeline = ChannelPipeline([Channel(0.1), Channel(0.2)])
+    seq = "ACGTACGTACGT"
+    serial = pipeline.simulate(seq)
+    mpi_result = pipeline.simulate(
+        seq,
+        parallel=True,
+        workers=2,
+        use_mpi=True,
+    )
+    assert serial == mpi_result


### PR DESCRIPTION
## Summary
- add MPI executor option to `ChannelPipeline`
- expose MPI flags in `genecoder` CLI
- extend `ChannelOptions` for MPI usage
- create MPI specific tests
- fix mypy issue in cloud worker

## Testing
- `pre-commit run --files src/genecoder/simulators/pipeline.py src/genecoder/cli/options.py src/genecoder/cli/channel.py tests/test_cli_channel_mpi.py tests/test_mpi_pipeline.py src/genecoder/cloud/worker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f08d320148326b054706020b335eb