### PR TITLE
Add heatmap metrics and compatibility fix

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -90,3 +90,10 @@ genecoder data fetch illumina_profile.json --url https://example.com/profiles
 Profiles are saved under `~/.genecoder/data` by default. The location can be
 customized with the `--cache-dir` option or the `GENECODER_DATA_DIR`
 environment variable.
+
+## Dashboard Heatmaps
+
+The built-in dashboard renders GC content and homopolymer length as heatmaps.
+Start the web server and open `http://localhost:8000/dashboard`. Paste a DNA
+sequence and click **Analyze** to see the new visualizations next to the
+sequence plot.

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -220,48 +220,54 @@ def register_subcommand(
     apply_parser = channel_sub.add_parser(
         "apply", help="Apply simulators and synthesis constraints"
     )
+
     add_single_io_args(
         apply_parser,
         input_help="Path to input FASTA",
         output_help="Path to output FASTA",
     )
-    apply_parser.add_argument(
-        "--simulator",
-        dest="simulators",
-        action="append",
-        default=[],
-        help="Simulator to apply (can be repeated)",
-    )
-    apply_parser.add_argument(
-        "--config",
-        type=str,
-        help="YAML/JSON config defining simulators, synthesis and pipeline",
-    )
-    apply_parser.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
-    apply_parser.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
-    apply_parser.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
-    apply_parser.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
-    apply_parser.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
-    apply_parser.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
-    apply_parser.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
-    apply_parser.add_argument(
-        "--parallel",
-        action="store_true",
-        help="Run channel steps concurrently",
-    )
-    apply_parser.add_argument("--threads", type=int, default=None, help="Number of worker threads")
-    apply_parser.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
-    apply_parser.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
-    apply_parser.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
-    apply_parser.add_argument(
-        "--batch-workers",
-        type=int,
-        default=None,
-        help="Process sequences in parallel using N workers",
-    )
-    apply_parser.set_defaults(func=_handle_command)
 
-    parser.set_defaults(channel_command="apply", func=_handle_command)
+    parser.add_argument("--input-file", type=str, help="Path to input FASTA")
+    parser.add_argument("--output-file", type=str, help="Path to output FASTA")
+
+    for target in (parser, apply_parser):
+        target.add_argument(
+            "--simulator",
+            dest="simulators",
+            action="append",
+            default=[],
+            help="Simulator to apply (can be repeated)",
+        )
+        target.add_argument(
+            "--config",
+            type=str,
+            help="YAML/JSON config defining simulators, synthesis and pipeline",
+        )
+        target.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
+        target.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
+        target.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
+        target.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
+        target.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
+        target.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
+        target.add_argument("--max-homopolymer", type=int, default=4, help="Maximum homopolymer")
+        target.add_argument(
+            "--parallel",
+            action="store_true",
+            help="Run channel steps concurrently",
+        )
+        target.add_argument("--threads", type=int, default=None, help="Number of worker threads")
+        target.add_argument("--processes", type=int, default=None, help="Use process pool with N workers")
+        target.add_argument("--mpi", action="store_true", help="Use MPI for parallel execution")
+        target.add_argument("--mpi-workers", type=int, default=None, help="Number of MPI workers")
+        target.add_argument(
+            "--batch-workers",
+            type=int,
+            default=None,
+            help="Process sequences in parallel using N workers",
+        )
+        target.set_defaults(func=_handle_command)
+
+    parser.set_defaults(channel_command="apply")
 
 
 def _handle_command(args: argparse.Namespace) -> None:

--- a/web/helix-ui/src/Dashboard.jsx
+++ b/web/helix-ui/src/Dashboard.jsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import Heatmaps from './Heatmaps.jsx';
+import HeatmapLoader from './HeatmapLoader.jsx';
 
 export default function Dashboard() {
   const [sequence, setSequence] = useState('ACGT');
   const [data, setData] = useState(null);
-  const [plotData, setPlotData] = useState(null);
   const [deepdna, setDeepdna] = useState(null);
 
   const loadFile = async (e) => {
@@ -22,14 +21,6 @@ export default function Dashboard() {
     });
     const json = await resp.json();
     setData(json);
-
-    const respPlot = await fetch('/dashboard/plot-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ dna_sequence: sequence }),
-    });
-    const plotJson = await respPlot.json();
-    setPlotData(plotJson);
   };
 
   const decodeDeepdna = async () => {
@@ -65,9 +56,7 @@ export default function Dashboard() {
           <p>Max Homopolymer: {data.max_homopolymer}</p>
           <p>Error Rate: {(data.error_rate * 100).toFixed(2)}%</p>
           <img src={`data:image/png;base64,${data.plot}`} style={{ maxWidth: '100%' }} />
-          {plotData && (
-            <Heatmaps gcArray={plotData.gc_array} hpArray={plotData.hp_array} />
-          )}
+          <HeatmapLoader sequence={sequence} />
           {deepdna && (
             <div>
               <p>DeepDNA corrected: {deepdna.corrected}</p>

--- a/web/helix-ui/src/HeatmapLoader.jsx
+++ b/web/helix-ui/src/HeatmapLoader.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import Heatmaps from './Heatmaps.jsx';
+
+export default function HeatmapLoader({ sequence }) {
+  const [gcArray, setGcArray] = useState(null);
+  const [hpArray, setHpArray] = useState(null);
+
+  useEffect(() => {
+    if (!sequence) return;
+    const load = async () => {
+      const gcResp = await fetch('/gc-array', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dna_sequence: sequence })
+      });
+      const gcJson = await gcResp.json();
+      setGcArray(gcJson.gc_array);
+
+      const hpResp = await fetch('/homopolymer-array', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dna_sequence: sequence })
+      });
+      const hpJson = await hpResp.json();
+      setHpArray(hpJson.hp_array);
+    };
+    load();
+  }, [sequence]);
+
+  if (!gcArray || !hpArray) return null;
+  return <Heatmaps gcArray={gcArray} hpArray={hpArray} />;
+}

