### PR TITLE
Fix typing of _request helper

### DIFF
--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import Any
+
 
 import httpx
 import pytest
@@ -12,7 +12,7 @@ fastapi = pytest.importorskip("fastapi")
 import web.main as main
 
 
-def _request(method: str, url: str, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
+def _request(method: str, url: str, **kwargs: object) -> httpx.Response:
     async def _call() -> httpx.Response:
         transport = httpx.ASGITransport(app=main.app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:


### PR DESCRIPTION
## Summary
- type the `_request` helper in `tests/test_web_bundle_metrics.py`

## Testing
- `ruff check tests`
- `pytest tests/test_web_bundle_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6877ff5381248326a80a10ae4f77e422