### PR TITLE
Add codec interfaces and update plugins

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -14,6 +14,11 @@ _LAZY_ATTRS = {
     "CloudClient",
 }
 
+try:
+    from .cloud import CloudClient  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CloudClient = None  # type: ignore
+
 from .plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,

--- a/src/genecoder/bch_codec.py
+++ b/src/genecoder/bch_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_BCHLIB = False
 
 if TYPE_CHECKING:
@@ -53,6 +55,16 @@ def decode_data_bch(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes, int
     return bytes(decoded), corrected
 
 
+class BCHFEC(BaseFEC):
+    """BCH FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, m: int = 8, t: int = 4) -> Tuple[bytes, Mapping[str, int]]:
+        return encode_data_bch(data, m=m, t=t)
+
+    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+        return decode_data_bch(encoded, info)
+
+
 from typing import Callable
 
 
@@ -67,4 +79,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("bch", encode_data_bch, decode_data_bch)
+    register_fec("bch", BCHFEC)
+

--- a/src/genecoder/codecs/__init__.py
+++ b/src/genecoder/codecs/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Base classes for pluggable codecs and FEC backends."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping, Tuple
+
+
+class BaseCodec(ABC):
+    """Abstract base class for simple codecs."""
+
+    @abstractmethod
+    def encode(self, data: bytes, /, **kwargs: Any) -> Any:
+        """Encode ``data`` and return the encoded representation."""
+
+    @abstractmethod
+    def decode(self, encoded: Any, /, **kwargs: Any) -> bytes:
+        """Decode ``encoded`` data back into bytes."""
+
+
+class BaseFEC(ABC):
+    """Abstract base class for forward error correction backends."""
+
+    @abstractmethod
+    def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, Any]]:
+        """Encode ``data`` returning encoded bytes and associated info."""
+
+    @abstractmethod
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any) -> Tuple[bytes, int]:
+        """Decode ``encoded`` bytes using ``info`` returning the original data and number of corrections."""
+
+__all__ = ["BaseCodec", "BaseFEC"]
+

--- a/src/genecoder/deepdna_codec.py
+++ b/src/genecoder/deepdna_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_DEEPDNA = False
 
 if TYPE_CHECKING:
@@ -43,6 +45,16 @@ def decode_data_deepdna(encoded: bytes, info: Mapping[str, str]) -> Tuple[bytes,
     return decoded, 0
 
 
+class DeepDNAFEC(BaseFEC):
+    """DeepDNA FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, model_name: str = "deepdna-small") -> Tuple[bytes, Mapping[str, str]]:
+        return encode_data_deepdna(data, model_name)
+
+    def decode(self, encoded: bytes, info: Mapping[str, str], /) -> Tuple[bytes, int]:
+        return decode_data_deepdna(encoded, info)
+
+
 from typing import Callable
 
 
@@ -57,4 +69,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("deepdna", encode_data_deepdna, decode_data_deepdna)
+    register_fec("deepdna", DeepDNAFEC)
+

--- a/src/genecoder/dnaformer_codec.py
+++ b/src/genecoder/dnaformer_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_DNAFORMER = False
 
 if TYPE_CHECKING:
@@ -45,6 +47,16 @@ def decode_data_dnaformer(
     return decoded, 0
 
 
+class DNAFormerFEC(BaseFEC):
+    """DNAformer FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, model_name: str = "dnaformer-small") -> Tuple[bytes, Mapping[str, str]]:
+        return encode_data_dnaformer(data, model_name)
+
+    def decode(self, encoded: bytes, info: Mapping[str, str], /) -> Tuple[bytes, int]:
+        return decode_data_dnaformer(encoded, info)
+
+
 from typing import Callable
 
 
@@ -59,4 +71,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("dnaformer", encode_data_dnaformer, decode_data_dnaformer)
+    register_fec("dnaformer", DNAFormerFEC)
+

--- a/src/genecoder/fec/framed.py
+++ b/src/genecoder/fec/framed.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from ..codecs import BaseFEC
+
 _HAS_FRAMED = False
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -67,6 +69,16 @@ def decode_data_framed(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, 
     return data, int(corrected[0])
 
 
+class FrameDFEC(BaseFEC):
+    """FrameD FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /) -> Tuple[bytes, Mapping[str, Any]]:
+        return encode_data_framed(data)
+
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> Tuple[bytes, int]:
+        return decode_data_framed(encoded, info)
+
+
 from typing import Callable
 
 
@@ -82,4 +94,5 @@ def register(
 ) -> None:
     """Register this module's FEC backend."""
 
