### PR TITLE
Add scoreboard submission form and tests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -310,4 +310,6 @@ retrieved via ``GET /catalog/challenge``. Post new points with the same
 ``http://localhost:8000/rankings`` to view the scoreboard. When the React build
 is available the server serves ``dist/scoreboard.html``; otherwise it falls back
 to ``helix-ui/scoreboard.html``. The page fetches the latest rankings and
-updates automatically as submissions arrive.
+updates automatically as submissions arrive. The page also provides a form to
+submit scores directly by entering a participant name, point value and API
+token.

--- a/tests/test_scoreboard_api.py
+++ b/tests/test_scoreboard_api.py
@@ -36,3 +36,18 @@ def test_challenge_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     r2 = client.get("/catalog/challenge")
     assert r2.status_code == 200
     assert r2.json()["entries"] == {"team": 7}
+
+
+def test_challenge_accumulates_points(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_catalog, "CHALLENGE_PATH", str(tmp_path / "c.json"), raising=False)
+    plugin_catalog.CHALLENGE.clear()
+
+    payload = {"name": "team", "points": 2}
+    r = client.post("/catalog/challenge", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+
+    payload2 = {"name": "team", "points": 3}
+    r = client.post("/catalog/challenge", headers=AUTH_HEADERS, json=payload2)
+    assert r.status_code == 200
+
+    assert plugin_catalog.CHALLENGE["team"] == 5

--- a/web/helix-ui/src/Scoreboard.jsx
+++ b/web/helix-ui/src/Scoreboard.jsx
@@ -2,16 +2,38 @@ import React, { useEffect, useState } from 'react';
 
 export default function Scoreboard() {
   const [entries, setEntries] = useState(null);
+  const [name, setName] = useState('');
+  const [points, setPoints] = useState('');
+  const [token, setToken] = useState('');
 
-  useEffect(() => {
+  const load = () => {
     fetch('/catalog/challenge')
       .then((r) => r.json())
       .then((data) => setEntries(data.entries || {}));
+  };
+
+  useEffect(() => {
+    load();
   }, []);
 
   if (!entries) {
     return <div>Loading...</div>;
   }
+
+  const submit = async (e) => {
+    e.preventDefault();
+    await fetch('/catalog/challenge', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ name, points: parseInt(points, 10) }),
+    });
+    setName('');
+    setPoints('');
+    load();
+  };
 
   const sorted = Object.entries(entries).sort((a, b) => b[1] - a[1]);
 
@@ -19,12 +41,31 @@ export default function Scoreboard() {
     <div style={{ padding: 20 }}>
       <h1>Challenge Rankings</h1>
       <ol>
-        {sorted.map(([name, points]) => (
-          <li key={name}>
-            {name} - {points} pts
+        {sorted.map(([n, p]) => (
+          <li key={n}>
+            {n} - {p} pts
           </li>
         ))}
       </ol>
+      <form onSubmit={submit} style={{ marginTop: 20 }}>
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          placeholder="Points"
+          type="number"
+          value={points}
+          onChange={(e) => setPoints(e.target.value)}
+        />
+        <input
+          placeholder="Token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+        />
+        <button type="submit">Submit</button>
+      </form>
     </div>
   );
 }

--- a/web/helix-ui/src/Scoreboard.test.jsx
+++ b/web/helix-ui/src/Scoreboard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import Scoreboard from './Scoreboard.jsx';
@@ -25,4 +25,25 @@ test('renders entries sorted by score', async () => {
   const items = await screen.findAllByRole('listitem');
   expect(items[0]).toHaveTextContent('Alice - 40 pts');
   expect(items[1]).toHaveTextContent('Bob - 30 pts');
+});
+
+test('submits a new score', async () => {
+  render(<Scoreboard />);
+  await screen.findAllByRole('listitem');
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+  fireEvent.change(screen.getAllByPlaceholderText(/name/i)[0], {
+    target: { value: 'Carl' },
+  });
+  fireEvent.change(screen.getAllByPlaceholderText(/points/i)[0], {
+    target: { value: '3' },
+  });
+  fireEvent.change(screen.getAllByPlaceholderText(/token/i)[0], {
+    target: { value: 'tok' },
+  });
+  fireEvent.click(screen.getAllByRole('button', { name: /submit/i })[0]);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  const call = fetch.mock.calls[1];
+  expect(call[0]).toBe('/catalog/challenge');
+  expect(call[1].headers.Authorization).toBe('Bearer tok');
+  expect(JSON.parse(call[1].body)).toEqual({ name: 'Carl', points: 3 });
 });


### PR DESCRIPTION
## Summary
- allow submitting scores from the React scoreboard
- document how to use the scoreboard form
- test scoreboard accumulation and frontend submission

## Testing
- `npm test --prefix web/helix-ui`
- `pytest tests/test_scoreboard_api.py -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6871dc16a4a8832691bad852d12c2483