### PR TITLE
Improve plugin security checks

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -7,13 +7,14 @@ import os
 import sys
 import subprocess
 import urllib.request
+import tempfile
 from pathlib import Path
 import importlib
 import re
 
 yaml: ModuleType | None
 try:  # optional dependency
-    import yaml as yaml_module
+    import yaml as yaml_module  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover - optional
     yaml = None
 else:
@@ -105,16 +106,19 @@ def install_registry_plugins(url: str | None = None) -> None:
     """Install plugin packages listed in a YAML registry at ``url``."""
 
     if url is None:
+        url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
+    if not url:
         return
 
     yaml_module = yaml
     if yaml_module is None:
         try:  # lazy import for environments where PyYAML may be installed later
-            import yaml as yaml_module
+            import yaml as yaml_module_real
         except Exception:  # pragma: no cover - optional
             logger.warning("YAML support unavailable; skipping registry %s", url)
             return
         else:
+            yaml_module = yaml_module_real
             globals()["yaml"] = yaml_module
     if yaml_module is None:  # for type checkers
         logger.warning("YAML support unavailable; skipping registry %s", url)
@@ -130,8 +134,12 @@ def install_registry_plugins(url: str | None = None) -> None:
 
     for entry in data.get("packages", []):
         spec = ""
+        checksum = None
+        sig_b64: str | None = None
         if isinstance(entry, dict):
             spec = str(entry.get("spec") or entry.get("package") or entry.get("url") or "")
+            checksum = entry.get("checksum")
+            sig_b64 = entry.get("signature")
         else:
             spec = str(entry)
 
@@ -141,10 +149,61 @@ def install_registry_plugins(url: str | None = None) -> None:
 
         _validate_spec(spec)
 
+        install_target = spec
+        pkg_path = None
+        if checksum or sig_b64:
+            try:
+                with urllib.request.urlopen(spec, timeout=30) as resp:
+                    pkg_bytes = resp.read()
+            except Exception as exc:  # pragma: no cover - download error path
+                logger.warning("Failed to download plugin %s: %s", spec, exc)
+                raise
+
+            signature = None
+            public_key = None
+            if sig_b64:
+                try:
+                    signature = base64.b64decode(str(sig_b64), validate=True)
+                except Exception:
+                    logger.error("Invalid signature for plugin %s", spec)
+                    raise ValueError("Invalid signature")
+
+                key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
+                if not key_path:
+                    logger.error("Invalid signature for plugin %s", spec)
+                    raise ValueError("Invalid signature")
+                try:
+                    public_key = Path(key_path).read_bytes()
+                except Exception:
+                    logger.error("Invalid signature for plugin %s", spec)
+                    raise ValueError("Invalid signature")
+
+            try:
+                digest = compute_checksum(pkg_bytes, signature=signature, public_key=public_key)
+            except Exception:
+                logger.error("Invalid signature for plugin %s", spec)
+                raise ValueError("Invalid signature")
+
+            if checksum and digest != str(checksum):
+                logger.error("Checksum mismatch for plugin %s", spec)
+                raise ValueError("Checksum mismatch")
+
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            pkg_path = tmp.name
+            tmp.write(pkg_bytes)
+            tmp.close()
+            install_target = pkg_path
+
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+            subprocess.check_call([sys.executable, "-m", "pip", "install", install_target])
         except Exception as exc:  # pragma: no cover - install error path
             logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
+        finally:
+            if pkg_path is not None:
+                try:
+                    os.unlink(pkg_path)
+                except Exception:
+                    pass
 
 
 def _load_and_register(

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -1,4 +1,5 @@
 import base64
+import sys
 from pathlib import Path
 import logging
 
@@ -69,3 +70,75 @@ def test_registry_invalid_signature(monkeypatch: pytest.MonkeyPatch, caplog: pyt
 
     assert not installs
     assert "Invalid signature for plugin https://example.com/pkg.whl" in caplog.text
+
+
+def test_registry_valid_checksum_and_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+    checksum = compute_checksum(pkg)
+    sig_b64 = base64.b64encode(b"sig").decode()
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig_b64}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+    key = Path("/tmp/pub.pem")
+    key.write_text("PUB")
+
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+    ) -> str:
+        assert signature == b"sig"
+        assert public_key == b"PUB"
+        return compute_checksum(data)
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
+
+    plugins.install_registry_plugins()
+
+    assert installs and installs[0][:4] == [sys.executable, "-m", "pip", "install"]
+
+
+def test_registry_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    pkg = b"PKG"
+    wrong_checksum = "deadbeef"
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        with caplog.at_level(logging.ERROR):
+            plugins.install_registry_plugins()
+
+    assert not installs
+    assert "Checksum mismatch for plugin https://example.com/pkg.whl" in caplog.text


### PR DESCRIPTION
## Summary
- validate registry URLs using environment variable if needed
- verify plugin wheel checksum and signature before installation
- add plugin security tests for checksum and signature verification

## Testing
- `ruff check --fix src/genecoder/plugin_manager.py tests/test_plugin_security.py`
- `mypy --config-file pyproject.toml --show-error-codes src/genecoder/plugin_manager.py`
- `python -m pytest -q tests/test_plugin_security.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c163b214832695dbe3c9c2e9e722