### PR TITLE
fix: resolve ModuleType redefinition

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -11,7 +11,6 @@ import urllib.request
 from urllib.parse import urlparse
 from pathlib import Path
 import importlib
-from types import ModuleType
 
 yaml: ModuleType | None
 try:  # optional dependency


### PR DESCRIPTION
## Summary
- remove duplicate ModuleType import in `plugin_manager`

## Testing
- `ruff check src/genecoder/plugin_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68813e241a848326b579d84cbe328e26