### PR TITLE
Add advanced simulator profiles

### DIFF
--- a/configs/dnarsim_profile.yaml
+++ b/configs/dnarsim_profile.yaml
@@ -1,0 +1,5 @@
+simulators:
+  - name: dnarsim
+    error_rate: 0.05
+pipeline:
+  nanopore_profile: r9

--- a/configs/illumina_iss_example.yaml
+++ b/configs/illumina_iss_example.yaml
@@ -1,0 +1,5 @@
+simulators:
+  - name: insilicoseq
+    read_length: 150
+pipeline:
+  illumina_profile: hiseq

--- a/src/genecoder/channel_config.py
+++ b/src/genecoder/channel_config.py
@@ -13,3 +13,5 @@ class ChannelConfig:
     workers: int | None = None
     use_process_pool: bool = False
     use_mpi: bool = False
+    illumina_profile: str | None = None
+    nanopore_profile: str | None = None

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -74,6 +74,8 @@ def _load_config(
         workers=pipeline.get("workers"),
         use_process_pool=bool(pipeline.get("use_process_pool", False)),
         use_mpi=bool(pipeline.get("use_mpi", False)),
+        illumina_profile=pipeline.get("illumina_profile"),
+        nanopore_profile=pipeline.get("nanopore_profile"),
     )
 
     extra = {
@@ -288,6 +290,8 @@ def run_channel(args: argparse.Namespace) -> None:
         workers=opts.mpi_workers or opts.processes or opts.threads,
         use_process_pool=opts.processes is not None,
         use_mpi=opts.mpi,
+        illumina_profile=None,
+        nanopore_profile=None,
     )
     simulators = opts.simulator_specs
     if simulators is None:

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -33,7 +33,7 @@ def simulate_d2sim(
     if rng is None:
         rng = make_rng()
 
-    return _simulate_adapter("d2sim", sequence, error_rate, rng)
+    return _simulate_adapter("d2sim", sequence, error_rate, rng, None)
 
 
 class D2SimChannel(BaseChannel):

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -26,23 +26,31 @@ def simulate_dnarsim(
     sequence: str,
     error_rate: float = 0.05,
     rng: random.Random | None = None,
+    profile: str | None = None,
 ) -> str:
     """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
         rng = make_rng()
 
-    return _simulate_adapter("dnarsim", sequence, error_rate, rng)
+    extra = ["-p", profile] if profile else None
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng, extra)
 
 
 class DNArSimChannel(BaseChannel):
     """Channel wrapper for the optional ``dnarsim`` simulator."""
 
-    def __init__(self, error_rate: float = 0.05) -> None:
+    def __init__(self, error_rate: float = 0.05, profile: str | None = None) -> None:
         self.error_rate = error_rate
+        self.profile = profile
 
     def simulate(self, sequence: str) -> str:
-        return simulate_dnarsim(sequence, error_rate=self.error_rate, rng=make_rng())
+        return simulate_dnarsim(
+            sequence,
+            error_rate=self.error_rate,
+            rng=make_rng(),
+            profile=self.profile,
+        )
 
 
 def register(

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -86,7 +86,11 @@ def _run_external(command: Sequence[str] | str, sequence: str) -> str:
 
 
 def _simulate_adapter(
-    command: str, sequence: str, error_rate: float, rng: random.Random | None
+    command: str,
+    sequence: str,
+    error_rate: float,
+    rng: random.Random | None,
+    extra_args: Sequence[str] | None = None,
 ) -> str:
 
     """Return ``sequence`` processed by an external ``command`` if available."""
@@ -95,6 +99,8 @@ def _simulate_adapter(
             cmd_list = [command]
             if command in {"d2sim", "dnarsim", "squigulator"}:
                 cmd_list += ["-e", str(error_rate)]
+            if extra_args:
+                cmd_list += list(extra_args)
             cmd_list += _parse_env_options(command)
             return _run_external(cmd_list, sequence)
         except ValueError as exc:  # pragma: no cover - invalid options
@@ -137,7 +143,10 @@ simulate_nanopore = simulate_d2sim
 
 
 def simulate_dnarsim(
-    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+    profile: str | None = None,
 ) -> str:
     """Use ``dnarsim`` if available, else fall back to :func:`simulate_errors`.
 
@@ -149,7 +158,8 @@ def simulate_dnarsim(
     if rng is None:
         rng = make_rng()
 
-    return _simulate_adapter("dnarsim", sequence, error_rate, rng)
+    extra = ["-p", profile] if profile else None
+    return _simulate_adapter("dnarsim", sequence, error_rate, rng, extra)
 
 
 def simulate_squigulator(

--- a/src/genecoder/simulators/insilicoseq.py
+++ b/src/genecoder/simulators/insilicoseq.py
@@ -6,7 +6,6 @@ from typing import Callable
 
 try:  # pragma: no cover - optional dependency
     from iss.generator import simulate_read
-    from iss.error_models.perfect import PerfectErrorModel
     _HAS_ISS = True
 except Exception:  # pragma: no cover - missing optional dependency
     _HAS_ISS = False
@@ -18,18 +17,21 @@ __all__ = ["InsilicoSeqChannel", "register"]
 
 
 class InsilicoSeqChannel(BaseChannel):
-    """Channel using InSilicoSeq's perfect error model."""
+    """Channel using InSilicoSeq with selectable error models."""
 
-    def __init__(self, read_length: int = 100) -> None:
+    def __init__(self, read_length: int = 100, profile: str = "hiseq") -> None:
         self.read_length = read_length
+        self.profile = profile
 
     def simulate(self, sequence: str) -> str:
         if not _HAS_ISS:
             raise ImportError(
                 "insilicoseq is required for this simulator. Install it via 'pip install insilicoseq'."
             )
-        _ = PerfectErrorModel()  # load dependency
-        return sequence
+        result = simulate_read(sequence, model=self.profile, n_reads=1, read_length=self.read_length)
+        if isinstance(result, (list, tuple)):
+            return str(result[0])
+        return str(result)
 
 
 def register(

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -41,17 +41,33 @@ class ChannelPipeline(BaseChannel):
         use_process_pool = config.use_process_pool
         use_mpi = config.use_mpi
 
+        channels = []
+        for ch in self.channels:
+            if (
+                config.illumina_profile is not None
+                and hasattr(ch, "profile")
+                and ch.__class__.__name__ == "InsilicoSeqChannel"
+            ):
+                ch = type(ch)(read_length=getattr(ch, "read_length", 150), profile=config.illumina_profile)
+            elif (
+                config.nanopore_profile is not None
+                and hasattr(ch, "profile")
+                and ch.__class__.__name__ == "DNArSimChannel"
+            ):
+                ch = type(ch)(error_rate=getattr(ch, "error_rate", 0.05), profile=config.nanopore_profile)
+            channels.append(ch)
+
         if use_mpi:
             parallel = True
 
-        if not parallel or len(self.channels) <= 1:
-            for channel in self.channels:
+        if not parallel or len(channels) <= 1:
+            for channel in channels:
                 sequence = channel.simulate(sequence)
             metrics.increment("oligos_simulated")
             return sequence
 
         if workers is None:
-            workers = min(len(self.channels), os.cpu_count() or 1)
+            workers = min(len(channels), os.cpu_count() or 1)
 
         if use_mpi:
             try:
@@ -68,7 +84,7 @@ class ChannelPipeline(BaseChannel):
 
         with executor_cls(max_workers=workers) as executor:
             fut: concurrent.futures.Future[str] | None = None
-            for channel in self.channels:
+            for channel in channels:
                 if fut is None:
                     fut = executor.submit(_run_channel, sequence, channel)
                 else:

--- a/src/genecoder/squigulator_adapter.py
+++ b/src/genecoder/squigulator_adapter.py
@@ -32,7 +32,7 @@ def simulate_squigulator(
     if rng is None:
         rng = make_rng()
 
-    return _simulate_adapter("squigulator", sequence, error_rate, rng)
+    return _simulate_adapter("squigulator", sequence, error_rate, rng, None)
 
 
 class SquigulatorChannel(BaseChannel):

--- a/tests/test_channel_profiles.py
+++ b/tests/test_channel_profiles.py
@@ -1,0 +1,37 @@
+from genecoder.simulators.pipeline import ChannelPipeline
+from genecoder.channel_config import ChannelConfig
+from genecoder.simulators.insilicoseq import InsilicoSeqChannel
+from genecoder import dnarsim_adapter, nanopore_sim
+
+
+def test_insilicoseq_profile(monkeypatch):
+    calls = []
+    import genecoder.simulators.insilicoseq as iss_mod
+    monkeypatch.setattr(iss_mod, "_HAS_ISS", True)
+
+    def fake_sim(seq, model="hiseq", n_reads=1, read_length=100):
+        calls.append((seq, model, n_reads, read_length))
+        return ["SIM"]
+
+    monkeypatch.setattr(iss_mod, "simulate_read", fake_sim, raising=False)
+    pipeline = ChannelPipeline([InsilicoSeqChannel(read_length=50)])
+    cfg = ChannelConfig(illumina_profile="novaseq")
+    result = pipeline.simulate("ACGTACGT", config=cfg)
+    assert result == "SIM"
+    assert calls == [("ACGTACGT", "novaseq", 1, 50)]
+
+
+def test_dnarsim_profile(monkeypatch):
+    run_called = []
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda c: "/usr/bin/" + c)
+
+    def fake_run(cmd, seq):
+        run_called.append(cmd)
+        return "OK"
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    pipeline = ChannelPipeline([dnarsim_adapter.DNArSimChannel(error_rate=0.1)])
+    cfg = ChannelConfig(nanopore_profile="r9")
+    result = pipeline.simulate("TTTT", config=cfg)
+    assert result == "OK"
+    assert run_called == [["dnarsim", "-e", "0.1", "-p", "r9"]]


### PR DESCRIPTION
## Summary
- add illumina_profile and nanopore_profile options
- extend ChannelPipeline to use advanced profiles
- wrap InSilicoSeq and DNArSim profile parameters
- provide sample configs
- test pipeline profile selection

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ece67fcd0832696cde26a0a2c765e