### PR TITLE
Introduce plugin catalog cache

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -23,7 +23,10 @@ from .plugin_manager import (
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
 from .channel_config import ChannelConfig
 from .pipeline import SequencePipeline
-from .cloud import CloudClient
+try:  # optional dependency for cloud client
+    from .cloud import CloudClient
+except Exception:  # pragma: no cover - missing optional dependency
+    CloudClient = None  # type: ignore[misc,assignment]
 
 
 

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -83,6 +83,8 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
 
 def _handle_list(args: argparse.Namespace) -> None:
     if not plugins.PLUGIN_CATALOG:
+        plugins.fetch_plugin_catalog()
+    if not plugins.PLUGIN_CATALOG:
         logger.info("No plugin catalog available")
         return
     for name, meta in plugins.PLUGIN_CATALOG.items():
@@ -97,6 +99,8 @@ def _handle_list(args: argparse.Namespace) -> None:
 def download_plugin_bytes(name: str) -> tuple[str, bytes]:
     """Return ``(filename, bytes)`` for plugin ``name`` after verification."""
 
+    if not plugins.PLUGIN_CATALOG:
+        plugins.fetch_plugin_catalog()
     meta = plugins.PLUGIN_CATALOG.get(name)
     if not meta:
         logger.error("Unknown plugin: %s", name)
@@ -165,6 +169,8 @@ def download_plugin_bytes(name: str) -> tuple[str, bytes]:
 
 def _handle_install(args: argparse.Namespace) -> None:
     name = args.name
+    if not plugins.PLUGIN_CATALOG:
+        plugins.fetch_plugin_catalog()
     meta = plugins.PLUGIN_CATALOG.get(name)
     if not meta:
         logger.error("Unknown plugin: %s", name)

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -74,7 +74,7 @@ except Exception:  # pragma: no cover - optional dependency
         return result
 
     _yaml = ModuleType("yaml")
-    _yaml.safe_load = _simple_safe_load  # type: ignore[attr-defined]
+    _yaml.safe_load = _simple_safe_load
 
 yaml: Any | None = _yaml
 
@@ -93,6 +93,9 @@ logger = logging.getLogger(__name__)
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
+
+# Environment variable name for plugin catalog cache path
+CATALOG_CACHE_ENV = "GENECODER_CATALOG_CACHE"
 
 # re-export for tests
 verify_signature = _verify_signature
@@ -225,6 +228,51 @@ def rate_plugin(
             item["stars"] = avg
             break
     return avg
+
+
+def _catalog_cache_path(path: str | None = None) -> Path | None:
+    cache_env = path or os.getenv(CATALOG_CACHE_ENV)
+    if cache_env:
+        return Path(cache_env)
+    return None
+
+
+def load_catalog_cache(
+    path: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, list[int]]]:
+    """Load plugin catalog from cache ``path``."""
+    PLUGIN_CATALOG.clear()
+    cache_path = _catalog_cache_path(path)
+    if cache_path is None:
+        return [], {}
+    catalog, ratings = load_catalog(str(cache_path))
+    if not catalog:
+        return [], {}
+    for entry in catalog:
+        name = entry.get("name")
+        checksum = entry.get("checksum")
+        signature = entry.get("signature")
+        if not name or not checksum or not signature:
+            continue
+        PLUGIN_CATALOG[name] = {
+            "version": entry.get("version", ""),
+            "url": entry.get("url", ""),
+            "description": entry.get("description", ""),
+            "checksum": checksum,
+            "signature": signature,
+            "author": entry.get("author", ""),
+            "stars": entry.get("stars", 0),
+        }
+    return catalog, ratings
+
+
+def save_catalog_cache(path: str | None = None) -> None:
+    """Write ``PLUGIN_CATALOG`` to cache ``path``."""
+    cache_path = _catalog_cache_path(path)
+    if cache_path is None:
+        return
+    catalog = [{"name": name, **meta} for name, meta in PLUGIN_CATALOG.items()]
+    save_catalog(str(cache_path), catalog, {})
 
 
 def _install_registry_plugins(url: str) -> None:
@@ -451,12 +499,22 @@ def load_builtin_plugins() -> None:
         builtin.register_builtin_plugins()
 
 
-def fetch_plugin_catalog() -> None:
-    """Fetch plugin catalog from :envvar:`GENECODER_PLUGIN_CATALOG_URL`."""
+def fetch_plugin_catalog(*, use_cache: bool = True) -> None:
+    """Fetch plugin catalog using optional local cache."""
+
+    if use_cache:
+        catalog, _ = load_catalog_cache()
+        if catalog:
+            return
 
     catalog_url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
     if catalog_url:
         _fetch_catalog(catalog_url)
+        if use_cache:
+            try:
+                save_catalog_cache()
+            except Exception:
+                pass
     else:
         PLUGIN_CATALOG.clear()
 

--- a/web/plugin_catalog.py
+++ b/web/plugin_catalog.py
@@ -40,7 +40,7 @@ class RatingRequest(BaseModel):
 
 def _load_catalog() -> None:
     global CATALOG, PLUGIN_RATINGS
-    CATALOG, PLUGIN_RATINGS = plugins.load_catalog(CATALOG_PATH)
+    CATALOG, PLUGIN_RATINGS = plugins.load_catalog_cache(CATALOG_PATH)
 
 
 def _load_challenge() -> None:
@@ -61,6 +61,7 @@ def _load_challenge() -> None:
 
 def _save_catalog() -> None:
     plugins.save_catalog(CATALOG_PATH, CATALOG, PLUGIN_RATINGS)
+    plugins.save_catalog_cache(CATALOG_PATH)
 
 
 def _save_challenge() -> None:


### PR DESCRIPTION
## Summary
- cache plugin catalog in plugin_manager
- load/save catalog cache when starting the web catalog
- ensure CLI plugin commands refresh catalog from cache
- make CloudClient optional if web dependencies are missing

## Testing
- `ruff` and `mypy` pre-commit hooks
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e49b1c58c83269e20157fec5ff26b