### PR TITLE
Add sequence pipeline with parallel batch option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,6 +201,15 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file channel.fasta --config config.yml
    ```
 
+   The command processes each FASTA record through a pipeline of steps. Use
+   ``--batch-workers`` to run multiple records in parallel:
+
+   ```bash
+   genecoder channel --input-file encoded.fasta \
+       --output-file channel.fasta --config config.yml \
+       --batch-workers 4
+   ```
+
 14. **AI-assisted decoding**
 
    Install the optional `dnaformer` extras to enable a machine learning model

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -22,6 +22,7 @@ from .plugin_manager import (
 )
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
 from .channel_config import ChannelConfig
+from .pipeline import SequencePipeline
 from .cloud import CloudClient
 
 
@@ -37,6 +38,7 @@ __all__ = [
     "load_plugins",
     "install_registry_plugins",
     "ChannelConfig",
+    "SequencePipeline",
     "encrypt_data",
     "decrypt_data",
     "compute_checksum",

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -18,6 +18,7 @@ from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
+from genecoder.parallel import parallel_map
 from .options import ChannelOptions, build_channel_options
 from .shared import add_single_io_args
 
@@ -69,6 +70,7 @@ def process_channel(
     del_prob: float = 0.0,
     seed: int | None = None,
     config: ChannelConfig | None = None,
+    batch_workers: int | None = None,
 ) -> None:
     try:
         with open(input_file, "r", encoding="utf-8") as f:
@@ -85,17 +87,16 @@ def process_channel(
         synth = SynthesisConstraints(**constraints)
     except ValueError:
         synth = SynthesisConstraints()
-    processed_records: list[tuple[str, str]] = []
-    for header, seq in records:
+    headers = [h for h, _ in records]
+    sequences = [s for _, s in records]
+
+    def _process(item: tuple[int, str]) -> str:
+        idx, seq = item
         if simulators:
             cfg = config or ChannelConfig()
-            seq = _apply_simulators(
-                seq,
-                simulators,
-                config=cfg,
-            )
+            seq = _apply_simulators(seq, simulators, config=cfg)
         else:
-            rng = random.Random(seed)
+            rng = random.Random(seed + idx if seed is not None else None)
             seq = introduce_errors(
                 seq,
                 substitution_prob=sub_prob,
@@ -104,12 +105,21 @@ def process_channel(
                 rng=rng,
             )
             metrics.increment("oligos_simulated")
-
         if not validate_sequence(seq, synth):
-            logger.error("Sequence violates synthesis constraints")
-            raise SystemExit(1)
+            raise ValueError("Sequence violates synthesis constraints")
         logger.info("Sequence satisfies synthesis constraints")
-        processed_records.append((header, seq))
+        return seq
+
+    if batch_workers and len(sequences) > 1:
+        processed_seqs = parallel_map(
+            _process,
+            list(enumerate(sequences)),
+            workers=batch_workers,
+        )
+    else:
+        processed_seqs = [_process(p) for p in enumerate(sequences)]
+
+    processed_records = list(zip(headers, processed_seqs))
 
     fasta_out = "".join(
         to_fasta(seq, header, line_width=80) for header, seq in processed_records
@@ -163,6 +173,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
     parser.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
+    parser.add_argument(
+        "--batch-workers",
+        type=int,
+        default=None,
+        help="Process sequences in parallel using N workers",
+    )
     parser.set_defaults(func=_handle_command)
 
 
@@ -189,4 +205,5 @@ def _handle_command(args: argparse.Namespace) -> None:
         del_prob=opts.del_prob,
         seed=opts.seed,
         config=cfg,
+        batch_workers=opts.batch_workers,
     )

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -24,6 +24,7 @@ class ChannelOptions:
     processes: int | None = None
     mpi: bool = False
     mpi_workers: int | None = None
+    batch_workers: int | None = None
 
 
 def _validate_simulator_prob_args(
@@ -108,6 +109,8 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("Cannot combine MPI with threads or processes")
     if args.mpi_workers is not None and not args.mpi:
         raise ValueError("--mpi-workers requires --mpi")
+    if args.batch_workers is not None and args.batch_workers <= 0:
+        raise ValueError("batch_workers must be greater than 0")
 
     return ChannelOptions(
         simulators=simulators,
@@ -121,4 +124,5 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         processes=args.processes,
         mpi=args.mpi,
         mpi_workers=args.mpi_workers,
+        batch_workers=args.batch_workers,
     )

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple pipeline for processing sequences step by step."""
+
+from typing import Callable, Iterable, Sequence
+
+from .parallel import parallel_map
+
+__all__ = ["SequencePipeline"]
+
+
+class SequencePipeline:
+    """Process sequences through a series of transformation steps."""
+
+    def __init__(self, steps: Iterable[Callable[[str], str]] | None = None) -> None:
+        self.steps: list[Callable[[str], str]] = list(steps or [])
+
+    def add_step(self, step: Callable[[str], str]) -> None:
+        """Append ``step`` to the pipeline."""
+        self.steps.append(step)
+
+    def run(self, sequence: str) -> str:
+        """Return ``sequence`` processed by each step."""
+        for step in self.steps:
+            sequence = step(sequence)
+        return sequence
+
+    def run_batch(
+        self,
+        sequences: Sequence[str],
+        *,
+        parallel: bool = False,
+        workers: int | None = None,
+        use_processes: bool = False,
+    ) -> list[str]:
+        """Apply the pipeline to ``sequences`` optionally in parallel."""
+        if parallel:
+            return parallel_map(
+                self.run,
+                sequences,
+                workers=workers,
+                use_processes=use_processes,
+            )
+        return [self.run(s) for s in sequences]
+

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -20,6 +20,7 @@ def _make_args(**kwargs: Any) -> argparse.Namespace:
         processes=None,
         mpi=False,
         mpi_workers=None,
+        batch_workers=None,
         config=None,
         min_length=1,
         max_length=300,
@@ -127,5 +128,11 @@ def test_max_length_negative() -> None:
 def test_min_length_greater_than_max() -> None:
     args = _make_args(simulators=["simple"], min_length=10, max_length=5)
     with pytest.raises(ValueError, match="min_length cannot be greater"):
+        build_channel_options(args)
+
+
+def test_batch_workers_invalid() -> None:
+    args = _make_args(simulators=["simple"], batch_workers=0)
+    with pytest.raises(ValueError, match="batch_workers"):
         build_channel_options(args)
 

--- a/tests/test_sequence_pipeline.py
+++ b/tests/test_sequence_pipeline.py
@@ -1,0 +1,14 @@
+from genecoder.pipeline import SequencePipeline
+
+
+def test_sequence_pipeline_basic() -> None:
+    pipeline = SequencePipeline([lambda s: s + "A", lambda s: s + "B"])
+    assert pipeline.run("X") == "XAB"
+
+
+def test_sequence_pipeline_parallel() -> None:
+    pipeline = SequencePipeline([str.lower])
+    seqs = ["A", "B", "C"]
+    out = pipeline.run_batch(seqs, parallel=True, workers=2)
+    assert out == ["a", "b", "c"]
+


### PR DESCRIPTION
## Summary
- support pipeline processing over sequences
- allow parallel batch execution via `--batch-workers`
- document new option in usage guide
- add tests for option validation and pipeline module

## Testing
- `pytest -q tests/test_sequence_pipeline.py tests/test_channel_options_validation.py::test_batch_workers_invalid`
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/pipeline.py src/genecoder/__init__.py tests/test_sequence_pipeline.py tests/test_channel_options_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_687332b47050832697c6f50032f847e1