### PR TITLE
Add plugin API and enforce subclassing

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -17,13 +17,17 @@ And the plugin module:
 
 ```python
 # my_package/my_plugin.py
+from genecoder.api import Codec
+
+class MyCodec(Codec):
+    def encode(self, data: bytes) -> str:
+        ...
+
+    def decode(self, text: str) -> bytes:
+        ...
 
 def register(register_codec):
-    def encode(data: bytes) -> str:
-        ...
-    def decode(text: str) -> bytes:
-        ...
-    register_codec("mycodec", encode, decode)
+    register_codec("mycodec", MyCodec)
 ```
 
 To add a custom [FEC](glossary.md#forward-error-correction-fec) implementation you would use the `genecoder.fec` group and
@@ -36,18 +40,22 @@ myfec = "my_package.my_fec"
 
 ```python
 # my_package/my_fec.py
+from genecoder.api import FEC
+
+class MyFEC(FEC):
+    def encode(self, data: bytes):
+        ...
+
+    def decode(self, encoded: bytes, info):
+        ...
 
 def register(register_fec):
-    def encode(data: bytes):
-        ...
-    def decode(encoded: bytes, info):
-        ...
-register_fec("myfec", encode, decode)
+    register_fec("myfec", MyFEC)
 ```
 
 Simulator plugins follow the same pattern using the `genecoder.simulators`
 group with a `register_simulator` callback that receives an object implementing
-the :class:`genecoder.channels.base.BaseChannel` protocol.
+the :class:`genecoder.api.Simulator` interface.
 
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.
@@ -75,7 +83,7 @@ instructions on signing the distribution.
 ## Developing a Plugin Step by Step
 
 1. Copy `src/plugins/reverse_codec.py` as a starting point.
-2. Implement `encode` and `decode` functions for your algorithm.
+2. Implement a class with `encode` and `decode` methods for your algorithm.
 3. In the module's `register()` function call `register_codec` with a unique name.
 4. Add an entry under `genecoder.plugins` in the `[project.entry-points]`
    section of your `pyproject.toml` pointing to the module.

--- a/plugins-examples/example_codec/example_codec/__init__.py
+++ b/plugins-examples/example_codec/example_codec/__init__.py
@@ -1,15 +1,16 @@
 from typing import Callable
+from genecoder.api import Codec
 
 
-def register(
-    register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]
-) -> None:
-    """Register a simple example codec."""
-
-    def encode(data: bytes) -> str:
+class ExampleCodec(Codec):  # type: ignore[misc]
+    def encode(self, data: bytes) -> str:
         return data.hex()
 
-    def decode(text: str) -> bytes:
+    def decode(self, text: str) -> bytes:
         return bytes.fromhex(text)
 
-    register_codec("example", encode, decode)
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    """Register a simple example codec."""
+
+    register_codec("example", ExampleCodec)

--- a/plugins-examples/example_fec/example_fec/__init__.py
+++ b/plugins-examples/example_fec/example_fec/__init__.py
@@ -1,15 +1,16 @@
 from typing import Callable, Mapping, Any
