### PR TITLE
Harden HPC job input validation

### DIFF
--- a/src/genecoder/cli/cloud.py
+++ b/src/genecoder/cli/cloud.py
@@ -5,7 +5,6 @@ import base64
 import tempfile
 import zipfile
 import time
-import re
 from pathlib import Path
 
 
@@ -55,12 +54,17 @@ def _handle_submit(args: argparse.Namespace) -> None:
     hpc_cfg = getattr(args, "hpc_config", None)
     if hpc_cfg:
         payload = yaml.safe_load(Path(hpc_cfg).read_text()) or {}
-        from genecoder.cloud.hpc import generate_slurm_script, submit_slurm_job
+        from genecoder.cloud.hpc import (
+            generate_slurm_script,
+            submit_slurm_job,
+            _validate_safe,
+        )
 
         script = payload.get("script")
         if isinstance(script, str):
-            if any(c in script for c in "\n\r") or re.search(r"[;&|<>`$]", script):
+            if any(c in script for c in "\n\r"):
                 raise ValueError("script contains unsafe characters")
+            _validate_safe(script, "script")
         else:
             command = payload.get("command")
             if not isinstance(command, str):

--- a/src/genecoder/cloud/hpc.py
+++ b/src/genecoder/cloud/hpc.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 import re
 import subprocess
 
+_UNSAFE_RE = re.compile(r"[;&|<>`$(){}\[\]*?!~]")
+
+
+def _validate_safe(value: str, field: str) -> None:
+    if any(ord(c) < 32 or ord(c) == 127 for c in value):
+        raise ValueError(f"{field} contains control characters")
+    if _UNSAFE_RE.search(value):
+        raise ValueError(f"{field} contains unsafe characters")
+
 
 def generate_slurm_script(
     command: str,
@@ -14,20 +23,25 @@ def generate_slurm_script(
 ) -> str:
     """Return a simple Slurm batch script.
 
-    ``command`` must not contain newlines or shell metacharacters such as
-    ``;``, ``&&`` or ``|``. This prevents accidental command injection when the
-    script is written to disk.
+    ``command`` as well as ``job_name``, ``partition`` and ``output`` are
+    validated to ensure they do not contain control characters or common shell
+    metacharacters. This prevents accidental command injection when the script
+    is written to disk.
     """
     if any(c in command for c in "\n\r"):
         raise ValueError("command must not contain newlines")
-    if re.search(r"[;&|<>`$]", command):
-        raise ValueError("command contains unsafe characters")
+    _validate_safe(command, "command")
 
     allowed = re.compile(r"^[A-Za-z0-9_-]+$")
+    _validate_safe(job_name, "job_name")
     if not allowed.fullmatch(job_name):
         raise ValueError("job_name contains invalid characters")
-    if partition is not None and not allowed.fullmatch(partition):
-        raise ValueError("partition contains invalid characters")
+    if partition is not None:
+        _validate_safe(partition, "partition")
+        if not allowed.fullmatch(partition):
+            raise ValueError("partition contains invalid characters")
+    if output is not None:
+        _validate_safe(output, "output")
 
     lines = ["#!/bin/bash", f"#SBATCH --job-name={job_name}"]
     lines.append(f"#SBATCH --output={output or '%x-%j.out'}")

--- a/tests/test_cloud_hpc.py
+++ b/tests/test_cloud_hpc.py
@@ -44,6 +44,12 @@ def test_generate_slurm_script_bad_partition(partition: str) -> None:
         generate_slurm_script("echo hi", partition=partition)
 
 
+@pytest.mark.parametrize("output", ["bad;out", "bad\nout"])
+def test_generate_slurm_script_bad_output(output: str) -> None:
+    with pytest.raises(ValueError):
+        generate_slurm_script("echo hi", output=output)
+
+
 def test_submit_slurm_job(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
 
@@ -163,6 +169,32 @@ def test_cloud_cli_hpc_bad_script(
     pytest.importorskip("yaml")
     cfg = tmp_path / "job.yml"
     cfg.write_text(f'script: "{bad}"\n')
+
+    result = run_cli_command(["cloud", "submit", "--hpc-config", str(cfg)])
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("command", "echo hi && rm"),
+        ("job_name", "bad;name"),
+        ("partition", "part|ition"),
+        ("output", "out.txt && rm"),
+    ],
+)
+def test_cloud_cli_hpc_bad_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, field: str, value: str
+) -> None:
+    pytest.importorskip("yaml")
+    cfg = tmp_path / "job.yml"
+    base = {
+        "command": "echo hi",
+        "job_name": "good",
+        "partition": "debug",
+    }
+    base[field] = value
+    cfg.write_text("\n".join(f"{k}: {v}" for k, v in base.items()))
 
     result = run_cli_command(["cloud", "submit", "--hpc-config", str(cfg)])
     assert result.returncode != 0


### PR DESCRIPTION
## Summary
- validate slurm job inputs for control and shell characters
- tighten cloud CLI checks when submitting HPC jobs
- test invalid output and config values

## Testing
- `ruff check src/genecoder/cloud/hpc.py src/genecoder/cli/cloud.py tests/test_cloud_hpc.py`
- `mypy src/genecoder/cloud/hpc.py src/genecoder/cli/cloud.py --ignore-missing-imports`
- `pytest tests/test_cloud_hpc.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e445324ac83268fe2cb71ccace24a