### PR TITLE
Add signature enforcement for plugin registries

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -117,6 +117,8 @@ packages and then run the installer. Example:
 export GENECODER_PLUGIN_REGISTRY_URL=https://example.com/registry.yaml
 ```
 
+PyYAML is required to parse registry files; install it with ``pip install PyYAML`` if it's not already available.
+
 Then install the packages with:
 
 ```bash
@@ -136,8 +138,9 @@ packages:
 ```
 
 Set ``GENECODER_PLUGIN_PUBLIC_KEY`` to the path of the PEM encoded public key
-used to verify these signatures. Registry entries without a valid ``signature``
-field are ignored. Only HTTPS URLs (or ``file://`` for local testing) are
+used to verify these signatures. Each registry entry **must** include a
+``signature``. Installation aborts with an error if the signature is missing or
+fails verification. Only HTTPS URLs (or ``file://`` for local testing) are
 accepted. Each package is installed only if the signature verifies and the
 checksum matches; installation uses ``pip install --require-hashes`` so the
 downloaded file must match the expected SHA256 digest; otherwise installation

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -25,7 +25,7 @@ import logging
 import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from .plugin_security import compute_checksum, verify_signature
+from .plugin_security import compute_checksum
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ def _verify_catalog_signature(data: bytes, signature: str) -> bool:
         return False
 
     try:
-        sig_bytes = base64.b64decode(signature)
+        sig_bytes = base64.b64decode(signature, validate=True)
         pubkey = Path(key_path).read_bytes()
     except Exception:
         return False
@@ -113,12 +113,15 @@ def _install_registry_plugins(url: str) -> None:
             checksum = str(entry.get("checksum", ""))
             sig_b64 = entry.get("signature")
             if not isinstance(sig_b64, str):
-                raise ValueError(f"Missing signature for plugin entry {entry}")
+                msg = f"Missing signature for plugin entry {entry}"
+                logger.error(msg)
+                raise ValueError(msg)
             try:
-                signature = base64.b64decode(sig_b64)
+                signature = base64.b64decode(sig_b64, validate=True)
             except Exception as exc:
-                raise ValueError(
-                    f"Invalid signature for plugin entry {entry}") from exc
+                msg = f"Invalid signature for plugin entry {entry}"
+                logger.error(msg)
+                raise ValueError(msg) from exc
         else:
             logger.warning("Missing checksum for plugin entry %s", entry)
             continue
@@ -141,17 +144,16 @@ def _install_registry_plugins(url: str) -> None:
 
         if signature is not None:
             if pubkey is None:
-                logger.warning(
-                    "No public key configured for signed plugin %s", spec
-                )
+                logger.warning("No public key configured for signed plugin %s", spec)
                 continue
             try:
                 digest = compute_checksum(
                     pkg_bytes, signature=signature, public_key=pubkey
                 )
             except Exception as exc:
-                raise ValueError(
-                    f"Invalid signature for plugin {spec}: {exc}") from exc
+                msg = f"Invalid signature for plugin {spec}: {exc}"
+                logger.error(msg)
+                raise ValueError(msg) from exc
         else:
             digest = compute_checksum(pkg_bytes)
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -4,6 +4,7 @@ import logging
 from typing import Callable
 
 import pytest
+
 httpx = pytest.importorskip("httpx")
 
 import genecoder.plugin_manager as plugins
@@ -27,7 +28,6 @@ class DummyResponse:
 
 
 def test_registry_install(monkeypatch):
-
     installs = []
 
     def fake_check_call(cmd):
@@ -178,7 +178,9 @@ def test_registry_checksum_mismatch(monkeypatch, caplog):
     assert "Checksum mismatch for plugin https://example.com/pkgD.whl" in caplog.text
 
 
-def test_registry_signature_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_registry_signature_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     pkg = b"FFF"
     checksum = compute_checksum(pkg)
 
@@ -198,7 +200,9 @@ def test_registry_signature_failure(monkeypatch: pytest.MonkeyPatch, caplog: pyt
     key = Path("/tmp/pub.pem")
     key.write_text("PUB")
 
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
@@ -215,10 +219,78 @@ def test_registry_signature_failure(monkeypatch: pytest.MonkeyPatch, caplog: pyt
 
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
 
-    with pytest.raises(ValueError):
-        plugins.install_registry_plugins()
+    with pytest.raises(ValueError, match="Invalid signature"):
+        with caplog.at_level(logging.ERROR):
+            plugins.install_registry_plugins()
 
     assert not installs
+    assert "Invalid signature for plugin https://example.com/pkgF.whl" in caplog.text
+
+
+def test_registry_missing_signature_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pkg = b"GGG"
+    checksum = compute_checksum(pkg)
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgG.whl\n    checksum: {checksum}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgG.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="Missing signature"):
+        with caplog.at_level(logging.ERROR):
+            plugins.install_registry_plugins()
+
+    assert "Missing signature for plugin entry" in caplog.text
+
+
+def test_registry_invalid_signature_format(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pkg = b"HHH"
+    checksum = compute_checksum(pkg)
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkgH.whl\n    checksum: {checksum}\n    signature: not_base64"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkgH.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
+    )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="Invalid signature"):
+        with caplog.at_level(logging.ERROR):
+            plugins.install_registry_plugins()
+
+    assert "Invalid signature for plugin entry" in caplog.text
 
 
 def test_registry_checksum_validation(monkeypatch):
@@ -301,9 +373,7 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(
-        plugins.urllib.request, "urlopen", _urlopen_via_httpx(client)
-    )
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", _urlopen_via_httpx(client))
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
     monkeypatch.setattr(
         plugins,
@@ -350,9 +420,7 @@ def test_registry_install_via_httpx_checksum_mismatch(
         "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
     )
     monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(
-        plugins.urllib.request, "urlopen", _urlopen_via_httpx(client)
-    )
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", _urlopen_via_httpx(client))
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
     monkeypatch.setattr(
         plugins,


### PR DESCRIPTION
## Summary
- enforce signature verification in `_install_registry_plugins`
- document required signatures in plugin registries
- note that PyYAML is needed when using registries
- test registry signature handling

## Testing
- `pytest tests/test_plugin_registry.py::test_registry_missing_signature_error tests/test_plugin_registry.py::test_registry_invalid_signature_format tests/test_plugin_registry.py::test_registry_signature_failure -q`
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_registry.py`
- `mypy src/genecoder/plugin_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6871c3aa228083268a58499aa2ee3b38