### PR TITLE
Add marketplace page

### DIFF
--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -53,7 +53,10 @@ class Metrics:
     def increment(self, key: str) -> None:
         with self._lock:
             metrics = _load(self.path)
-            metrics[key] = metrics.get(key, 0) + 1
+            current = metrics.get(key, 0)
+            if not isinstance(current, int):
+                current = 0
+            metrics[key] = current + 1
             if key == "oligos_simulated":
                 ts_list = metrics.get("oligos_simulated_ts", [])
                 if not isinstance(ts_list, list):
@@ -70,6 +73,8 @@ class Metrics:
         with self._lock:
             data = _load(self.path)
             ts_list = data.get("oligos_simulated_ts", [])
+            if not isinstance(ts_list, list):
+                ts_list = []
         counts: dict[str, int] = {}
         for ts in ts_list:
             try:

--- a/web/helix-ui/marketplace.html
+++ b/web/helix-ui/marketplace.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plugin Marketplace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/marketplace_main.jsx"></script>
+  </body>
+</html>

--- a/web/helix-ui/src/Marketplace.jsx
+++ b/web/helix-ui/src/Marketplace.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Marketplace() {
+  const [plugins, setPlugins] = useState(null);
+  const [installing, setInstalling] = useState({});
+  const [selectedRatings, setSelectedRatings] = useState({});
+  const [ratings, setRatings] = useState({});
+
+  useEffect(() => {
+    fetch('/catalog/plugins')
+      .then((r) => r.json())
+      .then((data) => setPlugins(data.plugins || []));
+  }, []);
+
+  const install = async (name) => {
+    setInstalling((s) => ({ ...s, [name]: true }));
+    await fetch('/plugins/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setInstalling((s) => ({ ...s, [name]: false }));
+  };
+
+  const rate = async (name) => {
+    const rating = selectedRatings[name];
+    if (!rating) return;
+    const resp = await fetch('/plugins/rate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, rating: Number(rating) }),
+    });
+    const json = await resp.json();
+    setRatings((r) => ({ ...r, [name]: json.average }));
+  };
+
+  if (!plugins) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Plugin Marketplace</h1>
+      <ul>
+        {plugins.map((p) => (
+          <li key={`${p.name}-${p.version}`}>
+            <strong>{p.name}</strong> v{p.version}{' '}
+            <button onClick={() => install(p.name)} disabled={installing[p.name]}>
+              {installing[p.name] ? 'Installing...' : 'Install'}
+            </button>{' '}
+            <select
+              value={selectedRatings[p.name] || ''}
+              onChange={(e) =>
+                setSelectedRatings((s) => ({ ...s, [p.name]: e.target.value }))
+              }
+            >
+              <option value="">Rate...</option>
+              {[1, 2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            <button onClick={() => rate(p.name)}>Rate</button>
+            {ratings[p.name] && <span> ⭐{ratings[p.name].toFixed(1)}</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/helix-ui/src/Marketplace.test.jsx
+++ b/web/helix-ui/src/Marketplace.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import Marketplace from './Marketplace.jsx';
+
+// Mock fetch for plugin list
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        plugins: [
+          { name: 'a', version: '1.0' },
+          { name: 'b', version: '1.1' },
+        ],
+      }),
+  })
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('renders plugins and handles actions', async () => {
+  render(<Marketplace />);
+  expect(await screen.findByText(/a/)).toBeInTheDocument();
+  // Install first plugin
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  const installBtn = screen.getAllByRole('button', { name: /install/i })[0];
+  fireEvent.click(installBtn);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  // Rate first plugin
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ average: 5 }) });
+  fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: '5' } });
+  const rateBtn = screen.getAllByRole('button', { name: /rate/i })[0];
+  fireEvent.click(rateBtn);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+});

--- a/web/helix-ui/src/marketplace_main.jsx
+++ b/web/helix-ui/src/marketplace_main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Marketplace from './Marketplace.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Marketplace />
+  </React.StrictMode>
+);

--- a/web/main.py
+++ b/web/main.py
@@ -161,6 +161,10 @@ plugin_index_path = helix_ui_dir / "dist" / "plugins.html"
 if not plugin_index_path.is_file():
     plugin_index_path = helix_ui_dir / "plugins.html"
 
+marketplace_index_path = helix_ui_dir / "dist" / "marketplace.html"
+if not marketplace_index_path.is_file():
+    marketplace_index_path = helix_ui_dir / "marketplace.html"
+
 scoreboard_index_path = helix_ui_dir / "dist" / "scoreboard.html"
 if not scoreboard_index_path.is_file():
     scoreboard_index_path = helix_ui_dir / "scoreboard.html"
@@ -190,6 +194,12 @@ async def dashboard() -> str:
 async def plugin_catalog_page() -> str:
     """Return the React-based plugin catalog interface."""
     return plugin_index_path.read_text(encoding="utf-8")
+
+
+@app.get("/marketplace", response_class=HTMLResponse)
+async def marketplace_page() -> str:
+    """Return the React-based marketplace interface."""
+    return marketplace_index_path.read_text(encoding="utf-8")
 
 
 @app.get("/rankings", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- add marketplace components and test
- create marketplace HTML entry point
- serve the new marketplace page from FastAPI
- fix mypy errors in metrics

## Testing
- `ruff check web/main.py`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest -q` *(637 passed, 67 skipped, 5 warnings)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687051834df08326a5aa5cbdf6422e89