### PR TITLE
Enforce plugin signature validation

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -165,7 +165,11 @@ def _handle_install(args: argparse.Namespace) -> None:
 
 
 def _handle_install_registry(args: argparse.Namespace) -> None:
-    plugins.install_registry_plugins(args.url)
+    try:
+        plugins.install_registry_plugins(args.url)
+    except ValueError as exc:
+        logger.error(str(exc))
+        raise SystemExit(1)
 
 
 def _handle_rate(args: argparse.Namespace) -> None:

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -113,13 +113,12 @@ def _install_registry_plugins(url: str) -> None:
             checksum = str(entry.get("checksum", ""))
             sig_b64 = entry.get("signature")
             if not isinstance(sig_b64, str):
-                logger.warning("Missing signature for plugin entry %s", entry)
-                continue
+                raise ValueError(f"Missing signature for plugin entry {entry}")
             try:
                 signature = base64.b64decode(sig_b64)
-            except Exception:
-                logger.warning("Invalid signature for plugin entry %s", entry)
-                continue
+            except Exception as exc:
+                raise ValueError(
+                    f"Invalid signature for plugin entry {entry}") from exc
         else:
             logger.warning("Missing checksum for plugin entry %s", entry)
             continue
@@ -143,13 +142,15 @@ def _install_registry_plugins(url: str) -> None:
         digest = compute_checksum(pkg_bytes)
         if signature is not None:
             if pubkey is None:
-                logger.warning("No public key configured for signed plugin %s", spec)
+                logger.warning(
+                    "No public key configured for signed plugin %s", spec
+                )
                 continue
             try:
                 verify_signature(pkg_bytes, signature, pubkey)
             except Exception as exc:
-                logger.warning("Invalid signature for plugin %s: %s", spec, exc)
-                continue
+                raise ValueError(
+                    f"Invalid signature for plugin {spec}: {exc}") from exc
 
         if digest != checksum:
             logger.warning("Checksum mismatch for plugin %s", spec)

--- a/tests/test_plugin_cli_registry.py
+++ b/tests/test_plugin_cli_registry.py
@@ -149,7 +149,7 @@ def test_cli_registry_signature_failure(
     monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: (_ for _ in ()).throw(ValueError("bad sig")))
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit):
         plugin_cli._handle_install_registry(
             argparse.Namespace(url="https://example.com/plugins.yaml")
         )

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -212,3 +212,58 @@ def test_catalog_invalid_signature(monkeypatch, caplog):
     assert "Invalid catalog signature" in caplog.text
     assert plugins.PLUGIN_CATALOG == {}
 
+
+def test_registry_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+
+    with pytest.raises(ValueError):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")
+
+
+def test_registry_signature_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(
+        plugins, "verify_signature", lambda d, s, k: (_ for _ in ()).throw(ValueError("bad")))
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+
+    with pytest.raises(ValueError):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")
+

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -215,11 +215,10 @@ def test_registry_signature_failure(monkeypatch: pytest.MonkeyPatch, caplog: pyt
 
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError):
         plugins.install_registry_plugins()
 
     assert not installs
-    assert "Invalid signature for plugin https://example.com/pkgF.whl" in caplog.text
 
 
 def test_registry_checksum_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- raise `ValueError` when plugin registry entries lack or have invalid signatures
- exit CLI with error on invalid registry signatures
- test error behaviour for missing or bad signatures

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687043b75fe08326951cfbef66eed299