### PR TITLE
Add registry YAML and dashboard tests

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -103,10 +103,16 @@ def _install_registry_plugins(url: str) -> None:
 
     try:
         with urllib.request.urlopen(url, timeout=30) as response:
-            data = yaml.safe_load(response.read()) or {}
+            raw = response.read()
     except Exception as exc:  # pragma: no cover - network error path
         logger.warning("Failed to fetch plugin registry %s: %s", url, exc)
         return
+
+    try:
+        data = yaml.safe_load(raw) or {}
+    except Exception as exc:
+        logger.warning("Failed to parse plugin registry %s: %s", url, exc)
+        raise ValueError("Invalid plugin registry YAML") from exc
 
     for entry in data.get("packages", []):
         if isinstance(entry, dict):

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+
+def test_dashboard_main_renders(tmp_path: Path) -> None:
+    data = {
+        "gc_distribution": [0.1, 0.2, 0.3],
+        "gc_content": 0.2,
+        "homopolymer_runs": [1, 2, 3],
+        "ecc_success_rates": {"hamming": 1.0},
+        "decode_success_rate": 0.9,
+    }
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(data))
+    def run_app(path: str) -> None:
+        from genecoder import dashboard as dash
+        dash.main(path)
+
+    app = AppTest.from_function(run_app, args=(str(results),))
+    app.run()
+    assert not app.exception

--- a/tests/test_plugin_install_malformed.py
+++ b/tests/test_plugin_install_malformed.py
@@ -1,0 +1,25 @@
+import pytest
+import genecoder.plugin_manager as plugins
+
+class DummyResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+    def __enter__(self):
+        return self
+    def __exit__(self, *exc):
+        return False
+    def read(self) -> bytes:
+        return self._data
+
+def test_install_registry_plugins_malformed_yaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        assert url == "https://example.com/plugins.yaml"
+        return DummyResponse(b"not: [yaml")
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="Invalid plugin registry YAML"):
+        plugins.install_registry_plugins()

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -142,10 +142,10 @@ def test_registry_bad_yaml(monkeypatch, caplog):
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING), pytest.raises(ValueError):
         plugins.install_registry_plugins()
 
-    assert "Failed to fetch plugin registry" in caplog.text
+    assert "Failed to parse plugin registry" in caplog.text
 
 
 def test_registry_checksum_mismatch(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- raise `ValueError` on malformed plugin registry YAML
- expect an exception in existing registry YAML test
- add test for registry installation failure with bad YAML
- add Streamlit dashboard render test

## Testing
- `ruff check tests/test_dashboard_render.py tests/test_plugin_install_malformed.py tests/test_plugin_registry.py src/genecoder/plugin_manager.py`
- `mypy src/genecoder/plugin_manager.py`
- `pytest tests/test_plugin_install_malformed.py tests/test_dashboard_render.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688042f285b48326bc5d2c7422a8baf6