### PR TITLE
Add network failure registry plugin test

### DIFF
--- a/src/genecoder/fec/framed.py
+++ b/src/genecoder/fec/framed.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Tuple, TYPE_CHECKING
+from typing import Any, Mapping, Tuple, TYPE_CHECKING, cast
 
 from ..api import FEC
 
@@ -55,7 +55,9 @@ def encode_data_framed(data: bytes) -> Tuple[bytes, Any]:
     assert _ffi is not None and _lib is not None
     out_len = _ffi.new("size_t*")
     buf = _lib.framed_encode(data, len(data), out_len)
-    encoded = bytes(_ffi.buffer(buf, out_len[0]))
+    # ``_ffi.buffer`` returns a ``_cffi_backend.buffer``. Cast to ``Any`` so
+    # ``bytes`` can consume it without mypy complaints.
+    encoded = bytes(cast(Any, _ffi.buffer(buf, out_len[0])))
     _lib.framed_free(buf)
     return encoded, {}
 
@@ -68,7 +70,9 @@ def decode_data_framed(encoded: bytes, info: Mapping[str, Any]) -> Tuple[bytes, 
     out_len = _ffi.new("size_t*")
     corrected = _ffi.new("int*")
     buf = _lib.framed_decode(encoded, len(encoded), out_len, corrected)
-    data = bytes(_ffi.buffer(buf, out_len[0]))
+    # Cast ``_ffi.buffer`` result to ``Any`` before converting to ``bytes`` to
+    # placate type checkers.
+    data = bytes(cast(Any, _ffi.buffer(buf, out_len[0])))
     _lib.framed_free(buf)
     return data, int(corrected[0])
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,5 +1,6 @@
 import sys
 import logging
+import subprocess
 
 from typing import Callable
 from pathlib import Path
@@ -155,3 +156,36 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert plugins._verify_catalog_signature(b"DATA", sig_b64)
     assert calls == [(b"DATA", b"sig", b"PUB")]
+
+
+def test_registry_network_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def fake_check_call(cmd: list[str]) -> None:
+        raise subprocess.CalledProcessError(1, cmd, "network unreachable")
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                "  - spec: https://example.com/pkgD.whl\n"
+            ).encode()
+            return DummyResponse(data)
+        raise AssertionError(url)
+
+    class FakeYAML:
+        @staticmethod
+        def safe_load(raw: bytes) -> dict[str, list[str]]:
+            return {"packages": ["https://example.com/pkgD.whl"]}
+
+    monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins, "yaml", FakeYAML)
+
+    with caplog.at_level(logging.WARNING):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")
+
+    assert (
+        "Failed to install plugin https://example.com/pkgD.whl from registry" in caplog.text
+    )


### PR DESCRIPTION
## Summary
- add a regression test for network failures during registry plugin installs
- fix FrameD buffer conversion so mypy passes

## Testing
- `ruff check tests/test_plugin_registry.py`
- `mypy --install-types --non-interactive --config-file pyproject.toml`
- `pytest tests/test_plugin_registry.py::test_registry_network_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_6882e1a071088326b101822a89248f8d