### PR TITLE
Add dashboard metrics fixture and tests

### DIFF
--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -1,0 +1,10 @@
+{
+  "gc_distribution": [0.1, 0.2, 0.3, 0.4],
+  "gc_content": 0.25,
+  "homopolymer_runs": [1, 2, 1, 0],
+  "ecc_success_rates": {
+    "rs": 0.98,
+    "bch": 0.95
+  },
+  "decode_success_rate": 0.97
+}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,36 @@
+import json
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = SimpleNamespace(
+        title=lambda *a, **k: None,
+        write=lambda *a, **k: None,
+        header=lambda *a, **k: None,
+        line_chart=lambda *a, **k: None,
+        metric=lambda *a, **k: None,
+        bar_chart=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    monkeypatch.setitem(sys.modules, "streamlit", dummy)
+
+
+def test_load_metrics_fixture() -> None:
+    path = Path(__file__).parent / "data" / "metrics.json"
+    from genecoder import dashboard
+    expected = json.loads(path.read_text())
+    assert dashboard._load_metrics(str(path)) == expected
+
+
+def test_main_runs(tmp_path: Path) -> None:
+    path = tmp_path / "metrics.json"
+    path.write_text("{}")
+
+    mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
+    mod.main(str(path))


### PR DESCRIPTION
## Summary
- add metrics.json fixture for dashboard
- add tests for `_load_metrics` and `main`

## Testing
- `ruff check tests/test_dashboard.py tests/data/metrics.json`
- `pytest tests/test_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e5a953448326a3fd05367a5c58c0