### PR TITLE
Add InSilicoSeq Illumina channel

### DIFF
--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 
 from typing import Callable, Sequence, Dict, Iterable
 import random
+import shutil
+import subprocess
+import logging
 
 from .base import BaseSimulator
 
 from ..random_utils import make_rng
 from ..api import Simulator
 from ..error_simulation import _random_substitution, NUCLEOTIDES
-from ..nanopore_sim import simulate_d2sim
-from ..insilicoseq_adapter import simulate_insilicoseq
+from ..nanopore_sim import (
+    simulate_d2sim,
+    _run_external,
+    _parse_env_options,
+)
 from . import register_simulator as _register_simulator
 
 __all__ = ["IlluminaChannel", "IlluminaD2SimChannel", "IlluminaInSilicoSeqChannel", "register"]
@@ -105,13 +111,30 @@ class IlluminaD2SimChannel(Simulator):
 
 
 class IlluminaInSilicoSeqChannel(Simulator):
-    """Wrapper using the external ``InSilicoSeq`` simulator."""
+    """Use the ``insilicoseq`` CLI with a simple fallback."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
         self.error_rate = error_rate
+        self._fallback = IlluminaChannel(substitution_rate=error_rate)
 
     def simulate(self, sequence: str) -> str:
-        return simulate_insilicoseq(sequence, error_rate=self.error_rate, rng=make_rng())
+        cmd = "insilicoseq"
+        if shutil.which(cmd):
+            cmd_list = [cmd, "-e", str(self.error_rate)]
+            try:
+                cmd_list += _parse_env_options(cmd)
+                return _run_external(cmd_list, sequence)
+            except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
+                logging.getLogger(__name__).warning(
+                    "%s failed: %s; falling back to simple Illumina model",
+                    cmd,
+                    exc,
+                )
+        else:
+            logging.getLogger(__name__).warning(
+                "%s not found; falling back to simple Illumina model", cmd
+            )
+        return self._fallback.simulate(sequence)
 
 
 def register(

--- a/tests/test_illumina_insilicoseq_channel.py
+++ b/tests/test_illumina_insilicoseq_channel.py
@@ -1,0 +1,28 @@
+
+from genecoder.simulators.illumina import IlluminaInSilicoSeqChannel
+import genecoder.simulators.illumina as illumina
+
+
+def test_fallback_deterministic(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    monkeypatch.setattr(illumina.shutil, "which", lambda _: None)
+    channel = IlluminaInSilicoSeqChannel(error_rate=0.2)
+    first = channel.simulate("ACGTACGTACGT")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    second = channel.simulate("ACGTACGTACGT")
+    assert first == second == "ACGTCCCTTCGT"
+
+
+def test_cli_invocation(monkeypatch):
+    called = []
+    monkeypatch.setattr(illumina.shutil, "which", lambda _: "/usr/bin/insilicoseq")
+    monkeypatch.setattr(illumina, "_parse_env_options", lambda _: [])
+    def fake_run(cmd, seq):
+        called.append((cmd, seq))
+        return "ok"
+    monkeypatch.setattr(illumina, "_run_external", fake_run)
+    ch = IlluminaInSilicoSeqChannel(error_rate=0.1)
+    result = ch.simulate("ACGT")
+    assert result == "ok"
+    assert called == [(["insilicoseq", "-e", "0.1"], "ACGT")]
+


### PR DESCRIPTION
## Summary
- add IlluminaInSilicoSeqChannel calling the `insilicoseq` CLI with fallback to the simple Illumina model
- test deterministic fallback behaviour and CLI invocation

## Testing
- `ruff check --fix src/genecoder/simulators/illumina.py tests/test_illumina_insilicoseq_channel.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688784563c6c832685857acb501a4c2f