### PR TITLE
Add shared plugin initialization

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -16,6 +16,7 @@ _LAZY_ATTRS = {
 from .plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
+    init_plugins,
     load_plugins,
     install_registry_plugins,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "FEC_REGISTRY",
     "SIMULATOR_REGISTRY",
     "simulate_reads",
+    "init_plugins",
     "load_plugins",
     "install_registry_plugins",
     "encrypt_data",

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 from genecoder import __version__
-from genecoder.plugin_manager import load_plugins
+from genecoder.plugin_manager import init_plugins
 # simulators are imported lazily by subcommands that need them
 
 from typing import Any
@@ -90,7 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
     # simulators are available during subcommand registration.
-    load_plugins()
+    init_plugins()
 
     parser = argparse.ArgumentParser(
         description=(

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -370,6 +370,9 @@ def load_local_plugins() -> list[str]:
     return failures
 
 
+_initialized = False
+
+
 def load_plugins() -> None:
     """Load built-in, entry point and local plugins and fetch catalog entries."""
 
@@ -379,3 +382,16 @@ def load_plugins() -> None:
     failures.extend(load_local_plugins())
     if failures:
         logger.warning("Failed to import plugins: %s", ", ".join(failures))
+
+
+def init_plugins() -> None:
+    """Initialize plugins once with error handling."""
+
+    global _initialized
+    if _initialized:
+        return
+    try:
+        load_plugins()
+    except Exception as exc:  # pragma: no cover - unexpected error path
+        logger.warning("Failed to load plugins: %s", exc)
+    _initialized = True

--- a/tests/test_cli_plugin_catalog.py
+++ b/tests/test_cli_plugin_catalog.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import base64
 
 import pytest
 from genecoder.plugin_security import compute_checksum
@@ -25,18 +26,23 @@ class DummyResponse:
 def test_cli_catalog_list_and_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     pkg = b"PKG"
     checksum = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
     catalog = (
         "plugins:\n  - name: plug\n    version: '0.1'\n    url: https://example.com/pkg.whl\n    description: Example\n    checksum: "
         + checksum
+        + "\n    signature: "
+        + sig
     ).encode()
 
     patch_dir = tmp_path / "patch"
     patch_dir.mkdir()
     installed = tmp_path / "installed"
+    pub_key = patch_dir / "pub.pem"
     site_py = patch_dir / "sitecustomize.py"
     site_py.write_text(
         f"""
 import sys
+import os
 from pathlib import Path
 import genecoder.plugin_manager as plugins
 import genecoder.cli.plugin as plugin_cli
@@ -73,6 +79,11 @@ def fake_check_call(cmd):
         raise AssertionError(cmd)
 plugin_cli.subprocess.check_call = fake_check_call
 plugin_cli.plugins.entry_points = lambda group=None: []
+from genecoder.plugin_security import compute_checksum as _cc
+plugin_cli.plugins.compute_checksum = lambda d, *, signature=None, public_key=None: _cc(d)
+plugin_cli.plugins.verify_signature = lambda d, s, k: None
+Path('{pub_key}').write_text('PUB')
+os.environ['GENECODER_PLUGIN_PUBLIC_KEY'] = '{pub_key}'
 """
     )
 

--- a/tests/test_plugin_init.py
+++ b/tests/test_plugin_init.py
@@ -1,0 +1,67 @@
+import os
+import pytest
+
+import genecoder.plugin_manager as plugins
+
+
+def test_cli_init_plugins_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_load() -> None:
+        calls.append(True)
+
+    monkeypatch.setattr(plugins, "load_plugins", fake_load)
+    plugins._initialized = False
+    from genecoder.cli import cli
+
+    cli.build_parser()
+    cli.build_parser()
+
+    assert calls == [True]
+
+
+def test_web_init_plugins_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+
+    calls = []
+
+    def fake_load() -> None:
+        calls.append(True)
+
+    monkeypatch.setattr(plugins, "load_plugins", fake_load)
+    plugins._initialized = False
+
+    import importlib
+    import sys
+    import types
+
+    # Stub optional dependencies used by the web app
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.Lock = lambda *a, **k: open(os.devnull, "w")
+    limiter = types.ModuleType("fastapi_limiter")
+    limiter.FastAPILimiter = types.SimpleNamespace(
+        redis=None, init=lambda *_: None, close=lambda *_: None
+    )
+    depends = types.ModuleType("fastapi_limiter.depends")
+    depends.RateLimiter = lambda *_, **__: (lambda *_: None)
+    redis_mod = types.ModuleType("redis.asyncio")
+    redis_mod.from_url = lambda *_args, **_kwargs: None
+    redis_pkg = types.ModuleType("redis")
+    redis_pkg.asyncio = redis_mod
+    sys.modules.setdefault("portalocker", portalocker_stub)
+    sys.modules.setdefault("fastapi_limiter", limiter)
+    sys.modules.setdefault("fastapi_limiter.depends", depends)
+    sys.modules.setdefault("redis.asyncio", redis_mod)
+    sys.modules.setdefault("redis", redis_pkg)
+
+    web_main = importlib.import_module("web.main")
+    web_main.API_TOKEN = "token"
+    from fastapi.testclient import TestClient
+
+    with TestClient(web_main.app):
+        pass
+    with TestClient(web_main.app):
+        pass
+
+    assert calls == [True]

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -28,9 +28,12 @@ class DummyResponse:
 def test_catalog_list_and_install(monkeypatch, capsys):
     pkg = b"PKG"
     h = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
     catalog = (
         "plugins:\n  - name: plug\n    version: '0.1'\n    url: plug==0.1\n    description: Example\n    checksum: "
         + h
+        + "\n    signature: "
+        + sig
     ).encode()
 
     def fake_urlopen(url):
@@ -50,14 +53,24 @@ def test_catalog_list_and_install(monkeypatch, capsys):
         else:
             raise AssertionError(cmd)
 
-    def fake_compute_checksum(data: bytes) -> str:
+    def fake_compute_checksum(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+    ) -> str:
         calls.append(data)
         return compute_checksum(data)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
     monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute_checksum)
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
 
     plugins.load_plugins()
@@ -75,9 +88,12 @@ def test_catalog_list_and_install(monkeypatch, capsys):
 def test_install_checksum_mismatch(monkeypatch, caplog):
     pkg = b"PKG"
     wrong = compute_checksum(b"WRONG")
+    sig = base64.b64encode(b"sig").decode()
     catalog = (
         "plugins:\n  - name: plug\n    version: '0.1'\n    url: plug==0.1\n    checksum: "
         + wrong
+        + "\n    signature: "
+        + sig
     ).encode()
 
     def fake_urlopen(url):
@@ -96,10 +112,20 @@ def test_install_checksum_mismatch(monkeypatch, caplog):
         else:
             raise AssertionError(cmd)
 
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
     monkeypatch.setenv("GENECODER_PLUGIN_CATALOG_URL", "https://example.com/catalog.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
 
     plugins.load_plugins()
 

--- a/web/main.py
+++ b/web/main.py
@@ -17,7 +17,7 @@ import re
 
 from genecoder.options import EncodeOptions
 from genecoder import perform_encoding, perform_decoding
-from genecoder.plugins import load_plugins
+from genecoder.plugin_manager import init_plugins
 from genecoder import plugins
 from genecoder.cli import plugin as plugin_cli
 import argparse
@@ -107,7 +107,7 @@ REDIS_URL = os.getenv("GENECODER_REDIS_URL")
 @app.on_event("startup")
 async def _startup() -> None:
     global API_TOKEN
-    load_plugins()
+    init_plugins()
     _load_plugin_ratings()
     if API_TOKEN is None:
         API_TOKEN = secrets.token_urlsafe(16)


### PR DESCRIPTION
## Summary
- introduce `init_plugins` in `plugin_manager`
- export and use `init_plugins` from CLI and web
- drop unused type ignores
- test that plugin initialization runs only once
- handle optional dependencies in tests
- restore worker type ignores for mypy
- update plugin marketplace tests for new signature requirement

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687071923a6883269172dfaad55979b1