### PR TITLE
Update plugin docs for checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ genecli plugin install-registry --allow-registry
 
 The `--allow-registry` flag is required to opt in to downloading and
 executing third-party code. Only use registries from trusted sources.
+Every registry entry must include either a `checksum` or a `signature`
+which is verified during installation. Set `GENECODER_PLUGIN_PUBLIC_KEY`
+to the public key path when using signatures.
 
 For details on submitting scores to the plugin challenge and viewing the
 leaderboard interface see the

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -124,10 +124,10 @@ genecli plugin install-registry --allow-registry
 
 The command reads the `packages` array from the YAML document and installs each
 entry with `pip`. Entries may specify a `spec`, `package` or `url` value that is
-passed directly to `pip install`. Optional `checksum` and `signature` fields can
-be included for verification. When a `checksum` is provided the downloaded
-wheel's SHA256 digest must match. A `signature` is validated using the public
-key referenced by `GENECODER_PLUGIN_PUBLIC_KEY`.
+passed directly to `pip install`. **Every entry must now include either a**
+`checksum` **or a** `signature` **field**. When a `checksum` is provided the
+downloaded wheel's SHA256 digest must match. A `signature` is validated using
+the public key referenced by `GENECODER_PLUGIN_PUBLIC_KEY`.
 
 Example registry:
 
@@ -143,6 +143,13 @@ Installing plugins executes code from remote sources. Always verify checksums or
 signatures and only use registry files from trusted providers. The
 `--allow-registry` flag is required to opt in to this behaviour as a safety
 measure.
+
+Example environment setup:
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=https://example.com/plugins.yaml
+export GENECODER_PLUGIN_PUBLIC_KEY=/path/to/public.pem
+```
 
 
 ## Challenge Scoreboard


### PR DESCRIPTION
## Summary
- document mandatory checksum or signature in plugin registries
- note new verification requirement in README

## Testing
- `pre-commit` *(skipped: documentation-only changes)*

------
https://chatgpt.com/codex/tasks/task_e_6882c164c5208326af647d69885b84f3