### PR TITLE
Add job storage and polling API

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -23,7 +23,7 @@ genecoder cloud submit bundle.yaml --server https://worker:8000 --token TOKEN
 The command creates a ZIP archive containing the bundle file and any input files
 listed under the `encode.input_files` section. The archive is Base64 encoded and
 sent to the remote worker's `/jobs` endpoint. The returned job ID is printed to
-stdout.
+stdout and the command waits until the job completes by polling `/jobs/{id}`.
 
 ## Running the Worker
 
@@ -37,6 +37,8 @@ docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN ghcr.io/d0ttino/genecoder \
 ```
 
 Replace `TOKEN` with a secret value and use the same token when submitting jobs.
+Uploaded archives are stored under ``GENECODER_JOB_DIR`` (default ``worker_jobs``)
+and can be queried via ``GET /jobs/{id}`` to check progress.
 
 ## HPC Submission
 

--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import tempfile
 import zipfile
+import time
 from pathlib import Path
 
 
@@ -48,8 +49,9 @@ def _handle_submit(args: argparse.Namespace) -> None:
     if not args.server.startswith("https://"):
         warnings.warn("Using a non-HTTPS server URL", stacklevel=2)
 
-    if args.archive:
-        archive_b64 = base64.b64encode(Path(args.archive).read_bytes()).decode("utf-8")
+    archive = getattr(args, "archive", None)
+    if archive:
+        archive_b64 = base64.b64encode(Path(archive).read_bytes()).decode("utf-8")
     else:
         if args.bundle is None:
             raise ValueError("bundle file is required if --archive is not provided")
@@ -72,9 +74,19 @@ def _handle_submit(args: argparse.Namespace) -> None:
             async with AsyncCloudClient(args.server, args.token) as client:
                 jid = await client.submit("bundle", {"archive": archive_b64})
                 print(jid)
+                while True:
+                    info = await client.get_job(jid)
+                    if info.get("status") in {"completed", "failed"}:
+                        break
+                    await asyncio.sleep(1)
 
         asyncio.run(_run())
     else:
         with CloudClient(args.server, args.token) as client:
             job_id = client.submit("bundle", {"archive": archive_b64})
-        print(job_id)
+            print(job_id)
+            while True:
+                info = client.get_job(job_id)
+                if info.get("status") in {"completed", "failed"}:
+                    break
+                time.sleep(1)

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -56,6 +56,23 @@ class CloudClient:
             raise ValueError("Invalid response from server")
         return job_id
 
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        import httpx
+
+        try:
+            resp = self._client.get(f"/jobs/{job_id}", headers=headers)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"Failed to fetch job: {exc}") from exc
+
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("Invalid response from server")
+        return data
+
     def close(self) -> None:
         self._client.close()
 
@@ -104,6 +121,23 @@ class AsyncCloudClient:
         if not isinstance(job_id, str):
             raise ValueError("Invalid response from server")
         return job_id
+
+    async def get_job(self, job_id: str) -> dict[str, Any]:
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        import httpx
+
+        try:
+            resp = await self._client.get(f"/jobs/{job_id}", headers=headers)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"Failed to fetch job: {exc}") from exc
+
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("Invalid response from server")
+        return data
 
     async def close(self) -> None:
         await self._client.aclose()

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import json
 import os
 import secrets
 import tempfile
@@ -10,7 +11,7 @@ from pathlib import Path
 
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from genecoder.cli import bundle as bundle_cli
@@ -21,6 +22,7 @@ API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 security = HTTPBearer(auto_error=False)
 app = FastAPI(title="GeneCoder Worker")
 MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB limit for extracted files
+JOB_DIR = Path(os.getenv("GENECODER_JOB_DIR", "worker_jobs"))
 
 
 def verify_token(
@@ -39,8 +41,40 @@ def _startup() -> None:
         print(f"Generated API token: {API_TOKEN}")
 
 
+def _write_status(job_path: Path, data: dict[str, Any]) -> None:
+    (job_path / "status.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _process_job(job_id: str) -> None:
+    job_path = JOB_DIR / job_id
+    archive_path = job_path / "archive.zip"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            extract_zip_safely(archive_path.read_bytes(), tmpdir, max_file_size=MAX_FILE_SIZE)
+        except ValueError:
+            _write_status(job_path, {"status": "failed", "progress": 100})
+            return
+        tmp_path = Path(tmpdir)
+        yaml_files = [p for p in tmp_path.iterdir() if p.suffix in {".yaml", ".yml"}]
+        if not yaml_files:
+            _write_status(job_path, {"status": "failed", "progress": 100})
+            return
+        args = argparse.Namespace(
+            config=str(yaml_files[0]), cache_dir="bundle_runs", export_archive=None
+        )
+        try:
+            bundle_cli._handle_run(args)
+            _write_status(job_path, {"status": "completed", "progress": 100})
+        except Exception:
+            _write_status(job_path, {"status": "failed", "progress": 100})
+
+
 @app.post("/jobs")  # type: ignore[misc]
-def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) -> dict[str, str]:
+def submit_job(
+    payload: dict[str, Any],
+    background_tasks: BackgroundTasks,
+    _token: None = Depends(verify_token),
+) -> dict[str, str]:
     if payload.get("type") != "bundle":
         raise HTTPException(status_code=400, detail="Unsupported job type")
     body = payload.get("payload")
@@ -65,12 +99,25 @@ def submit_job(payload: dict[str, Any], _token: None = Depends(verify_token)) ->
         yaml_files = [p for p in tmp_path.iterdir() if p.suffix in {".yaml", ".yml"}]
         if not yaml_files:
             raise HTTPException(status_code=400, detail="Bundle file not found")
-        args = argparse.Namespace(
-            config=str(yaml_files[0]), cache_dir="bundle_runs", export_archive=None
-        )
-        bundle_cli._handle_run(args)
 
-    return {"job_id": str(uuid.uuid4())}
+    job_id = str(uuid.uuid4())
+    job_path = JOB_DIR / job_id
+    job_path.mkdir(parents=True, exist_ok=True)
+    (job_path / "archive.zip").write_bytes(data)
+    _write_status(job_path, {"status": "running", "progress": 0})
+    background_tasks.add_task(_process_job, job_id)
+    return {"job_id": job_id}
+
+
+@app.get("/jobs/{job_id}")  # type: ignore[misc]
+def job_status(job_id: str, _token: None = Depends(verify_token)) -> dict[str, Any]:
+    path = JOB_DIR / job_id / "status.json"
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Job not found")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - corrupt file
+        raise HTTPException(status_code=500, detail="Corrupt status") from exc
 
 
 def main() -> None:  # pragma: no cover - manual launch

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -154,10 +154,17 @@ def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
             calls["base_url"] = base_url
             calls["token"] = token
 
+
         def submit(self, job_type: str, payload: dict[str, object]) -> str:
             calls["job_type"] = job_type
             calls["payload"] = payload
             return "jid"
+
+        def get_job(self, job_id: str) -> dict[str, str]:
+            assert job_id == "jid"
+            calls["polled"] = True
+            return {"status": "completed"}
+
 
         def close(self) -> None:
             pass
@@ -175,6 +182,7 @@ def test_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert "archive" in cast(dict[str, object], calls["payload"])
     assert calls["base_url"] == "https://s"
     assert calls["token"] is None
+    assert calls.get("polled") is True
 
 
 def test_cloud_submit_archive_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,6 +200,10 @@ def test_cloud_submit_archive_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
             calls["job_type"] = job_type
             calls["payload"] = payload
             return "jid"
+        def get_job(self, job_id: str) -> dict[str, str]:
+            assert job_id == "jid"
+            calls["polled"] = True
+            return {"status": "completed"}
 
         def close(self) -> None:
             pass
@@ -209,6 +221,7 @@ def test_cloud_submit_archive_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     assert calls["base_url"] == "https://s"
     assert calls["token"] is None
     assert base64.b64decode(calls["payload"]["archive"]) == archive.read_bytes()
+    assert calls.get("polled") is True
 
 
 def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -227,6 +240,11 @@ def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
             calls["payload"] = payload
             return "jid"
 
+        async def get_job(self, job_id: str) -> dict[str, str]:
+            assert job_id == "jid"
+            calls["polled"] = True
+            return {"status": "completed"}
+
         async def close(self) -> None:
             pass
 
@@ -243,6 +261,7 @@ def test_async_cloud_submit_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert "archive" in cast(dict[str, object], calls["payload"])
     assert calls["base_url"] == "https://s"
     assert calls["token"] is None
+    assert calls.get("polled") is True
 
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
@@ -483,4 +502,29 @@ def test_worker_rejects_large_file() -> None:
         json={"type": "bundle", "payload": {"archive": archive_b64}},
     )
     assert r.status_code == 400
+
+
+def test_worker_job_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    worker.API_TOKEN = "tok"
+    monkeypatch.setattr(worker, "JOB_DIR", tmp_path)
+    called: dict[str, object] = {}
+
+    def dummy(args: argparse.Namespace) -> None:
+        called["config"] = args.config
+
+    monkeypatch.setattr(worker.bundle_cli, "_handle_run", dummy)
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+    client = TestClient(worker.app)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 200
+    job_id = r.json()["job_id"]
+    status_r = client.get(f"/jobs/{job_id}", headers={"Authorization": "Bearer tok"})
+    assert status_r.json()["status"] == "completed"
+    assert (tmp_path / job_id / "archive.zip").is_file()
 

--- a/tests/test_cloud_clients_small.py
+++ b/tests/test_cloud_clients_small.py
@@ -23,6 +23,19 @@ def test_cloud_client_submit_success() -> None:
     assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
 
 
+def test_cloud_client_get_job() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            assert request.url.path == "/jobs/jid"
+            return httpx.Response(200, json={"status": "completed"})
+        return httpx.Response(200, json={"job_id": "jid"})
+
+    transport = httpx.MockTransport(handler)
+    client = CloudClient("https://server", client=httpx.Client(base_url="https://server", transport=transport))
+    jid = client.submit("bundle", {})
+    assert client.get_job(jid)["status"] == "completed"
+
+
 def test_cloud_client_submit_failure() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
@@ -52,6 +65,28 @@ def test_async_cloud_client_submit_success() -> None:
         assert jid == "jid"
         assert captured["path"] == "/jobs"
         assert captured["data"] == {"type": "bundle", "payload": {"a": 1}}
+        await client.close()
+
+    asyncio.run(_run())
+
+
+def test_async_cloud_client_get_job() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            assert request.url.path == "/jobs/jid"
+            return httpx.Response(200, json={"status": "completed"})
+        return httpx.Response(200, json={"job_id": "jid"})
+
+    transport = httpx.MockTransport(handler)
+
+    async def _run() -> None:
+        client = AsyncCloudClient(
+            "https://server",
+            client=httpx.AsyncClient(base_url="https://server", transport=transport),
+        )
+        jid = await client.submit("bundle", {})
+        status = await client.get_job(jid)
+        assert status["status"] == "completed"
         await client.close()
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- persist uploaded archives to a worker directory
- expose `/jobs/{id}` for job progress
- let `CloudClient` query job progress and poll from CLI
- document new polling behavior
- test new CloudClient and worker features

## Testing
- `ruff check`
- `pytest tests/test_cloud.py tests/test_cloud_clients_small.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68746682682c8326b2aa316fb25a7c07