### PR TITLE
Improve plugin catalog security

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -26,6 +26,7 @@ import pkgutil
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
 from .plugin_security import compute_checksum as _compute_checksum
 import base64
+import json
 
 
 logger = logging.getLogger(__name__)
@@ -242,12 +243,69 @@ def load_local_plugins() -> list[str]:
 _initialized = False
 
 
+def load_plugin_catalog(url: str | None = None) -> None:
+    """Populate :data:`PLUGIN_CATALOG` from ``url`` or the environment."""
+
+    if url is None:
+        url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
+    if not url:
+        return
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            raw = response.read()
+    except Exception as exc:
+        logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
+        return
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception:
+        yaml_module = yaml
+        if yaml_module is None:
+            logger.warning("Failed to parse plugin catalog %s", url)
+            return
+        try:
+            data = yaml_module.safe_load(raw) or {}
+        except Exception as exc:
+            logger.warning("Failed to parse plugin catalog %s: %s", url, exc)
+            return
+
+    if isinstance(data, dict):
+        signature = data.get("signature")
+        if signature:
+            if not _verify_catalog_signature(raw, signature):
+                logger.warning("Invalid catalog signature for %s", url)
+                return
+        plugins_data = data.get("plugins", data.get("entries", {}))
+    else:
+        plugins_data = data
+
+    catalog: Dict[str, Dict[str, Any]] = {}
+    if isinstance(plugins_data, list):
+        for entry in plugins_data:
+            if isinstance(entry, dict) and "name" in entry:
+                meta = {k: v for k, v in entry.items() if k != "name"}
+                catalog[str(entry["name"])] = meta
+    elif isinstance(plugins_data, dict):
+        for name, meta in plugins_data.items():
+            if isinstance(meta, dict):
+                catalog[str(name)] = dict(meta)
+    else:
+        logger.warning("Invalid plugin catalog format from %s", url)
+        return
+
+    PLUGIN_CATALOG.clear()
+    PLUGIN_CATALOG.update(catalog)
+
+
 def load_plugins() -> None:
     """Load built-in, entry point and local plugins and fetch catalog entries."""
 
     load_builtin_plugins()
     failures = load_entry_point_plugins()
     failures.extend(load_local_plugins())
+    load_plugin_catalog()
     if failures:
         logger.warning("Failed to import plugins: %s", ", ".join(failures))
 

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -1,5 +1,8 @@
-import pytest
+import json
+import logging
 from pathlib import Path
+
+import pytest
 
 pytest.importorskip("fastapi_limiter")
 fastapi = pytest.importorskip("fastapi")
@@ -23,3 +26,40 @@ def test_challenge_endpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert isinstance(data, dict)
     assert "entries" in data
     assert isinstance(data["entries"], dict)
+
+
+def test_load_catalog_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import genecoder.plugin_manager as plugins
+
+    catalog = {"plugins": {"demo": {"description": "Demo"}}, "signature": "sig"}
+    path = tmp_path / "cat.json"
+    path.write_text(json.dumps(catalog))
+
+    calls: list[tuple[bytes, str]] = []
+
+    def fake_verify(data: bytes, sig: str) -> bool:
+        calls.append((data, sig))
+        return True
+
+    monkeypatch.setattr(plugins, "_verify_catalog_signature", fake_verify)
+    plugins.PLUGIN_CATALOG.clear()
+    plugins.load_plugin_catalog(f"file://{path}")
+
+    assert calls == [(path.read_bytes(), "sig")]
+    assert "demo" in plugins.PLUGIN_CATALOG
+
+
+def test_load_catalog_bad_signature(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+    import genecoder.plugin_manager as plugins
+
+    catalog = {"plugins": {"demo": {"description": "Demo"}}, "signature": "sig"}
+    path = tmp_path / "cat.json"
+    path.write_text(json.dumps(catalog))
+
+    monkeypatch.setattr(plugins, "_verify_catalog_signature", lambda d, s: False)
+    plugins.PLUGIN_CATALOG.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugin_catalog(f"file://{path}")
+
+    assert "Invalid catalog signature" in caplog.text
+    assert not plugins.PLUGIN_CATALOG

--- a/tests/test_yaml_errors.py
+++ b/tests/test_yaml_errors.py
@@ -1,6 +1,8 @@
 import pytest
 import genecoder.plugin_manager as plugins
 
+pytest.importorskip("yaml")
+
 
 def test_invalid_yaml_raises_error():
     with pytest.raises(plugins.yaml.YAMLError):


### PR DESCRIPTION
## Summary
- verify signed catalog before loading
- warn and ignore on signature failure
- test valid and invalid catalog signatures
- skip YAML error test when PyYAML is missing

## Testing
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_catalog.py tests/test_yaml_errors.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882859780dc83269f3dfe083fee540a