### PR TITLE
Add channel run wrapper

### DIFF
--- a/configs/channel_demo.yaml
+++ b/configs/channel_demo.yaml
@@ -1,6 +1,9 @@
 # Example channel configuration combining sequencing simulators
 # with synthesis constraints. The same structure can be saved as JSON.
 
+input: encoded/message.fasta
+output: simulated.fasta
+
 synthesis:
   min_length: 25
   max_length: 300

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -196,19 +196,17 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
      max_homopolymer: 5
    ```
 
-   ```bash
-   genecoder channel --input-file encoded.fasta \
-       --output-file channel.fasta --config config.yml
-   ```
+```bash
+genecoder channel run config.yml
+```
 
-   The command processes each FASTA record through a pipeline of steps. Use
-   ``--batch-workers`` to run multiple records in parallel:
+   The command processes each FASTA record through a pipeline of steps. Set
+   ``batch_workers`` in the YAML configuration to run multiple records in
+   parallel:
 
-   ```bash
-   genecoder channel --input-file encoded.fasta \
-       --output-file channel.fasta --config config.yml \
-       --batch-workers 4
-   ```
+```bash
+genecoder channel run config.yml
+```
 
 14. **AI-assisted decoding**
 

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -90,8 +90,7 @@ constraints is provided at `configs/channel_demo.yaml`.
 Apply the channel step using:
 
 ```bash
