### PR TITLE
Add ZIP path validation in worker

### DIFF
--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -56,6 +56,10 @@ def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) ->
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            for name in zf.namelist():
+                path = Path(name)
+                if path.is_absolute() or ".." in path.parts:
+                    raise HTTPException(status_code=400, detail="Invalid archive path")
             zf.extractall(tmpdir)
         tmp_path = Path(tmpdir)
         yaml_files = [p for p in tmp_path.iterdir() if p.suffix in {".yaml", ".yml"}]

--- a/tests/test_worker_security.py
+++ b/tests/test_worker_security.py
@@ -1,0 +1,30 @@
+import base64
+import zipfile
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from genecoder.cloud import worker
+
+
+def _build_archive(name: str, tmp_path: Path) -> str:
+    archive = tmp_path / "archive.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr(name, "x")
+    return base64.b64encode(archive.read_bytes()).decode()
+
+
+@pytest.mark.parametrize("name", ["../evil.yaml", "/abs.yaml"])
+def test_worker_rejects_bad_paths(tmp_path: Path, name: str) -> None:
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    archive_b64 = _build_archive(name, tmp_path)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary
- validate archive member paths in `genecoder.cloud.worker`
- reject archives with absolute or parent directory components
- cover malicious archive cases with a new regression test

## Testing
- `ruff check src/genecoder/cloud/worker.py tests/test_worker_security.py`
- `pytest tests/test_cloud.py tests/test_worker_metrics.py tests/test_worker_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1b03c4308326b07383c6b4f983af