--- a/web/helix-ui/src/HeatmapLoader.test.jsx
+++ b/web/helix-ui/src/HeatmapLoader.test.jsx
@@ -1,0 +1,34 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import HeatmapLoader from './HeatmapLoader.jsx';
+
+global.fetch = vi.fn((url) => {
+  if (url.endsWith('gc-array')) {
+    return Promise.resolve({ json: () => Promise.resolve({ gc_array: [0, 1] }) });
+  }
+  return Promise.resolve({ json: () => Promise.resolve({ hp_array: [1, 1] }) });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+  }));
+});
+
+test('fetches arrays and renders heatmaps', async () => {
+  const { container } = render(<HeatmapLoader sequence="AC" />);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  expect(container.querySelector('canvas')).toBeInTheDocument();
+});

--- a/web/main.py
+++ b/web/main.py
@@ -434,6 +434,34 @@ def _gc_array(seq: str) -> list[int]:
     return [1 if base in "GC" else 0 for base in seq.upper()]
 
 
+class SequenceRequest(BaseModel):
+    """Simple DNA sequence request."""
+
+    dna_sequence: str
+
+
+@app.post("/gc-array")
+async def gc_array_endpoint(req: SequenceRequest) -> dict[str, list[int]]:
+    """Return ``1`` for G/C bases and ``0`` for A/T per position."""
+
+    seq = req.dna_sequence.upper()
+    if not DNA_RE.fullmatch(seq):
+        raise HTTPException(status_code=400, detail="Invalid DNA sequence")
+    return {"gc_array": _gc_array(seq)}
+
+
+@app.post("/homopolymer-array")
+async def homopolymer_array_endpoint(
+    req: SequenceRequest,
+) -> dict[str, list[int]]:
+    """Return the homopolymer length for each base."""
+
+    seq = req.dna_sequence.upper()
+    if not DNA_RE.fullmatch(seq):
+        raise HTTPException(status_code=400, detail="Invalid DNA sequence")
+    return {"hp_array": _homopolymer_lengths(seq)}
+
+
 @app.post("/dashboard/plot-data")
 async def dashboard_plot_data(
     req: PlotDataRequest,


### PR DESCRIPTION
## Summary
- expose `/gc-array` and `/homopolymer-array` endpoints
- add `HeatmapLoader` component to fetch heatmap data
- document dashboard heatmaps in cloud guide
- allow `genecoder channel` without explicit `apply` subcommand

## Testing
- `ruff check .`
- `mypy`
- `npm test --silent`
- `pytest tests/test_channel_run.py tests/test_cli.py::test_channel_command_probabilities tests/test_cli.py::test_channel_missing_input tests/test_cli.py::test_channel_unknown_simulator tests/test_cli_roundtrip.py::test_decode_sim_errors_deterministic -q`

------
https://chatgpt.com/codex/tasks/task_e_687e66a7275883269fa9dc79faf580d8