### PR TITLE
Fix HPC script validation

### DIFF
--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -5,6 +5,7 @@ import base64
 import tempfile
 import zipfile
 import time
+import re
 from pathlib import Path
 
 
@@ -57,7 +58,10 @@ def _handle_submit(args: argparse.Namespace) -> None:
         from genecoder.cloud.hpc import generate_slurm_script, submit_slurm_job
 
         script = payload.get("script")
-        if not isinstance(script, str):
+        if isinstance(script, str):
+            if any(c in script for c in "\n\r") or re.search(r"[;&|<>`$]", script):
+                raise ValueError("script contains unsafe characters")
+        else:
             command = payload.get("command")
             if not isinstance(command, str):
                 raise ValueError("command is required for HPC job")

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from genecoder.metrics import get_metrics, oligos_per_week
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -23,7 +23,6 @@ StatsData: TypeAlias = dict[str, int | list[str] | dict[str, int]]
 def collect_stats() -> StatsData:
     """Return current usage metrics."""
 
-    data: dict[str, object] = get_metrics()
-
+    data = cast(StatsData, get_metrics())
     data["oligos_per_week"] = oligos_per_week()
     return data

--- a/src/genecoder/cloud/http_client.py
+++ b/src/genecoder/cloud/http_client.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    import httpx
+
+
 class HTTPClient:
     """Thin wrapper around ``httpx.Client``."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         import httpx
 
         self._client = httpx.Client(*args, **kwargs)
 
-    def post(self, *args, **kwargs):
+    def post(self, *args: object, **kwargs: object) -> "httpx.Response":
         return self._client.post(*args, **kwargs)
 
-    def get(self, *args, **kwargs):
+    def get(self, *args: object, **kwargs: object) -> "httpx.Response":
         return self._client.get(*args, **kwargs)
 
     def close(self) -> None:
@@ -21,25 +27,25 @@ class HTTPClient:
         self._client.__enter__()
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:  # pragma: no cover - passthrough
         self._client.__exit__(exc_type, exc, tb)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._client, name)
 
 
 class AsyncHTTPClient:
     """Thin wrapper around ``httpx.AsyncClient``."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         import httpx
 
         self._client = httpx.AsyncClient(*args, **kwargs)
 
-    async def post(self, *args, **kwargs):
+    async def post(self, *args: object, **kwargs: object) -> "httpx.Response":
         return await self._client.post(*args, **kwargs)
 
-    async def get(self, *args, **kwargs):
+    async def get(self, *args: object, **kwargs: object) -> "httpx.Response":
         return await self._client.get(*args, **kwargs)
 
     async def aclose(self) -> None:
@@ -49,10 +55,10 @@ class AsyncHTTPClient:
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:  # pragma: no cover - passthrough
         await self._client.__aexit__(exc_type, exc, tb)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._client, name)
 
 

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -143,3 +143,17 @@ job_name: cli
     assert called["command"] == "echo hi"
     assert called["job_name"] == "cli"
     assert called["script"] == "script"
+
+
+@pytest.mark.parametrize(
+    "bad", ["echo hi && rm", "bad\ncmd"]
+)
+def test_cloud_cli_hpc_bad_script(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bad: str
+) -> None:
+    pytest.importorskip("yaml")
+    cfg = tmp_path / "job.yml"
+    cfg.write_text(f'script: "{bad}"\n')
+
+    result = run_cli_command(["cloud", "submit", "--hpc-config", str(cfg)])
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- validate `script` value in cloud CLI against unsafe content
- test rejecting HPC scripts containing newlines or shell metacharacters
- type hint HTTP client helpers and stats CLI functions

## Testing
- `ruff check src/genecoder/cloud/http_client.py src/genecoder/cli/stats.py src/genecoder/cli/cloud.py tests/test_cloud_hpc.py`
- `SKIP=pytest pre-commit run --files src/genecoder/cli/cloud.py tests/test_cloud_hpc.py src/genecoder/cloud/http_client.py src/genecoder/cli/stats.py`
- `pytest tests/test_cloud_hpc.py -k test_cloud_cli_hpc_bad_script -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3f9bc7c88326b1bc1be0a63e3a05