### PR TITLE
Implement strict DNA checks

### DIFF
--- a/tests/test_web_api_design.py
+++ b/tests/test_web_api_design.py
@@ -64,3 +64,21 @@ def test_design_fix_gc_extreme() -> None:
     data = r.json()
     assert data["gc_content"] >= 0.75
     assert get_max_homopolymer_length(data["sequence"]) <= 3
+
+
+def test_design_validate_invalid_chars() -> None:
+    payload = {"sequence": "ACGX"}
+    r = client.post("/design/validate", json=payload)
+    assert r.status_code == 400
+
+
+def test_design_validate_empty_sequence() -> None:
+    payload = {"sequence": ""}
+    r = client.post("/design/validate", json=payload)
+    assert r.status_code == 400
+
+
+def test_design_fix_invalid_sequence() -> None:
+    payload = {"sequence": "1234"}
+    r = client.post("/design/fix", json=payload)
+    assert r.status_code == 400

--- a/web/main.py
+++ b/web/main.py
@@ -470,6 +470,8 @@ async def design_validate(req: DesignRequest) -> dict[str, object]:
     """Validate a sequence against GC and homopolymer constraints."""
 
     seq = req.sequence.upper()
+    if not seq or not DNA_RE.fullmatch(seq):
+        raise HTTPException(status_code=400, detail="Invalid DNA sequence")
     gc_val = calculate_gc_content(seq)
     max_hp = get_max_homopolymer_length(seq)
     valid = req.gc_min <= gc_val <= req.gc_max and max_hp <= req.max_homopolymer
@@ -484,8 +486,12 @@ async def design_validate(req: DesignRequest) -> dict[str, object]:
 async def design_fix(req: DesignRequest) -> dict[str, object]:
     """Return a sequence adjusted to satisfy constraints."""
 
+    seq = req.sequence.upper()
+    if not seq or not DNA_RE.fullmatch(seq):
+        raise HTTPException(status_code=400, detail="Invalid DNA sequence")
+
     fixed = constraint_fixer.fix_sequence(
-        req.sequence,
+        seq,
         target_gc_min=req.gc_min,
         target_gc_max=req.gc_max,
         max_homopolymer=req.max_homopolymer,


### PR DESCRIPTION
## Summary
- ensure `/design/validate` and `/design/fix` reject empty or non-DNA sequences
- return HTTP 400 when the sequence fails validation
- test invalid sequence handling in the design API

## Testing
- `ruff check`
- `pytest tests/test_web_api_design.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a493c4883268e1a66b7942e71d6