### PR TITLE
Add new run_pipeline simulator tests

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -14,7 +14,7 @@ import re
 
 yaml: ModuleType | None
 try:  # optional dependency
-    import yaml as yaml_module  # type: ignore[import-untyped]
+    import yaml as yaml_module
 except Exception:  # pragma: no cover - optional
     yaml = None
 else:

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -62,3 +62,51 @@ def test_pipeline_roundtrip_fountain(tmp_path: Path) -> None:
     assert result == data
     assert outp.read_bytes() == data
 
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_pipeline_roundtrip_rs_illumina(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    init_plugins()
+    _register_base_codec()
+
+    data = b"pipeline RS illumina"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result = run_pipeline(
+        "base4",
+        "reed_solomon",
+        "illumina",
+        str(inp),
+        str(outp),
+    )
+    assert result == data
+    assert outp.read_bytes() == data
+
+
+def test_pipeline_roundtrip_fountain_nanopore(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pytest.importorskip("pyfinite")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    init_plugins()
+    _register_base_codec()
+
+    data = b"pipeline fountain nanopore"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result = run_pipeline(
+        "base4",
+        "fountain",
+        "nanopore",
+        str(inp),
+        str(outp),
+    )
+    assert result == data
+    assert outp.read_bytes() == data
+


### PR DESCRIPTION
## Summary
- test run_pipeline with Illumina + Reed–Solomon
- test run_pipeline with Nanopore + Fountain
- fix unused mypy ignore in plugin manager

## Testing
- `pre-commit run --files tests/test_pipeline_roundtrip.py src/genecoder/plugin_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c910fddc8326892b9d147b50fc16