### PR TITLE
Add deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ GeneCoder is an educational toolkit for exploring DNA-based data storage. It pro
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
+For deployment instructions including building the React dashboard and running the
+[cloud worker](docs/deployment.md) see the new guide.
 Introductory Jupyter notebooks with encoding and decoding examples are available in the [notebooks/](notebooks) directory.
 Step-by-step lesson notebooks covering encoding basics, FEC, simulators and analysis can be found in [notebooks/lessons](notebooks/lessons).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,36 @@
+# Deployment Guide
+
+This guide summarizes how to build the React dashboard, start a cloud worker with Docker and submit jobs via the CLI.
+
+## Build the Dashboard
+
+The web interface lives in `web/helix-ui` and uses React and Vite. Compile the static assets once before running the backend:
+
+```bash
+cd web/helix-ui
+npm install
+npm run build
+```
+
+The generated files are placed in `web/helix-ui/dist`. The FastAPI server automatically serves this folder when available.
+
+## Launch the Cloud Worker
+
+`genecoder.cloud.worker` provides a minimal REST API for running bundles remotely. Start it inside a container:
+
+```bash
+docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN \
+    ghcr.io/d0ttino/genecoder python -m genecoder.cloud.worker
+```
+
+Replace `TOKEN` with a secret value. The CLI must use the same token when submitting jobs.
+
+## Submit a Job
+
+Packages and uploads are handled by `genecoder cloud submit`:
+
+```bash
+genecoder cloud submit bundle.yaml --server http://localhost:8000 --token TOKEN
+```
+
+The command archives the bundle and any input files then posts it to `/jobs` on the running worker. The returned job identifier is printed to the console.


### PR DESCRIPTION
## Summary
- add `docs/deployment.md` explaining how to build the React dashboard, start the worker in Docker, and submit jobs
- link to this doc from `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871dc184f0483269107205e8e3e6832