### PR TITLE
Add MPI demo configuration and example docs

### DIFF
--- a/configs/mpi_demo.yaml
+++ b/configs/mpi_demo.yaml
@@ -1,0 +1,10 @@
+# Demo configuration enabling MPI execution with two simple channels
+simulators:
+  - name: simple
+    error_rate: 0.01
+  - name: simple
+    error_rate: 0.02
+pipeline:
+  parallel: true
+  workers: 2
+  use_mpi: true

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -72,3 +72,13 @@ mpiexec -n 4 genecli channel run config.yml
 
 MPI requires an installed MPI implementation (such as MPICH or OpenMPI) in addition to `mpi4py`.
 
+### MPI Example
+
+A ready-to-run configuration at `configs/mpi_demo.yaml` shows two simple channels
+with `use_mpi: true`.
+Execute it using:
+
+```bash
+mpiexec -n 2 genecli channel run configs/mpi_demo.yaml
+```
+


### PR DESCRIPTION
## Summary
- add `configs/mpi_demo.yaml` showing how to enable MPI
- document MPI example in `docs/parallel.md`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e31b30f083268054320df982c6ea