### PR TITLE
Add pipeline roundtrip tests

### DIFF
--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from genecoder.core import run_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.channel_sim import Channel
+from genecoder.api import Codec
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+        return decode_base4_direct(encoded)[0]
+
+
+def _register_base_codec() -> None:
+    CODEC_REGISTRY["base4"] = {
+        "encode": _Base4Codec().encode,
+        "decode": _Base4Codec().decode,
+    }
+
+
+def _setup_simple_channel(rate: float) -> None:
+    SIMULATOR_REGISTRY["simple"] = Channel(error_rate=rate)
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_pipeline_roundtrip_reed_solomon(tmp_path: Path) -> None:
+    init_plugins()
+    _register_base_codec()
+    _setup_simple_channel(rate=0.1)
+
+    data = b"pipeline RS"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
+    assert result == data
+    assert outp.read_bytes() == data
+
+
+def test_pipeline_roundtrip_fountain(tmp_path: Path) -> None:
+    pytest.importorskip("pyfinite")
+    init_plugins()
+    _register_base_codec()
+    _setup_simple_channel(rate=0.1)
+
+    data = b"pipeline fountain"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result = run_pipeline("base4", "fountain", "simple", str(inp), str(outp))
+    assert result == data
+    assert outp.read_bytes() == data
+


### PR DESCRIPTION
## Summary
- add new regression tests for pipeline round-trip with Reed–Solomon and Fountain FEC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881913a163083269a666b61e57a23ac