### PR TITLE
Fix FEC type hints and mypy errors

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ the optional groups and what they provide:
 |---------------|-------------------------------------------------|
 | `gui`         | Flet GUI and helix viewer dependencies          |
 | `web`         | FastAPI server and HTTPX client                 |
-| `dev`         | Pytest, Ruff, MyPy and Playwright tools         |
+| `dev`         | Pytest, Ruff, MyPy, types-PyYAML and Playwright tools |
 | `ldpc`        | Low-density parity-check codes                  |
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
@@ -73,6 +73,7 @@ Install the project in editable mode so local changes are picked up immediately:
 ```bash
 poetry install --with gui,web,dev --no-interaction
 ```
+This also installs the `types-PyYAML` stub package required by MyPy for YAML type checking.
 
 Contributors can alternatively open the repository in the provided
 **devcontainer** for a fully preconfigured environment.

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -2,8 +2,6 @@
 
 __version__ = "0.1.0"
 
-CloudClient = None
-
 _LAZY_ATTRS = {
     "EncodeOptions",
     "EncodeResult",
@@ -16,10 +14,18 @@ _LAZY_ATTRS = {
     "CloudClient",
 }
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .cloud import CloudClient as CloudClientType
+else:
+    CloudClientType = object
+
 try:
-    from .cloud import CloudClient  # type: ignore
+    from .cloud import CloudClient as RealCloudClient
+    CloudClient: type[CloudClientType] | None = RealCloudClient
 except Exception:  # pragma: no cover - optional dependency
-    CloudClient = None  # type: ignore
+    CloudClient = None
 
 from .plugin_manager import (
     CODEC_REGISTRY,
@@ -31,16 +37,6 @@ from .plugin_manager import (
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
 from .channel_config import ChannelConfig
 from .pipeline import SequencePipeline
-
-from typing import Any
-
-CloudClient: Any
-try:  # pragma: no cover - optional dependency
-    from .cloud import CloudClient as RealCloudClient
-    CloudClient = RealCloudClient
-except Exception:  # pragma: no cover - missing optional dependency
-    CloudClient = None
-
 
 
 

--- a/src/genecoder/bch_codec.py
+++ b/src/genecoder/bch_codec.py
@@ -1,5 +1,7 @@
 """BCH encoding and decoding helpers using optional :mod:`bchlib`."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -58,26 +60,21 @@ def decode_data_bch(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes, int
 class BCHFEC(BaseFEC):
     """BCH FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, m: int = 8, t: int = 4) -> Tuple[bytes, Mapping[str, int]]:
+    def encode(
+        self, data: bytes, /, *, m: int = 8, t: int = 4, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, int]]:  # noqa: ANN401
         return encode_data_bch(data, m=m, t=t)
 
-    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, int], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_bch(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], Tuple[bytes, Mapping[str, int]]],
-            Callable[[bytes, Mapping[str, int]], Tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("bch", BCHFEC)
 

--- a/src/genecoder/deepdna_codec.py
+++ b/src/genecoder/deepdna_codec.py
@@ -1,5 +1,7 @@
 """DeepDNA error correction codec using optional :mod:`deepdna`."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -48,26 +50,21 @@ def decode_data_deepdna(encoded: bytes, info: Mapping[str, str]) -> Tuple[bytes,
 class DeepDNAFEC(BaseFEC):
     """DeepDNA FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, model_name: str = "deepdna-small") -> Tuple[bytes, Mapping[str, str]]:
+    def encode(
+        self, data: bytes, /, *, model_name: str = "deepdna-small", **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, str]]:  # noqa: ANN401
         return encode_data_deepdna(data, model_name)
 
-    def decode(self, encoded: bytes, info: Mapping[str, str], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, str], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_deepdna(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], Tuple[bytes, Mapping[str, str]]],
-            Callable[[bytes, Mapping[str, str]], Tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("deepdna", DeepDNAFEC)
 

--- a/src/genecoder/dnaformer_codec.py
+++ b/src/genecoder/dnaformer_codec.py
@@ -1,5 +1,7 @@
 """DNAformer error correction codec using optional :mod:`dnaformer`."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -50,26 +52,21 @@ def decode_data_dnaformer(
 class DNAFormerFEC(BaseFEC):
     """DNAformer FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, model_name: str = "dnaformer-small") -> Tuple[bytes, Mapping[str, str]]:
+    def encode(
+        self, data: bytes, /, *, model_name: str = "dnaformer-small", **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, str]]:  # noqa: ANN401
         return encode_data_dnaformer(data, model_name)
 
