### PR TITLE
Add HTTP client wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ requirements.lock
 # Node.js artifacts
 web/helix-ui/node_modules/
 web/helix-ui/package-lock.json
+worker_jobs/

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from genecoder.metrics import get_metrics, oligos_per_week
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from .http_client import HTTPClient, AsyncHTTPClient
+
 
 
 class CloudClient:
@@ -11,13 +13,12 @@ class CloudClient:
         self,
         base_url: str,
         token: str | None = None,
-        client: httpx.Client | None = None,
+        client: HTTPClient | None = None,
     ) -> None:
-        import httpx
 
         self.base_url = base_url.rstrip("/")
         self.token = token
-        self._client = cast(Any, client) if client is not None else httpx.Client(base_url=self.base_url)
+        self._client = cast(Any, client) if client is not None else HTTPClient(base_url=self.base_url)
 
     def submit(self, job_type: str, payload: dict[str, Any]) -> str:
         if job_type == "hpc":
@@ -95,14 +96,13 @@ class AsyncCloudClient:
         self,
         base_url: str,
         token: str | None = None,
-        client: httpx.AsyncClient | None = None,
+        client: AsyncHTTPClient | None = None,
     ) -> None:
-        import httpx
 
         self.base_url = base_url.rstrip("/")
         self.token = token
         self._client = (
-            cast(Any, client) if client is not None else httpx.AsyncClient(base_url=self.base_url)
+            cast(Any, client) if client is not None else AsyncHTTPClient(base_url=self.base_url)
         )
 
     async def submit(self, job_type: str, payload: dict[str, Any]) -> str:

--- a/src/genecoder/cloud/http_client.py
+++ b/src/genecoder/cloud/http_client.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+class HTTPClient:
+    """Thin wrapper around ``httpx.Client``."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        import httpx
+
+        self._client = httpx.Client(*args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self._client.post(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self._client.get(*args, **kwargs)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "HTTPClient":
+        self._client.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+        self._client.__exit__(exc_type, exc, tb)
+
+    def __getattr__(self, name: str):
+        return getattr(self._client, name)
+
+
+class AsyncHTTPClient:
+    """Thin wrapper around ``httpx.AsyncClient``."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        import httpx
+
+        self._client = httpx.AsyncClient(*args, **kwargs)
+
+    async def post(self, *args, **kwargs):
+        return await self._client.post(*args, **kwargs)
+
+    async def get(self, *args, **kwargs):
+        return await self._client.get(*args, **kwargs)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncHTTPClient":
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+        await self._client.__aexit__(exc_type, exc, tb)
+
+    def __getattr__(self, name: str):
+        return getattr(self._client, name)
+
+
+__all__ = ["HTTPClient", "AsyncHTTPClient"]

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -7,6 +7,8 @@ from typing import cast
 
 import pytest
 httpx = pytest.importorskip("httpx")
+
+from genecoder.cloud.http_client import HTTPClient, AsyncHTTPClient
 import asyncio
 
 from genecoder.cloud import CloudClient, AsyncCloudClient
@@ -24,7 +26,7 @@ def test_cloud_client_submit() -> None:
     transport = httpx.MockTransport(handler)
     client = CloudClient(
         "https://s",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     jid = client.submit("bundle", {"a": 1})
     assert jid == "jid"
@@ -45,7 +47,7 @@ def test_async_cloud_client_submit() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://s",
-            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+            client=AsyncHTTPClient(base_url="https://s", transport=transport),
         )
         jid = await client.submit("bundle", {"a": 1})
         assert jid == "jid"
@@ -63,7 +65,7 @@ def test_cloud_client_submit_error() -> None:
     transport = httpx.MockTransport(handler)
     client = CloudClient(
         "https://s",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     with pytest.raises(RuntimeError, match="Failed to submit job"):
         client.submit("bundle", {"a": 1})
@@ -80,7 +82,7 @@ def test_cloud_client_invalid_token() -> None:
     client = CloudClient(
         "https://s",
         token="bad",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     with pytest.raises(RuntimeError, match="Failed to submit job"):
         client.submit("bundle", {"a": 1})
@@ -99,7 +101,7 @@ def test_async_cloud_client_invalid_token() -> None:
         client = AsyncCloudClient(
             "https://s",
             token="bad",
-            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+            client=AsyncHTTPClient(base_url="https://s", transport=transport),
         )
         with pytest.raises(RuntimeError, match="Failed to submit job"):
             await client.submit("bundle", {"a": 1})
@@ -117,7 +119,7 @@ def test_cloud_client_bad_payload() -> None:
     transport = httpx.MockTransport(handler)
     client = CloudClient(
         "https://s",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     with pytest.raises(ValueError, match="Invalid response from server"):
         client.submit("bundle", {"a": 1})
@@ -134,7 +136,7 @@ def test_async_cloud_client_bad_payload() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://s",
-            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+            client=AsyncHTTPClient(base_url="https://s", transport=transport),
         )
         with pytest.raises(ValueError, match="Invalid response from server"):
             await client.submit("bundle", {"a": 1})
@@ -152,7 +154,7 @@ def test_cloud_client_network_error() -> None:
     transport = httpx.MockTransport(handler)
     client = CloudClient(
         "https://s",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     with pytest.raises(RuntimeError, match="Failed to submit job"):
         client.submit("bundle", {"a": 1})
@@ -169,7 +171,7 @@ def test_async_cloud_client_network_error() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://s",
-            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+            client=AsyncHTTPClient(base_url="https://s", transport=transport),
         )
         with pytest.raises(RuntimeError, match="Failed to submit job"):
             await client.submit("bundle", {"a": 1})
@@ -187,7 +189,7 @@ def test_cloud_client_invalid_json() -> None:
     transport = httpx.MockTransport(handler)
     client = CloudClient(
         "https://s",
-        client=httpx.Client(base_url="https://s", transport=transport),
+        client=HTTPClient(base_url="https://s", transport=transport),
     )
     with pytest.raises(ValueError):
         client.submit("bundle", {"a": 1})
@@ -204,7 +206,7 @@ def test_async_cloud_client_invalid_json() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://s",
-            client=httpx.AsyncClient(base_url="https://s", transport=transport),
+            client=AsyncHTTPClient(base_url="https://s", transport=transport),
         )
         with pytest.raises(ValueError):
             await client.submit("bundle", {"a": 1})
@@ -380,7 +382,7 @@ def test_worker_integration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
         )
 
     transport = httpx.MockTransport(handler)
