### PR TITLE
Add Slurm submission option

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -72,6 +72,12 @@ job:
   partition: compute
 ```
 
+Use the CLI to submit such a file directly via Slurm:
+
+```bash
+genecoder cloud submit --hpc-config job.yaml
+```
+
 ## Fetching Error Profiles
 
 GeneCoder can download example anonymized error profiles for use with simulators.

--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -37,6 +37,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         action="store_true",
         help="Use asynchronous submission",
     )
+    submit.add_argument(
+        "--hpc-config",
+        type=str,
+        help="YAML file describing an HPC job to run via Slurm",
+    )
     submit.set_defaults(func=_handle_submit)
 
 
@@ -45,6 +50,27 @@ def _handle_submit(args: argparse.Namespace) -> None:
     import yaml
     import asyncio
     from genecoder.cloud import CloudClient, AsyncCloudClient
+
+    hpc_cfg = getattr(args, "hpc_config", None)
+    if hpc_cfg:
+        payload = yaml.safe_load(Path(hpc_cfg).read_text()) or {}
+        from genecoder.cloud.hpc import generate_slurm_script, submit_slurm_job
+
+        script = payload.get("script")
+        if not isinstance(script, str):
+            command = payload.get("command")
+            if not isinstance(command, str):
+                raise ValueError("command is required for HPC job")
+            script = generate_slurm_script(
+                command,
+                job_name=payload.get("job_name", "genecoder"),
+                time=payload.get("time", "01:00:00"),
+                partition=payload.get("partition"),
+                output=payload.get("output"),
+            )
+        jid = submit_slurm_job(script)
+        print(jid)
+        return
 
     if not args.server.startswith("https://"):
         warnings.warn("Using a non-HTTPS server URL", stacklevel=2)

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -1,8 +1,10 @@
 import pytest
 import subprocess
+from pathlib import Path
 
 from genecoder.cloud.hpc import generate_slurm_script, submit_slurm_job
 from genecoder.cloud import CloudClient
+from tests.test_cli import run_cli_command
 
 
 def test_generate_slurm_script() -> None:
@@ -110,3 +112,34 @@ def test_cloud_client_hpc(monkeypatch: pytest.MonkeyPatch) -> None:
     assert generated["job_name"] == "job"
     assert generated["time"] == "00:05:00"
     assert generated["script"] == "script"
+
+
+def test_cloud_cli_hpc(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pytest.importorskip("yaml")
+    cfg = tmp_path / "job.yml"
+    cfg.write_text(
+        """command: echo hi
+job_name: cli
+"""
+    )
+
+    called: dict[str, str] = {}
+
+    def fake_generate(command: str, **kwargs) -> str:
+        called["command"] = command
+        called.update(kwargs)
+        return "script"
+
+    def fake_submit(script: str) -> str:
+        called["script"] = script
+        return "99"
+
+    monkeypatch.setattr("genecoder.cloud.hpc.generate_slurm_script", fake_generate)
+    monkeypatch.setattr("genecoder.cloud.hpc.submit_slurm_job", fake_submit)
+
+    result = run_cli_command(["cloud", "submit", "--hpc-config", str(cfg)])
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "99"
+    assert called["command"] == "echo hi"
+    assert called["job_name"] == "cli"
+    assert called["script"] == "script"

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -3,10 +3,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-import httpx
 import pytest
 
-pytest.importorskip("httpx")
+httpx = pytest.importorskip("httpx")
 fastapi = pytest.importorskip("fastapi")
 
 import web.main as main


### PR DESCRIPTION
## Summary
- enable HPC job submission from `genecoder cloud submit`
- document the new `--hpc-config` option
- test the CLI path with monkeypatched `submit_slurm_job`
- fix web metrics test import order
- don't require httpx for HPC submission

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ff525ea48326bfb02e23276dc50b