### PR TITLE
Refactor plugin catalog helpers

### DIFF
--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from genecoder.metrics import get_metrics, oligos_per_week
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, cast, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    import httpx
 
 
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, Any, Iterable
+from typing import Callable, Dict, Any, Iterable, Optional
 from types import ModuleType
 import os
 import sys
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 import importlib
 import base64
 from pathlib import Path
+import json
+import portalocker
 
 _yaml: Any
 try:  # pragma: no cover - import is trivial
@@ -77,6 +79,95 @@ def _verify_catalog_signature(data: bytes, signature: str) -> bool:
         return False
 
     return True
+
+
+def load_catalog(
+    path: Optional[str],
+) -> tuple[list[dict[str, Any]], dict[str, list[int]]]:
+    """Return catalog and rating data from ``path``."""
+
+    if not path:
+        return [], {}
+    file_path = Path(path)
+    if not file_path.is_file():
+        return [], {}
+    try:
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+    except Exception:
+        return [], {}
+
+    catalog: list[dict[str, Any]] = []
+    ratings: dict[str, list[int]] = {}
+    items = data.get("plugins", [])
+    if isinstance(items, list):
+        catalog = [
+            {
+                "name": str(item.get("name", "")),
+                "version": str(item.get("version", "")),
+                "checksum": str(item.get("checksum", "")),
+                "signature": item.get("signature"),
+                **({"stars": float(item.get("stars", 0))} if "stars" in item else {}),
+            }
+            for item in items
+            if item.get("name")
+        ]
+
+    rating_data = data.get("ratings", {})
+    if isinstance(rating_data, dict):
+        ratings = {
+            str(k): [int(x) for x in v if isinstance(x, int)]
+            for k, v in rating_data.items()
+            if isinstance(v, list)
+        }
+
+    for entry in catalog:
+        r = ratings.get(entry["name"])
+        if r:
+            entry["stars"] = sum(r) / len(r)
+
+    return catalog, ratings
+
+
+def save_catalog(
+    path: Optional[str],
+    catalog: list[dict[str, Any]],
+    ratings: dict[str, list[int]],
+) -> None:
+    """Persist ``catalog`` and ``ratings`` to ``path``."""
+
+    if not path:
+        return
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps({"plugins": catalog, "ratings": ratings})
+    with portalocker.Lock(file_path, "a+", timeout=10, encoding="utf-8") as fh:
+        fh.seek(0)
+        fh.truncate(0)
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def rate_plugin(
+    catalog: list[dict[str, Any]],
+    ratings: dict[str, list[int]],
+    name: str,
+    rating: int,
+) -> float:
+    """Add ``rating`` for ``name`` and return the new average."""
+
+    if rating < 1 or rating > 5:
+        raise ValueError("rating must be 1-5")
+    if not any(item["name"] == name for item in catalog):
+        raise KeyError("Plugin not found")
+    rating_list = ratings.setdefault(name, [])
+    rating_list.append(rating)
+    avg = sum(rating_list) / len(rating_list)
+    for item in catalog:
+        if item["name"] == name:
+            item["stars"] = avg
+            break
+    return avg
 
 
 def _install_registry_plugins(url: str) -> None:

--- a/web/plugin_catalog.py
+++ b/web/plugin_catalog.py
@@ -9,6 +9,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 import web.main as main
+from genecoder import plugin_manager as plugins
 
 router = APIRouter()
 security = HTTPBearer(auto_error=False)
@@ -39,40 +40,7 @@ class RatingRequest(BaseModel):
 
 def _load_catalog() -> None:
     global CATALOG, PLUGIN_RATINGS
-    if not CATALOG_PATH:
-        return
-    path = Path(CATALOG_PATH)
-    if not path.is_file():
-        return
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return
-    items = data.get("plugins", [])
-    if isinstance(items, list):
-        CATALOG = [
-            {
-                "name": str(item.get("name", "")),
-                "version": str(item.get("version", "")),
-                "checksum": str(item.get("checksum", "")),
-                "signature": item.get("signature"),
-                **({"stars": float(item.get("stars", 0))} if "stars" in item else {}),
-            }
-            for item in items
-            if item.get("name")
-        ]
-
-    ratings = data.get("ratings", {})
-    if isinstance(ratings, dict):
-        PLUGIN_RATINGS = {
-            str(k): [int(x) for x in v if isinstance(x, int)]
-            for k, v in ratings.items()
-            if isinstance(v, list)
-        }
-    for entry in CATALOG:
-        r = PLUGIN_RATINGS.get(entry["name"])
-        if r:
-            entry["stars"] = sum(r) / len(r)
+    CATALOG, PLUGIN_RATINGS = plugins.load_catalog(CATALOG_PATH)
 
 
 def _load_challenge() -> None:
@@ -92,17 +60,7 @@ def _load_challenge() -> None:
 
 
 def _save_catalog() -> None:
-    if not CATALOG_PATH:
-        return
-    path = Path(CATALOG_PATH)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = json.dumps({"plugins": CATALOG, "ratings": PLUGIN_RATINGS})
-    with portalocker.Lock(path, "a+", timeout=10, encoding="utf-8") as fh:
-        fh.seek(0)
-        fh.truncate(0)
-        fh.write(data)
-        fh.flush()
-        os.fsync(fh.fileno())
+    plugins.save_catalog(CATALOG_PATH, CATALOG, PLUGIN_RATINGS)
 
 
 def _save_challenge() -> None:
@@ -161,17 +119,12 @@ def rate_plugin(
     req: RatingRequest,
     _: None = Depends(_verify_token),
 ) -> Dict[str, float]:
-    if req.rating < 1 or req.rating > 5:
-        raise HTTPException(status_code=400, detail="rating must be 1-5")
-    if not any(item["name"] == req.name for item in CATALOG):
-        raise HTTPException(status_code=404, detail="Plugin not found")
-    ratings = PLUGIN_RATINGS.setdefault(req.name, [])
-    ratings.append(req.rating)
-    avg = sum(ratings) / len(ratings)
-    for item in CATALOG:
-        if item["name"] == req.name:
-            item["stars"] = avg
-            break
+    try:
+        avg = plugins.rate_plugin(CATALOG, PLUGIN_RATINGS, req.name, req.rating)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Plugin not found") from exc
     _save_catalog()
     return {"average": avg}
 


### PR DESCRIPTION
## Summary
- move catalog persistence helpers to `plugin_manager`
- call new helpers from the FastAPI router
- keep type checking happy

## Testing
- `ruff check .`
- `pytest tests/test_plugin_catalog_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b14869c8326a7a49bb9f3f56115