### PR TITLE
Remove remote registry verification

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -6,9 +6,7 @@ from types import ModuleType
 import os
 import sys
 import subprocess
-import tempfile
 import urllib.request
-from urllib.parse import urlparse
 from pathlib import Path
 import importlib
 
@@ -26,11 +24,7 @@ import logging
 import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from .plugin_security import (
-    compute_checksum as _compute_checksum,
-    verify_signature as _verify_signature,
-)
-from .plugin_checks import decode_signature, verify_package
+from .plugin_security import compute_checksum as _compute_checksum
 import base64
 
 
@@ -41,7 +35,6 @@ FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 # re-export for tests
-verify_signature = _verify_signature
 compute_checksum = _compute_checksum
 
 
@@ -91,133 +84,41 @@ def register_simulator(name: str, channel: Simulator) -> None:
 
 
 
-def _install_registry_plugins(url: str) -> None:
+
+
+def install_registry_plugins(url: str | None = None) -> None:
     """Install plugin packages listed in a YAML registry at ``url``."""
+
+    if url is None:
+        return
 
     if yaml is None:
         logger.warning("YAML support unavailable; skipping registry %s", url)
         return
 
-    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
-    pubkey: bytes | None = None
-    if key_path:
-        try:
-            pubkey = Path(key_path).read_bytes()
-        except Exception:  # pragma: no cover - filesystem error path
-            logger.warning("Failed to read public key %s", key_path)
-            pubkey = None
-
-    if urlparse(url).scheme != "https":
-        logger.warning("Insecure plugin registry URL %s", url)
-        return
-
     try:
         with urllib.request.urlopen(url, timeout=30) as response:
             raw = response.read()
-    except Exception as exc:  # pragma: no cover - network error path
-        logger.warning("Failed to fetch plugin registry %s: %s", url, exc)
-        return
-
-    try:
         data = yaml.safe_load(raw) or {}
     except Exception as exc:
-        logger.warning("Failed to parse plugin registry %s: %s", url, exc)
+        logger.warning("Failed to fetch or parse plugin registry %s: %s", url, exc)
         raise ValueError("Invalid plugin registry YAML") from exc
 
     for entry in data.get("packages", []):
+        spec = ""
         if isinstance(entry, dict):
-            spec = str(
-                entry.get("spec") or entry.get("package") or entry.get("url") or ""
-            )
-            checksum = str(entry.get("checksum", ""))
-            sig_b64 = entry.get("signature")
-            if not isinstance(sig_b64, str):
-                msg = f"Missing signature for plugin entry {entry}"
-                logger.error(msg)
-                raise ValueError(msg)
-            try:
-                signature = decode_signature(sig_b64)
-            except ValueError as exc:
-                msg = f"Invalid signature for plugin entry {entry}"
-                logger.error(msg)
-                raise ValueError(msg) from exc
+            spec = str(entry.get("spec") or entry.get("package") or entry.get("url") or "")
         else:
-            logger.warning("Missing checksum for plugin entry %s", entry)
-            continue
+            spec = str(entry)
 
-        if not spec or not checksum:
-            logger.warning("Incomplete plugin entry in registry: %s", entry)
-            continue
-
-        scheme = urlparse(spec).scheme
-        if scheme not in {"https", "file"}:
-            logger.warning("Insecure plugin URL %s", spec)
+        if not spec:
+            logger.warning("Missing spec for plugin entry %s", entry)
             continue
 
         try:
-            with urllib.request.urlopen(spec, timeout=30) as resp:
-                pkg_bytes = resp.read()
-        except Exception as exc:  # pragma: no cover - download error path
-            logger.warning("Failed to download plugin %s: %s", spec, exc)
-            continue
-
-        try:
-            digest = verify_package(
-                pkg_bytes,
-                checksum=checksum,
-                signature=signature,
-                public_key=pubkey,
-                compute_fn=compute_checksum,
-            )
-        except ValueError as exc:
-            if str(exc) == "Checksum mismatch":
-                logger.warning("Checksum mismatch for plugin %s", spec)
-                continue
-            msg = f"Invalid signature for plugin {spec}: {exc}"
-            logger.error(msg)
-            raise ValueError(msg) from exc
-
-        tmp_file = None
-        req_file = None
-        try:
-            suffix = os.path.splitext(urlparse(spec).path)[1]
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                tmp.write(pkg_bytes)
-                tmp_file = tmp.name
-
-            with tempfile.NamedTemporaryFile("w", delete=False) as req:
-                req.write(f"{tmp_file} --hash=sha256:{digest}\n")
-                req_file = req.name
-
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--require-hashes",
-                    "-r",
-                    req_file,
-                ]
-            )
+            subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
         except Exception as exc:  # pragma: no cover - install error path
             logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