-    http_client = httpx.Client(transport=transport, base_url="http://worker")
+    http_client = HTTPClient(transport=transport, base_url="http://worker")
     client = CloudClient("http://worker", token="tok", client=http_client)
     jid = client.submit("bundle", {"archive": archive_b64})
     http_client.close()
@@ -402,7 +404,7 @@ def test_worker_integration_async(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     async def _run() -> None:
         transport = httpx.ASGITransport(app=worker.app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://worker") as ac_client:
+        async with AsyncHTTPClient(transport=transport, base_url="http://worker") as ac_client:
             async with AsyncCloudClient("http://worker", token="tok", client=ac_client) as ac:
                 jid = await ac.submit("bundle", {"archive": archive_b64})
                 assert jid

--- a/tests/test_cloud_clients_small.py
+++ b/tests/test_cloud_clients_small.py
@@ -5,6 +5,7 @@ import pytest
 httpx = pytest.importorskip("httpx")
 
 from genecoder.cloud import CloudClient, AsyncCloudClient
+from genecoder.cloud.http_client import HTTPClient, AsyncHTTPClient
 
 
 def test_cloud_client_submit_success() -> None:
@@ -16,7 +17,9 @@ def test_cloud_client_submit_success() -> None:
         return httpx.Response(200, json={"job_id": "jid"})
 
     transport = httpx.MockTransport(handler)
-    client = CloudClient("https://server", client=httpx.Client(base_url="https://server", transport=transport))
+    client = CloudClient(
+        "https://server", client=HTTPClient(base_url="https://server", transport=transport)
+    )
     jid = client.submit("bundle", {"a": 1})
     assert jid == "jid"
     assert captured["path"] == "/jobs"
@@ -31,7 +34,9 @@ def test_cloud_client_get_job() -> None:
         return httpx.Response(200, json={"job_id": "jid"})
 
     transport = httpx.MockTransport(handler)
-    client = CloudClient("https://server", client=httpx.Client(base_url="https://server", transport=transport))
+    client = CloudClient(
+        "https://server", client=HTTPClient(base_url="https://server", transport=transport)
+    )
     jid = client.submit("bundle", {})
     assert client.get_job(jid)["status"] == "completed"
 
@@ -41,7 +46,9 @@ def test_cloud_client_submit_failure() -> None:
         return httpx.Response(500)
 
     transport = httpx.MockTransport(handler)
-    client = CloudClient("https://server", client=httpx.Client(base_url="https://server", transport=transport))
+    client = CloudClient(
+        "https://server", client=HTTPClient(base_url="https://server", transport=transport)
+    )
     with pytest.raises(RuntimeError, match="Failed to submit job"):
         client.submit("bundle", {})
 
@@ -59,7 +66,7 @@ def test_async_cloud_client_submit_success() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://server",
-            client=httpx.AsyncClient(base_url="https://server", transport=transport),
+            client=AsyncHTTPClient(base_url="https://server", transport=transport),
         )
         jid = await client.submit("bundle", {"a": 1})
         assert jid == "jid"
@@ -82,7 +89,7 @@ def test_async_cloud_client_get_job() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://server",
-            client=httpx.AsyncClient(base_url="https://server", transport=transport),
+            client=AsyncHTTPClient(base_url="https://server", transport=transport),
         )
         jid = await client.submit("bundle", {})
         status = await client.get_job(jid)
@@ -101,7 +108,7 @@ def test_async_cloud_client_submit_failure() -> None:
     async def _run() -> None:
         client = AsyncCloudClient(
             "https://server",
-            client=httpx.AsyncClient(base_url="https://server", transport=transport),
+            client=AsyncHTTPClient(base_url="https://server", transport=transport),
         )
         with pytest.raises(RuntimeError, match="Failed to submit job"):
             await client.submit("bundle", {})


### PR DESCRIPTION
## Summary
- add thin wrappers around `httpx` clients
- refactor cloud clients to use the wrappers
- update tests for new wrappers
- ignore worker job artifacts

## Testing
- `ruff check .`
- `pytest tests/test_cloud.py tests/test_cloud_clients_small.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2b139a908326a8a488ad1e354e56