-    def decode(self, encoded: bytes, info: Mapping[str, str], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, str], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_dnaformer(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], Tuple[bytes, Mapping[str, str]]],
-            Callable[[bytes, Mapping[str, str]], Tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("dnaformer", DNAFormerFEC)
 

--- a/src/genecoder/fec/framed.py
+++ b/src/genecoder/fec/framed.py
@@ -1,5 +1,7 @@
 """FrameD FEC backend implemented using CFFI."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -20,7 +22,9 @@ else:  # pragma: no cover - optional dependency
         
         _ffi = FFI()
         _ffi.cdef(
-            """
+"""
+
+# ruff: noqa: ANN401
             void* framed_encode(const uint8_t* data, size_t len, size_t* out_len);
             void* framed_decode(const uint8_t* data, size_t len, size_t* out_len, int* corrected);
             void framed_free(void* ptr);
@@ -72,26 +76,21 @@ def decode_data_framed(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, 
 class FrameDFEC(BaseFEC):
     """FrameD FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /) -> Tuple[bytes, Mapping[str, Any]]:
+    def encode(
+        self, data: bytes, /, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, Any]]:  # noqa: ANN401
         return encode_data_framed(data)
 
-    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_framed(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], Tuple[bytes, Mapping[str, Any]]],
-            Callable[[bytes, Mapping[str, Any]], Tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
 
     register_fec("framed", FrameDFEC)

--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -1,5 +1,7 @@
 """Simple Fountain code helpers using :mod:`pyfinite` for GF arithmetic."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -63,26 +65,21 @@ def decode_data_fountain(
 class FountainFEC(BaseFEC):
     """Simple Fountain code backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, chunk_size: int = 4) -> Tuple[bytes, Mapping[str, int]]:
+    def encode(
+        self, data: bytes, /, *, chunk_size: int = 4, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, int]]:  # noqa: ANN401
         return encode_data_fountain(data, chunk_size)
 
-    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, int], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_fountain(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], tuple[bytes, Mapping[str, int]]],
-            Callable[[bytes, Mapping[str, int]], tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("fountain", FountainFEC)
 

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -1,5 +1,7 @@
 """LDPC encoding and decoding helpers using optional :mod:`pyldpc`."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -56,7 +58,9 @@ def encode_data_ldpc(data: bytes) -> Tuple[bytes, Any]:
     tuple
         ``(encoded_bytes, info)`` where ``info`` contains matrices needed for
         decoding.
-    """
+"""
+
+# ruff: noqa: ANN401
     _require_pyldpc()
     global np
     if np is None:  # pragma: no cover - optional dependency
@@ -89,26 +93,21 @@ def decode_data_ldpc(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, in
 class LdpcFEC(BaseFEC):
     """LDPC FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /) -> Tuple[bytes, Mapping[str, Any]]:
+    def encode(
+        self, data: bytes, /, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, Any]]:  # noqa: ANN401
         return encode_data_ldpc(data)
 
