### PR TITLE
Add opt-in plugin registry installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ export GENECODER_PLUGIN_CATALOG_URL=https://example.com/catalog.yaml
 Install registry packages with:
 
 ```bash
-genecoder plugin install-registry
+genecoder plugin install-registry --allow-registry
 ```
+
+The `--allow-registry` flag is required to opt in to downloading and
+executing third-party code. Only use registries from trusted sources.
 
 For details on submitting scores to the plugin challenge and viewing the
 leaderboard interface see

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -55,6 +55,16 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     install_parser.add_argument("name", help="Plugin name to install")
     install_parser.set_defaults(func=_handle_install)
 
+    reg_parser = plugin_sub.add_parser(
+        "install-registry", help="Install packages from the configured registry"
+    )
+    reg_parser.add_argument(
+        "--allow-registry",
+        action="store_true",
+        help="Allow downloading and installing packages from the registry",
+    )
+    reg_parser.set_defaults(func=_handle_install_registry)
+
 
 
 def _handle_list(args: argparse.Namespace) -> None:
@@ -212,6 +222,14 @@ def _handle_install(args: argparse.Namespace) -> None:
             ["install", "--require-hashes", "-r", str(req_file)],
             "pip install",
         )
+
+
+def _handle_install_registry(args: argparse.Namespace) -> None:
+    if not args.allow_registry:
+        logger.error("Registry installation requires --allow-registry")
+        raise SystemExit(1)
+
+    plugins.install_registry_plugins()
 
 
 

--- a/tests/test_cli_plugin_registry.py
+++ b/tests/test_cli_plugin_registry.py
@@ -1,0 +1,23 @@
+from tests.test_cli import run_cli_command
+import genecoder.plugin_manager as plugins
+
+
+def test_install_registry_requires_flag(monkeypatch):
+    calls = []
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "install_registry_plugins", lambda url=None: calls.append(url))
+
+    result = run_cli_command(["plugin", "install-registry"])
+    assert result.returncode != 0
+    assert not calls
+
+
+def test_install_registry_with_flag(monkeypatch):
+    calls = []
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins, "install_registry_plugins", lambda url=None: calls.append(url))
+
+    result = run_cli_command(["plugin", "install-registry", "--allow-registry"])
+    assert result.returncode == 0
+    assert calls == [None]
+


### PR DESCRIPTION
## Summary
- require `--allow-registry` flag for registry installs
- document the security implications
- test plugin registry CLI flag behavior

## Testing
- `pytest -q tests/test_cli_plugin_registry.py`
- `ruff check src/genecoder/cli/plugin.py tests/test_cli_plugin_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_6880506bfce48326b782614927d0b2e1