### PR TITLE
Fix parallel pipeline ordering

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -25,7 +25,7 @@ import logging
 import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from .plugin_security import compute_checksum
+from .plugin_security import compute_checksum, verify_signature  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -67,17 +67,17 @@ class ChannelPipeline(BaseChannel):
             )
 
         with executor_cls(max_workers=workers) as executor:
-            # submit all simulations before waiting on results so that they can
-            # run concurrently regardless of executor implementation
-            futures = [
-                executor.submit(_run_channel, sequence, channel)
-                for channel in self.channels
-            ]
+            fut: concurrent.futures.Future[str] | None = None
+            for channel in self.channels:
+                if fut is None:
+                    fut = executor.submit(_run_channel, sequence, channel)
+                else:
+                    fut = executor.submit(
+                        lambda f=fut, ch=channel: _run_channel(f.result(), ch)
+                    )
 
-            results = [f.result() for f in futures]
-
-        for res in results:
-            sequence = res
+            if fut is not None:
+                sequence = fut.result()
 
         metrics.increment("oligos_simulated")
         return sequence

--- a/tests/test_parallel_pipeline.py
+++ b/tests/test_parallel_pipeline.py
@@ -22,9 +22,7 @@ def test_parallel_pipeline_deterministic(
     cfg_threads = ChannelConfig(parallel=True, workers=2)
     parallel = pipeline.simulate(seq, config=cfg_threads)
 
-    expected = Channel(0.2).simulate(seq)
-    assert serial != parallel
-    assert parallel == expected
+    assert serial == parallel
 
 
 class _DelayChannel(BaseChannel):
@@ -39,39 +37,39 @@ class _DelayChannel(BaseChannel):
 
 
 def test_parallel_pipeline_concurrent(tmp_path: Path) -> None:
-    pipeline = ChannelPipeline([_DelayChannel(0.1), _DelayChannel(0.1)])
+    pipeline = ChannelPipeline([_DelayChannel(0.1)])
     os.environ["GENECODER_METRICS_PATH"] = str(tmp_path / "m.json")
-    seq = "AAAA"
+    seqs = ["AAAA", "TTTT"]
 
     start = time.perf_counter()
-    pipeline.simulate(seq)
+    for s in seqs:
+        pipeline.simulate(s)
     serial_time = time.perf_counter() - start
 
     cfg = ChannelConfig(parallel=True, workers=2)
+    from genecoder.parallel import parallel_map
     start = time.perf_counter()
-    pipeline.simulate(seq, config=cfg)
+    parallel_map(lambda s: pipeline.simulate(s, config=cfg), seqs, workers=2)
     parallel_time = time.perf_counter() - start
 
     assert parallel_time < serial_time * 0.75
 
 
 def test_parallel_pipeline_multi_channel_concurrent(tmp_path: Path) -> None:
-    """Ensure more than two channels run concurrently when parallel=True."""
-    pipeline = ChannelPipeline([
-        _DelayChannel(0.1),
-        _DelayChannel(0.1),
-        _DelayChannel(0.1),
-    ])
+    """Ensure multiple sequences run concurrently when parallel=True."""
+    pipeline = ChannelPipeline([_DelayChannel(0.1)])
     os.environ["GENECODER_METRICS_PATH"] = str(tmp_path / "m.json")
-    seq = "AAAA"
+    seqs = ["AAAA", "CCCC", "GGGG"]
 
     start = time.perf_counter()
-    pipeline.simulate(seq)
+    for s in seqs:
+        pipeline.simulate(s)
     serial_time = time.perf_counter() - start
 
     cfg = ChannelConfig(parallel=True, workers=3)
+    from genecoder.parallel import parallel_map
     start = time.perf_counter()
-    pipeline.simulate(seq, config=cfg)
+    parallel_map(lambda s: pipeline.simulate(s, config=cfg), seqs, workers=3)
     parallel_time = time.perf_counter() - start
 
     assert parallel_time < serial_time * 0.6


### PR DESCRIPTION
## Summary
- execute channels sequentially even when parallelizing `simulate`
- expose `verify_signature` in plugin manager for tests
- adapt parallel pipeline tests for new behaviour

## Testing
- `ruff check src/genecoder/simulators/pipeline.py tests/test_parallel_pipeline.py src/genecoder/plugin_manager.py`
- `mypy src/genecoder/simulators/pipeline.py src/genecoder/plugin_manager.py --config-file pyproject.toml --show-error-codes`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a4a14848326986a17035c51ad03