### PR TITLE
Add plugin search and download features

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -233,6 +233,25 @@ For convenience the CLI exposes a ``rate`` command:
 genecoder plugin rate myplugin 5 --server https://localhost:8000
 ```
 
+## Searching and Downloading Plugins
+
+Query the catalog through ``GET /plugins/search``. Provide a ``q`` parameter to
+search by name or description and ``min_stars`` to filter by rating. Example:
+
+```bash
+curl 'http://localhost:8000/plugins/search?q=codec&min_stars=4'
+```
+
+Download a package directly via ``GET /plugins/download``:
+
+```bash
+curl -o plugin.whl 'http://localhost:8000/plugins/download?name=myplugin'
+```
+
+The ``/plugin-catalog`` dashboard lets you browse search results and submit new
+plugins. Enter the plugin metadata and API token in the form at the bottom of
+the page to publish an entry.
+
 Always verify that catalog entries originate from reputable sources or trusted
 registries. A matching checksum only proves the downloaded file has not been
 corrupted or tampered with; it does not guarantee that the plugin's code is

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -94,6 +94,75 @@ def _handle_list(args: argparse.Namespace) -> None:
         print(display)
 
 
+def download_plugin_bytes(name: str) -> tuple[str, bytes]:
+    """Return ``(filename, bytes)`` for plugin ``name`` after verification."""
+
+    meta = plugins.PLUGIN_CATALOG.get(name)
+    if not meta:
+        logger.error("Unknown plugin: %s", name)
+        raise SystemExit(1)
+
+    spec = meta.get("url") or name
+    version = meta.get("version")
+    if version and not meta.get("url"):
+        spec = f"{name}=={version}"
+    checksum = meta.get("checksum")
+    signature_b64 = meta.get("signature")
+    pubkey: bytes | None = None
+
+    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
+    if signature_b64:
+        if not key_path:
+            logger.error("Missing public key for signed plugin %s", name)
+            raise SystemExit(1)
+        try:
+            pubkey = Path(key_path).read_bytes()
+        except Exception:
+            logger.warning("Failed to read public key %s", key_path)
+            pubkey = None
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        _run_pip(
+            ["download", "--no-deps", "-d", tmp_dir, spec],
+            "pip download",
+        )
+        files = list(Path(tmp_dir).iterdir())
+        if not files:
+            logger.error("No package downloaded for plugin %s", name)
+            raise SystemExit(1)
+        pkg_path = files[0]
+        pkg_bytes = pkg_path.read_bytes()
+
+        if signature_b64:
+            if pubkey is None:
+                logger.error("Missing public key for signed plugin %s", name)
+                raise SystemExit(1)
+            try:
+                sig_bytes = decode_signature(signature_b64)
+            except ValueError:
+                logger.error("Invalid signature for plugin %s", name)
+                raise SystemExit(1)
+        else:
+            sig_bytes = None
+
+        try:
+            verify_package(
+                pkg_bytes,
+                checksum=checksum,
+                signature=sig_bytes,
+                public_key=pubkey,
+                compute_fn=plugins.compute_checksum,
+            )
+        except ValueError as exc:
+            if str(exc) == "Checksum mismatch":
+                logger.error("Checksum mismatch for plugin %s", name)
+            else:
+                logger.error("Signature verification failed for plugin %s: %s", name, exc)
+            raise SystemExit(1)
+
+        return pkg_path.name, pkg_bytes
+
+
 def _handle_install(args: argparse.Namespace) -> None:
     name = args.name
     meta = plugins.PLUGIN_CATALOG.get(name)

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 
 from genecoder.metrics import get_metrics, oligos_per_week
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -23,7 +23,7 @@ StatsData: TypeAlias = dict[str, int | list[str] | dict[str, int]]
 def collect_stats() -> StatsData:
     """Return current usage metrics."""
 
-    data: dict[str, object] = get_metrics()
+    data: StatsData = cast(StatsData, get_metrics())
 
     data["oligos_per_week"] = oligos_per_week()
     return data

--- a/src/genecoder/cloud/__init__.py
+++ b/src/genecoder/cloud/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
-    import httpx
+    import httpx  # noqa: F401
 
 from .http_client import HTTPClient, AsyncHTTPClient
 

--- a/src/genecoder/cloud/http_client.py
+++ b/src/genecoder/cloud/http_client.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+from typing import Any
+from types import TracebackType
+
+import httpx
+
+
 class HTTPClient:
     """Thin wrapper around ``httpx.Client``."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        import httpx
-
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._client = httpx.Client(*args, **kwargs)
 
-    def post(self, *args, **kwargs):
+    def post(self, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
         return self._client.post(*args, **kwargs)
 
-    def get(self, *args, **kwargs):
+    def get(self, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
         return self._client.get(*args, **kwargs)
 
     def close(self) -> None:
@@ -21,25 +25,23 @@ class HTTPClient:
         self._client.__enter__()
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+    def __exit__(self, exc_type: type | None, exc: BaseException | None, tb: TracebackType | None) -> None:  # pragma: no cover - passthrough
         self._client.__exit__(exc_type, exc, tb)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._client, name)
 
 
 class AsyncHTTPClient:
     """Thin wrapper around ``httpx.AsyncClient``."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        import httpx
-
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         self._client = httpx.AsyncClient(*args, **kwargs)
 
-    async def post(self, *args, **kwargs):
+    async def post(self, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
         return await self._client.post(*args, **kwargs)
 
-    async def get(self, *args, **kwargs):
+    async def get(self, *args: Any, **kwargs: Any) -> httpx.Response:  # noqa: ANN401
         return await self._client.get(*args, **kwargs)
 
     async def aclose(self) -> None:
@@ -49,10 +51,10 @@ class AsyncHTTPClient:
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+    async def __aexit__(self, exc_type: type | None, exc: BaseException | None, tb: TracebackType | None) -> None:  # pragma: no cover - passthrough
         await self._client.__aexit__(exc_type, exc, tb)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._client, name)
 
 

--- a/tests/test_web_api_plugins.py
+++ b/tests/test_web_api_plugins.py
@@ -434,3 +434,40 @@ def test_challenge_crud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     r2 = client.get("/catalog/challenge")
     assert r2.status_code == 200
     assert r2.json()["entries"] == {"team": 10}
+
+
+def test_search_plugins() -> None:
+    plugins.PLUGIN_CATALOG.clear()
+    plugins.PLUGIN_CATALOG["alpha"] = {"description": "Alpha", "stars": 5}
+    plugins.PLUGIN_CATALOG["beta"] = {"description": "Beta", "stars": 3}
+
+    r = client.get("/plugins/search", params={"q": "alp"})
+    assert r.status_code == 200
+    names = [p["name"] for p in r.json()["plugins"]]
+    assert names == ["alpha"]
+
+    r = client.get("/plugins/search", params={"min_stars": 4})
+    assert r.status_code == 200
+    names = [p["name"] for p in r.json()["plugins"]]
+    assert names == ["alpha"]
+
+
+def test_download_plugin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pkg = b"PKG"
+    checksum = plugins.compute_checksum(pkg)
+    plugins.PLUGIN_CATALOG["demo"] = {"checksum": checksum}
+
+    def fake_check_call(cmd: list[str]) -> None:
+        if cmd[:4] == [sys.executable, "-m", "pip", "download"]:
+            dest = cmd[cmd.index("-d") + 1]
+            Path(dest).mkdir(parents=True, exist_ok=True)
+            (Path(dest) / "pkg.whl").write_bytes(pkg)
+        else:
+            raise AssertionError(cmd)
+
+    with monkeypatch.context() as m:
+        m.setattr(plugin_cli.subprocess, "check_call", fake_check_call)
+        r = client.get("/plugins/download", params={"name": "demo"})
+    assert r.status_code == 200
+    assert r.headers["content-disposition"].startswith("attachment")
+    assert r.content == pkg

--- a/web/helix-ui/src/PluginCatalog.jsx
+++ b/web/helix-ui/src/PluginCatalog.jsx
@@ -5,12 +5,27 @@ export default function PluginCatalog() {
   const [installing, setInstalling] = useState({});
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('name');
+  const [minStars, setMinStars] = useState('');
+  const [form, setForm] = useState({
+    name: '',
+    version: '',
+    checksum: '',
+    signature: '',
+    token: '',
+  });
+
+  const load = () => {
+    const params = new URLSearchParams();
+    if (search) params.append('q', search);
+    if (minStars) params.append('min_stars', minStars);
+    fetch(`/plugins/search?${params.toString()}`)
+      .then((r) => r.json())
+      .then((data) => setPlugins(data.plugins || []));
+  };
 
   useEffect(() => {
-    fetch('/plugins')
-      .then((r) => r.json())
-      .then((data) => setPlugins(data.plugins || {}));
-  }, []);
+    load();
+  }, [search, minStars]);
 
   const install = async (name) => {
     setInstalling((s) => ({ ...s, [name]: true }));
@@ -22,20 +37,28 @@ export default function PluginCatalog() {
     setInstalling((s) => ({ ...s, [name]: false }));
   };
 
+  const submit = async () => {
+    const { name, version, checksum, signature, token } = form;
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    await fetch('/catalog/plugins', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name, version, checksum, signature }),
+    });
+    setForm((f) => ({ ...f, name: '', version: '', checksum: '', signature: '' }));
+    load();
+  };
+
   if (!plugins) {
     return <div>Loading...</div>;
   }
 
-  const filtered = Object.entries(plugins).filter(([name, meta]) =>
-    name.toLowerCase().includes(search.toLowerCase()) ||
-    (meta.description || '').toLowerCase().includes(search.toLowerCase()),
-  );
-
-  const sorted = [...filtered].sort((a, b) => {
+  const sorted = [...plugins].sort((a, b) => {
     if (sortBy === 'stars') {
-      return (b[1].stars || 0) - (a[1].stars || 0);
+      return (b.stars || 0) - (a.stars || 0);
     }
-    return a[0].localeCompare(b[0]);
+    return a.name.localeCompare(b.name);
   });
 
   return (
@@ -48,6 +71,17 @@ export default function PluginCatalog() {
           onChange={(e) => setSearch(e.target.value)}
         />
         <label style={{ marginLeft: 10 }}>
+          Stars:
+          <select value={minStars} onChange={(e) => setMinStars(e.target.value)}>
+            <option value="">Any</option>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>
+                {n}+
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ marginLeft: 10 }}>
           Sort:
           <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
             <option value="name">Name</option>
@@ -56,20 +90,52 @@ export default function PluginCatalog() {
         </label>
       </div>
       <ul>
-        {sorted.map(([name, meta]) => (
-          <li key={name}>
-            <strong>{name}</strong>
-            {meta.author ? ` by ${meta.author}` : ''}
-            {meta.description ? ` - ${meta.description}` : ''}
-            {typeof meta.stars === 'number' && (
-              <span> ⭐{meta.stars.toFixed(1)}</span>
-            )}
-            <button onClick={() => install(name)} disabled={installing[name]}>
-              {installing[name] ? 'Installing...' : 'Install'}
+        {sorted.map((p) => (
+          <li key={p.name}>
+            <strong>{p.name}</strong>
+            {p.author ? ` by ${p.author}` : ''}
+            {p.description ? ` - ${p.description}` : ''}
+            {typeof p.stars === 'number' && <span> ⭐{p.stars.toFixed(1)}</span>}
+            <button onClick={() => install(p.name)} disabled={installing[p.name]}>
+              {installing[p.name] ? 'Installing...' : 'Install'}
             </button>
           </li>
         ))}
       </ul>
+      <h2>Submit Plugin</h2>
+      <div>
+        <input
+          aria-label="Name"
+          placeholder="Name"
+          value={form.name}
+          onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+        />
+        <input
+          aria-label="Version"
+          placeholder="Version"
+          value={form.version}
+          onChange={(e) => setForm((f) => ({ ...f, version: e.target.value }))}
+        />
+        <input
+          aria-label="Checksum"
+          placeholder="Checksum"
+          value={form.checksum}
+          onChange={(e) => setForm((f) => ({ ...f, checksum: e.target.value }))}
+        />
+        <input
+          aria-label="Signature"
+          placeholder="Signature"
+          value={form.signature}
+          onChange={(e) => setForm((f) => ({ ...f, signature: e.target.value }))}
+        />
+        <input
+          aria-label="Token"
+          placeholder="Token"
+          value={form.token}
+          onChange={(e) => setForm((f) => ({ ...f, token: e.target.value }))}
+        />
+        <button onClick={submit}>Submit</button>
+      </div>
     </div>
   );
 }

--- a/web/helix-ui/src/PluginCatalog.test.jsx
+++ b/web/helix-ui/src/PluginCatalog.test.jsx
@@ -7,10 +7,10 @@ global.fetch = vi.fn(() =>
   Promise.resolve({
     json: () =>
       Promise.resolve({
-        plugins: {
-          a: { description: 'A plugin', stars: 2 },
-          b: { description: 'B plugin', stars: 5 },
-        },
+        plugins: [
+          { name: 'a', description: 'A plugin', stars: 2 },
+          { name: 'b', description: 'B plugin', stars: 5 },
+        ],
       }),
   })
 );
@@ -24,8 +24,11 @@ test('renders plugins and installs', async () => {
   expect(await screen.findByText(/A plugin/)).toBeInTheDocument();
 
   const searchBox = screen.getByPlaceholderText(/search/i);
+  fetch.mockResolvedValueOnce({
+    json: () => Promise.resolve({ plugins: [{ name: 'b' }] }),
+  });
   fireEvent.change(searchBox, { target: { value: 'b' } });
-  expect(screen.queryByText(/A plugin/)).not.toBeInTheDocument();
+  await screen.findByText('b');
 
   const sortSelect = screen.getByLabelText(/sort/i);
   fireEvent.change(sortSelect, { target: { value: 'stars' } });
@@ -35,5 +38,13 @@ test('renders plugins and installs', async () => {
   fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
   const btn = screen.getAllByRole('button', { name: /install/i })[0];
   fireEvent.click(btn);
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok' }) });
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'x' } });
+  fireEvent.change(screen.getByLabelText(/version/i), { target: { value: '1' } });
+  fireEvent.change(screen.getByLabelText(/checksum/i), { target: { value: 'c' } });
+  fireEvent.change(screen.getByLabelText(/token/i), { target: { value: 't' } });
+  fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4));
 });

--- a/web/main.py
+++ b/web/main.py
@@ -637,6 +637,36 @@ async def get_plugin_rating(
     return {"average": avg}
 
 
+@app.get("/plugins/search")
+async def search_plugins(
+    q: str | None = None,
+    min_stars: float | None = None,
+) -> dict[str, list[dict[str, object]]]:
+    """Return plugins matching ``q`` and ``min_stars``."""
+
+    results: list[dict[str, object]] = []
+    query = (q or "").lower()
+    for name, meta in plugins.PLUGIN_CATALOG.items():
+        if query and query not in name.lower() and query not in str(meta.get("description", "")).lower():
+            continue
+        if min_stars is not None and float(meta.get("stars", 0)) < float(min_stars):
+            continue
+        results.append({"name": name, **meta})
+    return {"plugins": results}
+
+
+@app.get("/plugins/download")
+async def download_plugin(name: str) -> Response:
+    """Download the plugin package for ``name``."""
+
+    try:
+        fname, data = await asyncio.to_thread(plugin_cli.download_plugin_bytes, name)
+    except SystemExit as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    headers = {"Content-Disposition": f"attachment; filename={fname}"}
+    return Response(content=data, media_type="application/octet-stream", headers=headers)
+
+
 @app.get("/metrics")
 async def metrics() -> dict[str, object]:
     """Return encode, bundle and simulation usage metrics."""


### PR DESCRIPTION
## Summary
- allow downloading plugins from API and CLI layer
- add search and star filter API endpoints
- extend React plugin catalog with server-backed search and submission form
- document new plugin workflow
- test search and download endpoints
- address mypy issues in helper modules

## Testing
- `ruff check src/genecoder/cloud/http_client.py src/genecoder/cli/stats.py`
- `mypy --config-file pyproject.toml src/genecoder/cloud/http_client.py src/genecoder/cli/stats.py`
- `pytest tests/test_web_api_plugins.py::test_search_plugins tests/test_web_api_plugins.py::test_download_plugin -q`


------
https://chatgpt.com/codex/tasks/task_e_687d39ea6b288326ad5c7b6a36b3f031