### PR TITLE
Enable offline profile fetching

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -91,6 +91,11 @@ Profiles are saved under `~/.genecoder/data` by default. The location can be
 customized with the `--cache-dir` option or the `GENECODER_DATA_DIR`
 environment variable.
 
+If your machine is offline, place the profile files in a local directory and set
+the `GENECODER_PROFILE_DIR` environment variable to that location. The
+`fetch_profile` utility will copy the profile from this directory instead of
+downloading it.
+
 ## Dashboard Heatmaps
 
 The built-in dashboard renders GC content and homopolymer length as heatmaps.

--- a/src/genecoder/data_service.py
+++ b/src/genecoder/data_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 __all__ = ["get_cache_dir", "fetch_profile", "is_cached"]
 
 DEFAULT_BASE_URL = "https://example.com/profiles"
+PROFILE_DIR_ENV = "GENECODER_PROFILE_DIR"
 
 
 def get_cache_dir() -> Path:
@@ -28,13 +29,33 @@ def fetch_profile(
     cache_dir: Path | None = None,
     refresh: bool = False,
 ) -> Path:
-    """Download ``profile`` to ``cache_dir`` if needed and return its path."""
+    """Download ``profile`` to ``cache_dir`` if needed and return its path.
+
+    The function first checks ``PROFILE_DIR_ENV`` for a local directory
+    containing the requested profile. If the profile exists there, it is copied
+    to ``cache_dir`` and returned without attempting any network access.
+    """
     cache_dir = cache_dir or get_cache_dir()
     dest = cache_dir / profile
     if dest.is_file() and not refresh:
         return dest
+
     cache_dir.mkdir(parents=True, exist_ok=True)
+
+    local_dir = os.getenv(PROFILE_DIR_ENV)
+    if local_dir:
+        candidate = Path(local_dir) / profile
+        if candidate.is_file():
+            dest.write_bytes(candidate.read_bytes())
+            return dest
+
     url = f"{base_url.rstrip('/')}/{profile}"
-    with urllib.request.urlopen(url) as resp:
-        dest.write_bytes(resp.read())
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            dest.write_bytes(resp.read())
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to download {profile} from {url}. "
+            f"Provide it locally via {PROFILE_DIR_ENV} or download it manually."
+        ) from exc
     return dest

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -52,3 +52,30 @@ def test_cli_data_fetch(tmp_path: Path) -> None:
     assert result.returncode == 0
     cached = Path(env["GENECODER_DATA_DIR"]) / "illumina_profile.json"
     assert cached.is_file()
+
+
+def test_fetch_profile_from_env_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    (local_dir / "illumina_profile.json").write_text("local")
+    cache = tmp_path / "cache"
+
+    def fake_open(url: str, *, timeout: int | None = None):
+        raise RuntimeError("network call")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    monkeypatch.setenv("GENECODER_PROFILE_DIR", str(local_dir))
+    path = fetch_profile("illumina_profile.json", cache_dir=cache)
+    assert path.is_file()
+    assert path.read_text() == "local"
+
+
+def test_fetch_profile_network_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = tmp_path / "cache"
+
+    def fake_open(url: str, *, timeout: int | None = None):
+        raise urllib.error.URLError("unreachable")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    with pytest.raises(RuntimeError, match="Failed to download"):
+        fetch_profile("illumina_profile.json", cache_dir=cache)


### PR DESCRIPTION
## Summary
- allow `fetch_profile` to use local profiles from `GENECODER_PROFILE_DIR`
- raise descriptive error when remote download fails
- document local profile usage in cloud docs
- test new fetch_profile behavior

## Testing
- `ruff check src/genecoder/data_service.py`
- `ruff check tests/test_data_service.py`
- `pytest tests/test_data_service.py tests/test_channel_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8a5dfe6c8326af1c239b3dac4214