### PR TITLE
Fix asynchronous pipeline execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ reedsolo = "*"
 cryptography = "^45.0.4"
 pyyaml = "*"
 types-PyYAML = "*"
+portalocker = "*"
 numpy = {version = ">=2.2,<2.3", optional = true}
 pyldpc = {version = ">=0.7.6,<0.7.7", optional = true}
 pyfinite = {version = ">=1.9,<2.0", optional = true}
@@ -67,7 +68,6 @@ fastapi = ">=0.110"
 uvicorn = { version = "*", extras = ["standard"] }
 httpx = "<0.28"
 fastapi-limiter = "*"
-portalocker = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -79,6 +79,7 @@ class Metrics:
 
     def increment(self, key: str) -> None:
         with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
             with portalocker.Lock(self.path, "a+", timeout=10, encoding="utf-8") as fh:
                 metrics = _load(self.path, fh)
                 current = metrics.get(key, 0)

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -67,7 +67,14 @@ class ChannelPipeline(BaseChannel):
             )
 
         with executor_cls(max_workers=workers) as executor:
-            results = list(executor.map(_run_channel, [sequence] * len(self.channels), self.channels))
+            # submit all simulations before waiting on results so that they can
+            # run concurrently regardless of executor implementation
+            futures = [
+                executor.submit(_run_channel, sequence, channel)
+                for channel in self.channels
+            ]
+
+            results = [f.result() for f in futures]
 
         for res in results:
             sequence = res

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -25,7 +25,15 @@ def test_cli_version(tmp_path: Path):
 
     subprocess.run([str(pip_path), "install", "-U", "pip", "setuptools", "wheel"], check=True)
     subprocess.run(
-        [str(pip_path), "install", "matplotlib", "flet>=0.28,<0.29", "reedsolo", "cryptography"],
+        [
+            str(pip_path),
+            "install",
+            "matplotlib",
+            "flet>=0.28,<0.29",
+            "reedsolo",
+            "cryptography",
+            "portalocker",
+        ],
         check=True,
     )
 

--- a/tests/test_parallel_pipeline.py
+++ b/tests/test_parallel_pipeline.py
@@ -55,3 +55,25 @@ def test_parallel_pipeline_concurrent(tmp_path: Path) -> None:
     assert parallel_time < serial_time * 0.75
 
 
+def test_parallel_pipeline_multi_channel_concurrent(tmp_path: Path) -> None:
+    """Ensure more than two channels run concurrently when parallel=True."""
+    pipeline = ChannelPipeline([
+        _DelayChannel(0.1),
+        _DelayChannel(0.1),
+        _DelayChannel(0.1),
+    ])
+    os.environ["GENECODER_METRICS_PATH"] = str(tmp_path / "m.json")
+    seq = "AAAA"
+
+    start = time.perf_counter()
+    pipeline.simulate(seq)
+    serial_time = time.perf_counter() - start
+
+    cfg = ChannelConfig(parallel=True, workers=3)
+    start = time.perf_counter()
+    pipeline.simulate(seq, config=cfg)
+    parallel_time = time.perf_counter() - start
+
+    assert parallel_time < serial_time * 0.6
+
+


### PR DESCRIPTION
## Summary
- submit all channel simulations before awaiting results so they can run concurrently
- ensure metrics directory exists before locking file
- add portalocker dependency and include in packaging test

## Testing
- `ruff check src/genecoder/metrics.py src/genecoder/simulators/pipeline.py tests/test_parallel_pipeline.py tests/test_cli_version.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871c3ab0f188326874d59591e48e344