### PR TITLE
Add cloud worker documentation

### DIFF
--- a/docs/cloud_worker.md
+++ b/docs/cloud_worker.md
@@ -1,0 +1,31 @@
+# Cloud Worker Docker Setup
+
+GeneCoder includes a lightweight worker that exposes a REST API for running bundles remotely. A prebuilt Docker image makes deployment easy.
+
+## Running the Container
+
+Pull and start the worker image while exposing port `8000`:
+
+```bash
+docker run -p 8000:8000 \
+  -e GENECODER_API_TOKEN=TOKEN \
+  -e GENECODER_JOB_DIR=/data/jobs \
+  ghcr.io/d0ttino/genecoder python -m genecoder.cloud.worker
+```
+
+Replace `TOKEN` with a secret value. The `GENECODER_JOB_DIR` variable controls where uploaded archives and status files are stored (defaults to `worker_jobs`).
+
+## Environment Variables
+
+- `GENECODER_API_TOKEN` – bearer token required for all requests.
+- `GENECODER_JOB_DIR` – optional path for job archives.
+- `GENECODER_DATA_DIR` – directory for cached profiles and other data.
+
+## Authentication
+
+The worker uses HTTP bearer authentication. Clients must include the token in the `Authorization` header. The CLI automatically adds this header when you run:
+
+```bash
+genecoder cloud submit bundle.yaml --server http://localhost:8000 --token TOKEN
+```
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,7 @@
 # Deployment Guide
 
 This guide summarizes how to build the React dashboard, start a cloud worker with Docker and submit jobs via the CLI.
+See [cloud_worker.md](cloud_worker.md) for a detailed explanation of the worker container and environment variables.
 
 ## Build the Dashboard
 


### PR DESCRIPTION
## Summary
- document Docker-based cloud worker usage
- reference the new guide from the deployment docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d39eb6fd48326b52bdb4bf92eb7b0