### PR TITLE
Add challenge scoreboard API and UI

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -272,6 +272,22 @@ curl -X POST -H "Authorization: Bearer <TOKEN>" \
 
 List registered entries via ``GET /catalog/plugins``.
 
+## Plugin Challenge Rankings
+
+Set ``GENECODER_CHALLENGE_PATH`` to a JSON file to persist challenge scores. Add
+points by sending a POST request with a participant name and the number of
+points earned:
+
+```bash
+curl -X POST -H "Authorization: Bearer <TOKEN>" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "team1", "points": 5}' \
+     http://localhost:8000/catalog/challenge
+```
+
+Retrieve the current rankings via ``GET /catalog/challenge``. The ``/rankings``
+web page displays this data in a simple leaderboard.
+
 ## Submitting to the Marketplace
 
 Signed plugin packages can be shared publicly by submitting them to the GeneCoder marketplace. After building a wheel and generating the detached signature, visit the marketplace dashboard and upload both files. The system verifies the signature and runs automated checks before listing the plugin in the public catalog.

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -379,3 +379,23 @@ def test_plugin_catalog_crud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     r2 = client.get("/catalog/plugins")
     assert r2.status_code == 200
     assert r2.json()["plugins"] == [payload]
+
+
+def test_challenge_crud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_catalog, "CHALLENGE_PATH", str(tmp_path / "challenge.json"), raising=False)
+    plugin_catalog.CHALLENGE.clear()
+
+    r = client.get("/catalog/challenge")
+    assert r.status_code == 200
+    assert r.json() == {"entries": {}}
+
+    payload = {"name": "team", "points": 10}
+    r = client.post("/catalog/challenge", json=payload)
+    assert r.status_code == 401
+
+    r = client.post("/catalog/challenge", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+
+    r2 = client.get("/catalog/challenge")
+    assert r2.status_code == 200
+    assert r2.json()["entries"] == {"team": 10}

--- a/web/helix-ui/scoreboard.html
+++ b/web/helix-ui/scoreboard.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Challenge Rankings</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/scoreboard_main.jsx"></script>
+  </body>
+</html>

--- a/web/helix-ui/src/Scoreboard.jsx
+++ b/web/helix-ui/src/Scoreboard.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Scoreboard() {
+  const [entries, setEntries] = useState(null);
+
+  useEffect(() => {
+    fetch('/catalog/challenge')
+      .then((r) => r.json())
+      .then((data) => setEntries(data.entries || {}));
+  }, []);
+
+  if (!entries) {
+    return <div>Loading...</div>;
+  }
+
+  const sorted = Object.entries(entries).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Challenge Rankings</h1>
+      <ol>
+        {sorted.map(([name, points]) => (
+          <li key={name}>
+            {name} - {points} pts
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/web/helix-ui/src/scoreboard_main.jsx
+++ b/web/helix-ui/src/scoreboard_main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Scoreboard from './Scoreboard.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Scoreboard />
+  </React.StrictMode>
+);

--- a/web/main.py
+++ b/web/main.py
@@ -161,6 +161,10 @@ plugin_index_path = helix_ui_dir / "dist" / "plugins.html"
 if not plugin_index_path.is_file():
     plugin_index_path = helix_ui_dir / "plugins.html"
 
+scoreboard_index_path = helix_ui_dir / "dist" / "scoreboard.html"
+if not scoreboard_index_path.is_file():
+    scoreboard_index_path = helix_ui_dir / "scoreboard.html"
+
 design_index_path = helix_ui_dir / "dist" / "design.html"
 if not design_index_path.is_file():
     design_index_path = helix_ui_dir / "design.html"
@@ -186,6 +190,12 @@ async def dashboard() -> str:
 async def plugin_catalog_page() -> str:
     """Return the React-based plugin catalog interface."""
     return plugin_index_path.read_text(encoding="utf-8")
+
+
+@app.get("/rankings", response_class=HTMLResponse)
+async def rankings_page() -> str:
+    """Return the challenge rankings interface."""
+    return scoreboard_index_path.read_text(encoding="utf-8")
 
 
 @app.get("/design", response_class=HTMLResponse)

--- a/web/plugin_catalog.py
+++ b/web/plugin_catalog.py
@@ -1,7 +1,7 @@
 import os
 import json
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 import portalocker
 from fastapi import APIRouter, Depends, HTTPException
@@ -14,7 +14,9 @@ router = APIRouter()
 security = HTTPBearer(auto_error=False)
 
 CATALOG_PATH = os.getenv("GENECODER_CATALOG_PATH")
+CHALLENGE_PATH = os.getenv("GENECODER_CHALLENGE_PATH")
 CATALOG: List[Dict[str, Optional[str]]] = []
+CHALLENGE: Dict[str, int] = {}
 
 
 class PluginMetadata(BaseModel):
@@ -22,6 +24,11 @@ class PluginMetadata(BaseModel):
     version: str
     checksum: str
     signature: Optional[str] = None
+
+
+class ChallengeEntry(BaseModel):
+    name: str
+    points: int
 
 
 def _load_catalog() -> None:
@@ -49,6 +56,22 @@ def _load_catalog() -> None:
         ]
 
 
+def _load_challenge() -> None:
+    """Load challenge entries from ``CHALLENGE_PATH`` if configured."""
+    global CHALLENGE
+    if not CHALLENGE_PATH:
+        return
+    path = Path(CHALLENGE_PATH)
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if isinstance(data, dict):
+        CHALLENGE = {str(k): int(v) for k, v in data.items() if isinstance(v, int)}
+
+
 def _save_catalog() -> None:
     if not CATALOG_PATH:
         return
@@ -63,14 +86,30 @@ def _save_catalog() -> None:
         os.fsync(fh.fileno())
 
 
+def _save_challenge() -> None:
+    if not CHALLENGE_PATH:
+        return
+    path = Path(CHALLENGE_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(CHALLENGE)
+    with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as fh:
+        fh.seek(0)
+        fh.truncate(0)
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
 @router.on_event("startup")
 def _startup() -> None:
     _load_catalog()
+    _load_challenge()
 
 
 @router.on_event("shutdown")
 def _shutdown() -> None:
     _save_catalog()
+    _save_challenge()
 
 
 def _verify_token(
@@ -95,4 +134,21 @@ def add_plugin(
             raise HTTPException(status_code=409, detail="Plugin already exists")
     CATALOG.append(meta.dict())
     _save_catalog()
+    return {"status": "ok"}
+
+
+@router.get("/challenge")
+def list_challenge() -> Dict[str, Dict[str, int]]:
+    """Return current challenge rankings."""
+    return {"entries": CHALLENGE}
+
+
+@router.post("/challenge")
+def add_challenge(
+    entry: ChallengeEntry,
+    _: None = Depends(_verify_token),
+) -> Dict[str, str]:
+    """Submit challenge points for a participant."""
+    CHALLENGE[entry.name] = CHALLENGE.get(entry.name, 0) + entry.points
+    _save_challenge()
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- extend plugin catalog service with challenge support
- serve new rankings page from web UI
- document how to submit challenge scores

## Testing
- `ruff check .`
- `pytest -q` *(partial excerpt)*

------
https://chatgpt.com/codex/tasks/task_e_686f1491b2188326b7acf3acc37a26f1