### PR TITLE
Implement streaming GC balancer

### DIFF
--- a/src/genecoder/gc_balancer.py
+++ b/src/genecoder/gc_balancer.py
@@ -45,10 +45,43 @@ class AdvancedGCBalancer:
                 return False
         return True
 
-    def encode(self, data: bytes | Iterable[bytes], *, stream: bool = False) -> str:
+    def _window_ok(self, window: str) -> bool:
+        """Return ``True`` if ``window`` meets GC and homopolymer limits."""
+        gc = calculate_gc_content(window)
+        if gc < self.target_gc_min or gc > self.target_gc_max:
+            return False
+        if get_max_homopolymer_length(window) > self.max_homopolymer:
+            return False
+        return True
+
+    def encode(
+        self, data: bytes | Iterable[bytes], *, stream: bool = False
+    ) -> str | Iterable[str]:
         """Encode bytes ensuring GC balance across sliding windows."""
         if stream:
-            raise NotImplementedError("Streaming mode not supported for AdvancedGCBalancer")
+            iterable = [data] if isinstance(data, (bytes, bytearray)) else data
+
+            def gen() -> Iterable[str]:
+                dna_so_far = ""
+                next_start = 0
+                for dna_chunk in cast(
+                    Iterable[str], encode_base4_direct(iterable, stream=True)
+                ):
+                    dna_so_far += dna_chunk
+                    while next_start <= len(dna_so_far) - self.window_size:
+                        window = dna_so_far[next_start : next_start + self.window_size]
+                        if not self._window_ok(window):
+                            raise ValueError(
+                                "Encoded sequence violates GC content or homopolymer constraints"
+                            )
+                        next_start += self.step_size
+                    yield dna_chunk
+                if not self._check_constraints(dna_so_far):
+                    raise ValueError(
+                        "Encoded sequence violates GC content or homopolymer constraints"
+                    )
+
+            return gen()
         if not isinstance(data, (bytes, bytearray)):
             data = b"".join(data)
         dna = cast(str, encode_base4_direct(data, stream=False))
@@ -56,13 +89,41 @@ class AdvancedGCBalancer:
             raise ValueError("Encoded sequence violates GC content or homopolymer constraints")
         return dna
 
-    def decode(self, dna: str | Iterable[str], *, stream: bool = False) -> bytes:
+    def decode(
+        self, dna: str | Iterable[str], *, stream: bool = False
+    ) -> bytes | Iterable[bytes]:
         """Decode DNA produced by :meth:`encode`."""
         if stream:
-            raise NotImplementedError("Streaming mode not supported for AdvancedGCBalancer")
+            iterable = [dna] if isinstance(dna, str) else dna
+
+            def gen() -> Iterable[bytes]:
+                dna_so_far = ""
+                next_start = 0
+                for chunk in iterable:
+                    dna_so_far += chunk
+                    while next_start <= len(dna_so_far) - self.window_size:
+                        window = dna_so_far[next_start : next_start + self.window_size]
+                        if not self._window_ok(window):
+                            raise ValueError(
+                                "DNA sequence violates GC content or homopolymer constraints"
+                            )
+                        next_start += self.step_size
+                    decoded_tuple = cast(
+                        tuple[bytes, list[int]],
+                        decode_base4_direct(chunk, stream=False),
+                    )
+                    yield decoded_tuple[0]
+                if not self._check_constraints(dna_so_far):
+                    raise ValueError(
+                        "DNA sequence violates GC content or homopolymer constraints"
+                    )
+
+            return gen()
         if not isinstance(dna, str):
             dna = "".join(dna)
         if not self._check_constraints(dna):
             raise ValueError("DNA sequence violates GC content or homopolymer constraints")
-        decoded_tuple = cast(tuple[bytes, list[int]], decode_base4_direct(dna, stream=False))
+        decoded_tuple = cast(
+            tuple[bytes, list[int]], decode_base4_direct(dna, stream=False)
+        )
         return decoded_tuple[0]

--- a/tests/test_gc_balancer.py
+++ b/tests/test_gc_balancer.py
@@ -35,3 +35,24 @@ def test_gc_balancer_decode_checks_constraints():
     balancer = AdvancedGCBalancer(0.4, 0.6, 3, window_size=5, step_size=5)
     with pytest.raises(ValueError):
         balancer.decode("AAAAA")
+
+
+def test_gc_balancer_stream_roundtrip():
+    balancer = AdvancedGCBalancer(0.4, 0.6, 3)
+    chunks = [b"\x05", b"\x05", b"\x05", b"\x05"]
+    dna_chunks = list(balancer.encode(chunks, stream=True))
+    decoded_iter = balancer.decode(dna_chunks, stream=True)
+    decoded = b"".join(decoded_iter)
+    assert decoded == b"\x05\x05\x05\x05"
+
+
+def test_gc_balancer_stream_violation():
+    balancer = AdvancedGCBalancer(0.4, 0.6, 2, window_size=4, step_size=1)
+    with pytest.raises(ValueError):
+        list(balancer.encode([b"\x00", b"\x00"], stream=True))
+
+
+def test_gc_balancer_stream_decode_checks():
+    balancer = AdvancedGCBalancer(0.4, 0.6, 3, window_size=5, step_size=5)
+    with pytest.raises(ValueError):
+        list(balancer.decode(["AAAAA"], stream=True))


### PR DESCRIPTION
## Summary
- add `_window_ok` helper and implement streaming encode/decode
- validate GC and homopolymer constraints incrementally
- test streaming paths for `AdvancedGCBalancer`

## Testing
- `ruff check src/genecoder/gc_balancer.py tests/test_gc_balancer.py`
- `mypy src/genecoder/gc_balancer.py`
- `pytest tests/test_gc_balancer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d344439483269bc16fea1f676baf