+from genecoder.api import FEC
 
 
-def register(
-    register_fec: Callable[[str, Callable[[bytes], bytes], Callable[[bytes, Any], bytes]], None]
-) -> None:
+class ExampleFEC(FEC):  # type: ignore[misc]
+    def encode(self, data: bytes) -> tuple[bytes, Mapping[str, Any]]:
+        return data, {}
+
+    def decode(self, encoded: bytes, info: Mapping[str, Any]) -> tuple[bytes, int]:
+        return encoded, 0
+
+
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register a simple example FEC."""
 
-    def encode(data: bytes) -> bytes:
-        return data
-
-    def decode(encoded: bytes, info: Mapping[str, Any] | None = None) -> bytes:
-        return encoded
-
-    register_fec("example", encode, decode)
+    register_fec("example", ExampleFEC)

--- a/plugins-examples/example_simulator/example_simulator/__init__.py
+++ b/plugins-examples/example_simulator/example_simulator/__init__.py
@@ -1,16 +1,16 @@
 from typing import Callable
 
-from genecoder.channels.base import BaseChannel
+from genecoder.api import Simulator
 
 
-class PassthroughChannel:
+class PassthroughChannel(Simulator):  # type: ignore[misc]
     """Simple channel that returns sequences unchanged."""
 
     def simulate(self, sequence: str) -> str:
         return sequence
 
 
-def register(register_simulator: Callable[[str, BaseChannel], None]) -> None:
+def register(register_simulator: Callable[[str, Simulator], None]) -> None:
     """Register the example simulator."""
 
     register_simulator("example", PassthroughChannel())

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+# ruff: noqa: ANN401
+
+"""Public abstract interfaces for GeneCoder plugins."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping, Tuple
+
+__all__ = ["Codec", "FEC", "Simulator"]
+
+
+class Codec(ABC):
+    """Abstract base class for simple codecs."""
+
+    @abstractmethod
+    def encode(self, data: bytes, /, **kwargs: Any) -> Any:
+        """Encode ``data`` and return the encoded representation."""
+
+    @abstractmethod
+    def decode(self, encoded: Any, /, **kwargs: Any) -> bytes:
+        """Decode ``encoded`` data back into bytes."""
+
+
+class FEC(ABC):
+    """Abstract base class for forward error correction backends."""
+
+    @abstractmethod
+    def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, Any]]:
+        """Encode ``data`` returning encoded bytes and associated info."""
+
+    @abstractmethod
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any) -> Tuple[bytes, int]:
+        """Decode ``encoded`` bytes using ``info`` returning the original data and number of corrections."""
+
+
+class Simulator(ABC):
+    """Abstract base class for read simulators."""
+
+    @abstractmethod
+    def simulate(self, sequence: str) -> str:
+        """Return a possibly corrupted version of ``sequence``."""

--- a/src/genecoder/bch_codec.py
+++ b/src/genecoder/bch_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_BCHLIB = False
 
@@ -57,7 +57,7 @@ def decode_data_bch(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes, int
     return bytes(decoded), corrected
 
 
-class BCHFEC(BaseFEC):
+class BCHFEC(FEC):
     """BCH FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -74,7 +74,7 @@ class BCHFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("bch", BCHFEC)
 

--- a/src/genecoder/chamaeleo_codec.py
+++ b/src/genecoder/chamaeleo_codec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Codec wrapper exposing Chamaeleo via the plugin system."""
 
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING, Any
 from pathlib import Path
 import tempfile
 
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - missing optional dependency
     gc_mod = None
 
 from .plugin_manager import register_codec as _register_codec
+from .api import Codec
 
 __all__ = ["register"]
 
@@ -59,9 +60,19 @@ def decode_chamaeleo(text: str) -> bytes:
         return data.rstrip(b"\x00")
 
 
+class ChamaeleoCodec(Codec):
+    """Codec using the external Chamaeleo library."""
+
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:  # noqa: ANN401
+        return encode_chamaeleo(data)
+
+    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:  # noqa: ANN401
+        return decode_chamaeleo(encoded)
+
+
 def register(
-    registrar: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None] = _register_codec,
+    registrar: Callable[[str, type[Codec]], None] = _register_codec,
 ) -> None:
     """Register the Chamaeleo codec."""
 
