### PR TITLE
Refactor plugin checksums into helper module

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -25,7 +25,7 @@ import logging
 import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from .security import compute_checksum
+from .plugin_security import compute_checksum, verify_signature
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ def _verify_catalog_signature(data: bytes, signature: str) -> bool:
         return False
 
     try:
-        compute_checksum(data, signature=sig_bytes, public_key=pubkey)
+        verify_signature(data, sig_bytes, pubkey)
     except Exception:
         return False
 
@@ -140,17 +140,16 @@ def _install_registry_plugins(url: str) -> None:
             logger.warning("Failed to download plugin %s: %s", spec, exc)
             continue
 
+        digest = compute_checksum(pkg_bytes)
         if signature is not None:
             if pubkey is None:
                 logger.warning("No public key configured for signed plugin %s", spec)
                 continue
             try:
-                digest = compute_checksum(pkg_bytes, signature=signature, public_key=pubkey)
+                verify_signature(pkg_bytes, signature, pubkey)
             except Exception as exc:
                 logger.warning("Invalid signature for plugin %s: %s", spec, exc)
                 continue
-        else:
-            digest = compute_checksum(pkg_bytes)
 
         if digest != checksum:
             logger.warning("Checksum mismatch for plugin %s", spec)

--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Utilities for verifying plugin packages."""
+
+from .security import compute_checksum as _compute_checksum
+
+
+def compute_checksum(data: bytes) -> str:
+    """Return the SHA256 checksum of *data*."""
+    return _compute_checksum(data)
+
+
+def verify_signature(data: bytes, signature: bytes, public_key: bytes) -> None:
+    """Raise if *signature* does not verify *data* with *public_key*."""
+    _compute_checksum(data, signature=signature, public_key=public_key)

--- a/tests/test_cli_plugin_catalog.py
+++ b/tests/test_cli_plugin_catalog.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
-from genecoder.security import compute_checksum
+from genecoder.plugin_security import compute_checksum
 
 from tests.test_cli import run_cli_command
 

--- a/tests/test_plugin_cli_registry.py
+++ b/tests/test_plugin_cli_registry.py
@@ -8,7 +8,7 @@ import pytest
 
 import genecoder.plugin_manager as plugins
 from genecoder.cli import plugin as plugin_cli
-from genecoder.security import compute_checksum
+from genecoder.plugin_security import compute_checksum
 
 
 class DummyResponse:
@@ -52,6 +52,7 @@ def test_cli_registry_install(monkeypatch: pytest.MonkeyPatch) -> None:
         "compute_checksum",
         lambda d, *, signature=None, public_key=None: compute_checksum(d),
     )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
 
     plugin_cli._handle_install_registry(
@@ -98,6 +99,7 @@ def test_cli_registry_install_failure(
         "compute_checksum",
         lambda d, *, signature=None, public_key=None: compute_checksum(d),
     )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
 
     with caplog.at_level(logging.WARNING):
@@ -144,6 +146,7 @@ def test_cli_registry_signature_failure(
         return compute_checksum(data)
 
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: (_ for _ in ()).throw(ValueError("bad sig")))
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
 
     with caplog.at_level(logging.WARNING):
@@ -182,6 +185,7 @@ def test_cli_registry_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, caplog:
         "compute_checksum",
         lambda d, *, signature=None, public_key=None: compute_checksum(d),
     )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
 
     with caplog.at_level(logging.WARNING):

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -8,7 +8,7 @@ import pytest
 
 import genecoder.plugin_manager as plugins
 from genecoder.cli import plugin as plugin_cli
-from genecoder.security import compute_checksum
+from genecoder.plugin_security import compute_checksum
 
 
 class DummyResponse:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -7,7 +7,7 @@ import pytest
 httpx = pytest.importorskip("httpx")
 
 import genecoder.plugin_manager as plugins
-from genecoder.security import compute_checksum
+from genecoder.plugin_security import compute_checksum
 import base64
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- add `plugin_security` module for plugin checksum and signature verification
- use `plugin_security` in `plugin_manager`
- update plugin tests to import from `plugin_security`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702c8ed7488326be3831cefcbe734c