### PR TITLE
Add vitest for scoreboard sorting

### DIFF
--- a/web/helix-ui/src/Scoreboard.test.jsx
+++ b/web/helix-ui/src/Scoreboard.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import Scoreboard from './Scoreboard.jsx';
+
+// Mock the challenge fetch
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        entries: {
+          Bob: 30,
+          Alice: 40,
+        },
+      }),
+  })
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('renders entries sorted by score', async () => {
+  render(<Scoreboard />);
+  const items = await screen.findAllByRole('listitem');
+  expect(items[0]).toHaveTextContent('Alice - 40 pts');
+  expect(items[1]).toHaveTextContent('Bob - 30 pts');
+});


### PR DESCRIPTION
## Summary
- add Scoreboard.test.jsx
- verify scoreboard entries are sorted by score using mocked data

## Testing
- `npm test` in `web/helix-ui`
- `pre-commit run --files helix-ui/src/Scoreboard.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_686f236557588326adaeb5cba8cb1681