-    registrar("chamaeleo_gc", encode_chamaeleo, decode_chamaeleo)
+    registrar("chamaeleo_gc", ChamaeleoCodec)

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -6,7 +6,7 @@ from typing import Protocol, Callable
 
 from .random_utils import make_rng
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 
@@ -51,7 +51,7 @@ def simulate_errors(seq: str, p_error: float, rng: Optional[random.Random] = Non
 
 
 
-class Channel(BaseChannel):
+class Channel(Simulator):
     """Simple substitution error channel."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
@@ -62,7 +62,7 @@ class Channel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the simple substitution error simulator."""
 

--- a/src/genecoder/codecs/__init__.py
+++ b/src/genecoder/codecs/__init__.py
@@ -2,32 +2,19 @@ from __future__ import annotations
 
 """Base classes for pluggable codecs and FEC backends."""
 
-from abc import ABC, abstractmethod
-from typing import Any, Mapping, Tuple
+from ..api import Codec, FEC
 
 
-class BaseCodec(ABC):
+class BaseCodec(Codec):
     """Abstract base class for simple codecs."""
 
-    @abstractmethod
-    def encode(self, data: bytes, /, **kwargs: Any) -> Any:
-        """Encode ``data`` and return the encoded representation."""
-
-    @abstractmethod
-    def decode(self, encoded: Any, /, **kwargs: Any) -> bytes:
-        """Decode ``encoded`` data back into bytes."""
+    pass
 
 
-class BaseFEC(ABC):
+class BaseFEC(FEC):
     """Abstract base class for forward error correction backends."""
 
-    @abstractmethod
-    def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, Any]]:
-        """Encode ``data`` returning encoded bytes and associated info."""
-
-    @abstractmethod
-    def decode(self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any) -> Tuple[bytes, int]:
-        """Decode ``encoded`` bytes using ``info`` returning the original data and number of corrections."""
+    pass
 
 __all__ = ["BaseCodec", "BaseFEC"]
 

