### PR TITLE
Add HPC submission via Slurm

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -38,6 +38,38 @@ docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN ghcr.io/d0ttino/genecoder \
 
 Replace `TOKEN` with a secret value and use the same token when submitting jobs.
 
+## HPC Submission
+
+Jobs can also be dispatched directly to a Slurm cluster. Provide a command that
+will be executed on the compute node and optional Slurm parameters:
+
+```python
+from genecoder.cloud import CloudClient
+
+with CloudClient("unused") as client:
+    jid = client.submit(
+        "hpc",
+        {
+            "command": "genecoder bundle run bundle.yaml --cache-dir runs",
+            "job_name": "gc-run",
+            "time": "00:30:00",
+            "partition": "compute",
+        },
+    )
+    print(jid)
+```
+
+Equivalent settings can be expressed in YAML:
+
+```yaml
+job:
+  type: hpc
+  command: genecoder bundle run bundle.yaml --cache-dir runs
+  job_name: gc-run
+  time: 00:30:00
+  partition: compute
+```
+
 ## Fetching Error Profiles
 
 GeneCoder can download example anonymized error profiles for use with simulators.

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -19,6 +19,24 @@ class CloudClient:
         self._client = client or httpx.Client(base_url=self.base_url)
 
     def submit(self, job_type: str, payload: dict[str, Any]) -> str:
+        if job_type == "hpc":
+            from .hpc import generate_slurm_script, submit_slurm_job
+
+            if "script" in payload and isinstance(payload["script"], str):
+                script = payload["script"]
+            else:
+                command = payload.get("command")
+                if not isinstance(command, str):
+                    raise ValueError("command is required for hpc jobs")
+                script = generate_slurm_script(
+                    command,
+                    job_name=payload.get("job_name", "genecoder"),
+                    time=payload.get("time", "01:00:00"),
+                    partition=payload.get("partition"),
+                    output=payload.get("output"),
+                )
+            return submit_slurm_job(script)
+
         headers = {}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"

--- a/src/genecoder/cloud/hpc.py
+++ b/src/genecoder/cloud/hpc.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+import subprocess
+
+
+def generate_slurm_script(
+    command: str,
+    *,
+    job_name: str = "genecoder",
+    time: str = "01:00:00",
+    partition: str | None = None,
+    output: str | None = None,
+) -> str:
+    """Return a simple Slurm batch script."""
+    lines = ["#!/bin/bash", f"#SBATCH --job-name={job_name}"]
+    lines.append(f"#SBATCH --output={output or '%x-%j.out'}")
+    if partition:
+        lines.append(f"#SBATCH --partition={partition}")
+    if time:
+        lines.append(f"#SBATCH --time={time}")
+    lines.append("")
+    lines.append(command)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def submit_slurm_job(script: str, sbatch: str = "sbatch") -> str:
+    """Submit the script via ``sbatch`` and return the job ID."""
+    proc = subprocess.run(
+        [sbatch], input=script, text=True, capture_output=True, check=True
+    )
+    match = re.search(r"Submitted batch job (\d+)", proc.stdout)
+    if not match:
+        raise RuntimeError("Failed to parse sbatch output")
+    return match.group(1)

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -1,0 +1,63 @@
+import pytest
+
+from genecoder.cloud.hpc import generate_slurm_script, submit_slurm_job
+from genecoder.cloud import CloudClient
+
+
+def test_generate_slurm_script() -> None:
+    script = generate_slurm_script(
+        "echo hi", job_name="tst", time="00:10:00", partition="debug"
+    )
+    assert "#SBATCH --job-name=tst" in script
+    assert "#SBATCH --time=00:10:00" in script
+    assert "#SBATCH --partition=debug" in script
+    assert "echo hi" in script
+
+
+def test_submit_slurm_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def fake_run(cmd, *, input=None, text=None, capture_output=None, check=None):
+        called["cmd"] = cmd
+        called["input"] = input
+        class P:
+            stdout = "Submitted batch job 123"
+        return P()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    jid = submit_slurm_job("script")
+    assert jid == "123"
+    assert called["cmd"] == ["sbatch"]
+    assert called["input"] == "script"
+
+
+def test_cloud_client_hpc(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("httpx")
+    generated = {}
+
+    def fake_generate(command: str, **kwargs) -> str:
+        generated["command"] = command
+        generated.update(kwargs)
+        return "script"
+
+    def fake_submit(script: str) -> str:
+        generated["script"] = script
+        return "42"
+
+    monkeypatch.setattr("genecoder.cloud.hpc.generate_slurm_script", fake_generate)
+    monkeypatch.setattr("genecoder.cloud.hpc.submit_slurm_job", fake_submit)
+
+    client = CloudClient("http://unused")
+    jid = client.submit(
+        "hpc",
+        {
+            "command": "run.sh",
+            "job_name": "job",
+            "time": "00:05:00",
+        },
+    )
+    assert jid == "42"
+    assert generated["command"] == "run.sh"
+    assert generated["job_name"] == "job"
+    assert generated["time"] == "00:05:00"
+    assert generated["script"] == "script"


### PR DESCRIPTION
## Summary
- add `genecoder.cloud.hpc` with Slurm helpers
- extend `CloudClient` to dispatch `hpc` jobs
- document HPC usage in cloud docs
- test Slurm script helpers and HPC client

## Testing
- `ruff check --fix tests/test_cloud_hpc.py src/genecoder/cloud/hpc.py src/genecoder/cloud/__init__.py`
- `pytest tests/test_cloud_hpc.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870518269f083268e4a54881114f5b8