### PR TITLE
Add YAML error cases

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -157,7 +157,11 @@ def _handle_run(args: argparse.Namespace) -> None:
     import yaml
 
     with open(args.config, "r", encoding="utf-8") as fh:
-        config = yaml.safe_load(fh) or {}
+        try:
+            config = yaml.safe_load(fh) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML path
+            logger.error("Invalid YAML in %s: %s", args.config, exc)
+            raise SystemExit(1)
 
     if not isinstance(config, dict):
         raise TypeError("Top level YAML must be a mapping")

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 def _load_config(path: str) -> tuple[list[str], dict[str, int]]:
     import yaml
     with open(path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
+        try:
+            data = yaml.safe_load(f) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML path
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError("Config file must map keys to values")
     sim = data.get("simulators", [])

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -200,3 +200,18 @@ def test_bundle_archive_metadata(tmp_path: Path) -> None:
         data = json.loads(tf.extractfile(summary_name).read().decode())
     assert data.get("author") == "Alice"
     assert data.get("description") == "Test run"
+
+
+def test_bundle_bad_yaml(tmp_path: Path) -> None:
+    """Malformed YAML config aborts the run."""
+    cfg = tmp_path / "bad.yml"
+    cfg.write_text("encode: [oops")
+    res = run_cli_command([
+        "bundle",
+        "run",
+        str(cfg),
+        "--cache-dir",
+        str(tmp_path / "runs"),
+    ])
+    assert res.returncode != 0
+    assert "Invalid YAML" in res.stderr

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -235,3 +235,61 @@ def test_channel_cli_parallel_variants(
     assert data["simulators"] == ["simple"]
     assert data["metrics"]["length"] == len(seq)
 
+
+def test_channel_cli_bad_yaml(tmp_path: Path) -> None:
+    """Malformed YAML configuration results in an error."""
+    input_fasta = tmp_path / "in_bad.fasta"
+    create_fasta(input_fasta)
+    cfg = tmp_path / "bad.yml"
+    cfg.write_text("simulators: [simple")
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(tmp_path / "out_bad.fasta"),
+            "--config",
+            str(cfg),
+        ],
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "Invalid YAML" in result.stderr
+
+
+def test_channel_cli_wrong_type(tmp_path: Path) -> None:
+    """Wrong data types in YAML config are rejected."""
+    input_fasta = tmp_path / "in_type.fasta"
+    create_fasta(input_fasta)
+    cfg = tmp_path / "type.yml"
+    cfg.write_text("simulators: 1\n")
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(tmp_path / "out_type.fasta"),
+            "--config",
+            str(cfg),
+        ],
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "'simulators' must be a list" in result.stderr
+


### PR DESCRIPTION
## Summary
- handle YAML errors gracefully in `channel` and `bundle` CLIs
- test malformed YAML and wrong data types for `channel`
- test malformed YAML for `bundle`

## Testing
- `ruff check tests/test_cli_channel.py tests/test_bundle.py src/genecoder/cli/channel.py src/genecoder/cli/bundle.py`
- `pytest tests/test_cli_channel.py::test_channel_cli_bad_yaml tests/test_cli_channel.py::test_channel_cli_wrong_type tests/test_bundle.py::test_bundle_bad_yaml -q`

------
https://chatgpt.com/codex/tasks/task_e_68746682b4148326bcbcf6657a30a1c3