--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from typing import Callable
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 from .random_utils import make_rng
@@ -36,7 +36,7 @@ def simulate_d2sim(
     return _simulate_adapter("d2sim", sequence, error_rate, rng, None)
 
 
-class D2SimChannel(BaseChannel):
+class D2SimChannel(Simulator):
     """Channel wrapper for the optional ``d2sim`` simulator."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
@@ -47,7 +47,7 @@ class D2SimChannel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the ``d2sim`` simulator."""
 

--- a/src/genecoder/deepdna_codec.py
+++ b/src/genecoder/deepdna_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_DEEPDNA = False
 
@@ -47,7 +47,7 @@ def decode_data_deepdna(encoded: bytes, info: Mapping[str, str]) -> Tuple[bytes,
     return decoded, 0
 
 
-class DeepDNAFEC(BaseFEC):
+class DeepDNAFEC(FEC):
     """DeepDNA FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -64,7 +64,7 @@ class DeepDNAFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("deepdna", DeepDNAFEC)
 

--- a/src/genecoder/dnaformer_codec.py
+++ b/src/genecoder/dnaformer_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_DNAFORMER = False
 
@@ -49,7 +49,7 @@ def decode_data_dnaformer(
     return decoded, 0
 
 
-class DNAFormerFEC(BaseFEC):
+class DNAFormerFEC(FEC):
     """DNAformer FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -66,7 +66,7 @@ class DNAFormerFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("dnaformer", DNAFormerFEC)
 

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from typing import Callable
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .random_utils import make_rng
 from .nanopore_sim import _simulate_adapter, _run_external
 from .simulators import register_simulator as _register_simulator
@@ -37,7 +37,7 @@ def simulate_dnarsim(
     return _simulate_adapter("dnarsim", sequence, error_rate, rng, extra)
 
 
-class DNArSimChannel(BaseChannel):
+class DNArSimChannel(Simulator):
     """Channel wrapper for the optional ``dnarsim`` simulator."""
 
     def __init__(self, error_rate: float = 0.05, profile: str | None = None) -> None:
@@ -54,7 +54,7 @@ class DNArSimChannel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the ``dnarsim`` simulator."""
 

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 from .random_utils import make_rng
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 __all__ = ["introduce_errors", "apply_substitutions", "apply_insertions", "apply_deletions", "Channel", "register"]
@@ -101,7 +101,7 @@ def apply_deletions(sequence: str, prob: float, rng: random.Random | None = None
 
 
 
-class Channel(BaseChannel):
+class Channel(Simulator):
     """Channel applying substitution, insertion and deletion errors."""
 
     def __init__(
@@ -125,7 +125,7 @@ class Channel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the insertion/deletion error simulator."""
 

--- a/src/genecoder/fec/framed.py
+++ b/src/genecoder/fec/framed.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from ..codecs import BaseFEC
+from ..api import FEC
 
 _HAS_FRAMED = False
 
@@ -73,7 +73,7 @@ def decode_data_framed(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, 
     return data, int(corrected[0])
 
 
-class FrameDFEC(BaseFEC):
+class FrameDFEC(FEC):
     """FrameD FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -90,7 +90,7 @@ class FrameDFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
 
     register_fec("framed", FrameDFEC)

--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_PYFINITE = False
 
@@ -62,7 +62,7 @@ def decode_data_fountain(
     return data, 0
 
 
-class FountainFEC(BaseFEC):
+class FountainFEC(FEC):
     """Simple Fountain code backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -79,7 +79,7 @@ class FountainFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("fountain", FountainFEC)
 

--- a/src/genecoder/ldpc_codec.py
+++ b/src/genecoder/ldpc_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_PYLDPC = False
 
@@ -90,7 +90,7 @@ def decode_data_ldpc(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, in
     return np.packbits(data_bits).tobytes(), corrections
 
 
-class LdpcFEC(BaseFEC):
+class LdpcFEC(FEC):
     """LDPC FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -107,7 +107,7 @@ class LdpcFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("ldpc", LdpcFEC)
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -20,7 +20,7 @@ __all__ = [
     "Channel",
 ]
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 logger = logging.getLogger(__name__)
@@ -223,7 +223,7 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
     return _simulate_reads(sequence, simulator, error_rate=error_rate)
 
 
-class Channel(BaseChannel):
+class Channel(Simulator):
     """Adapter implementing :class:`BaseChannel` for built-in simulators."""
 
     def __init__(self, name: str, error_rate: float = 0.05) -> None:
@@ -237,7 +237,7 @@ class Channel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the builtin simulators."""
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -58,7 +58,6 @@ except Exception:  # pragma: no cover - optional dependency
 
 yaml: Any | None = _yaml
 
-from .channels.base import BaseChannel
 from importlib.metadata import entry_points, EntryPoints
 import logging
 import pkgutil
@@ -82,51 +81,45 @@ verify_signature = _verify_signature
 compute_checksum = _compute_checksum
 
 
-from .codecs import BaseCodec, BaseFEC
+from .api import Codec, FEC, Simulator
 
 
-def register_codec(
-    name: str,
-    encode: Callable[..., Any] | BaseCodec | type[BaseCodec],
-    decode: Callable[..., Any] | None = None,
-) -> None:
+def register_codec(name: str, codec: Codec | type[Codec]) -> None:
     """Register a codec implementation under ``name``."""
 
-    if isinstance(encode, BaseCodec):
-        CODEC_REGISTRY[name] = {"encode": encode.encode, "decode": encode.decode}
-        return
-    if isinstance(encode, type) and issubclass(encode, BaseCodec):
-        inst = encode()
-        CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
-        return
+    if isinstance(codec, type):
+        if not issubclass(codec, Codec):
+            raise TypeError("codec must subclass Codec")
+        inst = codec()
+    else:
+        if not isinstance(codec, Codec):
+            raise TypeError("codec must subclass Codec")
+        inst = codec
 
-    if decode is None:
-        raise TypeError("decode function required for legacy registration")
-    CODEC_REGISTRY[name] = {"encode": encode, "decode": decode}
+    CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
-def register_fec(
-    name: str,
-    encode: Callable[..., Any] | BaseFEC | type[BaseFEC],
-    decode: Callable[..., Any] | None = None,
-) -> None:
+def register_fec(name: str, fec: FEC | type[FEC]) -> None:
     """Register a FEC backend under ``name``."""
 
-    if isinstance(encode, BaseFEC):
-        FEC_REGISTRY[name] = {"encode": encode.encode, "decode": encode.decode}
-        return
-    if isinstance(encode, type) and issubclass(encode, BaseFEC):
-        inst = encode()
-        FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
-        return
+    if isinstance(fec, type):
+        if not issubclass(fec, FEC):
+            raise TypeError("FEC must subclass FEC")
+        inst = fec()
+    else:
+        if not isinstance(fec, FEC):
+            raise TypeError("FEC must subclass FEC")
+        inst = fec
 
-    if decode is None:
-        raise TypeError("decode function required for legacy registration")
-    FEC_REGISTRY[name] = {"encode": encode, "decode": decode}
+    FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
-def register_simulator(name: str, channel: BaseChannel) -> None:
+def register_simulator(name: str, channel: Simulator) -> None:
     """Register a read simulator under ``name``."""
+
+    if not isinstance(channel, Simulator):
+        raise TypeError("simulator must subclass Simulator")
+
     _register_simulator(name, channel)
 
 

--- a/src/genecoder/raptorq_codec.py
+++ b/src/genecoder/raptorq_codec.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-from .codecs import BaseFEC
+from .api import FEC
 
 _HAS_RAPTORQ = False
 
@@ -92,7 +92,7 @@ def decode_data_raptorq(encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes,
     return data, 0
 
 
-class RaptorqFEC(BaseFEC):
+class RaptorqFEC(FEC):
     """RaptorQ FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -109,7 +109,7 @@ class RaptorqFEC(BaseFEC):
 from typing import Callable
 
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("raptorq", RaptorqFEC)
 

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Tuple, TYPE_CHECKING, Mapping, Any
 
-from .codecs import BaseFEC
+from .api import FEC
 
 
 _HAS_REEDSOLO: bool = False
@@ -93,7 +93,7 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
     return bytes(decoded), len(err_pos)
 
 
-class ReedSolomonFEC(BaseFEC):
+class ReedSolomonFEC(FEC):
     """Reed--Solomon FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
@@ -110,7 +110,7 @@ class ReedSolomonFEC(BaseFEC):
 
 from typing import Callable
 
-def register(register_fec: Callable[[str, type[BaseFEC]], None]) -> None:
+def register(register_fec: Callable[[str, type[FEC]], None]) -> None:
     """Register this module's FEC backend."""
     register_fec("reed_solomon", ReedSolomonFEC)
 

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from typing import Dict
 
-from ..channels.base import BaseChannel
+from ..api import Simulator
 from .pipeline import ChannelPipeline
 
-SIMULATOR_REGISTRY: Dict[str, BaseChannel] = {}
+SIMULATOR_REGISTRY: Dict[str, Simulator] = {}
 
 
-def register_simulator(name: str, channel: BaseChannel) -> None:
+def register_simulator(name: str, channel: Simulator) -> None:
     """Register ``channel`` under ``name``."""
     SIMULATOR_REGISTRY[name] = channel
 

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 
 from typing import Sequence
 from dataclasses import dataclass
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+
+from ..api import Simulator
 
 
 __all__ = ["BaseSimulator"]
 
 
 @dataclass
-class BaseSimulator(ABC):
+class BaseSimulator(Simulator):
     """Base class for read simulators with simple error settings."""
     substitution_rate: float = 0.0
     insertion_rate: float = 0.0

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -6,7 +6,7 @@ from typing import Callable, Sequence
 from .base import BaseSimulator
 
 from ..random_utils import make_rng
-from ..channels.base import BaseChannel
+from ..api import Simulator
 from ..error_simulation import introduce_errors
 from ..nanopore_sim import simulate_d2sim
 from . import register_simulator as _register_simulator
@@ -48,7 +48,7 @@ class IlluminaChannel(BaseSimulator):
         )
 
 
-class IlluminaD2SimChannel(BaseChannel):
+class IlluminaD2SimChannel(Simulator):
     """Wrapper using the external ``d2sim`` simulator."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
@@ -59,7 +59,7 @@ class IlluminaD2SimChannel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     registrar("illumina", IlluminaChannel())
     registrar("illumina_d2sim", IlluminaD2SimChannel())

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -5,13 +5,13 @@ from typing import Callable
 
 from ..random_utils import make_rng
 from ..nanopore_sim import simulate_d2sim
-from ..channels.base import BaseChannel
+from ..api import Simulator
 from . import register_simulator as _register_simulator
 
 __all__ = ["NanoporeChannel", "register"]
 
 
-class NanoporeChannel(BaseChannel):
+class NanoporeChannel(Simulator):
     """Channel that delegates to :mod:`d2sim` if installed."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
@@ -22,6 +22,6 @@ class NanoporeChannel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     registrar("nanopore_d2sim", NanoporeChannel())

--- a/src/genecoder/squigulator_adapter.py
+++ b/src/genecoder/squigulator_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from typing import Callable
 
-from .channels.base import BaseChannel
+from .api import Simulator
 from .random_utils import make_rng
 from .nanopore_sim import _simulate_adapter, _run_external
 from .simulators import register_simulator as _register_simulator
@@ -35,7 +35,7 @@ def simulate_squigulator(
     return _simulate_adapter("squigulator", sequence, error_rate, rng, None)
 
 
-class SquigulatorChannel(BaseChannel):
+class SquigulatorChannel(Simulator):
     """Channel wrapper for the optional ``squigulator`` simulator."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
@@ -46,7 +46,7 @@ class SquigulatorChannel(BaseChannel):
 
 
 def register(
-    registrar: Callable[[str, BaseChannel], None] = _register_simulator,
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     """Register the ``squigulator`` simulator."""
 

--- a/src/plugins/reverse_codec.py
+++ b/src/plugins/reverse_codec.py
@@ -2,10 +2,10 @@
 
 from typing import Callable
 
-from genecoder.codecs import BaseCodec
+from genecoder.api import Codec
 
 
-class ReverseCodec(BaseCodec):  # type: ignore[misc]
+class ReverseCodec(Codec):  # type: ignore[misc]
     """Simple byte-reversing codec."""
 
     def encode(self, data: bytes, /) -> str:
@@ -15,7 +15,7 @@ class ReverseCodec(BaseCodec):  # type: ignore[misc]
         return encoded[::-1].encode("utf-8")
 
 
-def register(register_codec: Callable[[str, type[BaseCodec]], None]) -> None:
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
     """Register the reverse codec."""
 
     register_codec("reverse", ReverseCodec)

--- a/tests/test_plugin_abc_validation.py
+++ b/tests/test_plugin_abc_validation.py
@@ -1,0 +1,17 @@
+import pytest
+import genecoder.plugin_manager as plugins
+
+
+def test_register_codec_requires_subclass() -> None:
+    with pytest.raises(TypeError):
+        plugins.register_codec("bad", object())
+
+
+def test_register_fec_requires_subclass() -> None:
+    with pytest.raises(TypeError):
+        plugins.register_fec("bad", object())
+
+
+def test_register_simulator_requires_subclass() -> None:
+    with pytest.raises(TypeError):
+        plugins.register_simulator("bad", object())

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -9,13 +9,17 @@ def test_load_plugins_from_local_package(tmp_path, monkeypatch):
     (pkg / "tmp_codec.py").write_text(
         """
 from typing import Callable
+from genecoder.api import Codec
 
-def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]):
-    def enc(data: bytes) -> str:
+class TmpCodec(Codec):
+    def encode(self, data: bytes) -> str:
         return 'X'
-    def dec(text: str) -> bytes:
+
+    def decode(self, text: str) -> bytes:
         return b'X'
-    register_codec('tmp', enc, dec)
+
+def register(register_codec: Callable[[str, type[Codec]], None]):
+    register_codec('tmp', TmpCodec)
 """
     )
     monkeypatch.syspath_prepend(str(tmp_path))

--- a/tests/test_plugin_failures.py
+++ b/tests/test_plugin_failures.py
@@ -71,26 +71,34 @@ def test_duplicate_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mode: 
     mod1.write_text(
         """
 from typing import Callable
+from genecoder.api import Codec
 
-def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]) -> None:
-    def encode(data: bytes) -> str:
+class CodecOne(Codec):
+    def encode(self, data: bytes) -> str:
         return "one"
-    def decode(text: str) -> bytes:
+
+    def decode(self, text: str) -> bytes:
         return b"one"
-    register_codec("dup", encode, decode)
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    register_codec("dup", CodecOne)
 """
     )
     mod2 = tmp_path / "m2.py"
     mod2.write_text(
         """
 from typing import Callable
+from genecoder.api import Codec
 
-def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]) -> None:
-    def encode(data: bytes) -> str:
+class CodecTwo(Codec):
+    def encode(self, data: bytes) -> str:
         return "two"
