### PR TITLE
Add InSilicoSeq and DeSP simulators

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -59,6 +59,8 @@ def register_builtin_plugins() -> None:
             "genecoder.error_simulation",
             "genecoder.simulators.illumina",
             "genecoder.simulators.nanopore",
+            "genecoder.insilicoseq_adapter",
+            "genecoder.desp_adapter",
         ],
         register_simulator,
         "builtin",

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -379,6 +379,16 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         help="Extra command line options forwarded to dnarsim.",
     )
     parser.add_argument(
+        "--desp-options",
+        type=str,
+        help="Extra command line options forwarded to desp.",
+    )
+    parser.add_argument(
+        "--insilicoseq-options",
+        type=str,
+        help="Extra command line options forwarded to insilicoseq.",
+    )
+    parser.add_argument(
         "--squigulator-options",
         type=str,
         help="Extra command line options forwarded to squigulator.",
@@ -394,6 +404,10 @@ def decode_files(args: argparse.Namespace) -> None:
         os.environ["GENECODER_D2SIM_OPTIONS"] = args.d2sim_options
     if getattr(args, "dnarsim_options", None):
         os.environ["GENECODER_DNARSIM_OPTIONS"] = args.dnarsim_options
+    if getattr(args, "desp_options", None):
+        os.environ["GENECODER_DESP_OPTIONS"] = args.desp_options
+    if getattr(args, "insilicoseq_options", None):
+        os.environ["GENECODER_INSILICOSEQ_OPTIONS"] = args.insilicoseq_options
     if getattr(args, "squigulator_options", None):
         os.environ["GENECODER_SQUIGULATOR_OPTIONS"] = args.squigulator_options
 

--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -1,0 +1,52 @@
+"""Adapter for the optional ``DeSP`` nanopore simulator."""
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .api import Simulator
+from .random_utils import make_rng
+from .nanopore_sim import _simulate_adapter, _run_external
+from .simulators import register_simulator as _register_simulator
+
+
+class _DeSP:
+    """Internal helper to invoke the ``desp`` binary."""
+
+    command = "desp"
+
+    @staticmethod
+    def run(sequence: str) -> str:
+        """Run ``desp`` on ``sequence`` via :func:`_run_external`."""
+        return _run_external(_DeSP.command, sequence)
+
+
+def simulate_desp(
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+) -> str:
+    """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("desp", sequence, error_rate, rng)
+
+
+class DeSPChannel(Simulator):
+    """Channel wrapper for the optional ``DeSP`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_desp(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
+def register(
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
+) -> None:
+    """Register the ``desp`` simulator."""
+
+    registrar("desp", DeSPChannel())

--- a/src/genecoder/insilicoseq_adapter.py
+++ b/src/genecoder/insilicoseq_adapter.py
@@ -1,0 +1,52 @@
+"""Adapter for the optional ``InSilicoSeq`` Illumina simulator."""
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .api import Simulator
+from .random_utils import make_rng
+from .nanopore_sim import _simulate_adapter, _run_external
+from .simulators import register_simulator as _register_simulator
+
+
+class _InSilicoSeq:
+    """Internal helper to invoke the ``iss`` binary."""
+
+    command = "iss"
+
+    @staticmethod
+    def run(sequence: str) -> str:
+        """Run ``iss`` on ``sequence`` via :func:`_run_external`."""
+        return _run_external(_InSilicoSeq.command, sequence)
+
+
+def simulate_insilicoseq(
+    sequence: str,
+    error_rate: float = 0.05,
+    rng: random.Random | None = None,
+) -> str:
+    """Use ``InSilicoSeq`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("insilicoseq", sequence, error_rate, rng)
+
+
+class InSilicoSeqChannel(Simulator):
+    """Channel wrapper for the optional ``InSilicoSeq`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_insilicoseq(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
+def register(
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
+) -> None:
+    """Register the ``InSilicoSeq`` simulator."""
+
+    registrar("insilicoseq", InSilicoSeqChannel())

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -16,6 +16,8 @@ __all__ = [
     "simulate_d2sim",
     "simulate_dnarsim",
     "simulate_squigulator",
+    "simulate_desp",
+    "simulate_insilicoseq",
     "simulate_reads",
     "Channel",
 ]
@@ -113,7 +115,7 @@ def _simulate_adapter(
     if shutil.which(command):
         try:
             cmd_list = [command]
-            if command in {"d2sim", "dnarsim", "squigulator"}:
+            if command in {"d2sim", "dnarsim", "squigulator", "desp", "insilicoseq"}:
                 cmd_list += ["-e", str(error_rate)]
             if extra_args:
                 cmd_list += list(extra_args)
@@ -194,6 +196,28 @@ def simulate_squigulator(
     return _simulate_adapter("squigulator", sequence, error_rate, rng)
 
 
+def simulate_desp(
+    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+) -> str:
+    """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("desp", sequence, error_rate, rng)
+
+
+def simulate_insilicoseq(
+    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
+) -> str:
+    """Use ``insilicoseq`` if available, else fall back to :func:`simulate_errors`."""
+
+    if rng is None:
+        rng = make_rng()
+
+    return _simulate_adapter("insilicoseq", sequence, error_rate, rng)
+
+
 def simulate_none(
     sequence: str,
     error_rate: float = 0.0,
@@ -213,6 +237,8 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]]
     "d2sim": simulate_d2sim,
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
+    "desp": simulate_desp,
+    "insilicoseq": simulate_insilicoseq,
     # backward compatibility names
     "nanopore": simulate_d2sim,
     "none": simulate_none,

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -14,8 +14,8 @@ def register_simulator(name: str, channel: Simulator) -> None:
     SIMULATOR_REGISTRY[name] = channel
 
 from .base import BaseChannel, BaseSimulator
