### PR TITLE
Add typed CloudClient placeholder with lazy import test

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -2,7 +2,9 @@
 
 __version__ = "0.1.0"
 
-CloudClient = None
+# Placeholder for the optional cloud client implementation.  The actual
+# class is imported lazily when accessed via ``__getattr__``.
+CloudClient: type | None
 
 _LAZY_ATTRS = {
     "EncodeOptions",
@@ -16,10 +18,6 @@ _LAZY_ATTRS = {
     "CloudClient",
 }
 
-try:
-    from .cloud import CloudClient  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    CloudClient = None  # type: ignore
 
 from .plugin_manager import (
     CODEC_REGISTRY,
@@ -31,15 +29,6 @@ from .plugin_manager import (
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
 from .channel_config import ChannelConfig
 from .pipeline import SequencePipeline
-
-from typing import Any
-
-CloudClient: Any
-try:  # pragma: no cover - optional dependency
-    from .cloud import CloudClient as RealCloudClient
-    CloudClient = RealCloudClient
-except Exception:  # pragma: no cover - missing optional dependency
-    CloudClient = None
 
 
 
@@ -60,9 +49,6 @@ __all__ = [
     "decrypt_data",
     "compute_checksum",
 ]
-
-if CloudClient is not None:
-    __all__.append("CloudClient")
 
 
 

--- a/tests/test_cloudclient_init.py
+++ b/tests/test_cloudclient_init.py
@@ -1,0 +1,10 @@
+import genecoder
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+
+def test_cloudclient_lazy_import() -> None:
+    cls = genecoder.CloudClient
+    assert isinstance(cls, type)
+    assert cls.__name__ == "CloudClient"


### PR DESCRIPTION
## Summary
- add `CloudClient: type | None` placeholder in `genecoder.__init__`
- rely on `__getattr__` for lazy CloudClient loading
- test that accessing `genecoder.CloudClient` works when httpx is installed

## Testing
- `ruff check src/genecoder/__init__.py tests/test_cloudclient_init.py`
- `mypy src/genecoder/__init__.py`
- `pytest -q tests/test_cloudclient_init.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8a5c80788326a4dc05497718e5ec