### PR TITLE
Add ASGITransport tests for marketplace and slurm workflow

### DIFF
--- a/tests/test_cloud_hpc_extra.py
+++ b/tests/test_cloud_hpc_extra.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("httpx")
+
+from genecoder.cloud import CloudClient
+
+
+def test_cloud_client_hpc_with_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def fake_generate(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("generate_slurm_script should not run")
+
+    def fake_submit(script: str) -> str:
+        called["script"] = script
+        return "77"
+
+    monkeypatch.setattr("genecoder.cloud.hpc.generate_slurm_script", fake_generate)
+    monkeypatch.setattr("genecoder.cloud.hpc.submit_slurm_job", fake_submit)
+
+    client = CloudClient("http://unused")
+    jid = client.submit("hpc", {"script": "echo hi"})
+    assert jid == "77"
+    assert called["script"] == "echo hi"

--- a/tests/test_web_marketplace.py
+++ b/tests/test_web_marketplace.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+
+httpx = pytest.importorskip("httpx")
+fastapi = pytest.importorskip("fastapi")
+
+import web.main as main
+
+main.API_TOKEN = "test-token"
+AUTH_HEADERS = {"Authorization": f"Bearer {main.API_TOKEN}"}
+
+
+def _request(method: str, url: str, **kwargs: object) -> httpx.Response:
+    async def _call() -> httpx.Response:
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            return await ac.request(method, url, **kwargs)
+
+    return asyncio.run(_call())
+
+
+def test_marketplace_page_served() -> None:
+    r = _request("GET", "/marketplace")
+    assert r.status_code == 200
+    assert "<!DOCTYPE html>" in r.text
+
+
+def test_plugin_rate_roundtrip() -> None:
+    main.PLUGIN_RATINGS.clear()
+    r = _request(
+        "POST",
+        "/plugins/rate",
+        headers=AUTH_HEADERS,
+        json={"name": "demo", "rating": 5},
+    )
+    assert r.status_code == 200
+    assert r.json()["average"] == 5
+    r2 = _request("GET", "/plugins/rate", headers=AUTH_HEADERS, params={"name": "demo"})
+    assert r2.status_code == 200
+    assert r2.json()["average"] == 5


### PR DESCRIPTION
## Summary
- add tests for the marketplace HTML page and rating API using `httpx.ASGITransport`
- cover Slurm workflow when a script is provided directly

## Testing
- `ruff check tests/test_web_marketplace.py tests/test_cloud_hpc_extra.py`
- `mypy --config-file pyproject.toml`
- `pytest tests/test_web_marketplace.py tests/test_cloud_hpc_extra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e66a8cae88326bf1356ab8aad6f55