### PR TITLE
Add manifest metrics support in dashboard

### DIFF
--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -24,6 +24,9 @@ def _load_metrics(path: str) -> dict[str, Any]:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
         if isinstance(data, dict):
+            metrics = data.get("metrics")
+            if isinstance(metrics, dict):
+                return metrics
             return data
     except Exception as exc:  # pragma: no cover - I/O errors are surfaced in UI
         st.error(f"Failed to load {path}: {exc}")
@@ -44,7 +47,7 @@ def main(results_path: str | None = None) -> None:
 
     st.header("GC Distribution")
     if data["gc_distribution"]:
-        st.line_chart(data["gc_distribution"])
+        st.bar_chart(data["gc_distribution"])
     else:
         st.write("No GC distribution data.")
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,3 +34,19 @@ def test_main_runs(tmp_path: Path) -> None:
 
     mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
     mod.main(str(path))
+
+
+def test_load_metrics_manifest(tmp_path: Path) -> None:
+    metrics_path = Path(__file__).parent / "data" / "metrics.json"
+    metrics = json.loads(metrics_path.read_text())
+    manifest = {
+        "file": "test.bin",
+        "encoding_parameters": {"method": "base4_direct"},
+        "metrics": metrics,
+    }
+    manifest_path = tmp_path / "test.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    from genecoder import dashboard
+
+    assert dashboard._load_metrics(str(manifest_path)) == metrics

--- a/tests/test_dashboard_render.py
+++ b/tests/test_dashboard_render.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -10,15 +9,9 @@ except Exception:
 
 
 def test_dashboard_main_renders(tmp_path: Path) -> None:
-    data = {
-        "gc_distribution": [0.1, 0.2, 0.3],
-        "gc_content": 0.2,
-        "homopolymer_runs": [1, 2, 3],
-        "ecc_success_rates": {"hamming": 1.0},
-        "decode_success_rate": 0.9,
-    }
+    metrics_file = Path(__file__).parent / "data" / "metrics.json"
     results = tmp_path / "results.json"
-    results.write_text(json.dumps(data))
+    results.write_text(metrics_file.read_text())
     def run_app(path: str) -> None:
         from genecoder import dashboard as dash
         dash.main(path)


### PR DESCRIPTION
## Summary
- support reading metrics from a manifest file
- switch GC distribution plot to a histogram
- test the dashboard with a metrics file
- validate manifest loading in dashboard tests

## Testing
- `ruff check src/genecoder/dashboard.py tests/test_dashboard_render.py tests/test_dashboard.py`
- `mypy src/genecoder/dashboard.py tests/test_dashboard_render.py tests/test_dashboard.py`
- `pytest tests/test_dashboard.py tests/test_dashboard_render.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68878457c9308326bbde2c3a84db576a