### PR TITLE
Add data fetch service and CLI

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -37,3 +37,16 @@ docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN ghcr.io/d0ttino/genecoder \
 ```
 
 Replace `TOKEN` with a secret value and use the same token when submitting jobs.
+
+## Fetching Error Profiles
+
+GeneCoder can download example anonymized error profiles for use with simulators.
+Use the CLI to fetch a profile and store it in the local cache:
+
+```bash
+genecoder data fetch illumina_profile.json --url https://example.com/profiles
+```
+
+Profiles are saved under `~/.genecoder/data` by default. The location can be
+customized with the `--cache-dir` option or the `GENECODER_DATA_DIR`
+environment variable.

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -20,6 +20,7 @@ benchmark: Any | None = None
 cloud: Any | None = None
 decode_ai: Any | None = None
 stats: Any | None = None
+data: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -68,9 +69,10 @@ def build_parser() -> argparse.ArgumentParser:
         plugin as _plugin_mod,
         benchmark as _benchmark,
         stats as _stats,
+        data as _data,
     )
 
-    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai, stats
+    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai, stats, data
 
     encode = _encode
     decode = _decode
@@ -83,6 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
     plugin = _plugin_mod
     benchmark = _benchmark
     stats = _stats
+    data = _data
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -114,6 +117,7 @@ def build_parser() -> argparse.ArgumentParser:
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)
     stats.register_subcommand(subparsers)
+    data.register_subcommand(subparsers)
 
     return parser
 

--- a/src/genecoder/cli/data.py
+++ b/src/genecoder/cli/data.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from genecoder.data_service import fetch_profile, DEFAULT_BASE_URL
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser("data", help="Manage datasets")
+    data_sub = parser.add_subparsers(dest="data_cmd", required=True)
+
+    fetch_p = data_sub.add_parser("fetch", help="Download an error profile")
+    fetch_p.add_argument("profile", help="Profile name to download")
+    fetch_p.add_argument("--url", default=DEFAULT_BASE_URL, help="Base URL")
+    fetch_p.add_argument("--cache-dir", type=str, help="Cache directory")
+    fetch_p.add_argument("--refresh", action="store_true", help="Re-download even if cached")
+    fetch_p.set_defaults(func=_handle_fetch)
+
+
+def _handle_fetch(args: argparse.Namespace) -> None:
+    cache_dir = Path(args.cache_dir) if args.cache_dir else None
+    path = fetch_profile(args.profile, base_url=args.url, cache_dir=cache_dir, refresh=args.refresh)
+    print(path)

--- a/src/genecoder/data_service.py
+++ b/src/genecoder/data_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import urllib.request
+from pathlib import Path
+
+__all__ = ["get_cache_dir", "fetch_profile", "is_cached"]
+
+DEFAULT_BASE_URL = "https://example.com/profiles"
+
+
+def get_cache_dir() -> Path:
+    env = os.getenv("GENECODER_DATA_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".genecoder" / "data"
+
+
+def is_cached(profile: str, cache_dir: Path | None = None) -> bool:
+    path = (cache_dir or get_cache_dir()) / profile
+    return path.is_file()
+
+
+def fetch_profile(
+    profile: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    cache_dir: Path | None = None,
+    refresh: bool = False,
+) -> Path:
+    """Download ``profile`` to ``cache_dir`` if needed and return its path."""
+    cache_dir = cache_dir or get_cache_dir()
+    dest = cache_dir / profile
+    if dest.is_file() and not refresh:
+        return dest
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    url = f"{base_url.rstrip('/')}/{profile}"
+    with urllib.request.urlopen(url) as resp:
+        dest.write_bytes(resp.read())
+    return dest

--- a/tests/data/illumina_profile.json
+++ b/tests/data/illumina_profile.json
@@ -1,0 +1,1 @@
+{"sub_rate": 0.05, "ins_rate": 0.01, "del_rate": 0.02}

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+import urllib.request
+
+import pytest
+
+from genecoder.data_service import fetch_profile
+from tests.test_cli import run_cli_command
+
+
+def test_fetch_profile_download_and_cache(tmp_path: Path) -> None:
+    base = Path(__file__).parent / "data"
+    cache = tmp_path / "cache"
+    url = base.resolve().as_uri()
+    path = fetch_profile("illumina_profile.json", base_url=url, cache_dir=cache)
+    assert path.is_file()
+    assert path.read_bytes() == (base / "illumina_profile.json").read_bytes()
+    # second call should use cache
+    called = False
+
+    def fake_open(url: str):
+        nonlocal called
+        called = True
+        raise RuntimeError("network call")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    try:
+        path2 = fetch_profile(
+            "illumina_profile.json", base_url=url, cache_dir=cache
+        )
+    finally:
+        monkeypatch.undo()
+    assert path2 == path
+    assert not called
+
+
+def test_cli_data_fetch(tmp_path: Path) -> None:
+    base = Path(__file__).parent / "data"
+    env = os.environ.copy()
+    env["GENECODER_DATA_DIR"] = str(tmp_path / "cache")
+    src = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = str(src) + os.pathsep + env.get("PYTHONPATH", "")
+    result = run_cli_command([
+        "data",
+        "fetch",
+        "illumina_profile.json",
+        "--url",
+        base.resolve().as_uri(),
+    ], env=env)
+    assert result.returncode == 0
+    cached = Path(env["GENECODER_DATA_DIR"]) / "illumina_profile.json"
+    assert cached.is_file()


### PR DESCRIPTION
## Summary
- add `data_service` module for downloading/caching profiles
- implement `genecoder data fetch` CLI command
- document profile downloading in docs/cloud.md
- include sample profile for tests
- test new fetch logic and CLI

## Testing
- `ruff src/genecoder/cli/data.py src/genecoder/data_service.py tests/test_data_service.py docs/cloud.md`
- `mypy src/genecoder/cli/data.py src/genecoder/data_service.py tests/test_data_service.py`
- `pytest -q tests/test_data_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686f14911a488326a07854204ab1266f