### PR TITLE
Add depth and context options for sequencing simulators

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -248,6 +248,12 @@ def register_subcommand(
         target.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
         target.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
         target.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
+        target.add_argument("--illumina-depth", type=int, default=None, help="Coverage depth for Illumina reads")
+        target.add_argument("--illumina-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
+        target.add_argument("--illumina-context", type=str, default=None, help="Path to JSON/YAML context error map")
+        target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
+        target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
+        target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
         target.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
         target.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
         target.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
@@ -296,6 +302,26 @@ def run_channel(args: argparse.Namespace) -> None:
     simulators = opts.simulator_specs
     if simulators is None:
         simulators = [(name, {}) for name in opts.simulators]
+
+    updated: list[tuple[str, dict[str, object]]] = []
+    for name, params in simulators:
+        new_params = dict(params)
+        if name.startswith("illumina"):
+            if opts.illumina_depth is not None:
+                new_params.setdefault("coverage", opts.illumina_depth)
+            if opts.illumina_quality is not None:
+                new_params.setdefault("quality_profile", opts.illumina_quality)
+            if opts.illumina_context is not None:
+                new_params.setdefault("context_errors", opts.illumina_context)
+        if name.startswith("nanopore"):
+            if opts.nanopore_depth is not None:
+                new_params.setdefault("coverage", opts.nanopore_depth)
+            if opts.nanopore_quality is not None:
+                new_params.setdefault("quality_profile", opts.nanopore_quality)
+            if opts.nanopore_context is not None:
+                new_params.setdefault("context_errors", opts.nanopore_context)
+        updated.append((name, new_params))
+    simulators = updated
 
     process_channel(
         args.input_file,

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -26,6 +26,53 @@ class ChannelOptions:
     mpi_workers: int | None = None
     batch_workers: int | None = None
     simulator_specs: list[tuple[str, dict[str, object]]] | None = None
+    illumina_depth: int | None = None
+    nanopore_depth: int | None = None
+    illumina_quality: Sequence[float] | None = None
+    nanopore_quality: Sequence[float] | None = None
+    illumina_context: Dict[str, float] | None = None
+    nanopore_context: Dict[str, float] | None = None
+
+
+def _parse_quality(value: str | None) -> Sequence[float] | None:
+    if value is None:
+        return None
+    from pathlib import Path
+    try:
+        path = Path(value)
+        if path.is_file():
+            import json
+            import yaml
+            text = path.read_text(encoding="utf-8")
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                data = yaml.safe_load(text)
+            if isinstance(data, Sequence):
+                return [float(x) for x in data]
+            raise ValueError("quality profile must be a list")
+    except Exception:
+        pass
+    return [float(x) for x in value.split(",") if x]
+
+
+def _parse_context(value: str | None) -> Dict[str, float] | None:
+    if value is None:
+        return None
+    from pathlib import Path
+    path = Path(value)
+    if not path.is_file():
+        raise ValueError("context file not found")
+    import json
+    import yaml
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError("context must be a mapping")
+    return {str(k).upper(): float(v) for k, v in data.items()}
 
 
 def _validate_simulator_prob_args(
@@ -138,4 +185,10 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         mpi_workers=args.mpi_workers,
         batch_workers=args.batch_workers,
         simulator_specs=sim_specs,
+        illumina_depth=args.illumina_depth,
+        nanopore_depth=args.nanopore_depth,
+        illumina_quality=_parse_quality(args.illumina_quality),
+        nanopore_quality=_parse_quality(args.nanopore_quality),
+        illumina_context=_parse_context(args.illumina_context),
+        nanopore_context=_parse_context(args.nanopore_context),
     )

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,13 +1,14 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Dict, Iterable
+import random
 
 from .base import BaseSimulator
 
 from ..random_utils import make_rng
 from ..api import Simulator
-from ..error_simulation import introduce_errors
+from ..error_simulation import _random_substitution, NUCLEOTIDES
 from ..nanopore_sim import simulate_d2sim
 from . import register_simulator as _register_simulator
 
@@ -25,6 +26,7 @@ class IlluminaChannel(BaseSimulator):
         coverage: int = 1,
         read_length: int = 150,
         quality_profile: Sequence[float] | None = None,
+        context_errors: Dict[str, float] | None = None,
     ) -> None:
         super().__init__(
             substitution_rate=substitution_rate,
@@ -34,18 +36,61 @@ class IlluminaChannel(BaseSimulator):
             read_length=read_length,
             quality_profile=quality_profile,
         )
+        self.context_errors = {
+            k.upper(): float(v) for k, v in (context_errors or {}).items()
+        }
+
+    def _mutate_read(
+        self, read: str, quality: Sequence[float] | None, rng: random.Random
+    ) -> str:
+        mutated = []
+        for idx, nt in enumerate(read):
+            if rng.random() < self.deletion_rate:
+                continue
+
+            sub_rate = (
+                quality[idx] if quality is not None and idx < len(quality) else self.substitution_rate
+            )
+            if self.context_errors and idx > 0:
+                ctx = read[idx - 1 : idx + 1].upper()
+                sub_rate *= self.context_errors.get(ctx, 1.0)
+
+            if rng.random() < sub_rate:
+                nt = _random_substitution(nt, rng)
+
+            mutated.append(nt)
+            if rng.random() < self.insertion_rate:
+                mutated.append(rng.choice(NUCLEOTIDES))
+
+        return "".join(mutated)
+
+    @staticmethod
+    def _consensus(reads: Iterable[str]) -> str:
+        reads = list(reads)
+        if not reads:
+            return ""
+        length = max(len(r) for r in reads)
+        result = []
+        for i in range(length):
+            counts: Dict[str, int] = {}
+            for r in reads:
+                if i < len(r):
+                    base = r[i]
+                    counts[base] = counts.get(base, 0) + 1
+            if counts:
+                result.append(max(counts, key=lambda k: counts[k]))
+        return "".join(result)
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()
         read_length = self.get_read_length(sequence)
         read = sequence[:read_length]
-        return introduce_errors(
-            read,
-            substitution_prob=self.substitution_rate,
-            insertion_prob=self.insertion_rate,
-            deletion_prob=self.deletion_rate,
-            rng=rng,
-        )
+        quality = self.get_quality_profile(sequence, read_length)
+        coverage = max(1, self.get_coverage(sequence))
+        reads = [self._mutate_read(read, quality, rng) for _ in range(coverage)]
+        if coverage == 1:
+            return reads[0]
+        return self._consensus(reads)
 
 
 class IlluminaD2SimChannel(Simulator):

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -1,12 +1,14 @@
 """Wrapper for the optional d2sim nanopore simulator."""
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence, Dict, Iterable
+import random
 
 from ..random_utils import make_rng
 from ..nanopore_sim import simulate_d2sim
 from ..api import Simulator
 from .base import BaseChannel
+from ..error_simulation import _random_substitution, NUCLEOTIDES
 from . import register_simulator as _register_simulator
 
 __all__ = ["NanoporeChannel", "register"]
@@ -23,6 +25,8 @@ class NanoporeChannel(BaseChannel):
         insertion_rate: float = 0.0,
         deletion_rate: float = 0.0,
         coverage: int = 1,
+        quality_profile: Sequence[float] | None = None,
+        context_errors: Dict[str, float] | None = None,
     ) -> None:
         super().__init__(
             substitution_rate=substitution_rate,
@@ -31,9 +35,69 @@ class NanoporeChannel(BaseChannel):
             coverage=coverage,
         )
         self.error_rate = error_rate
+        self.quality_profile = (
+            tuple(quality_profile) if quality_profile is not None else None
+        )
+        self.context_errors = {
+            k.upper(): float(v) for k, v in (context_errors or {}).items()
+        }
 
     def simulate(self, sequence: str) -> str:
-        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
+        rng = make_rng()
+        quality = self.quality_profile
+        coverage = max(1, self.get_coverage(sequence))
+        reads = [
+            self._mutate_read(
+                simulate_d2sim(sequence, error_rate=self.error_rate, rng=rng),
+                quality,
+                rng,
+            )
+            for _ in range(coverage)
+        ]
+        if coverage == 1:
+            return reads[0]
+        return self._consensus(reads)
+
+    def _mutate_read(
+        self, read: str, quality: Sequence[float] | None, rng: random.Random
+    ) -> str:
+        mutated = []
+        for idx, nt in enumerate(read):
+            if rng.random() < self.deletion_rate:
+                continue
+
+            sub_rate = (
+                quality[idx] if quality is not None and idx < len(quality) else self.substitution_rate
+            )
+            if self.context_errors and idx > 0:
+                ctx = read[idx - 1 : idx + 1].upper()
+                sub_rate *= self.context_errors.get(ctx, 1.0)
+
+            if rng.random() < sub_rate:
+                nt = _random_substitution(nt, rng)
+
+            mutated.append(nt)
+            if rng.random() < self.insertion_rate:
+                mutated.append(rng.choice(NUCLEOTIDES))
+
+        return "".join(mutated)
+
+    @staticmethod
+    def _consensus(reads: Iterable[str]) -> str:
+        reads = list(reads)
+        if not reads:
+            return ""
+        length = max(len(r) for r in reads)
+        result = []
+        for i in range(length):
+            counts: Dict[str, int] = {}
+            for r in reads:
+                if i < len(r):
+                    base = r[i]
+                    counts[base] = counts.get(base, 0) + 1
+            if counts:
+                result.append(max(counts, key=lambda k: counts[k]))
+        return "".join(result)
 
 
 def register(

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -25,6 +25,12 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         min_length=1,
         max_length=300,
         max_homopolymer=4,
+        illumina_depth=None,
+        nanopore_depth=None,
+        illumina_quality=None,
+        nanopore_quality=None,
+        illumina_context=None,
+        nanopore_context=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)


### PR DESCRIPTION
## Summary
- extend `IlluminaChannel` to support coverage depth, context errors and quality profiles
- extend `NanoporeChannel` with the same features
- expose new CLI flags to configure coverage and error models
- parse quality lists and context maps in CLI options
- adjust tests for new defaults

## Testing
- `ruff check .`
- `mypy src/genecoder`
- `SKIP_PACKAGING_TESTS=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688042f12774832689603d9c6490a813