### PR TITLE
Add bundle metrics endpoint and UI

### DIFF
--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -22,3 +22,25 @@ genecoder cloud submit --archive output.tar.gz --server https://worker:8000 --to
 ```
 
 This is equivalent to supplying a bundle YAML file directly, but avoids rebuilding the archive when the workflow has already been run locally.
+
+## Server-side metrics
+
+When bundles are processed on a GeneCoder server, each encoded file writes a
+``*.manifest.json`` file capturing metrics like DNA length and bits per
+nucleotide. The server aggregates these manifests under the directory specified
+by the ``GENECODER_BUNDLE_DIR`` environment variable (default ``bundle_runs``).
+
+Aggregated values are available through the ``/bundle-metrics`` endpoint:
+
+```bash
+$ curl http://localhost:8000/bundle-metrics
+{
+  "files": 12,
+  "total_original_size": 12345,
+  "total_dna_length": 45678,
+  "avg_bits_per_nt": 1.23
+}
+```
+
+The React component in ``web/helix-ui`` displays these metrics graphically after
+running ``npm run build`` and opening ``dashboard.html``.

--- a/src/genecoder/bundle_metrics.py
+++ b/src/genecoder/bundle_metrics.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+__all__ = ["parse_manifests", "aggregate_metrics"]
+
+
+def parse_manifests(root: Path) -> Iterable[dict[str, Any]]:
+    """Yield manifest dictionaries found under *root*.
+
+    The function searches recursively for files ending with ``.manifest.json``
+    and loads any valid JSON objects found.
+    """
+    for path in root.rglob("*.manifest.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(data, dict):
+            yield data
+
+
+def aggregate_metrics(root: Path) -> dict[str, Any]:
+    """Return aggregate metrics for all manifests under *root*."""
+    total_files = 0
+    total_bytes = 0
+    total_nt = 0
+    bpn_values: list[float] = []
+    for manifest in parse_manifests(root):
+        total_files += 1
+        metrics = manifest.get("metrics", {})
+        if isinstance(metrics, dict):
+            b = metrics.get("original_size")
+            if isinstance(b, int):
+                total_bytes += b
+            n = metrics.get("dna_length")
+            if isinstance(n, int):
+                total_nt += n
+            bpn = metrics.get("bits_per_nt")
+            if isinstance(bpn, (int, float)):
+                bpn_values.append(float(bpn))
+    avg_bpn = sum(bpn_values) / len(bpn_values) if bpn_values else 0.0
+    return {
+        "files": total_files,
+        "total_original_size": total_bytes,
+        "total_dna_length": total_nt,
+        "avg_bits_per_nt": avg_bpn,
+    }

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -1,0 +1,43 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+pytest.importorskip("httpx")
+fastapi = pytest.importorskip("fastapi")
+
+import web.main as main
+
+
+def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+    async def _call() -> httpx.Response:
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            return await ac.request(method, url, **kwargs)
+
+    return asyncio.run(_call())
+
+
+def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GENECODER_BUNDLE_DIR", str(tmp_path))
+    main.BUNDLE_DIR = Path(tmp_path)
+    mdir = tmp_path / "run"
+    mdir.mkdir()
+    (mdir / "file.manifest.json").write_text(
+        json.dumps({
+            "file": "x",
+            "encoding_parameters": {"method": "base4_direct"},
+            "metrics": {"original_size": 10, "dna_length": 20, "bits_per_nt": 1.5},
+        })
+    )
+    r = _request("GET", "/bundle-metrics")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["files"] == 1
+    assert data["total_original_size"] == 10
+    assert data["total_dna_length"] == 20
+    assert abs(data["avg_bits_per_nt"] - 1.5) < 1e-6
+

--- a/web/helix-ui/src/MetricsCharts.jsx
+++ b/web/helix-ui/src/MetricsCharts.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function MetricsCharts() {
+  const [data, setData] = useState(null);
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    fetch('/bundle-metrics')
+      .then((r) => r.json())
+      .then(setData);
+  }, []);
+
+  useEffect(() => {
+    if (!data || !canvasRef.current) return;
+    const ctx = canvasRef.current.getContext('2d');
+    const width = 400;
+    const height = 200;
+    canvasRef.current.width = width;
+    canvasRef.current.height = height;
+    ctx.clearRect(0, 0, width, height);
+    const vals = [data.total_original_size, data.total_dna_length];
+    const labels = ['Bytes', 'Bases'];
+    const maxVal = Math.max(...vals, 1);
+    const barWidth = width / vals.length;
+    vals.forEach((v, i) => {
+      const barHeight = (v / maxVal) * (height - 20);
+      ctx.fillStyle = '#4e79a7';
+      ctx.fillRect(i * barWidth + 10, height - barHeight - 20, barWidth - 20, barHeight);
+      ctx.fillStyle = '#000';
+      ctx.textAlign = 'center';
+      ctx.fillText(labels[i], i * barWidth + barWidth / 2, height - 5);
+    });
+  }, [data]);
+
+  if (!data) {
+    return <div>Loading metrics...</div>;
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Bundle Metrics</h2>
+      <canvas ref={canvasRef} />
+      <p>Files: {data.files}</p>
+      <p>Avg bits/nt: {data.avg_bits_per_nt.toFixed(2)}</p>
+    </div>
+  );
+}

--- a/web/helix-ui/src/MetricsCharts.test.jsx
+++ b/web/helix-ui/src/MetricsCharts.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import MetricsCharts from './MetricsCharts.jsx';
+
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        files: 1,
+        total_original_size: 100,
+        total_dna_length: 200,
+        avg_bits_per_nt: 1.5,
+      }),
+  })
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+  }));
+});
+
+test('renders bundle metrics', async () => {
+  render(<MetricsCharts />);
+  expect(await screen.findByText(/Files:/)).toBeInTheDocument();
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+});

--- a/web/main.py
+++ b/web/main.py
@@ -39,6 +39,7 @@ from genecoder.report import (
     decode_to_html,
 )
 from genecoder.metrics import get_metrics, oligos_per_week
+from genecoder.bundle_metrics import aggregate_metrics
 from typing import Any, cast
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
@@ -53,6 +54,7 @@ CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")
 security = HTTPBearer(auto_error=False)
 PLUGIN_RATINGS: dict[str, list[int]] = {}
 RATINGS_PATH = os.getenv("GENECODER_RATINGS_PATH")
+BUNDLE_DIR = Path(os.getenv("GENECODER_BUNDLE_DIR", "bundle_runs"))
 
 
 def _load_plugin_ratings() -> None:
@@ -115,7 +117,7 @@ async def _startup() -> None:
     if REDIS_URL:
         r = redis.from_url(
             REDIS_URL, encoding="utf-8", decode_responses=True
-        )  # type: ignore[no-untyped-call]
+        )
         await FastAPILimiter.init(r)
 
 
@@ -641,3 +643,9 @@ async def metrics() -> dict[str, object]:
     data: dict[str, object] = get_metrics()
     data["oligos_per_week"] = oligos_per_week()
     return data
+
+
+@app.get("/bundle-metrics")
+async def bundle_metrics_endpoint() -> dict[str, object]:
+    """Return aggregated metrics for bundle manifests."""
+    return aggregate_metrics(BUNDLE_DIR)


### PR DESCRIPTION
## Summary
- parse bundle manifest files for aggregate numbers
- expose `/bundle-metrics` API to return aggregated bundle stats
- visualize metrics with a new React component
- document server-side bundle metrics
- test the new endpoint and component

## Testing
- `ruff check src/genecoder/bundle_metrics.py web/main.py tests/test_web_bundle_metrics.py`
- `mypy src/genecoder/bundle_metrics.py web/main.py tests/test_web_bundle_metrics.py`
- `pytest -q tests/test_web_bundle_metrics.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68746680836083269358003320252b26