### PR TITLE
Add file locking to metrics

### DIFF
--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -3,7 +3,9 @@ import os
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TextIO, cast
+
+import portalocker
 
 __all__ = [
     "Metrics",
@@ -21,22 +23,46 @@ def _get_metrics_path() -> Path:
     return Path.home() / ".genecoder" / "metrics.json"
 
 
-def _load(path: Path) -> dict[str, object]:
+def _load(path: Path, fh: TextIO | None = None) -> dict[str, object]:
+    """Load metrics from ``path`` with optional file handle ``fh``."""
+    if fh is not None:
+        fh.seek(0)
+        content = fh.read()
+        if content:
+            try:
+                data = json.loads(content)
+                if isinstance(data, dict):
+                    return data
+            except Exception:
+                pass
+        return {}
+
     if path.is_file():
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                return data
+            with portalocker.Lock(path, "r", timeout=10, encoding="utf-8") as f:
+                return _load(path, f)
         except Exception:
             pass
     return {}
 
 
-def _save(path: Path, metrics: dict[str, object]) -> None:
+def _save(path: Path, metrics: dict[str, object], fh: TextIO | None = None) -> None:
+    """Persist ``metrics`` to ``path`` using optional open file handle ``fh``."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(metrics), encoding="utf-8")
-    os.replace(tmp, path)
+    data = json.dumps(metrics)
+
+    def _write(handle: TextIO) -> None:
+        handle.seek(0)
+        handle.truncate(0)
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    if fh is not None:
+        _write(fh)
+    else:
+        with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as f:
+            _write(f)
 
 
 class Metrics:
@@ -53,29 +79,34 @@ class Metrics:
 
     def increment(self, key: str) -> None:
         with self._lock:
-            metrics = _load(self.path)
-            current = metrics.get(key, 0)
-            if not isinstance(current, int):
-                current = 0
-            metrics[key] = current + 1
+            with portalocker.Lock(self.path, "a+", timeout=10, encoding="utf-8") as fh:
+                metrics = _load(self.path, fh)
+                current = metrics.get(key, 0)
+                if not isinstance(current, int):
+                    current = 0
+                metrics[key] = current + 1
 
-            if key == "oligos_simulated":
-                ts_obj: Any = metrics.get("oligos_simulated_ts", [])
-                ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
-                ts_list.append(datetime.now(timezone.utc).isoformat())
-                metrics["oligos_simulated_ts"] = ts_list
-            _save(self.path, metrics)
+                if key == "oligos_simulated":
+                    ts_obj: Any = metrics.get("oligos_simulated_ts", [])
+                    ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
+                    ts_list.append(datetime.now(timezone.utc).isoformat())
+                    metrics["oligos_simulated_ts"] = ts_list
+                _save(self.path, metrics, fh)
 
     def get_metrics(self) -> dict[str, object]:
         with self._lock:
-            return _load(self.path)
+            if self.path.is_file():
+                with portalocker.Lock(self.path, "r", timeout=10, encoding="utf-8") as fh:
+                    return _load(self.path, fh)
+            return {}
 
     def oligos_per_week(self) -> dict[str, int]:
         with self._lock:
-            data = _load(self.path)
-            ts_list = data.get("oligos_simulated_ts", [])
-            if not isinstance(ts_list, list):
-                ts_list = []
+            with portalocker.Lock(self.path, "r", timeout=10, encoding="utf-8") as fh:
+                data = _load(self.path, fh)
+                ts_list = data.get("oligos_simulated_ts", [])
+                if not isinstance(ts_list, list):
+                    ts_list = []
 
         counts: dict[str, int] = {}
         for ts in ts_list:

--- a/tests/test_metrics_lock.py
+++ b/tests/test_metrics_lock.py
@@ -1,0 +1,22 @@
+import json
+from multiprocessing import Process
+from pathlib import Path
+
+from genecoder.metrics import Metrics
+
+
+def _worker(path: str) -> None:
+    m = Metrics(Path(path))
+    m.increment("concurrent")
+
+
+def test_concurrent_increment(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "metrics.json"
+    procs = [Process(target=_worker, args=(str(metrics_path),)) for _ in range(2)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+
+    data = json.loads(metrics_path.read_text())
+    assert data["concurrent"] == 2


### PR DESCRIPTION
## Summary
- ensure metrics JSON reads/writes are guarded by an interprocess lock
- open file with portalocker during increment operations
- add concurrency test for metrics increment

## Testing
- `ruff check src/genecoder/metrics.py tests/test_metrics_lock.py`
- `pytest -q tests/test_metrics_lock.py`

------
https://chatgpt.com/codex/tasks/task_e_68713f2d780c8326ae28eed13be0637c