### PR TITLE
Add dashboard plotting API and ribbon visualization

### DIFF
--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -71,9 +71,9 @@ def test_dashboard_plot_data_valid_sequence() -> None:
         )
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data) >= {"gc_positions", "gc_values", "hp_lengths"}
-    assert data["gc_positions"] == [0, 10, 20, 30, 40, 50]
-    assert all(value == 0.5 for value in data["gc_values"])
-    assert len(data["hp_lengths"]) == len(seq)
-    assert all(length == 1 for length in data["hp_lengths"])
+    assert set(data) >= {"gc_array", "hp_array"}
+    assert data["gc_array"][:4] == [0, 1, 1, 0]
+    assert len(data["gc_array"]) == len(seq)
+    assert len(data["hp_array"]) == len(seq)
+    assert all(length == 1 for length in data["hp_array"])
 

--- a/web/helix-ui/src/Dashboard.jsx
+++ b/web/helix-ui/src/Dashboard.jsx
@@ -66,11 +66,7 @@ export default function Dashboard() {
           <p>Error Rate: {(data.error_rate * 100).toFixed(2)}%</p>
           <img src={`data:image/png;base64,${data.plot}`} style={{ maxWidth: '100%' }} />
           {plotData && (
-            <Heatmaps
-              gcPositions={plotData.gc_positions}
-              gcValues={plotData.gc_values}
-              hpLengths={plotData.hp_lengths}
-            />
+            <Heatmaps gcArray={plotData.gc_array} hpArray={plotData.hp_array} />
           )}
           {deepdna && (
             <div>

--- a/web/helix-ui/src/Heatmaps.jsx
+++ b/web/helix-ui/src/Heatmaps.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-export default function Heatmaps({ gcPositions, gcValues, hpLengths }) {
+export default function Heatmaps({ gcArray, hpArray }) {
   const canvasRef = useRef(null);
   const width = 600;
   const rowHeight = 40;
@@ -13,27 +13,34 @@ export default function Heatmaps({ gcPositions, gcValues, hpLengths }) {
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, width, totalHeight);
 
-    // GC content heatmap
-    if (gcPositions && gcValues && gcValues.length > 0) {
-      const barWidth = width / gcValues.length;
-      for (let i = 0; i < gcValues.length; i++) {
-        const intensity = gcValues[i];
-        ctx.fillStyle = `rgba(0,0,255,${intensity})`;
-        ctx.fillRect(i * barWidth, 0, barWidth, rowHeight);
+    const drawRibbon = (values, yOffset, color) => {
+      if (!values || values.length === 0) return;
+      const barWidth = width / values.length;
+      ctx.beginPath();
+      ctx.moveTo(0, yOffset + rowHeight);
+      for (let i = 0; i < values.length; i++) {
+        const y = yOffset + rowHeight - values[i] * rowHeight;
+        ctx.lineTo(i * barWidth, y);
       }
+      ctx.lineTo(width, yOffset + rowHeight);
+      ctx.closePath();
+      ctx.fillStyle = color;
+      ctx.fill();
+    };
+
+    if (gcArray && gcArray.length > 0) {
+      drawRibbon(gcArray, 0, 'rgba(0,0,255,0.3)');
     }
 
-    // Homopolymer length heatmap
-    if (hpLengths && hpLengths.length > 0) {
-      const maxHp = Math.max(...hpLengths, 1);
-      const barWidth = width / hpLengths.length;
-      for (let i = 0; i < hpLengths.length; i++) {
-        const intensity = hpLengths[i] / maxHp;
-        ctx.fillStyle = `rgba(255,0,0,${intensity})`;
-        ctx.fillRect(i * barWidth, rowHeight + 4, barWidth, rowHeight);
-      }
+    if (hpArray && hpArray.length > 0) {
+      const maxHp = Math.max(...hpArray, 1);
+      drawRibbon(
+        hpArray.map((x) => x / maxHp),
+        rowHeight + 4,
+        'rgba(255,0,0,0.3)'
+      );
     }
-  }, [gcPositions, gcValues, hpLengths]);
+  }, [gcArray, hpArray]);
 
   return (
     <div style={{ width }}>

--- a/web/main.py
+++ b/web/main.py
@@ -426,12 +426,18 @@ def _homopolymer_lengths(seq: str) -> list[int]:
     return lengths
 
 
+def _gc_array(seq: str) -> list[int]:
+    """Return ``1`` for G/C bases and ``0`` for A/T per position."""
+
+    return [1 if base in "GC" else 0 for base in seq.upper()]
+
+
 @app.post("/dashboard/plot-data")
 async def dashboard_plot_data(
     req: PlotDataRequest,
     _: None = Depends(verify_token),
 ) -> dict[str, object]:
-    """Return windowed GC content and homopolymer lengths."""
+    """Return arrays for GC presence and homopolymer lengths."""
 
     seq = req.dna_sequence
     if not DNA_RE.fullmatch(seq):
@@ -440,11 +446,13 @@ async def dashboard_plot_data(
         seq, req.window_size, req.step_size
     )
     hp_lengths = _homopolymer_lengths(seq)
+    gc_array = _gc_array(seq)
 
     return {
         "gc_positions": starts,
         "gc_values": gc_values,
-        "hp_lengths": hp_lengths,
+        "gc_array": gc_array,
+        "hp_array": hp_lengths,
     }
 
 
@@ -538,7 +546,7 @@ async def upload_chunk(
     await asyncio.to_thread(chunk_path.write_bytes, chunk_bytes)
     manifest_path = base_dir / "upload.manifest"
     h = hashlib.sha256(chunk_bytes).hexdigest()
-    async def _append() -> None:
+    def _append() -> None:
         with open(manifest_path, "a", encoding="utf-8") as mf:
             mf.write(json.dumps({"offset": req.offset, "hash": h}) + "\n")
 


### PR DESCRIPTION
## Summary
- provide GC presence helper and new plot-data response
- render ribbon-style GC and homopolymer plots in the dashboard
- adjust dashboard to use new fields
- extend tests for new API behavior
- fix manifest logging helper

## Testing
- `ruff check web/main.py tests/test_dashboard_httpx.py`
- `mypy web/main.py tests/test_dashboard_httpx.py`
- `pytest tests/test_dashboard_httpx.py -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871dc1585ac8326b1da09a35d5a6903