### PR TITLE
Add plugin scaffold script

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -68,6 +68,10 @@ simulator and a small package plugin using the `genecoder.plugins`
 group. Install any of these packages with `pip install` to experiment
 with custom extensions locally.
 
+Run `scripts/scaffold_plugin.sh <name>` to create a new plugin project. The
+generated template registers an entry point and includes a README with
+instructions on signing the distribution.
+
 ## Developing a Plugin Step by Step
 
 1. Copy `src/plugins/reverse_codec.py` as a starting point.

--- a/scripts/scaffold_plugin.sh
+++ b/scripts/scaffold_plugin.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Scaffold a minimal GeneCoder plugin project.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $(basename "$0") <project-name>" >&2
+    exit 1
+fi
+
+PROJECT=$1
+MODULE=${PROJECT//-/_}
+
+mkdir -p "$PROJECT/$MODULE"
+
+cat > "$PROJECT/pyproject.toml" <<PY
+[project]
+name = "$PROJECT"
+version = "0.1.0"
+description = "GeneCoder plugin"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.entry-points."genecoder.plugins"]
+$PROJECT = "$MODULE.plugin:register"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+PY
+
+cat > "$PROJECT/$MODULE/plugin.py" <<PY
+"""$PROJECT plugin."""
+
+def register(register_plugin):
+    """Register the plugin with GeneCoder."""
+
+    def encode(data: bytes) -> str:
+        """Encode bytes to text."""
+        raise NotImplementedError
+
+    def decode(text: str) -> bytes:
+        """Decode text back to bytes."""
+        raise NotImplementedError
+
+    register_plugin("$PROJECT", encode, decode)
+PY
+
+cat > "$PROJECT/README.md" <<'PY'
+# GeneCoder Plugin
+
+After implementing your plugin, build and sign a wheel:
+
+```bash
+python -m build
+openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -in private.pem -pubout -out public.pem
+openssl dgst -sha256 -sign private.pem -binary dist/*.whl | base64 > signature.txt
+```
+
+Distribute `public.pem` alongside your signed wheel so users can verify it.
+PY
+
+echo "Plugin scaffold created in $PROJECT"
+


### PR DESCRIPTION
## Summary
- scaffold new plugin projects with a helper script
- document how to use the script in plugin docs

## Testing
- `SKIP=pytest pre-commit run --files scripts/scaffold_plugin.sh docs/plugins.md`
- `pytest tests/test_utils.py::test_bit_error_rate_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_68746681374c8326ae18fe4e7e5cd39c