### PR TITLE
Improve symlink detection in archive extraction

### DIFF
--- a/src/genecoder/cloud/utils.py
+++ b/src/genecoder/cloud/utils.py
@@ -29,8 +29,8 @@ def extract_zip_safely(
                 raise ValueError("Invalid archive path")
 
             is_symlink = False
-            if hasattr(info, "is_symlink"):
-                is_symlink = info.is_symlink()
+            if getattr(info, "is_symlink", None):
+                is_symlink = info.is_symlink()  # type: ignore[attr-defined]
             else:
                 is_symlink = ((info.external_attr >> 16) & 0o170000) == stat.S_IFLNK
             if is_symlink:

--- a/tests/test_worker_security.py
+++ b/tests/test_worker_security.py
@@ -17,11 +17,33 @@ def _build_archive(name: str, tmp_path: Path) -> str:
     return base64.b64encode(archive.read_bytes()).decode()
 
 
+def _build_symlink_archive(tmp_path: Path) -> str:
+    archive = tmp_path / "archive.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zi = zipfile.ZipInfo("link")
+        zi.create_system = 3
+        zi.external_attr = 0o120777 << 16
+        zf.writestr(zi, "target")
+    return base64.b64encode(archive.read_bytes()).decode()
+
+
 @pytest.mark.parametrize("name", ["../evil.yaml", "/abs.yaml"])
 def test_worker_rejects_bad_paths(tmp_path: Path, name: str) -> None:
     worker.API_TOKEN = "tok"
     client = TestClient(worker.app)
     archive_b64 = _build_archive(name, tmp_path)
+    r = client.post(
+        "/jobs",
+        headers={"Authorization": "Bearer tok"},
+        json={"type": "bundle", "payload": {"archive": archive_b64}},
+    )
+    assert r.status_code == 400
+
+
+def test_worker_rejects_symlink(tmp_path: Path) -> None:
+    worker.API_TOKEN = "tok"
+    client = TestClient(worker.app)
+    archive_b64 = _build_symlink_archive(tmp_path)
     r = client.post(
         "/jobs",
         headers={"Authorization": "Bearer tok"},


### PR DESCRIPTION
## Summary
- better feature check for `ZipInfo.is_symlink`
- reject symlink archives in worker security tests

## Testing
- `ruff check src/genecoder/cloud/utils.py tests/test_worker_security.py`
- `pytest tests/test_worker_security.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687d1d94f3cc8326b490a42c7096ffbe