### PR TITLE
Add metrics manager and migrate module usage

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -7,3 +7,9 @@ GeneCoder records basic usage statistics in a `metrics.json` file located in `~/
 - `oligos_simulated` – total sequences processed by channel simulations.
 
 Display these values with `genecoder stats` or via the `/metrics` web API endpoint. Set the `GENECODER_METRICS_PATH` environment variable to use a custom file location.
+
+## Migration notes
+
+Version 0.1.1 replaces the previous module-level helpers with a `Metrics` manager
+found in `genecoder.metrics`. The legacy `increment` and `get_metrics` functions
+remain as thin wrappers around this instance.

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 from . import cli as cli_module
-from genecoder.metrics import increment as increment_metric
+from genecoder.metrics import metrics
 
 _ALLOWED_CACHE: dict[str, set[str]] | None = None
 
@@ -183,4 +183,4 @@ def _handle_run(args: argparse.Namespace) -> None:
     if args.export_archive:
         _create_archive(run_dir, Path(args.export_archive), config_hash)
 
-    increment_metric("bundle_runs")
+    metrics.increment("bundle_runs")

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -16,7 +16,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
-from genecoder.metrics import increment as increment_metric
+from genecoder.metrics import metrics
 from .options import ChannelOptions, build_channel_options
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ def process_channel(
                 deletion_prob=del_prob,
                 rng=rng,
             )
-            increment_metric("oligos_simulated")
+            metrics.increment("oligos_simulated")
 
         if not validate_sequence(seq, synth):
             logger.error("Sequence violates synthesis constraints")

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -10,7 +10,7 @@ import os
 from ..options import EncodingOptions
 from pathlib import Path
 from .options import build_encoding_options
-from genecoder.metrics import increment as increment_metric
+from genecoder.metrics import metrics
 
 from genecoder.manifest import generate_manifest
 from genecoder.encoders import (
@@ -611,5 +611,5 @@ def _handle_command(args: argparse.Namespace) -> None:
             writer.writerows(csv_rows)
         logger.info(f"CSV order file written to {args.export_csv}")
 
-    increment_metric("encode_runs")
+    metrics.increment("encode_runs")
 

--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -1,8 +1,9 @@
 import json
 import os
+import threading
 from pathlib import Path
 
-__all__ = ["increment", "get_metrics"]
+__all__ = ["Metrics", "metrics", "increment", "get_metrics"]
 
 
 def _get_metrics_path() -> Path:
@@ -12,8 +13,7 @@ def _get_metrics_path() -> Path:
     return Path.home() / ".genecoder" / "metrics.json"
 
 
-def _load() -> dict[str, int]:
-    path = _get_metrics_path()
+def _load(path: Path) -> dict[str, int]:
     if path.is_file():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -24,17 +24,44 @@ def _load() -> dict[str, int]:
     return {}
 
 
-def _save(metrics: dict[str, int]) -> None:
-    path = _get_metrics_path()
+def _save(path: Path, metrics: dict[str, int]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(metrics), encoding="utf-8")
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(metrics), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+class Metrics:
+    """Simple metrics manager for atomic updates."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """Metrics file path, respecting environment overrides."""
+        return self._path or _get_metrics_path()
+
+    def increment(self, key: str) -> None:
+        with self._lock:
+            metrics = _load(self.path)
+            metrics[key] = metrics.get(key, 0) + 1
+            _save(self.path, metrics)
+
+    def get_metrics(self) -> dict[str, int]:
+        with self._lock:
+            return _load(self.path)
+
+
+metrics = Metrics()
 
 
 def increment(key: str) -> None:
-    metrics = _load()
-    metrics[key] = metrics.get(key, 0) + 1
-    _save(metrics)
+    metrics.increment(key)
 
 
 def get_metrics() -> dict[str, int]:
-    return _load()
+    return metrics.get_metrics()
+
+

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -5,7 +5,7 @@ import concurrent.futures
 import os
 
 from ..channels.base import BaseChannel
-from ..metrics import increment as increment_metric
+from ..metrics import metrics
 
 __all__ = ["ChannelPipeline"]
 
@@ -37,7 +37,7 @@ class ChannelPipeline(BaseChannel):
         if not parallel or len(self.channels) <= 1:
             for channel in self.channels:
                 sequence = channel.simulate(sequence)
-            increment_metric("oligos_simulated")
+            metrics.increment("oligos_simulated")
             return sequence
 
         if workers is None:
@@ -60,5 +60,5 @@ class ChannelPipeline(BaseChannel):
         with executor_cls(max_workers=workers) as executor:
             for channel in self.channels:
                 current = executor.submit(channel.simulate, current).result()
-        increment_metric("oligos_simulated")
+        metrics.increment("oligos_simulated")
         return current


### PR DESCRIPTION
## Summary
- add `Metrics` manager class for atomic updates
- swap old increment helpers for `metrics.increment`
- note the new manager in the metrics docs
- fix metrics manager to respect `GENECODER_METRICS_PATH`

## Testing
- `ruff check src/genecoder/metrics.py src/genecoder/cli/bundle.py src/genecoder/cli/encode.py src/genecoder/cli/channel.py src/genecoder/simulators/pipeline.py`
- `mypy src/genecoder/metrics.py src/genecoder/cli/bundle.py src/genecoder/cli/encode.py src/genecoder/cli/channel.py src/genecoder/simulators/pipeline.py`
- `pytest tests/test_metrics.py tests/test_worker_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68702c8ef76c83268ed1231f601cba35