### PR TITLE
Add scoreboard API persistence test

### DIFF
--- a/tests/test_scoreboard_api.py
+++ b/tests/test_scoreboard_api.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+import web.main as main
+from web import plugin_catalog
+
+main.API_TOKEN = "test-token"
+client = TestClient(main.app)
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
+
+def test_challenge_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_catalog, "CHALLENGE_PATH", str(tmp_path / "challenge.json"), raising=False)
+    plugin_catalog.CHALLENGE.clear()
+
+    r = client.get("/catalog/challenge")
+    assert r.status_code == 200
+    assert r.json() == {"entries": {}}
+
+    payload = {"name": "team", "points": 7}
+    r = client.post("/catalog/challenge", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+
+    data = json.loads((tmp_path / "challenge.json").read_text())
+    assert data == {"team": 7}
+
+    plugin_catalog.CHALLENGE.clear()
+    plugin_catalog._load_challenge()
+
+    assert plugin_catalog.CHALLENGE == {"team": 7}
+
+    r2 = client.get("/catalog/challenge")
+    assert r2.status_code == 200
+    assert r2.json()["entries"] == {"team": 7}


### PR DESCRIPTION
## Summary
- add a new test for scoreboard challenge API persistence

## Testing
- `ruff check tests/test_scoreboard_api.py`
- `pytest tests/test_scoreboard_api.py::test_challenge_persistence -q`


------
https://chatgpt.com/codex/tasks/task_e_68701d15aa2883268ef3dc0782ffda53