### PR TITLE
Add unified channel config support

### DIFF
--- a/configs/channel_demo.yaml
+++ b/configs/channel_demo.yaml
@@ -1,0 +1,28 @@
+# Example channel configuration combining sequencing simulators
+# with synthesis constraints. The same structure can be saved as JSON.
+
+synthesis:
+  min_length: 25
+  max_length: 300
+  max_homopolymer: 4
+
+simulators:
+  - name: illumina
+    substitution_rate: 0.001
+    insertion_rate: 0.0001
+    deletion_rate: 0.0001
+    coverage: 1
+    read_length: 150
+  - name: adv_nanopore
+    substitution_rate: 0.02
+    insertion_rate: 0.04
+    deletion_rate: 0.04
+    homopolymer_factor: 2.0
+    coverage: 1
+    read_length: 500
+
+pipeline:
+  parallel: false
+  workers: null
+  use_process_pool: false
+  use_mpi: false

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -83,6 +83,17 @@ genecoder bundle run configs/vertical_slice_demo.yaml --cache-dir runs
 The `scripts/vertical_slice.sh` helper executes the same command automatically
 as part of the demo.
 
+## Channel Configuration
+
+A unified configuration describing sequencing simulators and synthesis
+constraints is provided at `configs/channel_demo.yaml`.
+Apply the channel step using:
+
+```bash
+genecoder channel --config configs/channel_demo.yaml \
+  --input-file encoded/message.fasta --output-file simulated.fasta
+```
+
 ## Launch the GUI
 
 ```bash

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -8,7 +8,7 @@ import logging
 import os
 import random
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, Dict, Any
 
 
 from genecoder.formats import from_fasta, to_fasta
@@ -25,39 +25,77 @@ from .shared import add_single_io_args
 logger = logging.getLogger(__name__)
 
 
-def _load_config(path: str) -> tuple[list[str], dict[str, int]]:
+def _load_config(
+    path: str,
+) -> tuple[list[tuple[str, Dict[str, Any]]], dict[str, int], ChannelConfig]:
     import yaml
+
     with open(path, "r", encoding="utf-8") as f:
         try:
             data = yaml.safe_load(f) or {}
         except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML path
             raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
+
     if not isinstance(data, dict):
         raise ValueError("Config file must map keys to values")
-    sim = data.get("simulators", [])
-    if not isinstance(sim, Sequence):
+
+    sim_section = data.get("simulators", [])
+    if not isinstance(sim_section, Sequence):
         raise ValueError("'simulators' must be a list")
-    constraints = data.get("constraints", {})
-    if not isinstance(constraints, dict):
-        raise ValueError("'constraints' must be a mapping")
-    return list(sim), {k: int(v) for k, v in constraints.items()}
+
+    simulators: list[tuple[str, Dict[str, Any]]] = []
+    for item in sim_section:
+        if isinstance(item, str):
+            simulators.append((item, {}))
+        elif isinstance(item, dict):
+            name = item.get("name")
+            if not isinstance(name, str):
+                raise ValueError("Simulator mapping must contain a string 'name'")
+            params = {k: v for k, v in item.items() if k != "name"}
+            simulators.append((name, params))
+        else:
+            raise ValueError("Each simulator must be a string or mapping")
+
+    synth_section = data.get("synthesis", data.get("constraints", {}))
+    if not isinstance(synth_section, dict):
+        raise ValueError("'synthesis' must be a mapping")
+
+    pipeline = data.get("pipeline", {})
+    if not isinstance(pipeline, dict):
+        raise ValueError("'pipeline' must be a mapping")
+
+    cfg = ChannelConfig(
+        parallel=bool(pipeline.get("parallel", False)),
+        workers=pipeline.get("workers"),
+        use_process_pool=bool(pipeline.get("use_process_pool", False)),
+        use_mpi=bool(pipeline.get("use_mpi", False)),
+    )
+
+    return simulators, {k: int(v) for k, v in synth_section.items()}, cfg
 
 
 def _apply_simulators(
     sequence: str,
-    simulators: Sequence[str],
+    simulators: Sequence[tuple[str, Dict[str, Any]]],
     *,
     config: ChannelConfig,
 ) -> str:
     channels: list[BaseChannel] = []
-    for name in simulators:
+    for name, params in simulators:
         if name not in SIMULATOR_REGISTRY:
             logger.error("Unknown simulator: %s", name)
             raise SystemExit(1)
-        channels.append(SIMULATOR_REGISTRY[name])
+        channel = SIMULATOR_REGISTRY[name]
+        if params:
+            try:
+                channel = type(channel)(**params)
+            except Exception as exc:
+                logger.error("Invalid parameters for %s: %s", name, exc)
+                raise SystemExit(1)
+        channels.append(channel)
     pipeline = ChannelPipeline(channels)
     result: str = pipeline.simulate(sequence, config=config)
-    for name in simulators:
+    for name, _ in simulators:
         logger.info("Applied %s simulator", name)
     return result
 
@@ -65,7 +103,7 @@ def _apply_simulators(
 def process_channel(
     input_file: str,
     output_file: str,
-    simulators: Sequence[str],
+    simulators: Sequence[tuple[str, Dict[str, Any]]],
     constraints: dict[str, int],
     *,
     sub_prob: float = 0.0,
@@ -134,7 +172,7 @@ def process_channel(
     total_len = sum(len(seq) for _, seq in processed_records)
     manifest = {
         "file": os.path.basename(Path(input_file).as_posix()),
-        "simulators": list(simulators),
+        "simulators": [name for name, _ in simulators],
         "probabilities": {
             "sub_prob": sub_prob,
             "ins_prob": ins_prob,
@@ -159,7 +197,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         default=[],
         help="Simulator to apply (can be repeated)",
     )
-    parser.add_argument("--config", type=str, help="YAML config defining simulators and constraints")
+    parser.add_argument(
+        "--config",
+        type=str,
+        help="YAML/JSON config defining simulators, synthesis and pipeline",
+    )
     parser.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
     parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
     parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
@@ -204,10 +246,14 @@ def run_channel(args: argparse.Namespace) -> None:
         use_process_pool=opts.processes is not None,
         use_mpi=opts.mpi,
     )
+    simulators = opts.simulator_specs
+    if simulators is None:
+        simulators = [(name, {}) for name in opts.simulators]
+
     process_channel(
         args.input_file,
         args.output_file,
-        opts.simulators,
+        simulators,
         opts.constraints,
         sub_prob=opts.sub_prob,
         ins_prob=opts.ins_prob,

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -25,6 +25,7 @@ class ChannelOptions:
     mpi: bool = False
     mpi_workers: int | None = None
     batch_workers: int | None = None
+    simulator_specs: list[tuple[str, dict[str, object]]] | None = None
 
 
 def _validate_simulator_prob_args(
@@ -88,11 +89,22 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         "max_homopolymer": args.max_homopolymer,
     }
 
+    sim_specs: list[tuple[str, dict[str, object]]] | None = None
     if args.config:
-        cfg_sim, cfg_con = _load_config(args.config)
+        cfg_sim, cfg_con, cfg_pipeline = _load_config(args.config)
         if cfg_sim:
-            simulators = cfg_sim
+            sim_specs = cfg_sim
+            simulators = [name for name, _ in cfg_sim]
         constraints.update(cfg_con)
+        if not args.parallel and cfg_pipeline.parallel:
+            args.parallel = True
+        if args.threads is None and args.processes is None and args.mpi_workers is None:
+            if cfg_pipeline.workers is not None:
+                args.threads = cfg_pipeline.workers
+        if cfg_pipeline.use_process_pool:
+            args.processes = args.threads
+        if cfg_pipeline.use_mpi:
+            args.mpi = True
 
     _validate_simulator_prob_args(
         simulators, args.sub_prob, args.ins_prob, args.del_prob
@@ -125,4 +137,5 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         mpi=args.mpi,
         mpi_workers=args.mpi_workers,
         batch_workers=args.batch_workers,
+        simulator_specs=sim_specs,
     )

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -55,7 +55,7 @@ def test_no_simulators_or_probabilities_error() -> None:
 
 def test_config_and_probabilities_error(tmp_path: Path) -> None:
     cfg = tmp_path / "cfg.yml"
-    cfg.write_text("simulators:\n  - simple\n")
+    cfg.write_text("simulators:\n  - name: simple\n")
     args = _make_args(config=str(cfg), sub_prob=0.1)
     with pytest.raises(ValueError, match="Probability options cannot"):
         build_channel_options(args)
@@ -87,7 +87,7 @@ def test_mpi_workers_requires_mpi() -> None:
 
 def test_config_missing_simulators_error(tmp_path: Path) -> None:
     cfg = tmp_path / "cfg.yml"
-    cfg.write_text("constraints:\n  max_length: 200\n")
+    cfg.write_text("synthesis:\n  max_length: 200\n")
     args = _make_args(config=str(cfg))
     with pytest.raises(ValueError, match="At least one simulator"):
         build_channel_options(args)

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -55,7 +55,7 @@ def test_channel_cli_yaml(tmp_path: Path) -> None:
     create_fasta(input_fasta)
     config = tmp_path / "cfg.yml"
     config.write_text(
-        """simulators:\n  - simple\nconstraints:\n  min_length: 1\n  max_length: 10\n  max_homopolymer: 5\n"""
+        """simulators:\n  - name: simple\nsynthesis:\n  min_length: 1\n  max_length: 10\n  max_homopolymer: 5\n"""
     )
     output_fasta = tmp_path / "out2.fasta"
     env = os.environ.copy()

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -12,7 +12,7 @@ fastapi = pytest.importorskip("fastapi")
 import web.main as main
 
 
-def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
     async def _call() -> httpx.Response:
         transport = httpx.ASGITransport(app=main.app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:


### PR DESCRIPTION
## Summary
- add `channel_demo.yaml` with combined simulator & synthesis schema
- support structured config in `cli/channel.py`
- carry simulator settings through new `simulator_specs` option
- document unified channel workflow in `docs/vertical_slice.md`
- update tests for new config format

## Testing
- `ruff check . --fix`
- `PYTHONPATH=src pytest tests/test_cli_channel.py::test_channel_cli_yaml tests/test_channel_options_validation.py::test_config_and_probabilities_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f556dfe08326a382cc2950ac31e6