### PR TITLE
Update offline setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ framework backends. Expect the installation to consume around **2&nbsp;GB** of
 disk space and take roughly **10&nbsp;minutes** on a typical broadband
 connection.
 
+For running GeneCoder without any network access see
+[the offline setup notes](docs/installation.md#offline-setup).
+
 
 Desktop packages are available on the [releases page](https://github.com/d0tTino/GeneCoder/releases).
 Download the `.msix` file for Windows or the `.dmg` for macOS and follow your

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -198,3 +198,21 @@ poetry run mkdocs build
 
 The combined PDF will be available at `site/pdf/combined.pdf`.
 
+## Offline Setup
+
+GeneCoder works without network access by default. Only plugins already
+installed in the current environment are loaded and no external profiles are
+fetched. To explicitly disable remote lookups set these environment variables to
+empty strings:
+
+```bash
+export GENECODER_PLUGIN_REGISTRY_URL=
+export GENECODER_PROFILE_DIR=
+```
+
+Setting `GENECODER_PROFILE_DIR` avoids attempts to download simulator profiles
+while `GENECODER_PLUGIN_REGISTRY_URL` ensures plugins are discovered solely from
+local packages. The CLI and GUI behave the same way when these variables are
+unset or empty, making this the recommended configuration for air‑gapped
+systems.
+


### PR DESCRIPTION
## Summary
- document offline setup in docs/installation.md
- link to the offline notes from README's quick start section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883f1429c4c8326a07c071608ecd7b5