### PR TITLE
Fix F821 in plugin manager and test registry loading

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -26,6 +26,7 @@ import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
 from .plugin_security import compute_checksum, verify_signature as _verify_signature
+from .plugin_checks import decode_signature, verify_package
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -1,0 +1,61 @@
+import base64
+from pathlib import Path
+
+import pytest
+
+import genecoder.plugin_manager as plugins
+from genecoder.plugin_security import compute_checksum
+
+
+class DummyResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def test_load_plugins_with_signed_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    sig = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str) -> DummyResponse:
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    plugins.install_registry_plugins()
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert "reverse" in plugins.CODEC_REGISTRY


### PR DESCRIPTION
## Summary
- import `decode_signature` and `verify_package` in plugin_manager
- add unit test for loading a signed plugin registry

## Testing
- `ruff check --select F821`
- `pytest tests/test_plugin_registry_loading.py::test_load_plugins_with_signed_registry -q`

------
https://chatgpt.com/codex/tasks/task_e_6877effccdac8326aa8915144c6ac8ae