### PR TITLE
Improve plugin catalog validation

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -233,12 +233,21 @@ def _fetch_catalog(url: str) -> None:
         name = str(entry.get("name", ""))
         if not name:
             continue
+        checksum = entry.get("checksum")
+        if not checksum:
+            logger.error("Missing checksum for plugin %s", name)
+            continue
+        signature = entry.get("signature")
+        if not signature:
+            logger.error("Missing signature for plugin %s", name)
+            continue
+
         PLUGIN_CATALOG[name] = {
             "version": str(entry.get("version", "")),
             "url": str(entry.get("url", "")),
             "description": str(entry.get("description", "")),
-            "checksum": str(entry.get("checksum", "")),
-            "signature": str(entry.get("signature", "")),
+            "checksum": str(checksum),
+            "signature": str(signature),
             "author": str(entry.get("author", "")),
             "stars": entry.get("stars", 0),
         }

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -213,6 +213,68 @@ def test_catalog_invalid_signature(monkeypatch, caplog):
     assert plugins.PLUGIN_CATALOG == {}
 
 
+def test_catalog_missing_checksum(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Entries without a checksum are ignored."""
+
+    catalog = (
+        "plugins:\n"
+        "  - name: plug\n"
+        "    version: '0.1'\n"
+        "    url: plug==0.1\n"
+        "    signature: deadbeef"
+    ).encode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        assert url == "https://example.com/catalog.yaml"
+        return DummyResponse(catalog)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    with caplog.at_level("ERROR"):
+        plugins.load_plugins()
+
+    assert "Missing checksum for plugin plug" in caplog.text
+    assert "plug" not in plugins.PLUGIN_CATALOG
+
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        plugin_cli._handle_install(argparse.Namespace(name="plug"))
+    assert "Unknown plugin: plug" in caplog.text
+
+
+def test_catalog_missing_signature(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Entries without a signature are ignored."""
+
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    catalog = (
+        "plugins:\n"
+        "  - name: plug\n"
+        "    version: '0.1'\n"
+        "    url: plug==0.1\n"
+        f"    checksum: {checksum}"
+    ).encode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        assert url == "https://example.com/catalog.yaml"
+        return DummyResponse(catalog)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    with caplog.at_level("ERROR"):
+        plugins.load_plugins()
+
+    assert "Missing signature for plugin plug" in caplog.text
+    assert "plug" not in plugins.PLUGIN_CATALOG
+
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        plugin_cli._handle_install(argparse.Namespace(name="plug"))
+    assert "Unknown plugin: plug" in caplog.text
+
+
 def test_registry_missing_signature(monkeypatch: pytest.MonkeyPatch) -> None:
     pkg = b"PKG"
     checksum = compute_checksum(pkg)


### PR DESCRIPTION
## Summary
- skip catalog entries that omit checksum or signature
- add regression tests for missing checksum or signature

## Testing
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_marketplace.py`
- `mypy --follow-imports=skip src/genecoder/plugin_manager.py`
- `pytest -q tests/test_plugin_marketplace.py::test_catalog_missing_checksum tests/test_plugin_marketplace.py::test_catalog_missing_signature`

------
https://chatgpt.com/codex/tasks/task_e_6870518595a88326a928dd3b633c9646