### PR TITLE
Add Streamlit dashboard and CLI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -301,6 +301,17 @@ python -m genecoder.flet_app
 
 The GUI exposes encoding options, error correction choices and displays metrics and analysis plots.
 
+### Launching the Streamlit Dashboard
+
+The dashboard visualizes simulation output stored in a JSON file. Install the optional GUI extras and run:
+
+```bash
+poetry install --with gui --no-interaction
+genecoder dashboard results.json
+```
+
+The interface plots GC distribution, homopolymer runs and ECC success rates from the given file.
+
 ### Constraint Fix Suggestions
 
 Both the CLI `analyze` command and the GUI provide simple suggestions when a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ deepdna = {version = "*", optional = true}
 flet = ">=0.28,<0.29"
 matplotlib = "*"
 flet-webview = "*"
+streamlit = "*"
 
 [tool.poetry.group.web.dependencies]
 fastapi = ">=0.110"
@@ -120,7 +121,7 @@ raptorq = ["raptorq", "numpy"]
 bch = ["bchlib"]
 deepdna = ["deepdna", "torch"]
 
-gui = ["flet", "matplotlib", "flet-webview"]
+gui = ["flet", "matplotlib", "flet-webview", "streamlit"]
 web = ["fastapi", "uvicorn", "httpx"]
 
 [build-system]

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "0.1.0"
 
+CloudClient = None
+
 _LAZY_ATTRS = {
     "EncodeOptions",
     "EncodeResult",

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -21,6 +21,7 @@ cloud: Any | None = None
 decode_ai: Any | None = None
 stats: Any | None = None
 data: Any | None = None
+dashboard: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -70,9 +71,10 @@ def build_parser() -> argparse.ArgumentParser:
         benchmark as _benchmark,
         stats as _stats,
         data as _data,
+        dashboard as _dashboard,
     )
 
-    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai, stats, data
+    global encode, decode, analyze, report, channel, bundle, cloud, plugin, benchmark, decode_ai, stats, data, dashboard
 
     encode = _encode
     decode = _decode
@@ -86,6 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     benchmark = _benchmark
     stats = _stats
     data = _data
+    dashboard = _dashboard
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -118,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     benchmark.register_subcommand(subparsers)
     stats.register_subcommand(subparsers)
     data.register_subcommand(subparsers)
+    dashboard.register_subcommand(subparsers)
 
     return parser
 

--- a/src/genecoder/cli/dashboard.py
+++ b/src/genecoder/cli/dashboard.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+
+def register_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "dashboard", help="Launch the Streamlit dashboard"
+    )
+    parser.add_argument("results_json", help="Path to results JSON file")
+    parser.set_defaults(func=_handle_command)
+
+
+def _handle_command(args: argparse.Namespace) -> None:
+    from genecoder.dashboard import launch
+
+    launch(args.results_json)

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Streamlit dashboard for simulation metrics."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import streamlit as st
+
+
+_DEF_METRICS: dict[str, Any] = {
+    "gc_distribution": [],
+    "homopolymer_runs": [],
+    "ecc_success_rates": {},
+}
+
+
+def _load_metrics(path: str) -> dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data
+    except Exception as exc:  # pragma: no cover - I/O errors are surfaced in UI
+        st.error(f"Failed to load {path}: {exc}")
+    return {}
+
+
+def main(results_path: str | None = None) -> None:
+    """Render the dashboard from ``results_path``."""
+    if results_path is None and len(sys.argv) > 1:
+        results_path = sys.argv[1]
+
+    st.title("GeneCoder Dashboard")
+    if not results_path:
+        st.write("No results file provided.")
+        return
+
+    data = {**_DEF_METRICS, **_load_metrics(results_path)}
+
+    st.header("GC Distribution")
+    if data["gc_distribution"]:
+        st.line_chart(data["gc_distribution"])
+    else:
+        st.write("No GC distribution data.")
+
+    st.header("Homopolymer Runs")
+    if data["homopolymer_runs"]:
+        st.bar_chart(data["homopolymer_runs"])
+    else:
+        st.write("No homopolymer data.")
+
+    st.header("ECC Success Rates")
+    ecc = data["ecc_success_rates"]
+    if isinstance(ecc, dict) and ecc:
+        st.bar_chart({k: float(v) for k, v in ecc.items()})
+    else:
+        st.write("No ECC success rate data.")
+
+
+def launch(results_path: str) -> None:
+    """Start the Streamlit server for ``results_path``."""
+    import streamlit.web.bootstrap as bootstrap
+
+    bootstrap.run(Path(__file__).as_posix(), False, [results_path], {})
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    path = sys.argv[1] if len(sys.argv) > 1 else ""
+    launch(path)

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+import pytest
+from tests.test_cli import run_cli_command
+
+streamlit = pytest.importorskip("streamlit")
+bootstrap = pytest.importorskip("streamlit.web.bootstrap")
+
+
+def test_dashboard_cli_starts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"gc_distribution": [0.5], "homopolymer_runs": [1], "ecc_success_rates": {"hamming": 1.0}}
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(data))
+
+    called = False
+
+    def fake_run(path: str, is_hello: bool, args: list[str], flag_options: dict, *, stop_immediately_for_testing: bool = False) -> None:
+        nonlocal called
+        assert Path(path).name == "dashboard.py"
+        assert args == [str(results)]
+        called = True
+
+    monkeypatch.setattr(bootstrap, "run", fake_run)
+    res = run_cli_command(["dashboard", str(results)])
+    assert res.returncode == 0, res.stderr
+    assert called


### PR DESCRIPTION
## Summary
- implement `genecoder.dashboard` using Streamlit
- expose a new `dashboard` CLI command
- document dashboard usage
- provide smoke test for dashboard startup
- support Streamlit via `gui` extras

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml --show-error-codes --no-error-summary`
- `pytest tests/test_channel_run.py tests/test_dashboard_streamlit.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb3f9755c8326a599e8270005be9f