### PR TITLE
docs: sync cloud feature documentation

### DIFF
--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -15,13 +15,7 @@ The archive has the following layout:
 
 The `summary.json` file includes the configuration hash, timestamp and a list of all files in the archive. If provided, the author and description values are also recorded.
 
-Once an archive has been created it can be uploaded to a remote worker using the cloud CLI:
-
-```bash
-genecoder cloud submit --archive output.tar.gz --server https://worker:8000 --token TOKEN
-```
-
-This is equivalent to supplying a bundle YAML file directly, but avoids rebuilding the archive when the workflow has already been run locally.
+After exporting an archive you may manually inspect or transfer the file as needed.
 
 ## Server-side metrics
 

--- a/docs/cloud_worker.md
+++ b/docs/cloud_worker.md
@@ -1,31 +1,4 @@
-# Cloud Worker Docker Setup
+# Cloud Worker Removed
 
-GeneCoder includes a lightweight worker that exposes a REST API for running bundles remotely. A prebuilt Docker image makes deployment easy.
-
-## Running the Container
-
-Pull and start the worker image while exposing port `8000`:
-
-```bash
-docker run -p 8000:8000 \
-  -e GENECODER_API_TOKEN=TOKEN \
-  -e GENECODER_JOB_DIR=/data/jobs \
-  ghcr.io/d0ttino/genecoder python -m genecoder.cloud.worker
-```
-
-Replace `TOKEN` with a secret value. The `GENECODER_JOB_DIR` variable controls where uploaded archives and status files are stored (defaults to `worker_jobs`).
-
-## Environment Variables
-
-- `GENECODER_API_TOKEN` – bearer token required for all requests.
-- `GENECODER_JOB_DIR` – optional path for job archives.
-- `GENECODER_DATA_DIR` – directory for cached profiles and other data.
-
-## Authentication
-
-The worker uses HTTP bearer authentication. Clients must include the token in the `Authorization` header. The CLI automatically adds this header when you run:
-
-```bash
-genecoder cloud submit bundle.yaml --server http://localhost:8000 --token TOKEN
-```
-
+Previous versions of GeneCoder shipped a REST worker and Docker image for remote bundle execution. This component is no longer maintained.
+All workflows should run locally using `genecoder bundle run`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 # Deployment Guide
 
-This guide summarizes how to build the React dashboard, start a cloud worker with Docker and submit jobs via the CLI.
-See [cloud_worker.md](cloud_worker.md) for a detailed explanation of the worker container and environment variables.
+This guide summarizes how to build the React dashboard and run the web server locally.
+Remote job submission via the old cloud worker has been removed.
 
 ## Build the Dashboard
 
@@ -15,23 +15,14 @@ npm run build
 
 The generated files are placed in `web/helix-ui/dist`. The FastAPI server automatically serves this folder when available.
 
-## Launch the Cloud Worker
+## Run the Web Server
 
-`genecoder.cloud.worker` provides a minimal REST API for running bundles remotely. Start it inside a container:
-
-```bash
-docker run -p 8000:8000 -e GENECODER_API_TOKEN=TOKEN \
-    ghcr.io/d0ttino/genecoder python -m genecoder.cloud.worker
-```
-
-Replace `TOKEN` with a secret value. The CLI must use the same token when submitting jobs.
-
-## Submit a Job
-
-Packages and uploads are handled by `genecoder cloud submit`:
+Install the optional `web` extras and start the FastAPI server locally:
 
 ```bash
-genecoder cloud submit bundle.yaml --server http://localhost:8000 --token TOKEN
+poetry install --with web --no-interaction
+uvicorn web.main:app --reload
 ```
 
-The command archives the bundle and any input files then posts it to `/jobs` on the running worker. The returned job identifier is printed to the console.
+Set `GENECODER_API_TOKEN` to your desired bearer token. When the server is
+running it serves the dashboard from `web/helix-ui/dist` at the root URL.


### PR DESCRIPTION
## Summary
- clarify cloud removal notice in `cloud_worker.md`
- update deployment guide to run the server locally
- drop outdated remote workflow instructions from bundle docs

## Testing
- `pre-commit` *(skipped: documentation changes only)*

------
https://chatgpt.com/codex/tasks/task_e_68813e24e1cc8326997b0fa4e8f08072