### PR TITLE
Add edge case FEC and simulator tests

### DIFF
--- a/tests/test_fec_roundtrip_params.py
+++ b/tests/test_fec_roundtrip_params.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+
+from genecoder.reed_solomon_codec import (
+    encode_data_rs,
+    decode_data_rs,
+    _HAS_REEDSOLO,
+)
+from genecoder.fountain_codec import encode_data_fountain, decode_data_fountain
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+@pytest.mark.parametrize("nsym,length", [(5, 16), (12, 32)])
+def test_reed_solomon_roundtrip_params(nsym, length):
+    data = os.urandom(length)
+    encoded, used_nsym = encode_data_rs(data, nsym=nsym)
+    decoded, corrected = decode_data_rs(encoded, used_nsym)
+    assert decoded == data
+    assert corrected == 0
+
+
+pytest.importorskip("pyfinite")
+@pytest.mark.parametrize("chunk_size,length", [(3, 10), (8, 25)])
+def test_fountain_roundtrip_params(chunk_size, length):
+    data = os.urandom(length)
+    encoded, info = encode_data_fountain(data, chunk_size=chunk_size)
+    assert info["chunk_size"] == chunk_size
+    decoded, _ = decode_data_fountain(encoded, info)
+    assert decoded == data

--- a/tests/test_gc_constraint_failures.py
+++ b/tests/test_gc_constraint_failures.py
@@ -1,0 +1,24 @@
+import pytest
+
+from genecoder.gc_constrained_encoder import (
+    decode_gc_balanced,
+    calculate_gc_content,
+    get_max_homopolymer_length,
+)
+from genecoder.encoders import encode_base4_direct
+
+
+@pytest.mark.parametrize("which", ["gc", "homopolymer"])
+def test_decode_gc_balanced_constraint_failures(which):
+    data = b"edge"
+    payload = encode_base4_direct(data)
+    dna = "0" + payload
+    gc = calculate_gc_content(payload)
+    hp = get_max_homopolymer_length(payload)
+
+    if which == "gc":
+        with pytest.raises(ValueError, match="GC content"):
+            decode_gc_balanced(dna, expected_gc_min=gc + 0.1)
+    else:
+        with pytest.raises(ValueError, match="homopolymer"):
+            decode_gc_balanced(dna, expected_max_homopolymer=hp - 1)

--- a/tests/test_simulator_edge_cases.py
+++ b/tests/test_simulator_edge_cases.py
@@ -1,0 +1,25 @@
+
+from genecoder.simulators.illumina import IlluminaChannel
+from genecoder import nanopore_sim
+
+
+def test_illumina_high_insertion(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    channel = IlluminaChannel(
+        substitution_rate=0.0,
+        insertion_rate=1.0,
+        deletion_rate=0.0,
+        read_length=4,
+    )
+    result = channel.simulate("ACGTACGT")
+    assert len(result) == 8
+    assert result[::2] == "ACGT"
+
+
+def test_nanopore_high_error_rate(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "2")
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda _: None)
+    result = nanopore_sim.simulate_d2sim("AAAA", error_rate=1.0)
+    assert len(result) == 4
+    assert set(result) <= {"A", "C", "G", "T"}
+    assert "A" not in result


### PR DESCRIPTION
## Summary
- test extreme insertion rates for Illumina and Nanopore simulators
- verify Reed–Solomon and Fountain round trips with additional parameters
- add GC/homopolymer constraint failure checks
- fix lint in simulator edge-case tests

## Testing
- `ruff check tests/test_simulator_edge_cases.py tests/test_fec_roundtrip_params.py tests/test_gc_constraint_failures.py`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest --cov=src tests/test_simulator_edge_cases.py tests/test_fec_roundtrip_params.py tests/test_gc_constraint_failures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687fb4b9fdd88326b4e7c09959f0d8a9