### PR TITLE
Add network failure & invalid JSON tests

### DIFF
--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -143,6 +143,76 @@ def test_async_cloud_client_bad_payload() -> None:
     asyncio.run(_run())
 
 
+def test_cloud_client_network_error() -> None:
+    """Network failures raise ``RuntimeError``."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = CloudClient(
+        "https://s",
+        client=httpx.Client(base_url="https://s", transport=transport),
+    )
+    with pytest.raises(RuntimeError, match="Failed to submit job"):
+        client.submit("bundle", {"a": 1})
+
+
+def test_async_cloud_client_network_error() -> None:
+    """Async network failures raise ``RuntimeError``."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    async def _run() -> None:
+        client = AsyncCloudClient(
+            "https://s",
+            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+        )
+        with pytest.raises(RuntimeError, match="Failed to submit job"):
+            await client.submit("bundle", {"a": 1})
+        await client.close()
+
+    asyncio.run(_run())
+
+
+def test_cloud_client_invalid_json() -> None:
+    """Malformed JSON responses raise ``ValueError``."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"{bad json}")
+
+    transport = httpx.MockTransport(handler)
+    client = CloudClient(
+        "https://s",
+        client=httpx.Client(base_url="https://s", transport=transport),
+    )
+    with pytest.raises(ValueError):
+        client.submit("bundle", {"a": 1})
+
+
+def test_async_cloud_client_invalid_json() -> None:
+    """Async client errors on malformed JSON."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"{bad json}")
+
+    transport = httpx.MockTransport(handler)
+
+    async def _run() -> None:
+        client = AsyncCloudClient(
+            "https://s",
+            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+        )
+        with pytest.raises(ValueError):
+            await client.submit("bundle", {"a": 1})
+        await client.close()
+
+    asyncio.run(_run())
+
+
 def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bundle = tmp_path / "b.yaml"
     bundle.write_text("encode:\n  input_files: []\n")

--- a/tests/test_plugin_cli_rate.py
+++ b/tests/test_plugin_cli_rate.py
@@ -32,3 +32,41 @@ def test_plugin_rate_cli(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Capture
     assert called["json"] == {"name": "demo", "rating": 5}
     out = capsys.readouterr().out.strip()
     assert out == "4.0"
+
+
+def test_plugin_rate_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Network failures abort the command."""
+
+    httpx = pytest.importorskip("httpx")
+
+    def fake_post(url: str, *, json: dict[str, object], headers: dict[str, str]):
+        raise httpx.ConnectError("offline", request=httpx.Request("POST", url))
+
+    dummy = SimpleNamespace(post=fake_post, HTTPError=httpx.HTTPError)
+    monkeypatch.setitem(sys.modules, "httpx", dummy)
+    args = argparse.Namespace(name="demo", rating=5, server="https://s", token=None)
+    with pytest.raises(SystemExit):
+        plugin_cli._handle_rate(args)
+
+
+def test_plugin_rate_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid JSON responses propagate errors."""
+
+    class DummyResp:
+        def __init__(self) -> None:
+            self.status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict[str, float]:
+            raise ValueError("no json")
+
+    def fake_post(url: str, *, json: dict[str, object], headers: dict[str, str]):
+        return DummyResp()
+
+    dummy = SimpleNamespace(post=fake_post, HTTPError=Exception)
+    monkeypatch.setitem(sys.modules, "httpx", dummy)
+    args = argparse.Namespace(name="demo", rating=5, server="https://s", token=None)
+    with pytest.raises(ValueError):
+        plugin_cli._handle_rate(args)


### PR DESCRIPTION
## Summary
- cover network failures and malformed JSON responses in CloudClient
- test plugin CLI rating error handling for networking issues and bad JSON

## Testing
- `ruff check tests/test_cloud.py tests/test_plugin_cli_rate.py`
- `pytest tests/test_cloud.py::test_cloud_client_network_error tests/test_cloud.py::test_async_cloud_client_network_error tests/test_cloud.py::test_cloud_client_invalid_json tests/test_cloud.py::test_async_cloud_client_invalid_json tests/test_plugin_cli_rate.py::test_plugin_rate_network_error tests/test_plugin_cli_rate.py::test_plugin_rate_invalid_json -q`

------
https://chatgpt.com/codex/tasks/task_e_68746683bc3083268c80b2f88782068f