### PR TITLE
Add plugin challenge scoreboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ The `--allow-registry` flag is required to opt in to downloading and
 executing third-party code. Only use registries from trusted sources.
 
 For details on submitting scores to the plugin challenge and viewing the
-leaderboard interface see
-[docs/plugins.md#challenge-scoreboard](docs/plugins.md#challenge-scoreboard).
+leaderboard interface see the
+[Challenge Scoreboard](docs/plugins.md#challenge-scoreboard) section.
 
 ### Web Server Environment Variables
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -112,3 +112,10 @@ project locally, import GeneCoder or invoke the CLI to register the new plugin.
 Registered codecs and simulators appear in the respective registries once
 `genecoder.plugins.load_plugins()` runs.
 
+
+## Challenge Scoreboard
+
+The GeneCoder web server exposes a small API for recording plugin challenge results. Scores can be retrieved with `GET /catalog/challenge` and new entries submitted via `POST /catalog/challenge`. Include a bearer token in the `Authorization` header when `GENECODER_API_TOKEN` is set.
+
+A React page in `web/helix-ui` displays the standings. After building the web assets open `helix-ui/scoreboard.html` (or `dist/scoreboard.html`) in a browser while the server is running to view the leaderboard.
+

--- a/web/helix-ui/README.md
+++ b/web/helix-ui/README.md
@@ -12,3 +12,7 @@ npm run build
 ```
 
 The compiled assets will be placed in the `dist` folder. During development you can run `npm run dev` to launch a hot-reload server.
+
+## Scoreboard
+
+The React scoreboard page lives in `scoreboard.html` and relies on the `/catalog/challenge` API. After running `npm run build` open `dist/scoreboard.html` directly or visit `/helix-ui/scoreboard.html` while the backend server is running to view and submit challenge scores.


### PR DESCRIPTION
## Summary
- document challenge scoreboard API and React page
- update README link
- mention scoreboard in Helix UI docs

## Testing
- `pre-commit` *(fails: no need since docs only)*

------
https://chatgpt.com/codex/tasks/task_e_68828597403083268f71d4da8ad2ed36