### PR TITLE
Refactor simulators with BaseChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   if it still violates GC content or homopolymer limits.
 - Added ``--d2sim-options`` and ``GENECODER_D2SIM_OPTIONS`` to customize ``d2sim`` calls.
 - Refactored ``BaseSimulator`` for shared simulator settings.
+- Added ``BaseChannel`` with common error parameters for simulators.
 - Plugin registry now verifies package checksums before installation.
 
 ## [0.1.0] - 2025-06-12

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -13,13 +13,14 @@ def register_simulator(name: str, channel: Simulator) -> None:
     """Register ``channel`` under ``name``."""
     SIMULATOR_REGISTRY[name] = channel
 
-from .base import BaseSimulator
+from .base import BaseChannel, BaseSimulator
 from .illumina import IlluminaChannel
 from .nanopore import NanoporeChannel
 
 __all__ = [
     "SIMULATOR_REGISTRY",
     "register_simulator",
+    "BaseChannel",
     "BaseSimulator",
     "IlluminaChannel",
     "NanoporeChannel",

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -8,26 +8,37 @@ from abc import abstractmethod
 from ..api import Simulator
 
 
-__all__ = ["BaseSimulator"]
+__all__ = ["BaseChannel", "BaseSimulator"]
 
 
 @dataclass
-class BaseSimulator(Simulator):
-    """Base class for read simulators with simple error settings."""
+class BaseChannel(Simulator):
+    """Base class for sequencing channels with simple error rates."""
+
     substitution_rate: float = 0.0
     insertion_rate: float = 0.0
     deletion_rate: float = 0.0
     coverage: int = 1
+
+    def get_coverage(self, sequence: str) -> int:
+        """Hook returning desired coverage for ``sequence``."""
+        return self.coverage
+
+    @abstractmethod
+    def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
+        """Return a possibly corrupted version of ``sequence``."""
+        raise NotImplementedError
+
+
+@dataclass
+class BaseSimulator(BaseChannel):
+    """Base class for read simulators with quality/length settings."""
     read_length: int = 150
     quality_profile: Sequence[float] | None = None
 
     def __post_init__(self) -> None:
         if self.quality_profile is not None:
             self.quality_profile = tuple(self.quality_profile)
-
-    def get_coverage(self, sequence: str) -> int:
-        """Hook returning desired coverage for ``sequence``."""
-        return self.coverage
 
     def get_read_length(self, sequence: str) -> int:
         """Hook returning read length for ``sequence``."""

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -6,15 +6,30 @@ from typing import Callable
 from ..random_utils import make_rng
 from ..nanopore_sim import simulate_d2sim
 from ..api import Simulator
+from .base import BaseChannel
 from . import register_simulator as _register_simulator
 
 __all__ = ["NanoporeChannel", "register"]
 
 
-class NanoporeChannel(Simulator):
+class NanoporeChannel(BaseChannel):
     """Channel that delegates to :mod:`d2sim` if installed."""
 
-    def __init__(self, error_rate: float = 0.05) -> None:
+    def __init__(
+        self,
+        error_rate: float = 0.05,
+        *,
+        substitution_rate: float = 0.0,
+        insertion_rate: float = 0.0,
+        deletion_rate: float = 0.0,
+        coverage: int = 1,
+    ) -> None:
+        super().__init__(
+            substitution_rate=substitution_rate,
+            insertion_rate=insertion_rate,
+            deletion_rate=deletion_rate,
+            coverage=coverage,
+        )
         self.error_rate = error_rate
 
     def simulate(self, sequence: str) -> str:
@@ -25,3 +40,4 @@ def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     registrar("nanopore_d2sim", NanoporeChannel())
+


### PR DESCRIPTION
## Summary
- introduce `BaseChannel` with shared error-rate settings
- derive `BaseSimulator` and Nanopore channel from `BaseChannel`
- export `BaseChannel` from simulators package
- document change in changelog

## Testing
- `pre-commit run --files CHANGELOG.md src/genecoder/simulators/base.py src/genecoder/simulators/nanopore.py src/genecoder/simulators/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68802c8d28a483269d71c5900c84051b