### PR TITLE
Improve plugin spec validation

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -9,6 +9,7 @@ import subprocess
 import urllib.request
 from pathlib import Path
 import importlib
+import re
 
 yaml: ModuleType | None
 try:  # optional dependency
@@ -36,6 +37,19 @@ PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 # re-export for tests
 compute_checksum = _compute_checksum
+
+_SAFE_PKG_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SAFE_URL_RE = re.compile(r"^(?:https?|file)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$")
+
+
+def _validate_spec(spec: str) -> None:
+    """Raise ``ValueError`` if *spec* is not a safe package name or URL."""
+
+    if not spec or re.search(r"[\s;&|`$<>]", spec):
+        raise ValueError("Unsafe plugin spec")
+    if _SAFE_PKG_RE.fullmatch(spec) or _SAFE_URL_RE.fullmatch(spec):
+        return
+    raise ValueError("Unsafe plugin spec")
 
 
 from .api import Codec, FEC, Simulator
@@ -123,6 +137,8 @@ def install_registry_plugins(url: str | None = None) -> None:
         if not spec:
             logger.warning("Missing spec for plugin entry %s", entry)
             continue
+
+        _validate_spec(spec)
 
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", spec])

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,40 @@
+import pytest
+
+import genecoder.plugin_manager as plugins
+
+pytest.importorskip("yaml")
+
+
+class DummyResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+from typing import Callable
+
+
+def _fake_urlopen(data: str) -> Callable[[str], DummyResponse]:
+    def _open(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        return DummyResponse(data.encode())
+
+    return _open
+
+
+@pytest.mark.parametrize("bad", ["bad;rm", "foo bar", "evil&&stuff"])
+def test_install_registry_bad_spec(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    data = f"packages:\n  - spec: {bad}\n"
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", _fake_urlopen(data))
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+
+    with pytest.raises(ValueError):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")


### PR DESCRIPTION
## Summary
- validate plugin specs in `install_registry_plugins`
- add unit tests for invalid specs

## Testing
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_manager.py`
- `mypy --config-file pyproject.toml --show-error-codes src/genecoder/plugin_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828ffd09d48326b64afe0ba34db3fc