### PR TITLE
Add negative length tests for synthesis constraints

### DIFF
--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -3,6 +3,7 @@ import os
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, cast
 
 __all__ = [
     "Metrics",
@@ -53,11 +54,11 @@ class Metrics:
     def increment(self, key: str) -> None:
         with self._lock:
             metrics = _load(self.path)
-            metrics[key] = metrics.get(key, 0) + 1
+            count = cast(int, metrics.get(key, 0))
+            metrics[key] = count + 1
             if key == "oligos_simulated":
-                ts_list = metrics.get("oligos_simulated_ts", [])
-                if not isinstance(ts_list, list):
-                    ts_list = []
+                ts_obj: Any = metrics.get("oligos_simulated_ts", [])
+                ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
                 ts_list.append(datetime.now(timezone.utc).isoformat())
                 metrics["oligos_simulated_ts"] = ts_list
             _save(self.path, metrics)
@@ -69,7 +70,8 @@ class Metrics:
     def oligos_per_week(self) -> dict[str, int]:
         with self._lock:
             data = _load(self.path)
-            ts_list = data.get("oligos_simulated_ts", [])
+            ts_obj: Any = data.get("oligos_simulated_ts", [])
+            ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
         counts: dict[str, int] = {}
         for ts in ts_list:
             try:

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -106,8 +106,20 @@ def test_min_length_invalid() -> None:
         build_channel_options(args)
 
 
+def test_min_length_negative() -> None:
+    args = _make_args(simulators=["simple"], min_length=-1)
+    with pytest.raises(ValueError, match="min_length"):
+        build_channel_options(args)
+
+
 def test_max_length_invalid() -> None:
     args = _make_args(simulators=["simple"], max_length=0)
+    with pytest.raises(ValueError, match="max_length"):
+        build_channel_options(args)
+
+
+def test_max_length_negative() -> None:
+    args = _make_args(simulators=["simple"], max_length=-1)
     with pytest.raises(ValueError, match="max_length"):
         build_channel_options(args)
 

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -42,9 +42,19 @@ def test_constraints_invalid_min_length() -> None:
         SynthesisConstraints(min_length=0, max_length=10)
 
 
+def test_constraints_negative_min_length() -> None:
+    with pytest.raises(ValueError):
+        SynthesisConstraints(min_length=-1, max_length=10)
+
+
 def test_constraints_invalid_max_length() -> None:
     with pytest.raises(ValueError):
         SynthesisConstraints(min_length=5, max_length=0)
+
+
+def test_constraints_negative_max_length() -> None:
+    with pytest.raises(ValueError):
+        SynthesisConstraints(min_length=5, max_length=-1)
 
 
 def test_constraints_min_gt_max() -> None:


### PR DESCRIPTION
## Summary
- test negative min_length and max_length in synthesis constraints
- verify CLI option builder rejects negative lengths
- fix mypy errors in metrics by casting types

## Testing
- `ruff check src/genecoder/metrics.py tests/test_channel_options_validation.py tests/test_synthesis.py`
- `mypy src/genecoder/metrics.py tests/test_channel_options_validation.py tests/test_synthesis.py`
- `pytest tests/test_channel_options_validation.py tests/test_synthesis.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687051849cf88326b63d5a646d91086a