### PR TITLE
Add shared plugin verification helpers

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import base64
 import logging
 import os
 import sys
@@ -13,6 +12,7 @@ from pip._internal.exceptions import InstallationSubprocessError
 from pip._internal.utils.subprocess import call_subprocess
 
 import genecoder.plugin_manager as plugins
+from genecoder.plugin_checks import decode_signature, verify_package
 
 logger = logging.getLogger(__name__)
 
@@ -141,20 +141,25 @@ def _handle_install(args: argparse.Namespace) -> None:
                 logger.error("Missing public key for signed plugin %s", name)
                 raise SystemExit(1)
             try:
-                digest = plugins.compute_checksum(
-                    pkg_bytes,
-                    signature=base64.b64decode(signature_b64),
-                    public_key=pubkey,
-                )
-            except Exception as exc:
-                logger.error(
-                    "Signature verification failed for plugin %s: %s", name, exc
-                )
+                sig_bytes = decode_signature(signature_b64)
+            except ValueError:
+                logger.error("Invalid signature for plugin %s", name)
                 raise SystemExit(1)
         else:
-            digest = plugins.compute_checksum(pkg_bytes)
-        if checksum and digest != checksum:
-            logger.error("Checksum mismatch for plugin %s", name)
+            sig_bytes = None
+        try:
+            digest = verify_package(
+                pkg_bytes,
+                checksum=checksum,
+                signature=sig_bytes,
+                public_key=pubkey,
+                compute_fn=plugins.compute_checksum,
+            )
+        except ValueError as exc:
+            if str(exc) == "Checksum mismatch":
+                logger.error("Checksum mismatch for plugin %s", name)
+            else:
+                logger.error("Signature verification failed for plugin %s: %s", name, exc)
             raise SystemExit(1)
         req_file = Path(tmp_dir) / "req.txt"
         req_file.write_text(f"{pkg_path} --hash=sha256:{digest}\n")

--- a/src/genecoder/plugin_checks.py
+++ b/src/genecoder/plugin_checks.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Helper utilities for validating plugin packages."""
+
+import base64
+from typing import Callable
+
+from .security import compute_checksum
+
+__all__ = ["decode_signature", "verify_package"]
+
+
+def decode_signature(signature_b64: str) -> bytes:
+    """Return raw signature bytes decoded from base64."""
+    try:
+        return base64.b64decode(signature_b64, validate=True)
+    except Exception as exc:  # pragma: no cover - invalid base64
+        raise ValueError("Invalid signature") from exc
+
+
+def verify_package(
+    data: bytes,
+    *,
+    checksum: str | None = None,
+    signature: bytes | None = None,
+    public_key: bytes | None = None,
+    compute_fn: Callable[..., str] | None = None,
+) -> str:
+    """Return the SHA256 digest of ``data`` after optional verification.
+
+    ``checksum`` is compared against the computed digest when provided.
+    ``signature`` and ``public_key`` are used for signature verification when
+    both are given. ``ValueError`` is raised on a checksum mismatch.
+    """
+    if compute_fn is None:
+        compute_fn = compute_checksum
+    digest = compute_fn(data, signature=signature, public_key=public_key)
+    if checksum is not None and digest != checksum:
+        raise ValueError("Checksum mismatch")
+    return digest

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -26,6 +26,7 @@ import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
 from .plugin_security import compute_checksum, verify_signature  # noqa: F401
+from .plugin_checks import decode_signature, verify_package
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +118,8 @@ def _install_registry_plugins(url: str) -> None:
                 logger.error(msg)
                 raise ValueError(msg)
             try:
-                signature = base64.b64decode(sig_b64, validate=True)
-            except Exception as exc:
+                signature = decode_signature(sig_b64)
+            except ValueError as exc:
                 msg = f"Invalid signature for plugin entry {entry}"
                 logger.error(msg)
                 raise ValueError(msg) from exc
@@ -142,24 +143,21 @@ def _install_registry_plugins(url: str) -> None:
             logger.warning("Failed to download plugin %s: %s", spec, exc)
             continue
 
-        if signature is not None:
-            if pubkey is None:
-                logger.warning("No public key configured for signed plugin %s", spec)
+        try:
+            digest = verify_package(
+                pkg_bytes,
+                checksum=checksum,
+                signature=signature,
+                public_key=pubkey,
+                compute_fn=compute_checksum,
+            )
+        except ValueError as exc:
+            if str(exc) == "Checksum mismatch":
+                logger.warning("Checksum mismatch for plugin %s", spec)
                 continue
-            try:
-                digest = compute_checksum(
-                    pkg_bytes, signature=signature, public_key=pubkey
-                )
-            except Exception as exc:
-                msg = f"Invalid signature for plugin {spec}: {exc}"
-                logger.error(msg)
-                raise ValueError(msg) from exc
-        else:
-            digest = compute_checksum(pkg_bytes)
-
-        if digest != checksum:
-            logger.warning("Checksum mismatch for plugin %s", spec)
-            continue
+            msg = f"Invalid signature for plugin {spec}: {exc}"
+            logger.error(msg)
+            raise ValueError(msg) from exc
 
         tmp_file = None
         req_file = None

--- a/tests/test_plugin_checks.py
+++ b/tests/test_plugin_checks.py
@@ -1,0 +1,31 @@
+import pytest
+
+import genecoder.plugin_checks as pc
+from genecoder.security import compute_checksum
+
+
+def test_verify_package_success():
+    data = b"DATA"
+    checksum = compute_checksum(data)
+    assert pc.verify_package(data, checksum=checksum) == checksum
+
+
+def test_verify_package_checksum_mismatch():
+    data = b"DATA"
+    wrong = compute_checksum(b"OTHER")
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        pc.verify_package(data, checksum=wrong)
+
+
+def test_decode_signature_invalid():
+    with pytest.raises(ValueError, match="Invalid signature"):
+        pc.decode_signature("not_base64")
+
+
+def test_verify_package_signature_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_compute(data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None) -> str:
+        raise ValueError("bad sig")
+
+    monkeypatch.setattr(pc, "compute_checksum", fake_compute)
+    with pytest.raises(ValueError, match="bad sig"):
+        pc.verify_package(b"DATA", signature=b"sig", public_key=b"PUB")


### PR DESCRIPTION
## Summary
- create `plugin_checks` utilities for verifying plugin signatures and checksums
- use the new helpers in plugin CLI and manager
- support injection of a custom checksum function for tests

## Testing
- `ruff check .`
- `pytest tests/test_cli_plugin_catalog.py::test_cli_catalog_list_and_install -q`
- `pytest tests/test_plugin_cli_registry.py::test_cli_registry_install tests/test_plugin_cli_registry.py::test_cli_registry_install_failure tests/test_plugin_cli_registry.py::test_cli_registry_signature_failure tests/test_plugin_cli_registry.py::test_cli_registry_checksum_mismatch -q`
- `pytest tests/test_plugin_marketplace.py::test_catalog_list_and_install tests/test_plugin_marketplace.py::test_install_checksum_mismatch tests/test_plugin_marketplace.py::test_install_signature_mismatch tests/test_plugin_marketplace.py::test_catalog_missing_checksum -q`
- `pytest tests/test_plugin_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687332b4e41c83268d8c74082df90874