### PR TITLE
Enforce signed plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -174,6 +174,9 @@ plugins:
     stars: 4.5
 ```
 
+Each plugin entry must include a ``checksum`` and ``signature`` field. Unsigned
+entries are ignored when the catalog is loaded.
+
 If the catalog is signed the file should also include a top-level
 ``signature`` field with the base64 encoded signature. Set
 ``GENECODER_CATALOG_PUBLIC_KEY`` to the path of the PEM encoded public key used
@@ -250,14 +253,13 @@ installation.
 
 ## Signed Plugin Packages
 
-For higher assurance you may sign plugin distributions with an RSA or ECDSA
-private key and publish the detached signature alongside the package. The
-catalog or registry entry should include the base64 encoded signature under the
-``signature`` field. Set the ``GENECODER_PLUGIN_PUBLIC_KEY`` environment
-variable to the path of the corresponding PEM encoded public key. During
-installation GeneCoder verifies the signature before falling back to the regular
-checksum check. A failed signature verification aborts the install and logs a
-warning.
+All plugin distributions **must** be signed with an RSA or ECDSA private key and
+the detached signature published alongside the package. The catalog or registry
+entry must include the base64 encoded signature under the ``signature`` field.
+Set the ``GENECODER_PLUGIN_PUBLIC_KEY`` environment variable to the path of the
+corresponding PEM encoded public key. GeneCoder refuses to install a plugin if
+the signature is missing or fails verification. The signature is checked before
+falling back to the regular checksum verification.
 
 Signed packages help detect tampering, but they do not make untrusted code safe.
 Always audit plugins and obtain public keys from verified sources.

--- a/src/genecoder/cli/benchmark.py
+++ b/src/genecoder/cli/benchmark.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import io
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -60,7 +61,11 @@ def _handle_fec(args: argparse.Namespace) -> None:
     ]
     for r in args.redundancy:
         cmd.extend(["--redundancy", str(r)])
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(Path(__file__).resolve().parents[3] / "src"), env.get("PYTHONPATH", "")] 
+    )
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr)
         raise SystemExit(proc.returncode)

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 from dataclasses import dataclass, fields, asdict
+from typing import Any, Mapping, cast
 
 from . import cli as cli_module
 from genecoder.metrics import metrics
@@ -69,7 +70,7 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     run_parser.set_defaults(func=_handle_run)
 
 
-def _channel_args(opts: dict[str, object]) -> list[str]:
+def _channel_args(opts: Mapping[str, object]) -> list[str]:
     if not isinstance(opts, dict):
         raise TypeError("simulate section must be a mapping")
 
@@ -79,7 +80,7 @@ def _channel_args(opts: dict[str, object]) -> list[str]:
         raise ValueError(f"Unknown channel options: {', '.join(sorted(unknown))}")
 
     args = ["channel"]
-    data = ChannelArgs(**opts)
+    data = ChannelArgs(**cast(dict[str, Any], opts))
     for key, value in asdict(data).items():
         if value is None:
             continue

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -524,7 +524,7 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     parser.set_defaults(func=_handle_command)
 
 
-def encode_files(args: argparse.Namespace) -> list[tuple[str, str]]:
+def encode_files(args: argparse.Namespace) -> list[tuple[str, str] | None]:
     """Encode files according to ``args`` and return CSV rows."""
 
     validate_chunk_size(args)

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -19,6 +19,6 @@ def _handle_command(_: argparse.Namespace) -> None:
 def collect_stats() -> dict[str, object]:
     """Return current usage metrics."""
 
-    data = get_metrics()
+    data: dict[str, object] = get_metrics()
     data["oligos_per_week"] = oligos_per_week()
     return data

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 
 class CloudClient:
@@ -16,7 +16,7 @@ class CloudClient:
 
         self.base_url = base_url.rstrip("/")
         self.token = token
-        self._client = client or httpx.Client(base_url=self.base_url)
+        self._client = cast(Any, client) if client is not None else httpx.Client(base_url=self.base_url)
 
     def submit(self, job_type: str, payload: dict[str, Any]) -> str:
         if job_type == "hpc":
@@ -100,7 +100,9 @@ class AsyncCloudClient:
 
         self.base_url = base_url.rstrip("/")
         self.token = token
-        self._client = client or httpx.AsyncClient(base_url=self.base_url)
+        self._client = (
+            cast(Any, client) if client is not None else httpx.AsyncClient(base_url=self.base_url)
+        )
 
     async def submit(self, job_type: str, payload: dict[str, Any]) -> str:
         headers = {}

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -9,7 +9,7 @@ import tempfile
 import uuid
 from pathlib import Path
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -115,7 +115,7 @@ def job_status(job_id: str, _token: None = Depends(verify_token)) -> dict[str, A
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Job not found")
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
     except Exception as exc:  # pragma: no cover - corrupt file
         raise HTTPException(status_code=500, detail="Corrupt status") from exc
 

--- a/src/genecoder/flet_handlers.py
+++ b/src/genecoder/flet_handlers.py
@@ -31,7 +31,7 @@ from .plotting import (
     identify_homopolymer_regions,
     generate_sequence_analysis_plot,
 )
-from . import perform_encoding
+from .app_helpers import perform_encoding, EncodeResult
 from .flet_ws import ws_clients
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,9 @@ def make_encode_handler(
                 return
 
             try:
-                result = await asyncio.to_thread(perform_encoding, input_data, options)
+                result: EncodeResult = await asyncio.to_thread(
+                    perform_encoding, input_data, options
+                )
             except ValueError as ex:
                 encode_status_text.value = f"Error: {ex}"
                 encode_status_text.color = COLORS.RED_ACCENT_700
@@ -193,13 +195,14 @@ def make_encode_handler(
                 encode_actual_gc_value.value = "N/A"
                 encode_actual_homopolymer_value.value = "N/A"
 
-            codeword_hist_image.src_base64 = result.plots.get("codeword_hist")
-            nucleotide_freq_image.src_base64 = result.plots.get("nucleotide_freq")
-            sequence_analysis_plot_image.src_base64 = result.plots.get(
+            plots = result.plots or {}
+            codeword_hist_image.src_base64 = plots.get("codeword_hist")
+            nucleotide_freq_image.src_base64 = plots.get("nucleotide_freq")
+            sequence_analysis_plot_image.src_base64 = plots.get(
                 "sequence_analysis"
             )
 
-            any_plot = any(result.plots.values())
+            any_plot = any(plots.values())
 
             if any_plot:
                 analysis_status_text.value = (

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -236,7 +236,6 @@ def _fetch_catalog(url: str) -> None:
             return
 
     PLUGIN_CATALOG.clear()
-    allow_unsigned = os.getenv("GENECODER_ALLOW_UNSIGNED_PLUGINS") == "1"
     for entry in data.get("plugins", []):
         name = str(entry.get("name", ""))
         if not name:
@@ -247,10 +246,8 @@ def _fetch_catalog(url: str) -> None:
             continue
         signature = entry.get("signature")
         if not signature:
-            logger.error("Missing signature for plugin %s", name)
-            if not allow_unsigned:
-                continue
-            signature = ""
+            logger.error("Plugin %s missing required signature", name)
+            continue
 
         PLUGIN_CATALOG[name] = {
             "version": str(entry.get("version", "")),

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -295,7 +295,7 @@ def test_catalog_missing_signature(monkeypatch: pytest.MonkeyPatch, caplog: pyte
     with caplog.at_level("ERROR"):
         plugins.load_plugins()
 
-    assert "Missing signature for plugin plug" in caplog.text
+    assert "Plugin plug missing required signature" in caplog.text
     assert "plug" not in plugins.PLUGIN_CATALOG
 
     with caplog.at_level("ERROR"), pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- reject unsigned catalog entries in plugin manager
- adjust test for new rejection message
- document mandatory plugin signatures
- fix mypy errors and benchmark env handling

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d1d96443c83269ce338566ba731cb