### PR TITLE
Refine type hints and run tests

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -524,7 +524,7 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.set_defaults(func=_handle_command)
 
 
-def encode_files(args: argparse.Namespace) -> list[tuple[str, str]]:
+def encode_files(args: argparse.Namespace) -> list[tuple[str, str] | None]:
     """Encode files according to ``args`` and return CSV rows."""
 
     validate_chunk_size(args)

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 from genecoder.metrics import get_metrics, oligos_per_week
+from typing import TypeAlias, cast
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -16,9 +17,12 @@ def _handle_command(_: argparse.Namespace) -> None:
         print(f"{k}: {v}")
 
 
-def collect_stats() -> dict[str, object]:
+StatsData: TypeAlias = dict[str, int | list[str] | dict[str, int]]
+
+
+def collect_stats() -> StatsData:
     """Return current usage metrics."""
 
-    data = get_metrics()
+    data = cast(StatsData, get_metrics())
     data["oligos_per_week"] = oligos_per_week()
     return data

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class CloudClient:
@@ -10,7 +13,7 @@ class CloudClient:
         self,
         base_url: str,
         token: str | None = None,
-        client: object | None = None,
+        client: httpx.Client | None = None,
     ) -> None:
         import httpx
 
@@ -94,7 +97,7 @@ class AsyncCloudClient:
         self,
         base_url: str,
         token: str | None = None,
-        client: object | None = None,
+        client: httpx.AsyncClient | None = None,
     ) -> None:
         import httpx
 


### PR DESCRIPTION
## Summary
- add a `StatsData` alias and use it in `collect_stats`
- return optional tuples from `encode_files`
- tighten client types for cloud interfaces

## Testing
- `ruff check .`
- `MYPYPATH=src mypy --config-file pyproject.toml src/genecoder/cli/stats.py src/genecoder/cli/encode.py src/genecoder/cloud/__init__.py --show-error-codes --no-error-summary`
- `pytest tests/test_metrics.py::test_stats_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1d96234c8326bf0adbb66c8ac3d0