### PR TITLE
Document profile dirs and extend challenge API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ Several environment variables control optional behaviour of the FastAPI server:
 - `GENECODER_CORS_ORIGINS` – comma-separated list of allowed origins for
   Cross-Origin Resource Sharing (CORS). The default `*` permits requests from any
   origin. Restrict this variable to limit which web clients may call the API.
+- `GENECODER_DATA_DIR` – directory used to cache simulator profiles
+  (default `~/.genecoder/data`).
+- `GENECODER_PROFILE_DIR` – optional path with pre-downloaded profiles for
+  running simulators offline.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -314,6 +314,11 @@ export GENECODER_PLUGIN_REGISTRY_URL=
 export GENECODER_PLUGIN_CATALOG_URL=
 ```
 
+Simulator profiles used by external tools are cached under
+`~/.genecoder/data` by default. Set `GENECODER_DATA_DIR` to change this
+location. Provide pre-downloaded profiles via `GENECODER_PROFILE_DIR` to
+run simulators without network access.
+
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App

--- a/tests/test_web_plugin_catalog.py
+++ b/tests/test_web_plugin_catalog.py
@@ -66,3 +66,56 @@ def test_challenge_roundtrip_requires_auth(tmp_path: Path, monkeypatch: pytest.M
     assert r3.status_code == 200
     assert r3.json() == {"entries": {"alice": 5}}
 
+
+def test_challenge_multiple_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GENECODER_API_TOKEN", "tok")
+    main.plugin_catalog.API_TOKEN = "tok"
+    challenge_file = tmp_path / "challenge_data.json"
+    monkeypatch.setattr(main.plugin_catalog, "CHALLENGE_PATH", challenge_file)
+    main.plugin_catalog._challenge = None
+    main.FastAPILimiter.redis = None  # type: ignore[attr-defined]
+
+    for name, pts in [("alice", 3), ("bob", 7)]:
+        r = _request(
+            "POST",
+            "/catalog/challenge",
+            headers={"Authorization": "Bearer tok"},
+            json={"name": name, "points": pts},
+        )
+        assert r.status_code == 200
+
+    main.plugin_catalog._challenge = None
+    r2 = _request("GET", "/catalog/challenge")
+    assert r2.status_code == 200
+    assert r2.json() == {"entries": {"alice": 3, "bob": 7}}
+
+
+def test_challenge_update_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GENECODER_API_TOKEN", "tok")
+    main.plugin_catalog.API_TOKEN = "tok"
+    challenge_file = tmp_path / "challenge_data.json"
+    monkeypatch.setattr(main.plugin_catalog, "CHALLENGE_PATH", challenge_file)
+    main.plugin_catalog._challenge = None
+    main.FastAPILimiter.redis = None  # type: ignore[attr-defined]
+
+    r1 = _request(
+        "POST",
+        "/catalog/challenge",
+        headers={"Authorization": "Bearer tok"},
+        json={"name": "alice", "points": 5},
+    )
+    assert r1.status_code == 200
+
+    r2 = _request(
+        "POST",
+        "/catalog/challenge",
+        headers={"Authorization": "Bearer tok"},
+        json={"name": "alice", "points": 9},
+    )
+    assert r2.status_code == 200
+
+    main.plugin_catalog._challenge = None
+    r3 = _request("GET", "/catalog/challenge")
+    assert r3.status_code == 200
+    assert r3.json() == {"entries": {"alice": 9}}
+


### PR DESCRIPTION
## Summary
- document `GENECODER_DATA_DIR` and `GENECODER_PROFILE_DIR`
- expand web API catalog challenge tests for scoreboard persistence

## Testing
- `ruff check tests/test_web_plugin_catalog.py docs/usage.md README.md`
- `mypy`
- `pytest -q tests/test_web_plugin_catalog.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d1d5e338832689be3ff102822c3a