### PR TITLE
Add YAML configuration to pipeline CLI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -226,6 +226,24 @@ genecli channel run config.yml
        --method ai
    ```
 
+15. **Run the full pipeline from a YAML file**
+
+   Create a configuration with the codec, FEC and channel settings:
+
+   ```yaml
+   codec: base4_direct
+   fec: reed_solomon
+   channel:
+     name: simple
+     substitution_rate: 0.01
+   ```
+
+   Then execute:
+
+   ```bash
+   genecli pipeline input.bin output.bin --config pipeline.yml
+   ```
+
 ### Manifest files
 
 Each encoded file produces a companion JSON manifest capturing the encoding

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -4,31 +4,158 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
+from typing import Any, Dict
 
 from genecoder.core import run_pipeline
-from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY
+from genecoder.plugin_manager import (
+    CODEC_REGISTRY,
+    FEC_REGISTRY,
+    yaml as yaml_module,
+    init_plugins,
+)
 from genecoder.simulators import SIMULATOR_REGISTRY
 
 logger = logging.getLogger(__name__)
 
 
-def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]]:
+    """Parse pipeline settings from a YAML ``path``."""
+
+    if yaml_module is None:  # pragma: no cover - optional dependency
+        import yaml as yaml_fallback
+    else:
+        yaml_fallback = yaml_module
+
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            data = yaml_fallback.safe_load(f) or {}
+        except Exception as exc:  # pragma: no cover - invalid YAML path
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Config file must map keys to values")
+
+    codec = data.get("codec")
+    if not isinstance(codec, str):
+        raise ValueError("'codec' must be a string")
+
+    fec = data.get("fec")
+    if fec is not None and not isinstance(fec, str):
+        raise ValueError("'fec' must be a string")
+
+    channel_info = data.get("channel")
+    channel = None
+    channel_params: Dict[str, Any] = {}
+    if isinstance(channel_info, str):
+        channel = channel_info
+    elif isinstance(channel_info, dict):
+        channel = channel_info.get("name")
+        if not isinstance(channel, str):
+            raise ValueError("'channel' mapping must contain a string 'name'")
+        channel_params = {k: v for k, v in channel_info.items() if k != "name"}
+    elif channel_info is not None:
+        raise ValueError("'channel' must be a string or mapping")
+
+    return codec, fec, channel, channel_params
+
+
+def _run_with_params(
+    codec: str,
+    fec: str | None,
+    channel: str | None,
+    channel_params: Dict[str, Any],
+    input_path: str,
+    output_path: str,
+) -> None:
+    """Run pipeline with optional ``channel_params``."""
+
+    init_plugins()
+
+    if codec not in CODEC_REGISTRY:
+        logger.error("Unknown codec: %s", codec)
+        raise SystemExit(1)
+    if fec and fec not in FEC_REGISTRY:
+        logger.error("Unknown FEC: %s", fec)
+        raise SystemExit(1)
+    if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
+        logger.error("Unknown channel: %s", channel)
+        raise SystemExit(1)
+
+    data = Path(input_path).read_bytes()
+
+    fec_info: Any | None = None
+    if fec:
+        data, fec_info = FEC_REGISTRY[fec]["encode"](data)
+
+    dna = CODEC_REGISTRY[codec]["encode"](data)
+
+    if channel and channel != "none":
+        ch = SIMULATOR_REGISTRY[channel]
+        if channel_params:
+            try:
+                ch = type(ch)(**channel_params)
+            except Exception as exc:
+                logger.error("Invalid channel parameters for %s: %s", channel, exc)
+                raise SystemExit(1)
+        dna = ch.simulate(dna)
+
+    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
+    assert isinstance(decoded_any, (bytes, bytearray))
+    decoded = bytes(decoded_any)
+
+    if fec:
+        assert fec_info is not None
+        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
+
+    Path(output_path).write_bytes(decoded)
+
+
+def register_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
     parser = subparsers.add_parser(
         "pipeline", help="Run encode->FEC->channel->decode pipeline"
     )
     codec_choices = sorted(CODEC_REGISTRY.keys()) or None
     fec_choices = sorted(FEC_REGISTRY.keys())
     chan_choices = ["none", *sorted(SIMULATOR_REGISTRY.keys())]
+
     parser.add_argument("input", help="Path to input file")
     parser.add_argument("output", help="Path to output file")
-    parser.add_argument("--codec", required=True, choices=codec_choices)
+
+    parser.add_argument("--config", help="YAML configuration file")
+
+    parser.add_argument("--codec", choices=codec_choices, default=None)
     if fec_choices:
         parser.add_argument("--fec", choices=fec_choices, default=None)
     else:
         parser.add_argument("--fec", default=None)
-    parser.add_argument("--channel", choices=chan_choices, default="none")
+    parser.add_argument("--channel", choices=chan_choices, default=None)
+
     parser.set_defaults(func=_handle_command)
 
 
 def _handle_command(args: argparse.Namespace) -> None:
-    run_pipeline(args.codec, args.fec, args.channel, args.input, args.output)
+    cfg_codec = cfg_fec = cfg_channel = None
+    cfg_params: Dict[str, Any] = {}
+
+    if args.config:
+        cfg_codec, cfg_fec, cfg_channel, cfg_params = _load_config(args.config)
+
+    codec = args.codec or cfg_codec
+    fec = args.fec if args.fec is not None else cfg_fec
+    channel = args.channel or cfg_channel
+    channel_params = cfg_params if channel == cfg_channel else {}
+
+    if codec is None:
+        logger.error("Codec must be specified via --codec or config")
+        raise SystemExit(1)
+
+    if channel is None:
+        channel = "none"
+
+    if channel_params:
+        _run_with_params(codec, fec, channel, channel_params, args.input, args.output)
+    else:
+        run_pipeline(codec, fec, channel, args.input, args.output)


### PR DESCRIPTION
## Summary
- allow `genecli pipeline` to read codec, FEC and channel settings from a YAML file
- parse simulator parameters from the YAML config
- document pipeline configuration usage

## Testing
- `pytest -q`
- `ruff check src/genecoder/cli/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6882c5bbcf548326b78170c411f6a4e0