### PR TITLE
Add helper script for installing test extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ Install the project in editable mode with development tools:
 poetry install --with gui,web,dev --no-interaction
 ```
 
-You can also run the helper script to install the optional GUI, web and
-development extras required by the test suite:
+You can also run the helper script to install all optional extras
+required by the full test suite:
 
 ```bash
-scripts/setup_test_env.sh
+scripts/install_extras.sh
 ```
 
 ## Running Tests
@@ -162,7 +162,7 @@ poetry install --with dev --no-interaction
 poetry run pytest -q
 ```
 
-The helper script above installs the GUI and web extras as well, enabling the
+The helper script above installs every extras group, enabling the
 full test matrix.
 
 

--- a/scripts/install_extras.sh
+++ b/scripts/install_extras.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install all extras needed for the full test suite
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+echo "Installing base package..."
+pip install -e .
+
+EXTRAS=(ldpc fountain bch raptorq)
+for extra in "${EXTRAS[@]}"; do
+    echo "Installing extras: $extra"
+    if pip install -e ".[$extra]"; then
+        echo "Installed $extra"
+    else
+        echo "Skipping $extra (dependency not available)"
+    fi
+done
+


### PR DESCRIPTION
## Summary
- add `scripts/install_extras.sh` to install all optional extras for full test suite
- update README Development Setup section to use new script
- fix extras install script to use pip when poetry install fails

## Testing
- `pre-commit run --files README.md scripts/install_extras.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880f1d45ce4832690328d15dcd37940