### PR TITLE
test: verify plugin registry error handling

### DIFF
--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -60,3 +60,84 @@ def test_load_plugins_with_signed_registry(monkeypatch: pytest.MonkeyPatch) -> N
     plugins.load_plugins()
 
     assert "reverse" in plugins.CODEC_REGISTRY
+
+
+def test_load_plugins_registry_missing_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL",
+        "https://example.com/plugins.yaml",
+    )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    with pytest.raises(ValueError, match="Missing signature"):
+        plugins.install_registry_plugins()
+
+
+def test_load_plugins_registry_checksum_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pkg = b"PKG"
+    wrong_checksum = compute_checksum(b"WRONG")
+    sig = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}\n    signature: {sig}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+    monkeypatch.setenv(
+        "GENECODER_PLUGIN_REGISTRY_URL",
+        "https://example.com/plugins.yaml",
+    )
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    installs: list[list[str]] = []
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(
+        plugins,
+        "compute_checksum",
+        lambda d, *, signature=None, public_key=None: compute_checksum(d),
+    )
+    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    plugins.install_registry_plugins()
+
+    assert not installs


### PR DESCRIPTION
## Summary
- expand plugin registry loading tests to check handling of missing `signature` field and checksum mismatches

## Testing
- `ruff check tests/test_plugin_registry_loading.py`
- `pytest tests/test_plugin_registry_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68813e255b748326955e828bc9107ceb