### PR TITLE
Add final encoding metrics and regression test

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -361,11 +361,16 @@ def process_single_encode(
             else 0.0
         )
 
+        final_gc = calculate_gc_content(final_encoded_dna_sequence)
+        final_hp = get_max_homopolymer_length(final_encoded_dna_sequence)
+
         metrics = {
             "original_size": original_size_bytes,
             "dna_length": final_encoded_length_nucleotides,
             "compression_ratio": compression_ratio,
             "bits_per_nt": bits_per_nucleotide,
+            "final_gc": final_gc,
+            "final_max_homopolymer": final_hp,
         }
 
         logger.info(f"\n--- Encoding Metrics for {input_file_path} ---")
@@ -383,6 +388,22 @@ def process_single_encode(
         logger.info(
             f"Bits per nucleotide: {bits_per_nucleotide:.2f} bits/nt (based on original data and final DNA length)"
         )
+
+        logger.info(f"Final GC content: {final_gc:.2%}")
+        logger.info(f"Final max homopolymer length: {final_hp}")
+        if not (args.gc_min <= final_gc <= args.gc_max):
+            logger.warning(
+                "Final GC content %.2f%% outside requested range [%.2f%%, %.2f%%]",
+                final_gc * 100,
+                args.gc_min * 100,
+                args.gc_max * 100,
+            )
+        if final_hp > args.max_homopolymer:
+            logger.warning(
+                "Final max homopolymer length %d exceeds limit %d",
+                final_hp,
+                args.max_homopolymer,
+            )
 
         if args.method == "gc_balanced":
             gc_balanced_payload_dna = (

--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -26,7 +26,7 @@ except Exception:  # pragma: no cover - fallback for tests
             if self.fh:
                 self.fh.close()
 
-    portalocker = types.SimpleNamespace(Lock=_NoLock)
+    portalocker = cast(Any, types.SimpleNamespace(Lock=_NoLock))
 
 __all__ = [
     "Metrics",

--- a/tests/test_cli_metrics.py
+++ b/tests/test_cli_metrics.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_encode_outputs_metrics(tmp_path: Path) -> None:
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("metrics")
+
+    result = run_cli_command([
+        "encode",
+        "--input-files",
+        str(input_file),
+        "--output-dir",
+        str(tmp_path),
+        "--method",
+        "base4_direct",
+    ])
+    assert result.returncode == 0, result.stderr
+    assert "Final GC content" in result.stdout
+    assert "Final max homopolymer length" in result.stdout


### PR DESCRIPTION
## Summary
- compute GC content and max homopolymer metrics after encoding
- warn if constraints are violated
- log metrics in CLI output
- add regression test for CLI metrics
- fix mypy complaint in metrics module

## Testing
- `ruff check src/genecoder/cli/encode.py tests/test_cli_metrics.py src/genecoder/metrics.py`
- `mypy --config-file pyproject.toml src/genecoder/cli/encode.py`
- `pytest tests/test_cli_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68805070618883268a2f15d4fb58c0d4