-    register_fec("framed", encode_data_framed, decode_data_framed)
+    register_fec("framed", FrameDFEC)
+

--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_PYFINITE = False
 
 if TYPE_CHECKING:
@@ -58,6 +60,16 @@ def decode_data_fountain(
     return data, 0
 
 
+class FountainFEC(BaseFEC):
+    """Simple Fountain code backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, chunk_size: int = 4) -> Tuple[bytes, Mapping[str, int]]:
+        return encode_data_fountain(data, chunk_size)
+
+    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+        return decode_data_fountain(encoded, info)
+
+
 from typing import Callable
 
 
@@ -72,4 +84,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("fountain", encode_data_fountain, decode_data_fountain)
+    register_fec("fountain", FountainFEC)
+

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_PYLDPC = False
 
 if TYPE_CHECKING:
@@ -84,6 +86,16 @@ def decode_data_ldpc(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, in
     return np.packbits(data_bits).tobytes(), corrections
 
 
+class LdpcFEC(BaseFEC):
+    """LDPC FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /) -> Tuple[bytes, Mapping[str, Any]]:
+        return encode_data_ldpc(data)
+
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> Tuple[bytes, int]:
+        return decode_data_ldpc(encoded, info)
+
+
 from typing import Callable
 
 
@@ -98,4 +110,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("ldpc", encode_data_ldpc, decode_data_ldpc)
+    register_fec("ldpc", LdpcFEC)
+

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -110,17 +110,46 @@ verify_signature = _verify_signature
 compute_checksum = _compute_checksum
 
 
+from .codecs import BaseCodec, BaseFEC
+
+
 def register_codec(
-    name: str, encode: Callable[..., Any], decode: Callable[..., Any]
+    name: str,
+    encode: Callable[..., Any] | BaseCodec | type[BaseCodec],
+    decode: Callable[..., Any] | None = None,
 ) -> None:
     """Register a codec implementation under ``name``."""
+
+    if isinstance(encode, BaseCodec):
+        CODEC_REGISTRY[name] = {"encode": encode.encode, "decode": encode.decode}
+        return
+    if isinstance(encode, type) and issubclass(encode, BaseCodec):
+        inst = encode()
+        CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
+        return
+
+    if decode is None:
+        raise TypeError("decode function required for legacy registration")
     CODEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
 
 def register_fec(
-    name: str, encode: Callable[..., Any], decode: Callable[..., Any]
+    name: str,
+    encode: Callable[..., Any] | BaseFEC | type[BaseFEC],
+    decode: Callable[..., Any] | None = None,
 ) -> None:
     """Register a FEC backend under ``name``."""
+
+    if isinstance(encode, BaseFEC):
+        FEC_REGISTRY[name] = {"encode": encode.encode, "decode": encode.decode}
+        return
+    if isinstance(encode, type) and issubclass(encode, BaseFEC):
+        inst = encode()
+        FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
+        return
+
+    if decode is None:
+        raise TypeError("decode function required for legacy registration")
     FEC_REGISTRY[name] = {"encode": encode, "decode": decode}
 
 

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
 _HAS_RAPTORQ = False
 
 if TYPE_CHECKING:
@@ -88,6 +90,16 @@ def decode_data_raptorq(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes,
     return data, 0
 
 
+class RaptorqFEC(BaseFEC):
+    """RaptorQ FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, symbol_size: int = 8) -> Tuple[bytes, Mapping[str, int]]:
+        return encode_data_raptorq(data, symbol_size)
+
+    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+        return decode_data_raptorq(encoded, info)
+
+
 from typing import Callable
 
 
@@ -102,4 +114,5 @@ def register(
     ]
 ) -> None:
     """Register this module's FEC backend."""
-    register_fec("raptorq", encode_data_raptorq, decode_data_raptorq)
+    register_fec("raptorq", RaptorqFEC)
+

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from typing import Tuple, TYPE_CHECKING
 
+from .codecs import BaseFEC
+
+
 _HAS_REEDSOLO: bool = False
 
 if TYPE_CHECKING:
@@ -86,9 +89,19 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
     return bytes(decoded), len(err_pos)
 
 
+class ReedSolomonFEC(BaseFEC):
+    """Reed--Solomon FEC backend implementing :class:`BaseFEC`."""
+
+    def encode(self, data: bytes, /, *, nsym: int = 10) -> Tuple[bytes, int]:
+        return encode_data_rs(data, nsym)
+
+    def decode(self, encoded: bytes, info: int, /) -> Tuple[bytes, int]:
+        return decode_data_rs(encoded, info)
+
+
 from typing import Callable, Any
 
-
-def register(register_fec: Callable[[str, Callable[[bytes], tuple[bytes, Any]], Callable[[bytes, Any], tuple[bytes, int]]], None]) -> None:
+def register(register_fec: Callable[[str, Callable[..., object], Callable[..., object]], None]) -> None:
     """Register this module's FEC backend."""
-    register_fec("reed_solomon", encode_data_rs, decode_data_rs)
+    register_fec("reed_solomon", ReedSolomonFEC)
+

--- a/src/plugins/reverse_codec.py
+++ b/src/plugins/reverse_codec.py
@@ -2,16 +2,23 @@
 
 from typing import Callable
 
+from genecoder.codecs import BaseCodec
+
+
+class ReverseCodec(BaseCodec):
+    """Simple byte-reversing codec."""
+
+    def encode(self, data: bytes, /) -> str:  # type: ignore[override]
+        return data[::-1].decode("utf-8")
+
+    def decode(self, encoded: str, /) -> bytes:  # type: ignore[override]
+        return encoded[::-1].encode("utf-8")
+
 
 def register(
-    register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]
+    register_codec: Callable[[str, Callable[..., object], Callable[..., object]], None]
 ) -> None:
     """Register the reverse codec."""
 
