### PR TITLE
Fix optional dependency tests

### DIFF
--- a/tests/test_alphabet_modes.py
+++ b/tests/test_alphabet_modes.py
@@ -1,5 +1,11 @@
-from genecoder.encoders import encode_base4_direct, decode_base4_direct
-from genecoder.utils import get_alphabet_maps
+import pytest
+
+encoders = pytest.importorskip("genecoder.encoders")
+utils = pytest.importorskip("genecoder.utils")
+
+encode_base4_direct = encoders.encode_base4_direct
+decode_base4_direct = encoders.decode_base4_direct
+get_alphabet_maps = utils.get_alphabet_maps
 
 
 def _roundtrip(alphabet: str) -> None:

--- a/tests/test_fountain_codec.py
+++ b/tests/test_fountain_codec.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("pyfinite")
+
 from genecoder.fountain_codec import encode_data_fountain, decode_data_fountain
 
 def test_fountain_roundtrip():

--- a/tests/test_metrics_lock.py
+++ b/tests/test_metrics_lock.py
@@ -2,6 +2,10 @@ import json
 from multiprocessing import Process
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("portalocker")
+
 from genecoder.metrics import Metrics
 
 

--- a/tests/test_streaming_fec.py
+++ b/tests/test_streaming_fec.py
@@ -46,6 +46,9 @@ def test_stream_encode_decode_with_fec(tmp_path, fec_name, encode_fn, decode_fn,
     if not available:
         pytest.skip(f"{fec_name} not available")
 
+    if fec_name == "fountain":
+        pytest.importorskip("pyfinite")
+
     data = os.urandom(256)
     encoded_bytes, info = encode_fn(data)
 


### PR DESCRIPTION
## Summary
- use `pytest.importorskip` for several optional dependencies
- skip metrics lock test when `portalocker` is missing

## Testing
- `pre-commit run --files tests/test_alphabet_modes.py tests/test_fountain_codec.py tests/test_streaming_fec.py tests/test_metrics_lock.py`
- `pytest tests/test_alphabet_modes.py tests/test_fountain_codec.py tests/test_streaming_fec.py tests/test_metrics_lock.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f1d5395483268ad22e5b899da04d