### PR TITLE
Add plugin download helper

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -149,79 +149,29 @@ def download_plugin_bytes(name: str) -> tuple[str, bytes]:
         return pkg_path.name, pkg_bytes
 
 
-def _handle_install(args: argparse.Namespace) -> None:
-    name = args.name
-    meta = plugins.PLUGIN_CATALOG.get(name)
-    if not meta:
-        logger.error("Unknown plugin: %s", name)
-        raise SystemExit(1)
-    spec = meta.get("url") or name
-    version = meta.get("version")
-    if version and not meta.get("url"):
-        spec = f"{name}=={version}"
-    checksum = meta.get("checksum")
-    signature_b64 = meta.get("signature")
-    pubkey: bytes | None = None
+def download_plugin(name: str) -> None:
+    """Download ``name`` from the catalog and install it via ``pip``."""
 
-    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
-    if signature_b64:
-        if not key_path:
-            logger.error("Missing public key for signed plugin %s", name)
-            raise SystemExit(1)
-        try:
-            pubkey = Path(key_path).read_bytes()
-        except Exception:  # pragma: no cover - filesystem error path
-            logger.warning("Failed to read public key %s", key_path)
-            pubkey = None
+    filename, pkg_bytes = download_plugin_bytes(name)
+    digest = plugins.compute_checksum(pkg_bytes)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        _run_pip(
-            [
-                "download",
-                "--no-deps",
-                "-d",
-                tmp_dir,
-                spec,
-            ],
-            "pip download",
-        )
-        files = list(Path(tmp_dir).iterdir())
-        if not files:
-            logger.error("No package downloaded for plugin %s", name)
-            raise SystemExit(1)
-        pkg_path = files[0]
-        pkg_bytes = pkg_path.read_bytes()
-        if signature_b64:
-            if pubkey is None:
-                logger.error("Missing public key for signed plugin %s", name)
-                raise SystemExit(1)
-            try:
-                sig_bytes = decode_signature(signature_b64)
-            except ValueError:
-                logger.error("Invalid signature for plugin %s", name)
-                raise SystemExit(1)
-        else:
-            sig_bytes = None
-        try:
-            digest = verify_package(
-                pkg_bytes,
-                checksum=checksum,
-                signature=sig_bytes,
-                public_key=pubkey,
-                compute_fn=plugins.compute_checksum,
-            )
-        except ValueError as exc:
-            if str(exc) == "Checksum mismatch":
-                logger.error("Checksum mismatch for plugin %s", name)
-            else:
-                logger.error("Signature verification failed for plugin %s: %s", name, exc)
-            raise SystemExit(1)
+        pkg_path = Path(tmp_dir) / filename
+        pkg_path.write_bytes(pkg_bytes)
+
         req_file = Path(tmp_dir) / "req.txt"
         req_file.write_text(f"{pkg_path} --hash=sha256:{digest}\n")
-        _run_pip(
-            ["install", "--require-hashes", "-r", str(req_file)],
-            "pip install",
-        )
+
+        _run_pip([
+            "install",
+            "--require-hashes",
+            "-r",
+            str(req_file),
+        ], "pip install")
+
+
+def _handle_install(args: argparse.Namespace) -> None:
+    download_plugin(args.name)
 
 
 def _handle_install_registry(args: argparse.Namespace) -> None:

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -18,7 +18,7 @@ app = FastAPI()
 API_TOKEN: str | None = None
 
 
-@app.post("/jobs")
+@app.post("/jobs")  # type: ignore[misc]
 def create_job(job: dict[str, Any], authorization: str | None = Header(None)) -> dict[str, str]:
     """Handle bundle job uploads from tests."""
     if authorization != f"Bearer {API_TOKEN}":

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -11,11 +11,15 @@ import urllib.request
 from urllib.parse import urlparse
 from pathlib import Path
 import importlib
+from types import ModuleType
 
+yaml: ModuleType | None
 try:  # optional dependency
-    import yaml
+    import yaml as yaml_module
 except Exception:  # pragma: no cover - optional
     yaml = None
+else:
+    yaml = yaml_module
 
 
 from importlib.metadata import entry_points, EntryPoints
@@ -90,6 +94,10 @@ def register_simulator(name: str, channel: Simulator) -> None:
 
 def _install_registry_plugins(url: str) -> None:
     """Install plugin packages listed in a YAML registry at ``url``."""
+
+    if yaml is None:
+        logger.warning("YAML support unavailable; skipping registry %s", url)
+        return
 
     key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
     pubkey: bytes | None = None

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -1,4 +1,3 @@
-import argparse
 import pytest
 
 pytest.importorskip("fastapi_limiter")
@@ -26,10 +25,10 @@ def test_list_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_install_plugin(monkeypatch: pytest.MonkeyPatch) -> None:
     called = []
 
-    def fake_install(args: argparse.Namespace) -> None:
-        called.append(args.name)
+    def fake_install(name: str) -> None:
+        called.append(name)
 
-    monkeypatch.setattr(plugin_cli, "_handle_install", fake_install)
+    monkeypatch.setattr(plugin_cli, "download_plugin", fake_install)
     plugins.PLUGIN_CATALOG["demo"] = {}
     r = client.post("/plugins/install", headers=AUTH_HEADERS, json={"name": "demo"})
     assert r.status_code == 200

--- a/web/main.py
+++ b/web/main.py
@@ -19,7 +19,6 @@ from genecoder import perform_encoding, perform_decoding
 from genecoder.plugin_manager import init_plugins
 from genecoder import plugins
 from genecoder.cli import plugin as plugin_cli
-import argparse
 from genecoder.formats import from_fasta
 from genecoder.encoders import calculate_gc_content, decode_base4_direct
 from genecoder.utils import get_max_homopolymer_length, get_temp_dir, bit_error_rate
@@ -558,9 +557,8 @@ async def install_plugin(
     req: PluginInstallRequest,
     _: None = Depends(verify_token),
 ) -> dict[str, str]:
-    args = argparse.Namespace(name=req.name)
     try:
-        await asyncio.to_thread(plugin_cli._handle_install, args)
+        await asyncio.to_thread(plugin_cli.download_plugin, req.name)
     except SystemExit as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add helper to install plugin from catalog
- call helper from CLI and API install handlers
- update API tests
- fix mypy errors in optional YAML logic

## Testing
- `ruff check src/genecoder/cli/plugin.py web/main.py tests/test_plugins_api.py`
- `poetry run mypy`
- `pytest -q tests/test_plugins_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6880e39450288326a38d03041b0a3f72