-    def encode_reverse(data: bytes) -> str:
-        return data[::-1].decode("utf-8")
+    register_codec("reverse", ReverseCodec)
 
-    def decode_reverse(text: str) -> bytes:
-        return text[::-1].encode("utf-8")
-
-    register_codec("reverse", encode_reverse, decode_reverse)

--- a/tests/test_plugin_class_registration.py
+++ b/tests/test_plugin_class_registration.py
@@ -1,0 +1,66 @@
+from importlib.metadata import EntryPoint
+from pathlib import Path
+from typing import Mapping, Any
+
+import genecoder.plugin_manager as plugins
+
+
+def test_class_based_plugins(monkeypatch, tmp_path: Path) -> None:
+    codec_mod = tmp_path / "cmod.py"
+    codec_mod.write_text(
+        """
+from genecoder.codecs import BaseCodec
+
+class DummyCodec(BaseCodec):
+    def encode(self, data: bytes, /) -> str:
+        return data.decode()[::-1]
+
+    def decode(self, encoded: str, /) -> bytes:
+        return encoded[::-1].encode()
+
+def register(register_codec):
+    register_codec('dummy_cls', DummyCodec)
+"""
+    )
+
+    fec_mod = tmp_path / "fmod.py"
+    fec_mod.write_text(
+        """
+from typing import Mapping, Any
+from genecoder.codecs import BaseFEC
+
+class DummyFEC(BaseFEC):
+    def encode(self, data: bytes, /) -> tuple[bytes, Mapping[str, Any]]:
+        return data + b'x', {}
+
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> tuple[bytes, int]:
+        return encoded[:-1], 0
+
+def register(register_fec):
+    register_fec('dummy_fec_cls', DummyFEC)
+"""
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    ep_codec = EntryPoint(name="dummy_cls", value="cmod", group="genecoder.plugins")
+    ep_fec = EntryPoint(name="dummy_fec_cls", value="fmod", group="genecoder.fec")
+
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda *, group=None: [e for e in (ep_codec, ep_fec) if e.group == group],
+    )
+
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert "dummy_cls" in plugins.CODEC_REGISTRY
+    assert plugins.CODEC_REGISTRY["dummy_cls"]["encode"](b"abc") == "cba"
+
+    assert "dummy_fec_cls" in plugins.FEC_REGISTRY
+    decoded, corr = plugins.FEC_REGISTRY["dummy_fec_cls"]["decode"](b"abcx", {})
+    assert decoded == b"abc" and corr == 0


### PR DESCRIPTION
## Summary
- add `BaseCodec` and `BaseFEC` abstract base classes
- update built‑in codec and FEC modules to implement the new interfaces
- extend `register_codec` and `register_fec` for class-based plugins
- register reverse codec and FECs using class implementations
- test discovery of class-based plugins

## Testing
- `ruff check .`
- `PYTHONPATH=src pytest tests/test_plugin_class_registration.py -q`
- `PYTHONPATH=src pytest tests/test_bch_codec.py::test_bch_roundtrip -q`
- `PYTHONPATH=src pytest tests/test_raptorq_codec.py::test_raptorq_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_687eb3f8c7a483268ca7ef4c8dc2f8d0