### PR TITLE
Expose CLI operations as functions

### DIFF
--- a/src/genecoder/cli/__init__.py
+++ b/src/genecoder/cli/__init__.py
@@ -7,21 +7,28 @@ from .options import (
     ChannelOptions,
     build_channel_options,
 )
-from .encode import run_encoding_pipeline
-from .decode import run_decoding_pipeline
+from .encode import run_encoding_pipeline, encode_files
+from .decode import run_decoding_pipeline, decode_files
 from .cli import main
-from .channel import process_channel
+from .channel import process_channel, run_channel
+from .analyze import analyze_files
+from .stats import collect_stats
 
 __all__ = [
     "EncodingOptions",
     "ChannelOptions",
     "build_channel_options",
     "build_encoding_options",
+    "encode_files",
     "run_encoding_pipeline",
     "DecodingOptions",
     "build_decoding_options",
+    "decode_files",
     "run_decoding_pipeline",
+    "analyze_files",
     "main",
     "process_channel",
+    "run_channel",
+    "collect_stats",
 ]
 

--- a/src/genecoder/cli/analyze.py
+++ b/src/genecoder/cli/analyze.py
@@ -142,6 +142,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    analyze_files(args)
+
+
+def analyze_files(args: argparse.Namespace) -> None:
+    """Analyze all input files specified in ``args``."""
+
     for input_file_path in args.input_files:
         process_single_analyze(input_file_path, args)
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -167,6 +167,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    run_channel(args)
+
+
+def run_channel(args: argparse.Namespace) -> None:
+    """Run the channel command using ``args``."""
+
     try:
         opts: ChannelOptions = build_channel_options(args)
     except ValueError as exc:

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -386,7 +386,9 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.set_defaults(func=_handle_command)
 
 
-def _handle_command(args: argparse.Namespace) -> None:
+def decode_files(args: argparse.Namespace) -> None:
+    """Decode files specified in ``args``."""
+
     validate_chunk_size(args)
     if getattr(args, "d2sim_options", None):
         os.environ["GENECODER_D2SIM_OPTIONS"] = args.d2sim_options
@@ -430,7 +432,9 @@ def _handle_command(args: argparse.Namespace) -> None:
                 base = Path(header_name).stem
             else:
                 base = Path(input_file_path).stem
-            ext = f".{args.file_type}" if getattr(args, "file_type", None) else (Path(header_name).suffix if header_name else ".bin")
+            ext = (
+                f".{args.file_type}" if getattr(args, "file_type", None) else (Path(header_name).suffix if header_name else ".bin")
+            )
             output_file_path = os.path.join(base_dir, f"{base}{ext}")
 
         base_output = output_file_path
@@ -443,4 +447,8 @@ def _handle_command(args: argparse.Namespace) -> None:
         tasks.append((input_file_path, output_file_path, args))
 
     run_tasks(tasks, process_single_decode, description="decoding")
+
+
+def _handle_command(args: argparse.Namespace) -> None:
+    decode_files(args)
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -524,7 +524,9 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.set_defaults(func=_handle_command)
 
 
-def _handle_command(args: argparse.Namespace) -> None:
+def encode_files(args: argparse.Namespace) -> list[tuple[str, str]]:
+    """Encode files according to ``args`` and return CSV rows."""
+
     validate_chunk_size(args)
     validate_output_paths(
         args,
@@ -558,7 +560,9 @@ def _handle_command(args: argparse.Namespace) -> None:
             continue
         tasks.append((input_file_path, output_file_path, args))
 
-    results = run_tasks(tasks, process_single_encode, description="encoding", collect_results=True)
+    results = run_tasks(
+        tasks, process_single_encode, description="encoding", collect_results=True
+    )
     if args.export_csv:
         csv_rows.extend([res for res in results if res])
 
@@ -571,4 +575,9 @@ def _handle_command(args: argparse.Namespace) -> None:
         logger.info(f"CSV order file written to {args.export_csv}")
 
     metrics.increment("encode_runs")
+    return results
+
+
+def _handle_command(args: argparse.Namespace) -> None:
+    encode_files(args)
 

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -11,8 +11,14 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 
 def _handle_command(_: argparse.Namespace) -> None:
-    metrics = get_metrics()
-    for k, v in metrics.items():
+    data = collect_stats()
+    for k, v in data.items():
         print(f"{k}: {v}")
-    weeks = oligos_per_week()
-    print(f"oligos_per_week: {weeks}")
+
+
+def collect_stats() -> dict[str, object]:
+    """Return current usage metrics."""
+
+    data = get_metrics()
+    data["oligos_per_week"] = oligos_per_week()
+    return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 import argparse
 import pytest
-import subprocess
 import os
-import sys
 import tempfile
+import io
+import contextlib
 from pathlib import Path
 from genecoder.utils import get_temp_dir
 from src.genecoder.formats import to_fasta, from_fasta
@@ -27,25 +27,35 @@ def small_fasta_file(temp_dir: Path) -> Path:
     fasta_path.write_text(to_fasta("ATGCATGC", "seq1"))
     return fasta_path
 
-def run_cli_command(command_args: list[str], env=None) -> subprocess.CompletedProcess:
-    """Helper function to run CLI commands."""
+class _Result:
+    def __init__(self, code: int, out: str, err: str) -> None:
+        self.returncode = code
+        self.stdout = out
+        self.stderr = err
+
+
+def run_cli_command(command_args: list[str], env=None) -> _Result:
+    """Invoke CLI main with arguments and capture output."""
+
+    from genecoder.cli.cli import main
     if env is None:
         env = os.environ.copy()
-        # Ensure PYTHONPATH includes the project root so genecoder.cli can be found
-        src_path = PROJECT_ROOT / "src"
-        env['PYTHONPATH'] = str(src_path) + os.pathsep + env.get('PYTHONPATH', '')
 
-    # Construct the command
-    # Using python -m genecoder.cli is generally more robust for module resolution
-    full_command = [sys.executable, "-m", "genecoder.cli"] + command_args
-    
-    return subprocess.run(
-        full_command,
-        capture_output=True,
-        text=True,
-        env=env,
-        cwd=PROJECT_ROOT # Run from project root
-    )
+    saved_env = os.environ.copy()
+    os.environ.update(env)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = 0
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            main(command_args)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
+
+    return _Result(code, stdout.getvalue(), stderr.getvalue())
 
 # --- Test Scenarios for Batch Encoding ---
 


### PR DESCRIPTION
## Summary
- add encode_files, decode_files and other callable APIs
- CLI subcommands now call these APIs
- refactor tests to invoke CLI main directly

## Testing
- `ruff check .`
- `pytest tests/test_cli.py::test_batch_encode_success -q`
- `pytest tests/test_cli_decode.py::test_cli_decode_duplicate_output_names -q`

------
https://chatgpt.com/codex/tasks/task_e_687332b53328832681b1c08b2ecedcf8