### PR TITLE
Improve cloud worker security

### DIFF
--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -5,6 +5,7 @@ import base64
 import io
 import os
 import secrets
+import stat
 import tempfile
 import uuid
 import zipfile
@@ -21,6 +22,7 @@ from genecoder.plugin_manager import load_plugins
 API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 security = HTTPBearer(auto_error=False)
 app = FastAPI(title="GeneCoder Worker")
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB limit for extracted files
 
 
 def verify_token(
@@ -30,7 +32,7 @@ def verify_token(
         raise HTTPException(status_code=401, detail="Invalid or missing token")
 
 
-@app.on_event("startup")  # type: ignore[misc]
+@app.on_event("startup")
 def _startup() -> None:
     global API_TOKEN
     load_plugins()
@@ -39,7 +41,7 @@ def _startup() -> None:
         print(f"Generated API token: {API_TOKEN}")
 
 
-@app.post("/jobs")  # type: ignore[misc]
+@app.post("/jobs")
 def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) -> dict[str, str]:
     if payload.get("type") != "bundle":
         raise HTTPException(status_code=400, detail="Unsupported job type")
@@ -56,9 +58,18 @@ def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) ->
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            for name in zf.namelist():
-                path = Path(name)
+            for info in zf.infolist():
+                path = Path(os.path.normpath(info.filename))
                 if path.is_absolute() or ".." in path.parts:
+                    raise HTTPException(status_code=400, detail="Invalid archive path")
+                is_symlink = False
+                if hasattr(info, "is_symlink"):
+                    is_symlink = info.is_symlink()
+                else:
+                    is_symlink = ((info.external_attr >> 16) & 0o170000) == stat.S_IFLNK
+                if is_symlink:
+                    raise HTTPException(status_code=400, detail="Invalid archive path")
+                if info.file_size > MAX_FILE_SIZE:
                     raise HTTPException(status_code=400, detail="Invalid archive path")
             zf.extractall(tmpdir)
         tmp_path = Path(tmpdir)

--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from .security import compute_checksum as _compute_checksum
 
 
-def compute_checksum(data: bytes) -> str:
+def compute_checksum(
+    data: bytes,
+    *,
+    signature: bytes | None = None,
+    public_key: bytes | None = None,
+) -> str:
     """Return the SHA256 checksum of *data*."""
-    return _compute_checksum(data)
+    return _compute_checksum(data, signature=signature, public_key=public_key)
 
 
 def verify_signature(data: bytes, signature: bytes, public_key: bytes) -> None:

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -412,3 +412,75 @@ def test_worker_submit_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert Path(called["config"]).name == "b.yaml"
     assert r.json()["job_id"]
 
+
+def _build_symlink_zip() -> str:
+    import base64
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zi = zipfile.ZipInfo("link")
+        zi.create_system = 3
+        zi.external_attr = 0o120777 << 16
+        zf.writestr(zi, "target")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _build_bad_path_zip() -> str:
+    import base64
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../bad.yaml", "data")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _build_large_zip() -> str:
+    import base64
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("big.bin", b"\0" * (101 * 1024 * 1024))
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_worker_rejects_symlink() -> None:
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    archive_b64 = _build_symlink_zip()
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_rejects_bad_path() -> None:
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    archive_b64 = _build_bad_path_zip()
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_rejects_large_file() -> None:
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    archive_b64 = _build_large_zip()
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 400
+


### PR DESCRIPTION
## Summary
- harden worker archive extraction by rejecting symlinks and path traversal
- enforce a 100MB per-file extraction limit
- expose checksum options for plugin security
- test worker against malicious archives

## Testing
- `ruff check src/genecoder/cloud/worker.py tests/test_cloud.py src/genecoder/plugin_security.py`
- `mypy src/genecoder/cloud/worker.py src/genecoder/plugin_security.py`
- `pytest tests/test_cloud.py -k 'rejects_symlink or rejects_bad_path or rejects_large_file' -q`

------
https://chatgpt.com/codex/tasks/task_e_68713f2e1db483268f7ff7ba065f8f26