### PR TITLE
Improve nanopore env option parsing

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -44,7 +44,11 @@ def _parse_env_options(command: str) -> list[str]:
     if not raw:
         return []
 
-    if any(c in raw for c in ";&|`$<>\\\n\r") or not raw.isprintable():
+    import re
+
+    # Reject characters outside a conservative whitelist to avoid
+    # command injection via shell metacharacters.
+    if not raw.isprintable() or not re.fullmatch(r"[A-Za-z0-9_\-./=:'\"\s]*", raw):
         raise ValueError(f"Unsafe characters in {env_var}")
 
     import shlex
@@ -54,6 +58,18 @@ def _parse_env_options(command: str) -> list[str]:
     except ValueError as exc:  # pragma: no cover - error path
         logger.warning("Invalid %s value: %s", env_var, exc)
         return []
+
+    flag_re = re.compile(r"^-{1,2}[A-Za-z0-9][A-Za-z0-9_-]*(=.+)?$")
+    arg_re = re.compile(r"^[A-Za-z0-9./:_-]+$")
+
+    for opt in options:
+        if opt.startswith("-"):
+            if not flag_re.fullmatch(opt):
+                raise ValueError(f"Invalid option {opt!r} in {env_var}")
+        else:
+            if not arg_re.fullmatch(opt):
+                raise ValueError(f"Invalid argument {opt!r} in {env_var}")
+
     logger.debug("Using %s=%r", env_var, options)
     return options
 

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -76,6 +76,22 @@ def test_parse_options_unsafe(monkeypatch, command):
         nanopore_sim._parse_env_options(command)
 
 
+@pytest.mark.parametrize("command", ["d2sim", "dnarsim", "squigulator"])
+def test_parse_options_bad_characters(monkeypatch, command):
+    env_var = f"GENECODER_{command.upper()}_OPTIONS"
+    monkeypatch.setenv(env_var, "--foo $(rm -rf /)")
+    with pytest.raises(ValueError):
+        nanopore_sim._parse_env_options(command)
+
+
+@pytest.mark.parametrize("command", ["d2sim", "dnarsim", "squigulator"])
+def test_parse_options_invalid_flag(monkeypatch, command):
+    env_var = f"GENECODER_{command.upper()}_OPTIONS"
+    monkeypatch.setenv(env_var, "---badflag")
+    with pytest.raises(ValueError):
+        nanopore_sim._parse_env_options(command)
+
+
 @pytest.mark.parametrize("name", ADAPTERS.keys())
 def test_adapters_invalid_env_options(monkeypatch, name):
     func, cmd = ADAPTERS[name]


### PR DESCRIPTION
## Summary
- harden `_parse_env_options` against unsafe characters and malformed flags
- test invalid options with malicious values

## Testing
- `ruff check src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688026a97b7c8326a60bfdffb60c0b12