### PR TITLE
Enable mypy error codes

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -160,7 +160,7 @@ jobs:
       run: pip install .[dev]
 
     - name: Run mypy
-      run: mypy --config-file mypy.ini --show-error-codes --no-error-summary
+      run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary
 
   glossary:
     needs: [changes, check-comments, lint]
@@ -224,7 +224,7 @@ jobs:
       run: pip install .[dev]
 
     - name: Run mypy
-      run: mypy --config-file mypy.ini --show-error-codes --no-error-summary
+      run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary
 
 
     - name: Setup Node

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        args: ["--config-file", "pyproject.toml"]
+        args: ["--config-file", "pyproject.toml", "--show-error-codes"]
         pass_filenames: false
         additional_dependencies: ["cryptography", "types-PyYAML"]
   - repo: https://github.com/tcort/markdown-link-check

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,4 +3,6 @@ python_version = 3.11
 ignore_missing_imports = true
 strict = true
 explicit_package_bases = true
+show_error_codes = true
+enable_error_code = ignore-without-code
 files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ python_version = "3.11"
 ignore_missing_imports = true
 strict = true
 explicit_package_bases = true
+show_error_codes = true
+enable_error_code = "ignore-without-code"
 files = [
     "src",
     "plugins-examples/example_codec/example_codec",

--- a/src/genecoder/bch_codec.py
+++ b/src/genecoder/bch_codec.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import bchlib
 else:  # pragma: no cover - optional dependency
     try:
-        import bchlib  # type: ignore
+        import bchlib
         try:
             # Verify library is functional; some wheels may load but fail
             bchlib.BCH(5, 2)
@@ -19,7 +19,7 @@ else:  # pragma: no cover - optional dependency
         else:
             _HAS_BCHLIB = True
     except Exception:  # pragma: no cover - missing optional dependency
-        bchlib = None  # type: ignore
+        bchlib = None
         _HAS_BCHLIB = False
 
 

--- a/src/genecoder/deepdna_codec.py
+++ b/src/genecoder/deepdna_codec.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
     import deepdna
 else:  # pragma: no cover - optional dependency
     try:
-        import deepdna  # type: ignore
+        import deepdna
         _HAS_DEEPDNA = True
     except Exception:  # pragma: no cover - missing optional dependency
-        deepdna = None  # type: ignore
+        deepdna = None
         _HAS_DEEPDNA = False
 
 

--- a/src/genecoder/dnaformer_codec.py
+++ b/src/genecoder/dnaformer_codec.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
     import dnaformer
 else:  # pragma: no cover - optional dependency
     try:
-        import dnaformer  # type: ignore
+        import dnaformer
         _HAS_DNAFORMER = True
     except Exception:  # pragma: no cover - missing optional dependency
-        dnaformer = None  # type: ignore
+        dnaformer = None
         _HAS_DNAFORMER = False
 
 

--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -13,7 +13,7 @@ else:
         from pyfinite import ffield
         _HAS_PYFINITE = True
     except Exception:  # pragma: no cover - missing optional dependency
-        ffield = None  # type: ignore
+        ffield = None
         _HAS_PYFINITE = False
 
 

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -24,12 +24,12 @@ else:
             _HAS_PYLDPC = False
         import importlib.util
         if importlib.util.find_spec("numpy") is None:  # pragma: no cover
-            np = None  # type: ignore
+            np = None
         else:
-            import numpy as np  # type: ignore
+            import numpy as np
     except Exception:  # pragma: no cover - missing optional dependency
-        make_ldpc = decode = utils = None  # type: ignore
-        np = None  # type: ignore
+        make_ldpc = decode = utils = None
+        np = None
         _HAS_PYLDPC = False
 
 

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
 
 else:  # pragma: no cover - optional dependency
     try:
-        import raptorq  # type: ignore
+        import raptorq
         try:
-            from raptorq import raptorq as _rq  # type: ignore
+            from raptorq import raptorq as _rq
         except Exception:
-            _rq = raptorq  # type: ignore
+            _rq = raptorq
         if hasattr(_rq, "Encoder") and hasattr(_rq, "Decoder"):
             try:
                 enc = _rq.Encoder.with_defaults(b"t", 1)
@@ -33,8 +33,8 @@ else:  # pragma: no cover - optional dependency
         else:
             _HAS_RAPTORQ = False
     except Exception:  # pragma: no cover - missing optional dependency
-        raptorq = None  # type: ignore
-        _rq = None  # type: ignore
+        raptorq = None
+        _rq = None
         _HAS_RAPTORQ = False
 
 


### PR DESCRIPTION
## Summary
- enforce error code annotations in mypy
- display mypy error codes in output
- update pre-commit hook to use the new setting
- drop unused `type: ignore` directives and tweak CI to use `pyproject.toml`

## Testing
- `pytest -q tests/test_plugin_loading.py::test_load_plugins_idempotent`
- `ruff check src/genecoder/ldpc_codec.py src/genecoder/bch_codec.py src/genecoder/deepdna_codec.py src/genecoder/dnaformer_codec.py src/genecoder/fountain_codec.py src/genecoder/raptorq_codec.py src/genecoder/cloud/worker.py`
- `mypy --config-file pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68703aeb5d54832688bf3f39d15d3db6