-    def decode(text: str) -> bytes:
+
+    def decode(self, text: str) -> bytes:
         return b"two"
-    register_codec("dup", encode, decode)
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    register_codec("dup", CodecTwo)
 """
     )
     monkeypatch.syspath_prepend(str(tmp_path))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -11,21 +11,28 @@ def test_external_plugin_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     (pkg / "__init__.py").write_text("")
     (pkg / "ext.py").write_text(
         """
-from typing import Callable, Tuple
+from typing import Callable, Mapping, Tuple
+from genecoder.api import Codec, FEC
 
-def register(register_codec: Callable[[str, Callable[[bytes], str], Callable[[str], bytes]], None]):
-    def enc(data: bytes) -> str:
+class ExtCodec(Codec):
+    def encode(self, data: bytes) -> str:
         return 'Y'
-    def dec(text: str) -> bytes:
-        return b'Y'
-    register_codec('ext_codec', enc, dec)
 
-def register_fec(register_fec: Callable[[str, Callable[[bytes], Tuple[bytes, int]], Callable[[bytes, int], Tuple[bytes, int]]], None]):
-    def enc(data: bytes) -> Tuple[bytes, int]:
-        return data + b'ZZ', 2
-    def dec(data: bytes, nsym: int) -> Tuple[bytes, int]:
-        return data[:-nsym], nsym
-    register_fec('ext_fec', enc, dec)
+    def decode(self, text: str) -> bytes:
+        return b'Y'
+
+class ExtFEC(FEC):
+    def encode(self, data: bytes) -> Tuple[bytes, Mapping[str, int]]:
+        return data + b'ZZ', {'n': 2}
+
+    def decode(self, encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes, int]:
+        return encoded[:-info['n']], info['n']
+
+def register(register_codec: Callable[[str, type[Codec]], None]):
+    register_codec('ext_codec', ExtCodec)
+
+def register_fec(register_fec: Callable[[str, type[FEC]], None]):
+    register_fec('ext_fec', ExtFEC)
 """
     )
     monkeypatch.syspath_prepend(str(tmp_path))


### PR DESCRIPTION
## Summary
- add a new `genecoder.api` module defining `Codec`, `FEC` and `Simulator`
- update all built-in plugins and examples to use the new ABCs
- enforce subclass checks in `plugin_manager`
- document the new interface
- add tests for rejecting non-subclassed plugins

## Testing
- `pre-commit run --files docs/plugins.md src/genecoder/api.py src/genecoder/bch_codec.py src/genecoder/chamaeleo_codec.py src/genecoder/channel_sim.py src/genecoder/codecs/__init__.py src/genecoder/d2sim_adapter.py src/genecoder/deepdna_codec.py src/genecoder/dnaformer_codec.py src/genecoder/dnarsim_adapter.py src/genecoder/error_simulation.py src/genecoder/fec/framed.py src/genecoder/fountain_codec.py src/genecoder/ldpc_codec.py src/genecoder/nanopore_sim.py src/genecoder/plugin_manager.py src/genecoder/raptorq_codec.py src/genecoder/reed_solomon_codec.py src/genecoder/simulators/__init__.py src/genecoder/simulators/base.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py src/genecoder/squigulator_adapter.py src/plugins/reverse_codec.py tests/test_plugin_discovery.py tests/test_plugin_failures.py tests/test_plugins.py tests/test_plugin_abc_validation.py plugins-examples/example_codec/example_codec/__init__.py plugins-examples/example_fec/example_fec/__init__.py plugins-examples/example_simulator/example_simulator/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687fb4b0566c8326aefa903b67d4b09b