### PR TITLE
Handle sbatch not found

### DIFF
--- a/src/genecoder/cloud/hpc.py
+++ b/src/genecoder/cloud/hpc.py
@@ -43,9 +43,12 @@ def generate_slurm_script(
 
 def submit_slurm_job(script: str, sbatch: str = "sbatch") -> str:
     """Submit the script via ``sbatch`` and return the job ID."""
-    proc = subprocess.run(
-        [sbatch], input=script, text=True, capture_output=True, check=True
-    )
+    try:
+        proc = subprocess.run(
+            [sbatch], input=script, text=True, capture_output=True, check=True
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("sbatch not found") from exc
     match = re.search(r"Submitted batch job (\d+)", proc.stdout)
     if not match:
         raise RuntimeError("Failed to parse sbatch output")

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -82,6 +82,15 @@ def test_submit_slurm_job_run_error(monkeypatch: pytest.MonkeyPatch) -> None:
         submit_slurm_job("script")
 
 
+def test_submit_slurm_job_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd, *, input=None, text=None, capture_output=None, check=None):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    with pytest.raises(RuntimeError, match="sbatch not found"):
+        submit_slurm_job("script")
+
+
 def test_cloud_client_hpc(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("httpx")
     generated = {}


### PR DESCRIPTION
## Summary
- catch missing `sbatch` when submitting Slurm jobs
- add regression test covering `FileNotFoundError`

## Testing
- `ruff check src/genecoder/cloud/hpc.py tests/test_cloud_hpc.py`
- `pytest tests/test_cloud_hpc.py::test_submit_slurm_job_not_found -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3f9c99e48326ac917e7b149579e4