### PR TITLE
Document dev extras for tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -100,6 +100,7 @@ jobs:
         key: poetry-${{ runner.os }}-${{ hashFiles(steps.lockfile.outputs.file) }}
 
     - name: Install dependencies
+      # The test suite relies on the dev group for tools like types-PyYAML
       run: |
         python -m pip install --upgrade pip
         pip install poetry

--- a/README.md
+++ b/README.md
@@ -146,12 +146,24 @@ Install the project in editable mode with development tools:
 poetry install --with gui,web,dev --no-interaction
 ```
 
-You can also run the helper script to install the optional GUI and web extras
-required by the test suite:
+You can also run the helper script to install the optional GUI, web and
+development extras required by the test suite:
 
 ```bash
 scripts/setup_test_env.sh
 ```
+
+## Running Tests
+
+Install the development dependencies before executing the test suite:
+
+```bash
+poetry install --with dev --no-interaction
+poetry run pytest -q
+```
+
+The helper script above installs the GUI and web extras as well, enabling the
+full test matrix.
 
 
 ## Continuous Integration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,9 +80,10 @@ Contributors can alternatively open the repository in the provided
 
 ## Running Tests
 
-Run the tests inside the Poetry environment:
+Install the development dependencies before running the tests:
 
 ```bash
+poetry install --with dev --no-interaction
 poetry run pytest -q
 ```
 

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -6,5 +6,5 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
-echo "Installing GUI and web extras..."
-poetry install --with gui,web --no-interaction
+echo "Installing GUI, web and development extras..."
+poetry install --with gui,web,dev --no-interaction


### PR DESCRIPTION
## Summary
- mention `poetry install --with dev` in README and installation guide
- update CI comments to note dev extras requirement
- expand helper script to install dev extras

## Testing
- `ruff check src`
- `pytest -k dashboard_main_renders tests/test_dashboard_render.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d3452ec08326ad0fd490182a67c2