### PR TITLE
Add GC constraint fixer to encode CLI

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -32,6 +32,7 @@ from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
+from genecoder.constraint_fixer import fix_sequence
 from .common import run_tasks
 from typing import Callable, cast
 
@@ -300,6 +301,13 @@ def process_single_encode(
             data_for_encoding, options, header_name
         )
 
+        final_encoded_dna_sequence = fix_sequence(
+            final_encoded_dna_sequence,
+            target_gc_min=args.gc_min,
+            target_gc_max=args.gc_max,
+            max_homopolymer=args.max_homopolymer,
+        )
+
         if checksum:
             fasta_header = f"{fasta_header} checksum={checksum}"
 
@@ -455,19 +463,28 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--gc-min",
         type=float,
         default=0.45,
-        help="Minimum GC content for gc_balanced encoding (default: 0.45).",
+        help=(
+            "Minimum GC content for gc_balanced encoding and constraint fixing "
+            "(default: 0.45)."
+        ),
     )
     parser.add_argument(
         "--gc-max",
         type=float,
         default=0.55,
-        help="Maximum GC content for gc_balanced encoding (default: 0.55).",
+        help=(
+            "Maximum GC content for gc_balanced encoding and constraint fixing "
+            "(default: 0.55)."
+        ),
     )
     parser.add_argument(
         "--max-homopolymer",
         type=int,
         default=3,
-        help="Maximum homopolymer length for gc_balanced encoding (default: 3).",
+        help=(
+            "Maximum homopolymer length for gc_balanced encoding and constraint "
+            "fixing (default: 3)."
+        ),
     )
     parser.add_argument(
         "--alphabet",

--- a/tests/test_cli_encode.py
+++ b/tests/test_cli_encode.py
@@ -52,3 +52,22 @@ def test_process_single_encode_windows_path_stream(tmp_path: Path) -> None:
     header = records[0][0]
     assert "input_file=seq.bin" in header
     assert "\\" not in header
+
+
+def test_process_single_encode_applies_fix(tmp_path: Path) -> None:
+    input_file = tmp_path / "data.bin"
+    # Produce low GC content and long homopolymers
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_fix.fasta"
+    args = _encode_args()
+    process_single_encode(str(input_file), str(output_file), args)
+
+    records = from_fasta(output_file.read_text())
+    seq = records[0][1]
+    from genecoder.encoders import calculate_gc_content
+    from genecoder.utils import get_max_homopolymer_length
+
+    gc_val = calculate_gc_content(seq)
+    max_hp = get_max_homopolymer_length(seq)
+    assert args.gc_min <= gc_val <= args.gc_max
+    assert max_hp <= args.max_homopolymer


### PR DESCRIPTION
## Summary
- ensure encode CLI can fix sequences for GC/homopolymer limits
- expose GC constraint options for fixing
- test new fix behaviour

## Testing
- `ruff check src/genecoder/cli/encode.py tests/test_cli_encode.py`
- `mypy src/genecoder/cli/encode.py tests/test_cli_encode.py`
- `pytest -q tests/test_cli_encode.py`

------
https://chatgpt.com/codex/tasks/task_e_688042f1bc80832682f1094ec6d61354