### PR TITLE
Add Illumina rate CLI options

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -8,7 +8,10 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
   `--simulator simple`.
 - **indel** — introduces insertions and deletions in addition to substitutions.
 - **none** — disable simulation (the default).
-- **illumina** — simple Illumina read errors.
+- **illumina** — simple Illumina read errors. Customize rates with
+  `--illumina-sub-rate`, `--illumina-ins-rate` and `--illumina-del-rate`. Depth
+  and quality can be adjusted using `--illumina-depth`, `--illumina-quality` and
+  `--illumina-context`.
 - **nanopore** — alias for `d2sim`.
 
 `GENECODER_SIM_SEED` can be set to an integer to reproduce the randomness used

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -257,6 +257,9 @@ def register_subcommand(
         target.add_argument("--illumina-depth", type=int, default=None, help="Coverage depth for Illumina reads")
         target.add_argument("--illumina-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--illumina-context", type=str, default=None, help="Path to JSON/YAML context error map")
+        target.add_argument("--illumina-sub-rate", type=float, default=None, help="Substitution rate for Illumina reads")
+        target.add_argument("--illumina-ins-rate", type=float, default=None, help="Insertion rate for Illumina reads")
+        target.add_argument("--illumina-del-rate", type=float, default=None, help="Deletion rate for Illumina reads")
         target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
         target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
@@ -310,13 +313,19 @@ def run_channel(args: argparse.Namespace) -> None:
     updated: list[tuple[str, dict[str, object]]] = []
     for name, params in simulators:
         new_params = dict(params)
-        if name.startswith("illumina"):
+        if name == "illumina":
             if opts.illumina_depth is not None:
                 new_params.setdefault("coverage", opts.illumina_depth)
             if opts.illumina_quality is not None:
                 new_params.setdefault("quality_profile", opts.illumina_quality)
             if opts.illumina_context is not None:
                 new_params.setdefault("context_errors", opts.illumina_context)
+            if opts.illumina_sub_rate is not None:
+                new_params.setdefault("substitution_rate", opts.illumina_sub_rate)
+            if opts.illumina_ins_rate is not None:
+                new_params.setdefault("insertion_rate", opts.illumina_ins_rate)
+            if opts.illumina_del_rate is not None:
+                new_params.setdefault("deletion_rate", opts.illumina_del_rate)
         if name.startswith("nanopore"):
             if opts.nanopore_depth is not None:
                 new_params.setdefault("coverage", opts.nanopore_depth)

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -30,6 +30,9 @@ class ChannelOptions:
     nanopore_quality: Sequence[float] | None = None
     illumina_context: Dict[str, float] | None = None
     nanopore_context: Dict[str, float] | None = None
+    illumina_sub_rate: float | None = None
+    illumina_ins_rate: float | None = None
+    illumina_del_rate: float | None = None
 
 
 def _parse_quality(value: str | None) -> Sequence[float] | None:
@@ -181,4 +184,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_quality=_parse_quality(args.nanopore_quality),
         illumina_context=_parse_context(args.illumina_context),
         nanopore_context=_parse_context(args.nanopore_context),
+        illumina_sub_rate=args.illumina_sub_rate,
+        illumina_ins_rate=args.illumina_ins_rate,
+        illumina_del_rate=args.illumina_del_rate,
     )

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -29,6 +29,9 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         nanopore_quality=None,
         illumina_context=None,
         nanopore_context=None,
+        illumina_sub_rate=None,
+        illumina_ins_rate=None,
+        illumina_del_rate=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -51,6 +51,51 @@ def test_channel_cli_simulator(tmp_path: Path) -> None:
     assert isinstance(data["metrics"].get("length"), int)
 
 
+def test_cli_illumina_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_rates.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_rates.fasta"
+    called: list[tuple[float, float, float]] = []
+
+    from genecoder.simulators.illumina import IlluminaChannel
+
+    def fake_simulate(self: IlluminaChannel, seq: str) -> str:
+        called.append((self.substitution_rate, self.insertion_rate, self.deletion_rate))
+        return seq
+
+    monkeypatch.setattr(IlluminaChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "illumina",
+            "--illumina-sub-rate",
+            "0.2",
+            "--illumina-ins-rate",
+            "0.3",
+            "--illumina-del-rate",
+            "0.1",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == [(0.2, 0.3, 0.1)]
+
+
 def test_channel_cli_yaml(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)


### PR DESCRIPTION
## Summary
- expose illumina substitution/insertion/deletion rate options in channel CLI
- pass these options to `IlluminaChannel`
- document illumina CLI parameters
- test CLI behaviour with new options

## Testing
- `pre-commit run --files docs/simulators.md src/genecoder/cli/channel.py src/genecoder/cli/options.py tests/test_channel_options_validation.py tests/test_cli_channel.py`

------
https://chatgpt.com/codex/tasks/task_e_6887895c93588326b34ba28f1f6107b6