-        finally:
-            for path in (tmp_file, req_file):
-                if path:
-                    try:
-                        os.unlink(path)
-                    except Exception:
-                        pass
-
-
-def install_registry_plugins(url: str | None = None) -> None:
-    """Install packages from a registry URL or :envvar:`GENECODER_PLUGIN_REGISTRY_URL`."""
-    if url is None:
-        url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
-    if not url:
-        return
-    _install_registry_plugins(url)
 
 
 def _load_and_register(

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -6,7 +6,7 @@ import pytest
 
 from genecoder.core import run_pipeline
 from genecoder.api import Codec
-from genecoder.plugin_manager import CODEC_REGISTRY, register_codec, init_plugins
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.reed_solomon_codec import _HAS_REEDSOLO
 

--- a/tests/test_plugin_install_malformed.py
+++ b/tests/test_plugin_install_malformed.py
@@ -17,9 +17,8 @@ def test_install_registry_plugins_malformed_yaml(monkeypatch: pytest.MonkeyPatch
         assert url == "https://example.com/plugins.yaml"
         return DummyResponse(b"not: [yaml")
 
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
     with pytest.raises(ValueError, match="Invalid plugin registry YAML"):
-        plugins.install_registry_plugins()
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,23 +1,15 @@
 import sys
 import logging
-import types
-import os
-
-# Provide a stub for portalocker if the real module is unavailable
-portalocker_stub = types.ModuleType("portalocker")
-portalocker_stub.Lock = lambda *a, **k: open(os.devnull, "w")  # type: ignore[attr-defined]
-sys.modules.setdefault("portalocker", portalocker_stub)
 
 from typing import Callable
+from pathlib import Path
+import base64
 
 import pytest
 
 httpx = pytest.importorskip("httpx")
 
 import genecoder.plugin_manager as plugins
-from genecoder.plugin_security import compute_checksum
-import base64
-from pathlib import Path
 
 
 class DummyResponse:
@@ -34,321 +26,70 @@ class DummyResponse:
         return self._data
 
 
-def test_registry_install(monkeypatch):
-    installs = []
+def test_registry_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    installs: list[list[str]] = []
 
-    def fake_check_call(cmd):
+    def fake_check_call(cmd: list[str]) -> None:
         installs.append(cmd)
 
-    def fake_urlopen(url, *, timeout=None):
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         if url == "https://example.com/plugins.yaml":
-            pkg_a = b"AAA"
-            pkg_b = b"BBB"
-            c1 = compute_checksum(pkg_a)
-            c2 = compute_checksum(pkg_b)
-            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgA.whl\n    checksum: {c1}\n    signature: {sig}\n"
-                f"  - spec: https://example.com/pkgB.whl\n    checksum: {c2}\n    signature: {sig}"
+                "  - spec: https://example.com/pkgA.whl\n"
+                "  - spec: https://example.com/pkgB.whl\n"
             ).encode()
             return DummyResponse(data)
-        elif url == "https://example.com/pkgA.whl":
-            return DummyResponse(b"AAA")
-        elif url == "https://example.com/pkgB.whl":
-            return DummyResponse(b"BBB")
         raise AssertionError(url)
 
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    orig_compute = plugins.compute_checksum
 
-    def fake_compute(
-        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
-    ) -> str:
-        if signature is not None:
-            assert signature == b"sig"
-            assert public_key == b"PUB"
-        return orig_compute(data)
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
-    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
-
-    plugins.install_registry_plugins()
-
-    assert [cmd[:5] for cmd in installs] == [
-        [sys.executable, "-m", "pip", "install", "--require-hashes"],
-        [sys.executable, "-m", "pip", "install", "--require-hashes"],
+    assert installs == [
+        [sys.executable, "-m", "pip", "install", "https://example.com/pkgA.whl"],
+        [sys.executable, "-m", "pip", "install", "https://example.com/pkgB.whl"],
     ]
 
 
-def test_registry_install_failure(monkeypatch, caplog):
-    def fake_check_call(cmd):
+def test_registry_install_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    def fake_check_call(cmd: list[str]) -> None:
         raise RuntimeError("boom")
 
-    def fake_urlopen(url, *, timeout=None):
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         if url == "https://example.com/plugins.yaml":
-            pkg = b"CCC"
-            c1 = compute_checksum(pkg)
-            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgC.whl\n    checksum: {c1}\n    signature: {sig}"
+                "  - spec: https://example.com/pkgC.whl\n"
             ).encode()
             return DummyResponse(data)
-        elif url == "https://example.com/pkgC.whl":
-            return DummyResponse(b"CCC")
         raise AssertionError(url)
 
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
 
     with caplog.at_level(logging.WARNING):
-        plugins.install_registry_plugins()
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
-    assert (
-        "Failed to install plugin https://example.com/pkgC.whl from registry"
-        in caplog.text
-    )
+    assert "Failed to install plugin https://example.com/pkgC.whl from registry" in caplog.text
 
 
-def test_registry_bad_yaml(monkeypatch, caplog):
-    def fake_urlopen(url, *, timeout=None):
+def test_registry_bad_yaml(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         assert url == "https://example.com/plugins.yaml"
         return DummyResponse(b"not: [yaml")
 
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
 
     with caplog.at_level(logging.WARNING), pytest.raises(ValueError):
-        plugins.install_registry_plugins()
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
-    assert "Failed to parse plugin registry" in caplog.text
-
-
-def test_registry_checksum_mismatch(monkeypatch, caplog):
-    installs = []
-
-    def fake_check_call(cmd):
-        installs.append(cmd)
-
-    def fake_urlopen(url, *, timeout=None):
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            wrong = compute_checksum(b"WRONG")
-            sig = base64.b64encode(b"sig").decode()
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkgD.whl\n    checksum: {wrong}\n    signature: {sig}"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkgD.whl":
-            return DummyResponse(b"DDD")
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
-
-    with caplog.at_level(logging.WARNING):
-        plugins.install_registry_plugins()
-
-    assert not installs
-    assert "Checksum mismatch for plugin https://example.com/pkgD.whl" in caplog.text
-
-
-def test_registry_signature_failure(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    pkg = b"FFF"
-    checksum = compute_checksum(pkg)
-
-    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            sig = base64.b64encode(b"sig").decode()
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkgF.whl\n    checksum: {checksum}\n    signature: {sig}"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkgF.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    installs: list[list[str]] = []
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-
-    def fake_compute(
-        data: bytes,
-        *,
-        signature: bytes | None = None,
-        public_key: bytes | None = None,
-    ) -> str:
-        if signature is not None:
-            raise ValueError("bad sig")
-        return compute_checksum(data)
-
-    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
-
-    with pytest.raises(ValueError, match="Invalid signature"):
-        with caplog.at_level(logging.ERROR):
-            plugins.install_registry_plugins()
-
-    assert not installs
-    assert "Invalid signature for plugin https://example.com/pkgF.whl" in caplog.text
-
-
-def test_registry_missing_signature_error(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    pkg = b"GGG"
-    checksum = compute_checksum(pkg)
-
-    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkgG.whl\n    checksum: {checksum}\n"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkgG.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-
-    with pytest.raises(ValueError, match="Missing signature"):
-        with caplog.at_level(logging.ERROR):
-            plugins.install_registry_plugins()
-
-    assert "Missing signature for plugin entry" in caplog.text
-
-
-def test_registry_invalid_signature_format(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    pkg = b"HHH"
-    checksum = compute_checksum(pkg)
-
-    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkgH.whl\n    checksum: {checksum}\n    signature: not_base64"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkgH.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-
-    with pytest.raises(ValueError, match="Invalid signature"):
-        with caplog.at_level(logging.ERROR):
-            plugins.install_registry_plugins()
-
-    assert "Invalid signature for plugin entry" in caplog.text
-
-
-def test_registry_checksum_validation(monkeypatch):
-    """The checksum is computed from the downloaded package bytes."""
-    pkg = b"EEE"
-    expected = compute_checksum(pkg)
-    calls: list[bytes] = []
-
-    orig_compute = compute_checksum
-
-    def fake_compute_checksum(data: bytes) -> str:
-        calls.append(data)
-        return orig_compute(data)
-
-    def fake_urlopen(url, *, timeout=None):
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            sig = base64.b64encode(b"sig").decode()
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkgE.whl\n    checksum: {expected}\n    signature: {sig}"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkgE.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: fake_compute_checksum(d),
-    )
-
-    plugins.install_registry_plugins()
-
-    assert calls == [pkg]
+    assert "Failed to fetch or parse plugin registry" in caplog.text
 
 
 def _urlopen_via_httpx(client: httpx.Client) -> Callable[[str], DummyResponse]:
@@ -363,17 +104,13 @@ def _urlopen_via_httpx(client: httpx.Client) -> Callable[[str], DummyResponse]:
 
 
 def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Plugins are installed when checksums match using ``httpx``."""
-
     pkg = b"PKG"
-    checksum = compute_checksum(pkg)
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/plugins.yaml":
-            sig = base64.b64encode(b"sig").decode()
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
+                "  - spec: https://example.com/pkg.whl\n"
             )
             return httpx.Response(200, text=data)
         elif request.url.path == "/pkg.whl":
@@ -383,21 +120,10 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
     client = httpx.Client(transport=httpx.MockTransport(handler))
     installs: list[list[str]] = []
 
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.urllib.request, "urlopen", _urlopen_via_httpx(client))
     monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
 
-    plugins.install_registry_plugins()
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
     assert installs and installs[0][:4] == [
         sys.executable,
@@ -407,53 +133,7 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
-def test_registry_install_via_httpx_checksum_mismatch(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Installation is refused when the checksum does not match."""
-
-    pkg = b"PKG"
-    wrong = compute_checksum(b"WRONG")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/plugins.yaml":
-            sig = base64.b64encode(b"sig").decode()
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong}\n    signature: {sig}"
-            )
-            return httpx.Response(200, text=data)
-        elif request.url.path == "/pkg.whl":
-            return httpx.Response(200, content=pkg)
-        raise AssertionError(request.url)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    installs: list[list[str]] = []
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml"
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", _urlopen_via_httpx(client))
-    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
-
-    with caplog.at_level(logging.WARNING):
-        plugins.install_registry_plugins()
-
-    assert not installs
-    assert "Checksum mismatch for plugin https://example.com/pkg.whl" in caplog.text
-
-
 def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Catalog signatures are verified using the configured public key."""
-
     key = Path("/tmp/pub.pem")
     key.write_text("PUB")
 
@@ -461,11 +141,14 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[bytes, bytes, bytes]] = []
 
     def fake_compute(
-        data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
     ) -> str:
         assert signature is not None and public_key is not None
         calls.append((data, signature, public_key))
-        return compute_checksum(data)
+        return plugins.compute_checksum(data)
 
     monkeypatch.setenv("GENECODER_CATALOG_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -1,10 +1,6 @@
-import base64
-from pathlib import Path
-
 import pytest
 
 import genecoder.plugin_manager as plugins
-from genecoder.plugin_security import compute_checksum
 
 
 class DummyResponse:
@@ -21,38 +17,26 @@ class DummyResponse:
         return self._data
 
 
-def test_load_plugins_with_signed_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_plugins_with_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     pkg = b"PKG"
-    checksum = compute_checksum(pkg)
-    sig = base64.b64encode(b"sig").decode()
 
     def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig}"
+                "  - spec: https://example.com/pkg.whl\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
             return DummyResponse(pkg)
         raise AssertionError(url)
 
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
-    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
 
-    plugins.install_registry_plugins()
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
     plugins.CODEC_REGISTRY.clear()
     plugins.FEC_REGISTRY.clear()
     plugins.SIMULATOR_REGISTRY.clear()
@@ -60,84 +44,3 @@ def test_load_plugins_with_signed_registry(monkeypatch: pytest.MonkeyPatch) -> N
     plugins.load_plugins()
 
     assert "reverse" in plugins.CODEC_REGISTRY
-
-
-def test_load_plugins_registry_missing_signature(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    pkg = b"PKG"
-    checksum = compute_checksum(pkg)
-
-    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkg.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL",
-        "https://example.com/plugins.yaml",
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
-    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
-    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
-
-    with pytest.raises(ValueError, match="Missing signature"):
-        plugins.install_registry_plugins()
-
-
-def test_load_plugins_registry_checksum_mismatch(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    pkg = b"PKG"
-    wrong_checksum = compute_checksum(b"WRONG")
-    sig = base64.b64encode(b"sig").decode()
-
-    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
-        assert timeout == 30
-        if url == "https://example.com/plugins.yaml":
-            data = (
-                "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}\n    signature: {sig}"
-            ).encode()
-            return DummyResponse(data)
-        elif url == "https://example.com/pkg.whl":
-            return DummyResponse(pkg)
-        raise AssertionError(url)
-
-    key = Path("/tmp/pub.pem")
-    key.write_text("PUB")
-    monkeypatch.setenv(
-        "GENECODER_PLUGIN_REGISTRY_URL",
-        "https://example.com/plugins.yaml",
-    )
-    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
-    installs: list[list[str]] = []
-    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
-    monkeypatch.setattr(
-        plugins,
-        "compute_checksum",
-        lambda d, *, signature=None, public_key=None: compute_checksum(d),
-    )
-    monkeypatch.setattr(plugins, "verify_signature", lambda d, s, k: None)
-    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
-
-    plugins.install_registry_plugins()
-
-    assert not installs


### PR DESCRIPTION
## Summary
- simplify plugin registry installation by removing signature and checksum validation
- drop environment variable support for registry URL
- update affected tests

## Testing
- `ruff check src tests`
- `mypy --config-file pyproject.toml --show-error-codes --no-error-summary`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816fafd9908326b0991e238cf1e633