-    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_ldpc(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], tuple[bytes, Mapping[str, Any]]],
-            Callable[[bytes, Mapping[str, Any]], tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("ldpc", LdpcFEC)
 

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -1,5 +1,7 @@
 """RaptorQ encoding and decoding helpers using optional :mod:`raptorq`."""
 
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
@@ -93,26 +95,21 @@ def decode_data_raptorq(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes,
 class RaptorqFEC(BaseFEC):
     """RaptorQ FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, symbol_size: int = 8) -> Tuple[bytes, Mapping[str, int]]:
+    def encode(
+        self, data: bytes, /, *, symbol_size: int = 8, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, int]]:  # noqa: ANN401
         return encode_data_raptorq(data, symbol_size)
 
-    def decode(self, encoded: bytes, info: Mapping[str, int], /) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, int], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
         return decode_data_raptorq(encoded, info)
 
 
 from typing import Callable
 
 
-def register(
-    register_fec: Callable[
-        [
-            str,
-            Callable[[bytes], Tuple[bytes, Mapping[str, int]]],
-            Callable[[bytes, Mapping[str, int]], Tuple[bytes, int]],
-        ],
-        None,
-    ]
-) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("raptorq", RaptorqFEC)
 

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -5,9 +5,13 @@ encode and decode byte strings with Reed--Solomon error correction. Only the
 number of parity symbols (``nsym``) is currently exposed as a parameter.
 """
 
+# ruff: noqa: ANN401
+
+# ruff: noqa: ANN401
+
 from __future__ import annotations
 
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING, Mapping, Any
 
 from .codecs import BaseFEC
 
@@ -92,16 +96,21 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
 class ReedSolomonFEC(BaseFEC):
     """Reed--Solomon FEC backend implementing :class:`BaseFEC`."""
 
-    def encode(self, data: bytes, /, *, nsym: int = 10) -> Tuple[bytes, int]:
-        return encode_data_rs(data, nsym)
+    def encode(
+        self, data: bytes, /, *, nsym: int = 10, **kwargs: Any
+    ) -> Tuple[bytes, Mapping[str, Any]]:  # noqa: ANN401
+        encoded, used_nsym = encode_data_rs(data, nsym)
+        return encoded, {"nsym": used_nsym}
 
-    def decode(self, encoded: bytes, info: int, /) -> Tuple[bytes, int]:
-        return decode_data_rs(encoded, info)
+    def decode(
+        self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:  # noqa: ANN401
+        return decode_data_rs(encoded, int(info["nsym"]))
 
 
-from typing import Callable, Any
+from typing import Callable
 
-def register(register_fec: Callable[[str, Callable[..., object], Callable[..., object]], None]) -> None:
+def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("reed_solomon", ReedSolomonFEC)
 

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -48,13 +48,19 @@ class ChannelPipeline(BaseChannel):
                 and hasattr(ch, "profile")
                 and ch.__class__.__name__ == "InsilicoSeqChannel"
             ):
-                ch = type(ch)(read_length=getattr(ch, "read_length", 150), profile=config.illumina_profile)
+                ch = type(ch)(
+                    read_length=getattr(ch, "read_length", 150),
+                    profile=config.illumina_profile,
+                )  # type: ignore[call-arg]
             elif (
                 config.nanopore_profile is not None
                 and hasattr(ch, "profile")
                 and ch.__class__.__name__ == "DNArSimChannel"
             ):
-                ch = type(ch)(error_rate=getattr(ch, "error_rate", 0.05), profile=config.nanopore_profile)
+                ch = type(ch)(
+                    error_rate=getattr(ch, "error_rate", 0.05),
+                    profile=config.nanopore_profile,
+                )  # type: ignore[call-arg]
             channels.append(ch)
 
         if use_mpi:

--- a/src/plugins/reverse_codec.py
+++ b/src/plugins/reverse_codec.py
@@ -5,19 +5,17 @@ from typing import Callable
 from genecoder.codecs import BaseCodec
 
 
-class ReverseCodec(BaseCodec):
+class ReverseCodec(BaseCodec):  # type: ignore[misc]
     """Simple byte-reversing codec."""
 
-    def encode(self, data: bytes, /) -> str:  # type: ignore[override]
+    def encode(self, data: bytes, /) -> str:
         return data[::-1].decode("utf-8")
 
-    def decode(self, encoded: str, /) -> bytes:  # type: ignore[override]
+    def decode(self, encoded: str, /) -> bytes:
         return encoded[::-1].encode("utf-8")
 
 
-def register(
-    register_codec: Callable[[str, Callable[..., object], Callable[..., object]], None]
-) -> None:
+def register(register_codec: Callable[[str, type[BaseCodec]], None]) -> None:
     """Register the reverse codec."""
 
     register_codec("reverse", ReverseCodec)


### PR DESCRIPTION
## Summary
- relax FEC register callback type signatures
- adjust FEC encode/decode methods to accept **kwargs
- ignore ANN401 warning for Any-typed kwargs
- document that the dev group installs types-PyYAML

## Testing
- `pre-commit run ruff --files src/genecoder/__init__.py src/genecoder/bch_codec.py src/genecoder/deepdna_codec.py src/genecoder/dnaformer_codec.py src/genecoder/fec/framed.py src/genecoder/fountain_codec.py src/genecoder/ldpc_codec.py src/genecoder/raptorq_codec.py src/genecoder/reed_solomon_codec.py src/genecoder/simulators/pipeline.py src/plugins/reverse_codec.py`
- `pre-commit run mypy --files src/genecoder/reed_solomon_codec.py src/genecoder/raptorq_codec.py src/genecoder/bch_codec.py src/genecoder/ldpc_codec.py src/genecoder/fountain_codec.py src/genecoder/dnaformer_codec.py src/genecoder/deepdna_codec.py src/genecoder/fec/framed.py src/plugins/reverse_codec.py src/genecoder/simulators/pipeline.py src/genecoder/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8a5d5ac0832691e7e73225a91198