### PR TITLE
Add validation for slurm job name and partition

### DIFF
--- a/src/genecoder/cloud/hpc.py
+++ b/src/genecoder/cloud/hpc.py
@@ -22,6 +22,13 @@ def generate_slurm_script(
         raise ValueError("command must not contain newlines")
     if re.search(r"[;&|<>`$]", command):
         raise ValueError("command contains unsafe characters")
+
+    allowed = re.compile(r"^[A-Za-z0-9_-]+$")
+    if not allowed.fullmatch(job_name):
+        raise ValueError("job_name contains invalid characters")
+    if partition is not None and not allowed.fullmatch(partition):
+        raise ValueError("partition contains invalid characters")
+
     lines = ["#!/bin/bash", f"#SBATCH --job-name={job_name}"]
     lines.append(f"#SBATCH --output={output or '%x-%j.out'}")
     if partition:

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -30,6 +30,18 @@ def test_generate_slurm_script_rejects_bad(cmd: str) -> None:
         generate_slurm_script(cmd)
 
 
+@pytest.mark.parametrize("job_name", ["bad name", "bad/name", "bad!", "foo$"])
+def test_generate_slurm_script_bad_job_name(job_name: str) -> None:
+    with pytest.raises(ValueError):
+        generate_slurm_script("echo hi", job_name=job_name)
+
+
+@pytest.mark.parametrize("partition", ["bad part", "bad/part", "bad!", "foo$"])
+def test_generate_slurm_script_bad_partition(partition: str) -> None:
+    with pytest.raises(ValueError):
+        generate_slurm_script("echo hi", partition=partition)
+
+
 def test_submit_slurm_job(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
 


### PR DESCRIPTION
## Summary
- validate job_name and partition for Slurm jobs
- add tests for invalid job_name and partition

## Testing
- `ruff check src/genecoder/cloud/hpc.py`
- `ruff check tests/test_cloud_hpc.py`
- `mypy src/genecoder/cloud/hpc.py`
- `pytest tests/test_cloud_hpc.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a48725c8326aa85d0d61c867c3a