-from .illumina import IlluminaChannel
-from .nanopore import NanoporeChannel
+from .illumina import IlluminaChannel, IlluminaInSilicoSeqChannel
+from .nanopore import NanoporeChannel, NanoporeDeSPChannel
 
 __all__ = [
     "SIMULATOR_REGISTRY",
@@ -23,7 +23,9 @@ __all__ = [
     "BaseChannel",
     "BaseSimulator",
     "IlluminaChannel",
+    "IlluminaInSilicoSeqChannel",
     "NanoporeChannel",
+    "NanoporeDeSPChannel",
     "ChannelPipeline",
     "simulate_reads",
 ]

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -10,9 +10,10 @@ from ..random_utils import make_rng
 from ..api import Simulator
 from ..error_simulation import _random_substitution, NUCLEOTIDES
 from ..nanopore_sim import simulate_d2sim
+from ..insilicoseq_adapter import simulate_insilicoseq
 from . import register_simulator as _register_simulator
 
-__all__ = ["IlluminaChannel", "IlluminaD2SimChannel", "register"]
+__all__ = ["IlluminaChannel", "IlluminaD2SimChannel", "IlluminaInSilicoSeqChannel", "register"]
 
 
 class IlluminaChannel(BaseSimulator):
@@ -103,8 +104,19 @@ class IlluminaD2SimChannel(Simulator):
         return simulate_d2sim(sequence, error_rate=self.error_rate, rng=make_rng())
 
 
+class IlluminaInSilicoSeqChannel(Simulator):
+    """Wrapper using the external ``InSilicoSeq`` simulator."""
+
+    def __init__(self, error_rate: float = 0.05) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:
+        return simulate_insilicoseq(sequence, error_rate=self.error_rate, rng=make_rng())
+
+
 def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     registrar("illumina", IlluminaChannel())
     registrar("illumina_d2sim", IlluminaD2SimChannel())
+    registrar("illumina_insilicoseq", IlluminaInSilicoSeqChannel())

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -5,13 +5,13 @@ from typing import Callable, Sequence, Dict, Iterable
 import random
 
 from ..random_utils import make_rng
-from ..nanopore_sim import simulate_d2sim
+from ..nanopore_sim import simulate_d2sim, simulate_desp
 from ..api import Simulator
 from .base import BaseChannel
 from ..error_simulation import _random_substitution, NUCLEOTIDES
 from . import register_simulator as _register_simulator
 
-__all__ = ["NanoporeChannel", "register"]
+__all__ = ["NanoporeChannel", "NanoporeDeSPChannel", "register"]
 
 
 class NanoporeChannel(BaseChannel):
@@ -47,61 +47,85 @@ class NanoporeChannel(BaseChannel):
         quality = self.quality_profile
         coverage = max(1, self.get_coverage(sequence))
         reads = [
-            self._mutate_read(
+            _mutate_read(
                 simulate_d2sim(sequence, error_rate=self.error_rate, rng=rng),
                 quality,
                 rng,
+                self,
             )
             for _ in range(coverage)
         ]
         if coverage == 1:
             return reads[0]
-        return self._consensus(reads)
+        return _consensus(reads)
 
-    def _mutate_read(
-        self, read: str, quality: Sequence[float] | None, rng: random.Random
-    ) -> str:
-        mutated = []
-        for idx, nt in enumerate(read):
-            if rng.random() < self.deletion_rate:
-                continue
 
-            sub_rate = (
-                quality[idx] if quality is not None and idx < len(quality) else self.substitution_rate
+class NanoporeDeSPChannel(NanoporeChannel):
+    """Channel wrapper using the external ``desp`` simulator."""
+
+    def simulate(self, sequence: str) -> str:
+        rng = make_rng()
+        quality = self.quality_profile
+        coverage = max(1, self.get_coverage(sequence))
+        reads = [
+            _mutate_read(
+                simulate_desp(sequence, error_rate=self.error_rate, rng=rng),
+                quality,
+                rng,
+                self,
             )
-            if self.context_errors and idx > 0:
-                ctx = read[idx - 1 : idx + 1].upper()
-                sub_rate *= self.context_errors.get(ctx, 1.0)
+            for _ in range(coverage)
+        ]
+        if coverage == 1:
+            return reads[0]
+        return _consensus(reads)
 
-            if rng.random() < sub_rate:
-                nt = _random_substitution(nt, rng)
 
-            mutated.append(nt)
-            if rng.random() < self.insertion_rate:
-                mutated.append(rng.choice(NUCLEOTIDES))
+def _mutate_read(
+    read: str, quality: Sequence[float] | None, rng: random.Random, channel: NanoporeChannel
+) -> str:
+    mutated = []
+    for idx, nt in enumerate(read):
+        if rng.random() < channel.deletion_rate:
+            continue
 
-        return "".join(mutated)
+        sub_rate = (
+            quality[idx] if quality is not None and idx < len(quality) else channel.substitution_rate
+        )
+        if channel.context_errors and idx > 0:
+            ctx = read[idx - 1 : idx + 1].upper()
+            sub_rate *= channel.context_errors.get(ctx, 1.0)
 
-    @staticmethod
-    def _consensus(reads: Iterable[str]) -> str:
-        reads = list(reads)
-        if not reads:
-            return ""
-        length = max(len(r) for r in reads)
-        result = []
-        for i in range(length):
-            counts: Dict[str, int] = {}
-            for r in reads:
-                if i < len(r):
-                    base = r[i]
-                    counts[base] = counts.get(base, 0) + 1
-            if counts:
-                result.append(max(counts, key=lambda k: counts[k]))
-        return "".join(result)
+        if rng.random() < sub_rate:
+            nt = _random_substitution(nt, rng)
+
+        mutated.append(nt)
+        if rng.random() < channel.insertion_rate:
+            mutated.append(rng.choice(NUCLEOTIDES))
+
+    return "".join(mutated)
+
+
+def _consensus(reads: Iterable[str]) -> str:
+    reads = list(reads)
+    if not reads:
+        return ""
+    length = max(len(r) for r in reads)
+    result = []
+    for i in range(length):
+        counts: Dict[str, int] = {}
+        for r in reads:
+            if i < len(r):
+                base = r[i]
+                counts[base] = counts.get(base, 0) + 1
+        if counts:
+            result.append(max(counts, key=lambda k: counts[k]))
+    return "".join(result)
 
 
 def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
     registrar("nanopore_d2sim", NanoporeChannel())
+    registrar("nanopore_desp", NanoporeDeSPChannel())
 

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -90,7 +90,7 @@ def test_cli_decode_duplicate_output_names(tmp_path: Path) -> None:
     assert out2.read_bytes() == b"two"
 
 
-@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator", "desp"])
 def test_cli_decode_missing_simulator(tmp_path: Path, sim_name: str) -> None:
     env = os.environ.copy()
     src_path = Path(__file__).resolve().parent.parent / "src"
@@ -142,7 +142,7 @@ def test_cli_decode_missing_simulator(tmp_path: Path, sim_name: str) -> None:
     assert out_file.read_text().startswith("missing")
 
 
-@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator", "desp"])
 def test_cli_decode_simulator_failure(tmp_path: Path, sim_name: str) -> None:
     env = os.environ.copy()
     src_path = Path(__file__).resolve().parent.parent / "src"

--- a/tests/test_cli_simulator_fallback.py
+++ b/tests/test_cli_simulator_fallback.py
@@ -4,7 +4,7 @@ import pytest
 from tests.test_cli import run_cli_command
 
 
-@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator"])
+@pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator", "desp"])
 def test_cli_simulator_fallback(tmp_path: Path, sim_name: str):
     env = os.environ.copy()
     src_path = Path(__file__).resolve().parent.parent / "src"

--- a/tests/test_cli_simulator_selection.py
+++ b/tests/test_cli_simulator_selection.py
@@ -4,11 +4,10 @@ from tests.test_cli import run_cli_command
 
 import pytest
 
-@pytest.mark.parametrize("sim_name", [
-    "illumina",
-    "illumina_d2sim",
-    "nanopore_d2sim",
-])
+@pytest.mark.parametrize(
+    "sim_name",
+    ["illumina", "illumina_d2sim", "illumina_insilicoseq", "nanopore_d2sim", "nanopore_desp"],
+)
 def test_cli_decode_with_builtin_simulator(tmp_path: Path, sim_name: str):
     env = os.environ.copy()
     src_path = Path(__file__).resolve().parent.parent / "src"

--- a/tests/test_error_statistics.py
+++ b/tests/test_error_statistics.py
@@ -1,0 +1,23 @@
+import os
+from genecoder import insilicoseq_adapter, desp_adapter
+
+
+def _sub_rate(original: str, mutated: str) -> float:
+    changes = sum(1 for a, b in zip(original, mutated) if a != b)
+    return changes / len(original)
+
+
+def test_insilicoseq_stats(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    seq = "ACGTACGTACGT"
+    out = insilicoseq_adapter.simulate_insilicoseq(seq, error_rate=0.2)
+    assert out == "TCGTACATACGT"
+    assert _sub_rate(seq, out) == 2 / len(seq)
+
+
+def test_desp_stats(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    seq = "ACGTACGTACGT"
+    out = desp_adapter.simulate_desp(seq, error_rate=0.2)
+    assert out == "TCGTACATACGT"
+    assert _sub_rate(seq, out) == 2 / len(seq)

--- a/tests/test_insilicoseq_desp_adapter.py
+++ b/tests/test_insilicoseq_desp_adapter.py
@@ -1,0 +1,148 @@
+import logging
+import subprocess
+import random
+import pytest
+
+from genecoder import insilicoseq_adapter, desp_adapter, nanopore_sim
+
+ADAPTERS = {
+    "insilicoseq": (
+        insilicoseq_adapter.simulate_insilicoseq,
+        insilicoseq_adapter._InSilicoSeq,
+        "insilicoseq",
+    ),
+    "desp": (
+        desp_adapter.simulate_desp,
+        desp_adapter._DeSP,
+        "desp",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_run_external(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    run_called = []
+
+    def fake_which(target):
+        which_called.append(target)
+        return "/usr/bin/" + target
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        return "external"
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+
+    result = func("ACGT")
+    assert result == "external"
+    assert which_called == [cmd]
+    assert run_called == [([cmd, "-e", "0.05"], "ACGT")]
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_fall_back(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+
+    result = func("ACGT", error_rate=0.1)
+    assert result == "fallback"
+    assert which_called == [cmd]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_external_error(monkeypatch, caplog, name):
+    func, cls, cmd = ADAPTERS[name]
+    which_called = []
+    run_called = []
+    errors_called = []
+
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t)
+
+    def fake_run(command, seq):
+        run_called.append((command, seq))
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT", error_rate=0.2)
+
+    assert result == "fallback"
+    assert which_called == [cmd]
+    assert run_called == [([cmd, "-e", "0.2"], "ACGT")]
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any("falling back" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_command_not_found_warning(monkeypatch, caplog, name):
+    func, cls, cmd = ADAPTERS[name]
+    errors_called = []
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: None)
+
+    def boom(*_):
+        raise AssertionError("_run_external should not be called")
+
+    monkeypatch.setattr(nanopore_sim, "_run_external", boom)
+    monkeypatch.setattr(
+        nanopore_sim,
+        "simulate_errors",
+        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = func("ACGT")
+
+    assert result == "fallback"
+    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert any(
+        rec.levelno == logging.WARNING and "not found" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_class_run(monkeypatch, name):
+    func, cls, cmd = ADAPTERS[name]
+    called = []
+
+    def fake_run_external(c, seq):
+        called.append((c, seq))
+        return "ok"
+
+    monkeypatch.setattr(cls, "command", cmd)
+    monkeypatch.setattr(insilicoseq_adapter if name == "insilicoseq" else desp_adapter, "_run_external", fake_run_external)
+
+    result = cls.run("ACGT")
+    assert result == "ok"
+    assert called == [(cmd, "ACGT")]
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_channel_object(monkeypatch, name):
+    from genecoder.channels.base import BaseChannel
+
+    module = insilicoseq_adapter if name == "insilicoseq" else desp_adapter
+    registry: dict[str, BaseChannel] = {}
+    module.register(lambda n, ch: registry.setdefault(n, ch))
+
+    assert name in registry
+    assert isinstance(registry[name], BaseChannel)
+


### PR DESCRIPTION
## Summary
- wrap InSilicoSeq and DeSP simulators
- expose new CLI options for simulator parameters
- integrate new simulators in builtin registry
- add tests for adapters and basic error statistics

## Testing
- `ruff check .`
- `mypy`
- `pytest -q tests/test_insilicoseq_desp_adapter.py tests/test_error_statistics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880506b7f348326afb8ef52bf5b92e5