### PR TITLE
Verify catalog signatures

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -167,6 +167,12 @@ plugins:
     stars: 4.5
 ```
 
+If the catalog is signed the file should also include a top-level
+``signature`` field with the base64 encoded signature. Set
+``GENECODER_CATALOG_PUBLIC_KEY`` to the path of the PEM encoded public key used
+to verify the catalog. GeneCoder ignores catalogs whose signatures fail to
+verify.
+
 The URL may use HTTP(S) or point to a local file via ``file://``.
 
 JSON uses the same keys:

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -9,7 +9,6 @@ import tempfile
 import urllib.request
 from urllib.parse import urlparse
 import importlib
-import hashlib
 import base64
 from pathlib import Path
 
@@ -55,17 +54,24 @@ def register_simulator(name: str, channel: BaseChannel) -> None:
 
 
 def _verify_catalog_signature(data: bytes, signature: str) -> bool:
-    """Return True if ``data`` matches ``signature``.
+    """Return ``True`` if ``signature`` verifies ``data`` using a public key."""
 
-    The default implementation uses a SHA256 hex digest. This is a minimal
-    check intended mainly for testing and does not provide real security.
-    """
+    key_path = os.getenv("GENECODER_CATALOG_PUBLIC_KEY")
+    if not key_path:
+        return False
 
     try:
-        digest = hashlib.sha256(data).hexdigest()
+        sig_bytes = base64.b64decode(signature)
+        pubkey = Path(key_path).read_bytes()
     except Exception:
         return False
-    return digest == signature
+
+    try:
+        compute_checksum(data, signature=sig_bytes, public_key=pubkey)
+    except Exception:
+        return False
+
+    return True
 
 
 def _install_registry_plugins(url: str) -> None:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -366,3 +366,26 @@ def test_registry_install_via_httpx_checksum_mismatch(
 
     assert not installs
     assert "Checksum mismatch for plugin https://example.com/pkg.whl" in caplog.text
+
+
+def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Catalog signatures are verified using the configured public key."""
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    sig_b64 = base64.b64encode(b"sig").decode()
+    calls: list[tuple[bytes, bytes, bytes]] = []
+
+    def fake_compute(
+        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
+    ) -> str:
+        assert signature is not None and public_key is not None
+        calls.append((data, signature, public_key))
+        return compute_checksum(data)
+
+    monkeypatch.setenv("GENECODER_CATALOG_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+
+    assert plugins._verify_catalog_signature(b"DATA", sig_b64)
+    assert calls == [(b"DATA", b"sig", b"PUB")]


### PR DESCRIPTION
## Summary
- verify plugin catalog signatures using compute_checksum with a public key
- document GENECODER_CATALOG_PUBLIC_KEY
- test catalog signature validation

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701d15654083268546c622804bd35d