### PR TITLE
Add command sanitization for HPC jobs

### DIFF
--- a/src/genecoder/cloud/hpc.py
+++ b/src/genecoder/cloud/hpc.py
@@ -12,7 +12,16 @@ def generate_slurm_script(
     partition: str | None = None,
     output: str | None = None,
 ) -> str:
-    """Return a simple Slurm batch script."""
+    """Return a simple Slurm batch script.
+
+    ``command`` must not contain newlines or shell metacharacters such as
+    ``;``, ``&&`` or ``|``. This prevents accidental command injection when the
+    script is written to disk.
+    """
+    if any(c in command for c in "\n\r"):
+        raise ValueError("command must not contain newlines")
+    if re.search(r"[;&|<>`$]", command):
+        raise ValueError("command contains unsafe characters")
     lines = ["#!/bin/bash", f"#SBATCH --job-name={job_name}"]
     lines.append(f"#SBATCH --output={output or '%x-%j.out'}")
     if partition:

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -14,6 +14,12 @@ def test_generate_slurm_script() -> None:
     assert "echo hi" in script
 
 
+@pytest.mark.parametrize("cmd", ["echo hi && rm -rf /", "echo hi; rm -rf /", "bad\ncmd"])
+def test_generate_slurm_script_rejects_bad(cmd: str) -> None:
+    with pytest.raises(ValueError):
+        generate_slurm_script(cmd)
+
+
 def test_submit_slurm_job(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
 


### PR DESCRIPTION
## Summary
- prevent injection in `generate_slurm_script`
- test command sanitization logic for HPC scripts

## Testing
- `ruff check src/genecoder/cloud/hpc.py tests/test_cloud_hpc.py`
- `mypy src/genecoder/cloud/hpc.py`
- `pytest -q tests/test_cloud_hpc.py`

------
https://chatgpt.com/codex/tasks/task_e_687061db0c448326a28b4b8e7670f417