### PR TITLE
Rename CLI command to genecli

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ using the CLI or GUI. When using GeneCoder as a library call
 Remote plugin sources can be configured via the environment variables
 ``GENECODER_PLUGIN_REGISTRY_URL`` and ``GENECODER_PLUGIN_CATALOG_URL``. Set
 ``GENECODER_PLUGIN_REGISTRY_URL`` to a YAML file with package names to install
-via the ``genecoder plugin install-registry`` command (or the
+via the ``genecli plugin install-registry`` command (or the
 :func:`genecoder.plugins.install_registry_plugins` function) and ``GENECODER_PLUGIN_CATALOG_URL`` to a JSON or YAML catalog
-used by the ``genecoder plugin`` commands. The catalog URL may be an HTTP(S)
+used by the ``genecli plugin`` commands. The catalog URL may be an HTTP(S)
 address or a local file via ``file://``.
 
 ```bash
@@ -204,7 +204,7 @@ export GENECODER_PLUGIN_CATALOG_URL=https://example.com/catalog.yaml
 Install registry packages with:
 
 ```bash
-genecoder plugin install-registry --allow-registry
+genecli plugin install-registry --allow-registry
 ```
 
 The `--allow-registry` flag is required to opt in to downloading and

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -1,9 +1,9 @@
 # Bundle Archives
 
-The `genecoder bundle run` command executes the steps defined in a YAML configuration. When the run completes, passing the `--export-archive` flag creates a gzipped tar archive containing the entire run directory. Optional `--author` and `--description` flags add metadata to the generated summary file.
+The `genecli bundle run` command executes the steps defined in a YAML configuration. When the run completes, passing the `--export-archive` flag creates a gzipped tar archive containing the entire run directory. Optional `--author` and `--description` flags add metadata to the generated summary file.
 
 ```
-genecoder bundle run workflow.yml --cache-dir runs --export-archive output.tar.gz
+genecli bundle run workflow.yml --cache-dir runs --export-archive output.tar.gz
 ```
 
 The archive has the following layout:

--- a/docs/cli_tutorial.md
+++ b/docs/cli_tutorial.md
@@ -7,16 +7,16 @@ This tutorial walks through basic command-line usage of GeneCoder.
 ```bash
 pip install genecoder[cli]
 
-genecoder encode --input-files example.txt --output-file example.fasta --method base4_direct
+genecli encode --input-files example.txt --output-file example.fasta --method base4_direct
 ```
 
 ## Decoding a file
 
 ```bash
-genecoder decode --input-files example.fasta --output-file decoded.txt --method base4_direct
+genecli decode --input-files example.fasta --output-file decoded.txt --method base4_direct
 ```
 
-See `genecoder --help` for all available options.
+See `genecli --help` for all available options.
 
 ## Running a bundle
 
@@ -33,7 +33,7 @@ decode:
 Execute the bundle:
 
 ```bash
-genecoder bundle run bundle.yaml --cache-dir runs/
+genecli bundle run bundle.yaml --cache-dir runs/
 ```
 
 Results are written to `runs/<hash>/<timestamp>/` and skipped when the same

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -2,4 +2,4 @@
 
 The previous cloud submission feature has been removed.
 All workflows should now be run locally with the standard CLI commands.
-Use `genecoder bundle run` to execute bundles on your machine.
+Use `genecli bundle run` to execute bundles on your machine.

--- a/docs/cloud_worker.md
+++ b/docs/cloud_worker.md
@@ -1,4 +1,4 @@
 # Cloud Worker Removed
 
 Previous versions of GeneCoder shipped a REST worker and Docker image for remote bundle execution. This component is no longer maintained.
-All workflows should run locally using `genecoder bundle run`.
+All workflows should run locally using `genecli bundle run`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,7 +127,7 @@ pre-commit install
 Verify the installation with a quick smoke test:
 
 ```powershell
-genecoder --version
+genecli --version
 poetry run pytest -q
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,13 +15,13 @@ metrics file location.
 GeneCoder's north-star goal is to accelerate DNA storage research by enabling more oligos to be simulated each week. The `oligos_per_week` metric aggregates `oligos_simulated_ts` into ISO weeks, providing a clear view of weekly usage trends.
 
 
-Display these values with `genecoder stats` or via the `/metrics` web API.
+Display these values with `genecli stats` or via the `/metrics` web API.
 Weekly counts appear under `oligos_per_week`.
 
 Example CLI output:
 
 ```bash
-$ genecoder stats
+$ genecli stats
 encode_runs: 3
 bundle_runs: 1
 oligos_simulated: 5

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -4,7 +4,7 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 
 ## Built-in simulators
 
-- **simple** — random substitution errors. Use `genecoder channel --sub-prob` or
+- **simple** — random substitution errors. Use `genecli channel --sub-prob` or
   `--simulator simple`.
 - **indel** — introduces insertions and deletions in addition to substitutions.
 - **none** — disable simulation (the default).
@@ -83,35 +83,35 @@ sudo make install
 Apply simple substitutions with a chosen probability using the ``channel`` command:
 
 ```bash
-genecoder channel --input-file input.fasta --output-file corrupted.fasta \
+genecli channel --input-file input.fasta --output-file corrupted.fasta \
     --sub-prob 0.02
-genecoder decode corrupted.fasta --output-file decoded.bin <other options>
+genecli decode corrupted.fasta --output-file decoded.bin <other options>
 ```
 
 Invoke a sequencing simulator before decoding:
 
 ```bash
-genecoder decode --simulator illumina <other options>
-genecoder decode --simulator nanopore <other options>
+genecli decode --simulator illumina <other options>
+genecli decode --simulator nanopore <other options>
 ```
 
 Invoke an external simulator before decoding:
 
 ```bash
-genecoder decode --simulator d2sim <other options>
+genecli decode --simulator d2sim <other options>
 ```
 
 Provide additional parameters to ``d2sim`` using ``--d2sim-options``:
 
 ```bash
-genecoder decode --simulator d2sim --d2sim-options "--seed 42" <other options>
+genecli decode --simulator d2sim --d2sim-options "--seed 42" <other options>
 ```
 
 Provide extra flags to ``dnarsim`` or ``squigulator`` in the same way:
 
 ```bash
-genecoder decode --simulator dnarsim --dnarsim-options "<opts>" <other options>
-genecoder decode --simulator squigulator --squigulator-options "<opts>" <other options>
+genecli decode --simulator dnarsim --dnarsim-options "<opts>" <other options>
+genecli decode --simulator squigulator --squigulator-options "<opts>" <other options>
 ```
 
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,15 +9,15 @@ For a hands-on introduction check the Jupyter notebooks in the [notebooks/](../n
 GeneCoder operations are performed with the `genecoder` CLI:
 
 ```bash
-genecoder <command> --input-files <path1> [<path2> ...] \
+genecli <command> --input-files <path1> [<path2> ...] \
     [--output-file <path>] [--output-dir <dir>] \
     --method <method_name> [--fec <fec_method>] [options]
 ```
 
-Run `genecoder --help` to see all available commands:
+Run `genecli --help` to see all available commands:
 
 ```bash
-genecoder --help
+genecli --help
 ```
 
 Example output:
@@ -25,8 +25,8 @@ Example output:
 A quick sanity check is to run the command and ensure the usage header appears.
 
 ```bash
-$ genecoder --help | head -n 5
-Usage: genecoder [-h] [--version] {encode,decode,analyze,channel} ...
+$ genecli --help | head -n 5
+Usage: genecli [-h] [--version] {encode,decode,analyze,channel} ...
 GeneCoder: Encode and decode data into simulated DNA sequences.
 ...
 ```
@@ -50,21 +50,21 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 1. **Encode using Base-4 Direct Mapping**
 
    ```bash
-   genecoder encode --input-files path/to/your_document.txt \
+   genecli encode --input-files path/to/your_document.txt \
        --output-file encoded_base4.fasta --method base4_direct
    ```
 
 2. **Decode using Base-4 Direct Mapping**
 
    ```bash
-   genecoder decode --input-files path/to/encoded_base4.fasta \
+   genecli decode --input-files path/to/encoded_base4.fasta \
        --output-file decoded_document.txt --method base4_direct
    ```
 
 3. **Encode with Huffman, parity and Triple-Repeat FEC**
 
    ```bash
-   genecoder encode --input-files path/to/my_data.bin \
+   genecli encode --input-files path/to/my_data.bin \
        --output-dir encoded_output/ --method huffman \
        --add-parity --fec triple_repeat
    ```
@@ -72,7 +72,7 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 4. **Encode using the base6 alphabet**
 
    ```bash
-   genecoder encode --input-files data.bin \
+   genecli encode --input-files data.bin \
        --output-file encoded_base6.fasta --alphabet base6
    ```
 
@@ -83,21 +83,21 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 5. **Encode with Base-4 Direct and Hamming(7,4) FEC**
 
    ```bash
-   genecoder encode --input-files path/to/important_data.txt \
+   genecli encode --input-files path/to/important_data.txt \
        --output-dir encoded_hamming/ --method base4_direct --fec hamming_7_4
    ```
 
 6. **Decode a Hamming(7,4) encoded file**
 
    ```bash
-   genecoder decode --input-files encoded_hamming/important_data.txt.fasta \
+   genecli decode --input-files encoded_hamming/important_data.txt.fasta \
        --output-file decoded_important_data.txt --method base4_direct
    ```
 
 7. **Batch encode multiple files using GC-Balanced**
 
    ```bash
-   genecoder encode --input-files file1.txt notes.md image.png \
+   genecli encode --input-files file1.txt notes.md image.png \
        --output-dir gc_encoded_batch/ --method gc_balanced \
        --gc-min 0.40 --gc-max 0.60 --max-homopolymer 4
    ```
@@ -105,16 +105,16 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 8. **Batch decode multiple FASTA files**
 
    ```bash
-   genecoder decode --input-files gc_encoded_batch/*.fasta \
+   genecli decode --input-files gc_encoded_batch/*.fasta \
        --output-dir decoded_batch/ --method gc_balanced
    ```
 
 9. **Stream encode and decode a large file**
 
    ```bash
-   genecoder encode --input-files big.bin --output-file big.fasta \
+   genecli encode --input-files big.bin --output-file big.fasta \
        --stream --method base4_direct
-   genecoder decode --input-files big.fasta --output-file big_decoded.bin \
+   genecli decode --input-files big.fasta --output-file big_decoded.bin \
        --stream --method base4_direct
    ```
 
@@ -124,9 +124,9 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 10. **Introduce channel errors before decoding**
 
    ```bash
-   genecoder channel --input-file encoded.fasta --output-file corrupted.fasta \
+   genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
        --sub-prob 0.02
-   genecoder decode corrupted.fasta --output-file decoded.bin
+   genecli decode corrupted.fasta --output-file decoded.bin
    ```
 
    Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
@@ -135,11 +135,11 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 11. **Encode, corrupt and decode a file with automatic extensions**
 
    ```bash
-   genecoder encode --input-files hello.jpg --output-dir encoded \
+   genecli encode --input-files hello.jpg --output-dir encoded \
        --method base4_direct --auto-ext
-   genecoder channel --input-file encoded/hello.jpg.dna --output-file corrupted.dna \
+   genecli channel --input-file encoded/hello.jpg.dna --output-file corrupted.dna \
        --sub-prob 0.01
-   genecoder decode corrupted.dna --output-dir decoded --auto-ext
+   genecli decode corrupted.dna --output-dir decoded --auto-ext
    ```
 
    Verify the round-trip checksum:
@@ -172,7 +172,7 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    ``genecoder.simulators.simulate_reads``.
 
    ```bash
-   genecoder decode --input-files encoded.fasta \
+   genecli decode --input-files encoded.fasta \
        --output-file decoded.bin --simulator squigulator
    ```
 
@@ -181,7 +181,7 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    Apply multiple simulators and enforce synthesis constraints:
 
    ```bash
-   genecoder channel --input-file encoded.fasta \
+   genecli channel --input-file encoded.fasta \
        --output-file channel.fasta --simulator simple --simulator indel
    ```
 
@@ -196,7 +196,7 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    ```
 
 ```bash
-genecoder channel run config.yml
+genecli channel run config.yml
 ```
 
    The command processes each FASTA record through a pipeline of steps. Set
@@ -204,7 +204,7 @@ genecoder channel run config.yml
    parallel:
 
 ```bash
-genecoder channel run config.yml
+genecli channel run config.yml
 ```
 
 14. **AI-assisted decoding**
@@ -214,7 +214,7 @@ genecoder channel run config.yml
 
    ```bash
    poetry install --extras dnaformer --no-interaction
-   genecoder decode --input-files noisy.fasta --output-file out.bin \
+   genecli decode --input-files noisy.fasta --output-file out.bin \
        --method ai
    ```
 
@@ -222,7 +222,7 @@ genecoder channel run config.yml
 
    ```bash
    poetry install --extras deepdna --no-interaction
-   genecoder decode --input-files noisy.fasta --output-file out.bin \
+   genecli decode --input-files noisy.fasta --output-file out.bin \
        --method ai
    ```
 
@@ -263,7 +263,7 @@ Use `--capsule` to store the encoded DNA and related metadata in a single JSON f
 This option works only with one input file. Example:
 
 ```bash
-genecoder encode --input-files msg.txt \
+genecli encode --input-files msg.txt \
     --output-dir out/ --method base4_direct \
     --capsule seq.capsule
 ```
@@ -276,9 +276,9 @@ decoding.
 
 
 ```bash
-genecoder encode --input-files secret.txt \
+genecli encode --input-files secret.txt \
     --output-dir out/ --method base4_direct --encrypt --key key.bin --checksum
-genecoder decode --input-files out/secret.txt.fasta \
+genecli decode --input-files out/secret.txt.fasta \
     --output-dir decoded/ --method base4_direct --encrypt --key key.bin --checksum
 
 ```
@@ -296,7 +296,7 @@ pip install mpi4py
 A minimal invocation on a single node:
 
 ```bash
-mpiexec -n 4 genecoder channel --input-file encoded.fasta \
+mpiexec -n 4 genecli channel --input-file encoded.fasta \
     --output-file mpi_out.fasta --simulator simple \
     --mpi --mpi-workers 4
 ```
@@ -304,7 +304,7 @@ mpiexec -n 4 genecoder channel --input-file encoded.fasta \
 Typical cluster schedulers use commands like `mpirun` or `srun`:
 
 ```bash
-mpirun -n 8 genecoder channel run config.yml --mpi --mpi-workers 8
+mpirun -n 8 genecli channel run config.yml --mpi --mpi-workers 8
 ```
 
 Make sure the `mpi4py` dependency is installed on all worker nodes.
@@ -332,7 +332,7 @@ The dashboard visualizes simulation output stored in a JSON file. Install the op
 
 ```bash
 poetry install --with gui --no-interaction
-genecoder dashboard results.json
+genecli dashboard results.json
 ```
 
 The interface plots GC content distribution and homopolymer histograms, and displays decoding success metrics from the given file.
@@ -341,7 +341,7 @@ The interface plots GC content distribution and homopolymer histograms, and disp
 
 Both the CLI `analyze` command and the GUI provide simple suggestions when a
 sequence falls outside the 40-60% GC range or exceeds the default homopolymer
-limit. After running `genecoder analyze`, a log entry shows the GC content and
+limit. After running `genecli analyze`, a log entry shows the GC content and
 maximum homopolymer length of an adjusted sequence. The GUI displays a
 "Suggested fix" message beneath the encoding status when applicable.
 

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -67,7 +67,7 @@ Ensure the command line interface is available and the test suite passes. On
 Windows this is run from PowerShell just like on Linux:
 
 ```bash
-genecoder --version
+genecli --version
 poetry run pytest -q
 ```
 
@@ -77,7 +77,7 @@ An example configuration file at `configs/vertical_slice_demo.yaml` demonstrates
 using a simulator and Hamming FEC. Run the bundle with:
 
 ```bash
-genecoder bundle run configs/vertical_slice_demo.yaml --cache-dir runs
+genecli bundle run configs/vertical_slice_demo.yaml --cache-dir runs
 ```
 
 The `scripts/vertical_slice.sh` helper executes the same command automatically
@@ -90,7 +90,7 @@ constraints is provided at `configs/channel_demo.yaml`.
 Apply the channel step using:
 
 ```bash
-genecoder channel run configs/channel_demo.yaml
+genecli channel run configs/channel_demo.yaml
 ```
 
 ## Launch the GUI
@@ -125,15 +125,15 @@ manifest before processing resumes:
 
 ```bash
 # initial encode
-genecoder encode --input-files big.bin --output-file big.fasta \
+genecli encode --input-files big.bin --output-file big.fasta \
   --stream --chunk-size 1048576
 
 # resume if interrupted
-genecoder encode --input-files big.bin --output-file big.fasta \
+genecli encode --input-files big.bin --output-file big.fasta \
   --stream --chunk-size 1048576 --resume
 
 # decoding with resume support
-genecoder decode --input-files big.fasta --output-file big.bin \
+genecli decode --input-files big.fasta --output-file big.bin \
   --stream --chunk-size 1048576 --resume
 ```
 
@@ -141,7 +141,7 @@ Using `--mirror` on the `encode` command automatically launches the helix
 viewer displaying the sequence and its reverse complement:
 
 ```bash
-genecoder encode --input-files hello.txt --output-file hello.fasta --mirror
+genecli encode --input-files hello.txt --output-file hello.fasta --mirror
 ```
 
 This document condenses the key steps from the installation and usage guides into a quick demo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ numba = "*"
 playwright = "*"
 
 [tool.poetry.scripts]
-genecoder = "genecoder.cli.cli:main"
+genecli = "genecoder.cli.cli:main"
 
 [tool.poetry.plugins."genecoder.plugins"]
 reverse = "plugins.reverse_codec"

--- a/src/genecoder/cli/__main__.py
+++ b/src/genecoder/cli/__main__.py
@@ -1,4 +1,4 @@
 from .cli import main
 
 if __name__ == "__main__":
-    main()
+    main(prog="genecli")

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -56,7 +56,7 @@ def setup_logging(level: int) -> None:
     root_logger.addHandler(stderr_handler)
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     from . import (
         encode as _encode,
         decode as _decode,
@@ -93,6 +93,7 @@ def build_parser() -> argparse.ArgumentParser:
     init_plugins()
 
     parser = argparse.ArgumentParser(
+        prog=prog,
         description=(
             "GeneCoder: Encode and decode data into simulated DNA sequences. "
             "For educational simulations only; see the README's Disclaimer. "
@@ -124,8 +125,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 
-def main(argv: list[str] | None = None) -> None:
-    parser = build_parser()
+def main(argv: list[str] | None = None, prog: str | None = None) -> None:
+    parser = build_parser(prog)
     args = parser.parse_args(argv)
 
     level = logging.INFO - (args.verbose * 10) + (args.quiet * 10)

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -26,4 +26,4 @@ def test_genecoder_version_entrypoint(tmp_path: Path) -> None:
     env["PATH"] = str(env_dir / bindir) + os.pathsep + env.get("PATH", "")
     env["PYTHONPATH"] = str(PROJECT_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
 
-    subprocess.run(["genecoder", "--version"], check=True, env=env)
+    subprocess.run(["genecli", "--version"], check=True, env=env)

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -21,7 +21,7 @@ def test_cli_version(tmp_path: Path):
     subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
     bin_dir = "Scripts" if os.name == "nt" else "bin"
     pip_path = venv_dir / bin_dir / "pip"
-    genecoder_path = venv_dir / bin_dir / "genecoder"
+    genecli_path = venv_dir / bin_dir / "genecli"
 
     subprocess.run([str(pip_path), "install", "-U", "pip", "setuptools", "wheel"], check=True)
     subprocess.run(
@@ -45,7 +45,7 @@ def test_cli_version(tmp_path: Path):
     ], check=True)
 
     result = subprocess.run(
-        [str(genecoder_path), "--version"],
+        [str(genecli_path), "--version"],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Summary
- rename CLI entry point to `genecli`
- use `genecli` in docs
- adjust Python CLI entry points
- update CLI tests for new command name

## Testing
- `pre-commit run --files src/genecoder/cli/__main__.py src/genecoder/cli/cli.py tests/test_cli_entrypoint.py tests/test_cli_version.py`

------
https://chatgpt.com/codex/tasks/task_e_6881693bd7148326b1e00ff6b808fea0