### PR TITLE
Add secure archive extraction helper

### DIFF
--- a/src/genecoder/cloud/utils.py
+++ b/src/genecoder/cloud/utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import io
+import os
+import stat
+import zipfile
+from pathlib import Path
+
+__all__ = ["extract_zip_safely"]
+
+
+def extract_zip_safely(
+    data: bytes,
+    dest: str | Path,
+    *,
+    max_file_size: int = 100 * 1024 * 1024,
+) -> None:
+    """Extract a zip archive with basic security checks.
+
+    The archive is inspected for unsafe paths, symlinks and oversized files
+    before extraction. A :class:`ValueError` is raised if any entry violates
+    these checks.
+    """
+    dest_path = Path(dest)
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for info in zf.infolist():
+            path = Path(os.path.normpath(info.filename))
+            if path.is_absolute() or ".." in path.parts:
+                raise ValueError("Invalid archive path")
+
+            is_symlink = False
+            if hasattr(info, "is_symlink"):
+                is_symlink = info.is_symlink()
+            else:
+                is_symlink = ((info.external_attr >> 16) & 0o170000) == stat.S_IFLNK
+            if is_symlink:
+                raise ValueError("Invalid archive path")
+
+            if info.file_size > max_file_size:
+                raise ValueError("Invalid archive path")
+
+        zf.extractall(dest_path)

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import argparse
 import base64
-import io
 import os
 import secrets
-import stat
 import tempfile
 import uuid
-import zipfile
 from pathlib import Path
 
 from typing import Any
@@ -18,6 +15,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from genecoder.cli import bundle as bundle_cli
 from genecoder.plugin_manager import load_plugins
+from genecoder.cloud.utils import extract_zip_safely
 
 API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 security = HTTPBearer(auto_error=False)
@@ -32,7 +30,7 @@ def verify_token(
         raise HTTPException(status_code=401, detail="Invalid or missing token")
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 def _startup() -> None:
     global API_TOKEN
     load_plugins()
@@ -41,7 +39,7 @@ def _startup() -> None:
         print(f"Generated API token: {API_TOKEN}")
 
 
-@app.post("/jobs")
+@app.post("/jobs")  # type: ignore[misc]
 def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) -> dict[str, str]:
     if payload.get("type") != "bundle":
         raise HTTPException(status_code=400, detail="Unsupported job type")
@@ -57,21 +55,12 @@ def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) ->
         raise HTTPException(status_code=400, detail="Invalid archive") from exc
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            for info in zf.infolist():
-                path = Path(os.path.normpath(info.filename))
-                if path.is_absolute() or ".." in path.parts:
-                    raise HTTPException(status_code=400, detail="Invalid archive path")
-                is_symlink = False
-                if hasattr(info, "is_symlink"):
-                    is_symlink = info.is_symlink()
-                else:
-                    is_symlink = ((info.external_attr >> 16) & 0o170000) == stat.S_IFLNK
-                if is_symlink:
-                    raise HTTPException(status_code=400, detail="Invalid archive path")
-                if info.file_size > MAX_FILE_SIZE:
-                    raise HTTPException(status_code=400, detail="Invalid archive path")
-            zf.extractall(tmpdir)
+        try:
+            extract_zip_safely(data, tmpdir, max_file_size=MAX_FILE_SIZE)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="Invalid archive path"
+            ) from exc
         tmp_path = Path(tmpdir)
         yaml_files = [p for p in tmp_path.iterdir() if p.suffix in {".yaml", ".yml"}]
         if not yaml_files:

--- a/tests/test_cloud_utils.py
+++ b/tests/test_cloud_utils.py
@@ -1,0 +1,49 @@
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from genecoder.cloud.utils import extract_zip_safely
+
+
+def _build_zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _build_symlink_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zi = zipfile.ZipInfo("link")
+        zi.create_system = 3
+        zi.external_attr = 0o120777 << 16
+        zf.writestr(zi, "target")
+    return buf.getvalue()
+
+
+def test_extract_zip_safely_valid(tmp_path: Path) -> None:
+    data = _build_zip({"a.yaml": b"x"})
+    extract_zip_safely(data, tmp_path)
+    assert (tmp_path / "a.yaml").exists()
+
+
+def test_extract_zip_safely_bad_path(tmp_path: Path) -> None:
+    data = _build_zip({"../evil.yaml": b"x"})
+    with pytest.raises(ValueError):
+        extract_zip_safely(data, tmp_path)
+
+
+def test_extract_zip_safely_symlink(tmp_path: Path) -> None:
+    data = _build_symlink_zip()
+    with pytest.raises(ValueError):
+        extract_zip_safely(data, tmp_path)
+
+
+def test_extract_zip_safely_large(tmp_path: Path) -> None:
+    data = _build_zip({"big.bin": b"x" * 2048})
+    with pytest.raises(ValueError):
+        extract_zip_safely(data, tmp_path, max_file_size=1024)


### PR DESCRIPTION
## Summary
- add `extract_zip_safely` utility for validated extraction
- use helper in worker API
- test archive extraction helper

## Testing
- `ruff check src/genecoder/cloud/utils.py src/genecoder/cloud/worker.py tests/test_cloud_utils.py`
- `mypy src/genecoder/cloud/utils.py src/genecoder/cloud/worker.py tests/test_cloud_utils.py`
- `pytest -q tests/test_cloud_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6871d347e9748326beeecc2c01f93a3a