-genecoder channel --config configs/channel_demo.yaml \
-  --input-file encoded/message.fasta --output-file simulated.fasta
+genecoder channel run configs/channel_demo.yaml
 ```
 
 ## Launch the GUI

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -27,7 +27,12 @@ logger = logging.getLogger(__name__)
 
 def _load_config(
     path: str,
-) -> tuple[list[tuple[str, Dict[str, Any]]], dict[str, int], ChannelConfig]:
+) -> tuple[
+    list[tuple[str, Dict[str, Any]]],
+    dict[str, int],
+    ChannelConfig,
+    dict[str, Any],
+]:
     import yaml
 
     with open(path, "r", encoding="utf-8") as f:
@@ -71,7 +76,17 @@ def _load_config(
         use_mpi=bool(pipeline.get("use_mpi", False)),
     )
 
-    return simulators, {k: int(v) for k, v in synth_section.items()}, cfg
+    extra = {
+        "input_file": data.get("input"),
+        "output_file": data.get("output"),
+        "sub_prob": float(data.get("sub_prob", 0.0) or 0.0),
+        "ins_prob": float(data.get("ins_prob", 0.0) or 0.0),
+        "del_prob": float(data.get("del_prob", 0.0) or 0.0),
+        "seed": data.get("seed"),
+        "batch_workers": data.get("batch_workers"),
+    }
+
+    return simulators, {k: int(v) for k, v in synth_section.items()}, cfg, extra
 
 
 def _apply_simulators(
@@ -187,44 +202,66 @@ def process_channel(
     logger.info("Manifest written to %s", manifest_path)
 
 
-def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    parser = subparsers.add_parser("channel", help="Combine simulators and synthesis constraints")
-    add_single_io_args(parser, input_help="Path to input FASTA", output_help="Path to output FASTA")
-    parser.add_argument(
+def register_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "channel", help="Combine simulators and synthesis constraints"
+    )
+
+    channel_sub = parser.add_subparsers(dest="channel_command")
+
+    run_parser = channel_sub.add_parser(
+        "run", help="Run channel pipeline from a YAML config"
+    )
+    run_parser.add_argument("config", type=str, help="Path to channel config")
+    run_parser.set_defaults(func=_handle_run)
+
+    apply_parser = channel_sub.add_parser(
+        "apply", help="Apply simulators and synthesis constraints"
+    )
+    add_single_io_args(
+        apply_parser,
+        input_help="Path to input FASTA",
+        output_help="Path to output FASTA",
+    )
+    apply_parser.add_argument(
         "--simulator",
         dest="simulators",
         action="append",
         default=[],
         help="Simulator to apply (can be repeated)",
     )
-    parser.add_argument(
+    apply_parser.add_argument(
         "--config",
         type=str,
         help="YAML/JSON config defining simulators, synthesis and pipeline",
     )
-    parser.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
-    parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
-    parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
-    parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
-    parser.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
-    parser.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
-    parser.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
-    parser.add_argument(
+    apply_parser.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
+    apply_parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
+    apply_parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
+    apply_parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
+    apply_parser.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
+    apply_parser.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
+    apply_parser.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
+    apply_parser.add_argument(
         "--parallel",
         action="store_true",
         help="Run channel steps concurrently",
     )
-    parser.add_argument("--threads", type=int, default=None, help="Number of worker threads")
-    parser.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
-    parser.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
-    parser.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
-    parser.add_argument(
+    apply_parser.add_argument("--threads", type=int, default=None, help="Number of worker threads")
+    apply_parser.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
+    apply_parser.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
+    apply_parser.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
+    apply_parser.add_argument(
         "--batch-workers",
         type=int,
         default=None,
         help="Process sequences in parallel using N workers",
     )
-    parser.set_defaults(func=_handle_command)
+    apply_parser.set_defaults(func=_handle_command)
+
+    parser.set_defaults(channel_command="apply", func=_handle_command)
 
 
 def _handle_command(args: argparse.Namespace) -> None:
@@ -261,4 +298,31 @@ def run_channel(args: argparse.Namespace) -> None:
         seed=opts.seed,
         config=cfg,
         batch_workers=opts.batch_workers,
+    )
+
+
+def _handle_run(args: argparse.Namespace) -> None:
+    try:
+        simulators, constraints, cfg, extra = _load_config(args.config)
+    except Exception as exc:  # pragma: no cover - config error handling
+        logger.error(str(exc))
+        raise SystemExit(1)
+
+    input_file = extra.get("input_file")
+    output_file = extra.get("output_file")
+    if not input_file or not output_file:
+        logger.error("Config must define 'input' and 'output' paths")
+        raise SystemExit(1)
+
+    process_channel(
+        input_file,
+        output_file,
+        simulators,
+        constraints,
+        sub_prob=extra.get("sub_prob", 0.0),
+        ins_prob=extra.get("ins_prob", 0.0),
+        del_prob=extra.get("del_prob", 0.0),
+        seed=extra.get("seed"),
+        config=cfg,
+        batch_workers=extra.get("batch_workers"),
     )

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -91,7 +91,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
 
     sim_specs: list[tuple[str, dict[str, object]]] | None = None
     if args.config:
-        cfg_sim, cfg_con, cfg_pipeline = _load_config(args.config)
+        cfg_sim, cfg_con, cfg_pipeline, _ = _load_config(args.config)
         if cfg_sim:
             sim_specs = cfg_sim
             simulators = [name for name, _ in cfg_sim]

--- a/tests/test_channel_run.py
+++ b/tests/test_channel_run.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from tests.test_cli import run_cli_command
+
+
+def test_channel_run(tmp_path: Path) -> None:
+    inp = tmp_path / "in.txt"
+    inp.write_text("hello")
+    enc = run_cli_command([
+        "encode",
+        "--input-files",
+        str(inp),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+    ])
+    assert enc.returncode == 0, enc.stderr
+    fasta = tmp_path / "in.txt.fasta"
+    cfg = tmp_path / "cfg.yml"
+    out_path = tmp_path / "out.fasta"
+    cfg.write_text(
+        f"input: {fasta}\noutput: {out_path}\nsimulators:\n  - simple\n"
+        "synthesis:\n  min_length: 1\n  max_length: 500\n  max_homopolymer: 10\n"
+    )
+    res = run_cli_command(["channel", "run", str(cfg)])
+    assert res.returncode == 0, res.stderr
+    assert out_path.exists()
+


### PR DESCRIPTION
## Summary
- add `channel run` subcommand to apply simulators from YAML
- extend `_load_config` to include file paths and options
- update docs with simplified `channel run` usage
- include input and output in `configs/channel_demo.yaml`
- test new wrapper

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py tests/test_channel_run.py`
- `mypy src/genecoder/cli/channel.py src/genecoder/cli/options.py --disable-error-code unused-ignore`
- `pytest -q tests/test_channel_run.py`

------
https://chatgpt.com/codex/tasks/task_e_687e49b27ff08326944a8cf67b27075e