### PR TITLE
Document offline plugin operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ export GENECODER_PLUGIN_REGISTRY_URL=https://example.com/registry.yaml
 export GENECODER_PLUGIN_CATALOG_URL=https://example.com/catalog.yaml
 ```
 
+GeneCoder works fully offline unless these variables are set. Plugins are loaded
+from packages already installed in the current Python environment. No network
+requests are made by the plugin manager when the registry and catalog URLs are
+unset. For air‑gapped deployments set them to empty strings to disable remote
+lookups entirely:
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=
+export GENECODER_PLUGIN_CATALOG_URL=
+```
+
 Install registry packages with:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -300,6 +300,20 @@ genecli decode --input-files out/secret.txt.fasta \
     --output-dir decoded/ --method base4_direct --encrypt --key key.bin --checksum
 
 ```
+
+### Offline Operation
+
+GeneCoder functions without network access. Plugins are discovered from packages
+already installed in the current Python environment. Remote registries or
+catalogs are only consulted when `GENECODER_PLUGIN_REGISTRY_URL` or
+`GENECODER_PLUGIN_CATALOG_URL` is set. For air‑gapped deployments leave these
+variables unset or set them to empty strings:
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=
+export GENECODER_PLUGIN_CATALOG_URL=
+```
+
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App


### PR DESCRIPTION
## Summary
- update README to clarify that plugin registries are optional
- describe how to disable remote lookups for air‑gapped environments
- add an Offline Operation section to docs/usage.md

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882dc8595208326ad0d21c62bec7c2a