### PR TITLE
Display decode success in dashboard

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -367,7 +367,7 @@ poetry install --with gui --no-interaction
 genecli dashboard results.json
 ```
 
-The interface plots GC content distribution and homopolymer histograms, and displays decoding success metrics from the given file.
+The interface plots GC content distribution, homopolymer histograms, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file.
 
 ### Constraint Fix Suggestions
 

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -19,6 +19,28 @@ _DEF_METRICS: dict[str, Any] = {
 }
 
 
+def _calc_decode_success(data: dict[str, Any]) -> float | None:
+    """Return overall decode success rate from ``data``.
+
+    Falls back to averaging ``ecc_success_rates`` when ``decode_success_rate``
+    is missing.
+    """
+    rate = data.get("decode_success_rate")
+    if isinstance(rate, (int, float)):
+        return float(rate)
+    ecc = data.get("ecc_success_rates")
+    if isinstance(ecc, dict) and ecc:
+        values = []
+        for val in ecc.values():
+            try:
+                values.append(float(val))
+            except Exception:
+                pass
+        if values:
+            return sum(values) / len(values)
+    return None
+
+
 def _load_metrics(path: str) -> dict[str, Any]:
     try:
         with open(path, "r", encoding="utf-8") as fh:
@@ -68,9 +90,9 @@ def main(results_path: str | None = None) -> None:
     else:
         st.write("No ECC success rate data.")
 
-    decode_rate = data.get("decode_success_rate")
-    if isinstance(decode_rate, (int, float)):
-        st.metric("Decode Success", f"{float(decode_rate):.2%}")
+    decode_rate = _calc_decode_success(data)
+    if decode_rate is not None:
+        st.metric("Decode Success", f"{decode_rate:.2%}")
     else:
         st.write("No decode success metric.")
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,17 +8,26 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> None:
+def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
+    calls: dict[str, list] = {"metric": [], "bar_chart": []}
+
+    def metric(*args, **kwargs) -> None:
+        calls["metric"].append((args, kwargs))
+
+    def bar_chart(*args, **kwargs) -> None:
+        calls["bar_chart"].append((args, kwargs))
+
     dummy = SimpleNamespace(
         title=lambda *a, **k: None,
         write=lambda *a, **k: None,
         header=lambda *a, **k: None,
         line_chart=lambda *a, **k: None,
-        metric=lambda *a, **k: None,
-        bar_chart=lambda *a, **k: None,
+        metric=metric,
+        bar_chart=bar_chart,
         error=lambda *a, **k: None,
     )
     monkeypatch.setitem(sys.modules, "streamlit", dummy)
+    return calls
 
 
 def test_load_metrics_fixture() -> None:
@@ -50,3 +59,27 @@ def test_load_metrics_manifest(tmp_path: Path) -> None:
     from genecoder import dashboard
 
     assert dashboard._load_metrics(str(manifest_path)) == metrics
+
+
+def test_display_ecc_and_decode_metric(
+    tmp_path: Path, dummy_streamlit: dict[str, list]
+) -> None:
+    data = {
+        "ecc_success_rates": {"rs": 0.8, "bch": 0.9},
+    }
+    path = tmp_path / "metrics.json"
+    path.write_text(json.dumps(data))
+
+    mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
+    mod.main(str(path))
+
+    # ECC success rates should be plotted
+    assert dummy_streamlit["bar_chart"], "bar_chart not called"
+    ecc_args, _ = dummy_streamlit["bar_chart"][0]
+    assert {"rs": 0.8, "bch": 0.9} == ecc_args[0]
+
+    # Decode success metric averages ECC rates
+    assert dummy_streamlit["metric"], "metric not called"
+    label, value = dummy_streamlit["metric"][0][0][:2]
+    assert label == "Decode Success"
+    assert value == "85.00%"


### PR DESCRIPTION
## Summary
- show decode success metric for dashboard JSON
- capture Streamlit calls in dashboard test
- test ECC success and decode metric
- document new charts in usage docs

## Testing
- `pre-commit run mypy --files src/genecoder/dashboard.py tests/test_dashboard.py`
- `pre-commit run ruff --files src/genecoder/dashboard.py tests/test_dashboard.py`
- `pytest tests/test_dashboard.py -q`
- `pytest tests/test_dashboard_streamlit.py -q` *(skipped: could not import streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_6887895ddf288326ab7205d8e41ef2e1