### PR TITLE
Add min/max length validation

### DIFF
--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -96,6 +96,12 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
     _validate_simulator_prob_args(
         simulators, args.sub_prob, args.ins_prob, args.del_prob
     )
+    if args.min_length <= 0:
+        raise ValueError("min_length must be greater than 0")
+    if args.max_length <= 0:
+        raise ValueError("max_length must be greater than 0")
+    if args.min_length > args.max_length:
+        raise ValueError("min_length cannot be greater than max_length")
     if args.threads is not None and args.processes is not None:
         raise ValueError("Cannot specify both --threads and --processes")
     if args.mpi and (args.threads is not None or args.processes is not None):

--- a/src/genecoder/synthesis.py
+++ b/src/genecoder/synthesis.py
@@ -15,6 +15,14 @@ class SynthesisConstraints:
     max_length: int = 300
     max_homopolymer: int = 4
 
+    def __post_init__(self) -> None:
+        if self.min_length <= 0:
+            raise ValueError("min_length must be greater than 0")
+        if self.max_length <= 0:
+            raise ValueError("max_length must be greater than 0")
+        if self.min_length > self.max_length:
+            raise ValueError("min_length cannot be greater than max_length")
+
 
 def validate_sequence(seq: str, constraints: SynthesisConstraints | None = None) -> bool:
     """Return ``True`` if ``seq`` satisfies ``constraints``."""

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -99,3 +99,21 @@ def test_mpi_options_ok() -> None:
     assert opts.mpi is True
     assert opts.mpi_workers == 2
 
+
+def test_min_length_invalid() -> None:
+    args = _make_args(simulators=["simple"], min_length=0)
+    with pytest.raises(ValueError, match="min_length"):
+        build_channel_options(args)
+
+
+def test_max_length_invalid() -> None:
+    args = _make_args(simulators=["simple"], max_length=0)
+    with pytest.raises(ValueError, match="max_length"):
+        build_channel_options(args)
+
+
+def test_min_length_greater_than_max() -> None:
+    args = _make_args(simulators=["simple"], min_length=10, max_length=5)
+    with pytest.raises(ValueError, match="min_length cannot be greater"):
+        build_channel_options(args)
+

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.formats import to_fasta
+import pytest
 
 
 import os
@@ -34,6 +35,21 @@ def test_validate_sequence_fail_length() -> None:
 def test_validate_sequence_fail_homopolymer() -> None:
     constraints = SynthesisConstraints(min_length=5, max_length=10, max_homopolymer=2)
     assert not validate_sequence("AAACCC", constraints)
+
+
+def test_constraints_invalid_min_length() -> None:
+    with pytest.raises(ValueError):
+        SynthesisConstraints(min_length=0, max_length=10)
+
+
+def test_constraints_invalid_max_length() -> None:
+    with pytest.raises(ValueError):
+        SynthesisConstraints(min_length=5, max_length=0)
+
+
+def test_constraints_min_gt_max() -> None:
+    with pytest.raises(ValueError):
+        SynthesisConstraints(min_length=10, max_length=5)
 
 
 def test_export_csv_and_analysis_warnings(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- validate min/max length range for channel options
- enforce length range in `SynthesisConstraints`
- test new checks

## Testing
- `ruff check src/genecoder/cli/options.py src/genecoder/synthesis.py tests/test_channel_options_validation.py tests/test_synthesis.py`
- `mypy --config-file pyproject.toml src/genecoder/cli/options.py src/genecoder/synthesis.py`
- `pytest -q tests/test_channel_options_validation.py tests/test_synthesis.py`


------
https://chatgpt.com/codex/tasks/task_e_687043b778b083269e23798af04c38d4