### PR TITLE
Add pipeline command

### DIFF
--- a/src/genecoder/cli/__init__.py
+++ b/src/genecoder/cli/__init__.py
@@ -9,6 +9,7 @@ from .options import (
 )
 from .encode import run_encoding_pipeline, encode_files
 from .decode import run_decoding_pipeline, decode_files
+from ..core import run_pipeline
 from .cli import main
 from .channel import process_channel, run_channel
 from .analyze import analyze_files
@@ -25,6 +26,7 @@ __all__ = [
     "build_decoding_options",
     "decode_files",
     "run_decoding_pipeline",
+    "run_pipeline",
     "analyze_files",
     "main",
     "process_channel",

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -21,6 +21,7 @@ decode_ai: Any | None = None
 stats: Any | None = None
 data: Any | None = None
 dashboard: Any | None = None
+pipeline: Any | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -70,9 +71,10 @@ def build_parser() -> argparse.ArgumentParser:
         stats as _stats,
         data as _data,
         dashboard as _dashboard,
+        pipeline as _pipeline,
     )
 
-    global encode, decode, analyze, report, channel, bundle, plugin, benchmark, decode_ai, stats, data, dashboard
+    global encode, decode, analyze, report, channel, bundle, plugin, benchmark, decode_ai, stats, data, dashboard, pipeline
 
     encode = _encode
     decode = _decode
@@ -86,6 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     stats = _stats
     data = _data
     dashboard = _dashboard
+    pipeline = _pipeline
 
 
     # Load plugins here so that dynamically registered codecs, FEC backends and
@@ -118,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     stats.register_subcommand(subparsers)
     data.register_subcommand(subparsers)
     dashboard.register_subcommand(subparsers)
+    pipeline.register_subcommand(subparsers)
 
     return parser
 

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""CLI helpers for the core encode/ECC/channel/decode pipeline."""
+
+import argparse
+import logging
+
+from genecoder.core import run_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        "pipeline", help="Run encode->FEC->channel->decode pipeline"
+    )
+    codec_choices = sorted(CODEC_REGISTRY.keys()) or None
+    fec_choices = sorted(FEC_REGISTRY.keys())
+    chan_choices = ["none", *sorted(SIMULATOR_REGISTRY.keys())]
+    parser.add_argument("input", help="Path to input file")
+    parser.add_argument("output", help="Path to output file")
+    parser.add_argument("--codec", required=True, choices=codec_choices)
+    if fec_choices:
+        parser.add_argument("--fec", choices=fec_choices, default=None)
+    else:
+        parser.add_argument("--fec", default=None)
+    parser.add_argument("--channel", choices=chan_choices, default="none")
+    parser.set_defaults(func=_handle_command)
+
+
+def _handle_command(args: argparse.Namespace) -> None:
+    run_pipeline(args.codec, args.fec, args.channel, args.input, args.output)

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Simple encode/ECC/channel/decode pipeline utilities."""
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
+from .simulators import SIMULATOR_REGISTRY
+
+__all__ = ["run_pipeline"]
+
+
+def run_pipeline(
+    codec: str,
+    fec: str | None,
+    channel: str | None,
+    input_path: str,
+    output_path: str,
+) -> bytes:
+    """Process ``input_path`` through the selected codec, FEC and channel.
+
+    The decoded bytes are written to ``output_path`` and also returned.
+    """
+    init_plugins()
+
+    if codec not in CODEC_REGISTRY:
+        raise ValueError(f"Unknown codec: {codec}")
+    if fec and fec not in FEC_REGISTRY:
+        raise ValueError(f"Unknown FEC: {fec}")
+    if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
+        raise ValueError(f"Unknown channel: {channel}")
+
+    data = Path(input_path).read_bytes()
+
+    fec_info: Mapping[str, Any] | None = None
+    if fec:
+        data, fec_info = FEC_REGISTRY[fec]["encode"](data)
+
+    dna = CODEC_REGISTRY[codec]["encode"](data)
+
+    if channel and channel != "none":
+        dna = SIMULATOR_REGISTRY[channel].simulate(dna)
+
+    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
+    assert isinstance(decoded_any, (bytes, bytearray))
+    decoded = bytes(decoded_any)
+
+    if fec:
+        assert fec_info is not None
+        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
+
+    Path(output_path).write_bytes(decoded)
+    return decoded

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genecoder.core import run_pipeline
+from genecoder.api import Codec
+from genecoder.plugin_manager import CODEC_REGISTRY, register_codec, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+        return decode_base4_direct(encoded)[0]
+
+
+def test_roundtrip_rs_simple(tmp_path: Path) -> None:
+    if not _HAS_REEDSOLO:
+        pytest.skip("reedsolo not installed")
+
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    SIMULATOR_REGISTRY["simple"] = type(SIMULATOR_REGISTRY["simple"])(error_rate=0.0)
+
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    data = b"pipeline test"
+    inp.write_bytes(data)
+
+    result = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
+    assert result == data
+    assert outp.read_bytes() == data


### PR DESCRIPTION
## Summary
- implement encode/FEC/channel/decode workflow in `core.run_pipeline`
- expose pipeline runner via new `pipeline` CLI command
- register the new command in the main CLI
- export helper in CLI package
- test round‑trip with Reed–Solomon FEC and simple channel

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest tests/test_core_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881693c8f648326a4aa2bd4b6bdb0a6