### PR TITLE
Refactor channel option validation

### DIFF
--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Sequence
 
 from genecoder.options import EncodingOptions, DecodingOptions
 
@@ -24,6 +24,22 @@ class ChannelOptions:
     processes: int | None = None
     mpi: bool = False
     mpi_workers: int | None = None
+
+
+def _validate_simulator_prob_args(
+    simulators: Sequence[str], sub_prob: float, ins_prob: float, del_prob: float
+) -> None:
+    """Ensure that simulator and probability arguments are valid."""
+
+    prob_specified = any([sub_prob, ins_prob, del_prob])
+    if simulators and prob_specified:
+        raise ValueError(
+            "Probability options cannot be combined with --simulator or --config"
+        )
+    if not simulators and not prob_specified:
+        raise ValueError(
+            "At least one simulator or probability option must be specified"
+        )
 
 
 def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
@@ -77,11 +93,9 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
             simulators = cfg_sim
         constraints.update(cfg_con)
 
-    prob_specified = any([args.sub_prob, args.ins_prob, args.del_prob])
-    if simulators and prob_specified:
-        raise ValueError("Probability options cannot be combined with --simulator or --config")
-    if not simulators and not prob_specified:
-        raise ValueError("At least one simulator or probability option must be specified")
+    _validate_simulator_prob_args(
+        simulators, args.sub_prob, args.ins_prob, args.del_prob
+    )
     if args.threads is not None and args.processes is not None:
         raise ValueError("Cannot specify both --threads and --processes")
     if args.mpi and (args.threads is not None or args.processes is not None):

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -1,0 +1,60 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from src.genecoder.cli.options import build_channel_options
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    defaults = dict(
+        simulators=[],
+        sub_prob=0.0,
+        ins_prob=0.0,
+        del_prob=0.0,
+        seed=None,
+        parallel=False,
+        threads=None,
+        processes=None,
+        mpi=False,
+        mpi_workers=None,
+        config=None,
+        min_length=1,
+        max_length=300,
+        max_homopolymer=4,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_only_simulators_ok() -> None:
+    args = _make_args(simulators=["simple"])
+    opts = build_channel_options(args)
+    assert opts.simulators == ["simple"]
+
+
+def test_only_probabilities_ok() -> None:
+    args = _make_args(sub_prob=0.1)
+    opts = build_channel_options(args)
+    assert opts.sub_prob == 0.1
+
+
+def test_simulators_and_probabilities_error() -> None:
+    args = _make_args(simulators=["simple"], sub_prob=0.1)
+    with pytest.raises(ValueError, match="Probability options cannot"):
+        build_channel_options(args)
+
+
+def test_no_simulators_or_probabilities_error() -> None:
+    args = _make_args()
+    with pytest.raises(ValueError, match="At least one simulator"):
+        build_channel_options(args)
+
+
+def test_config_and_probabilities_error(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("simulators:\n  - simple\n")
+    args = _make_args(config=str(cfg), sub_prob=0.1)
+    with pytest.raises(ValueError, match="Probability options cannot"):
+        build_channel_options(args)
+


### PR DESCRIPTION
## Summary
- refactor CLI option validation for channel subcommand
- add unit tests covering validation logic

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1fe3275c83268656d0b0b0a767a9