### PR TITLE
Ensure ruff and mypy run for all code PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,9 @@ pre-commit run --files plugins-examples/example_codec/example_codec/__init__.py
 
 The hook also runs automatically on each commit if installed.
 
+CI runs `ruff check` and `mypy` on pull requests that modify code. Fix any
+issues they report before merging.
+
 An additional `check-glossary-terms` hook verifies that every term in
 `docs/glossary.json` appears in at least one Markdown file. The commit
 will fail if any terms are missing.

--- a/src/genecoder/codecs/__init__.py
+++ b/src/genecoder/codecs/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# ruff: noqa: ANN401
+
 """Base classes for pluggable codecs and FEC backends."""
 
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Summary
- re-enable lint job gating on code changes
- clarify ruff and mypy requirement only for code PRs
- ignore ANN401 in codec base module

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml CONTRIBUTING.md src/genecoder/codecs/__init__.py` (with `SKIP=pytest`)
- `ruff check .`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest tests/test_app_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687fb4bb1d1c8326852d3baae99540e3