### PR TITLE
Add MPI example config and quickstart docs

### DIFF
--- a/configs/mpi_demo.yaml
+++ b/configs/mpi_demo.yaml
@@ -1,9 +1,13 @@
 # Demo configuration enabling MPI execution with two simple channels
+input: encoded/message.fasta
+output: mpi_output.fasta
+
 simulators:
   - name: simple
     error_rate: 0.01
   - name: simple
     error_rate: 0.02
+
 pipeline:
   parallel: true
   workers: 2

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -75,10 +75,42 @@ MPI requires an installed MPI implementation (such as MPICH or OpenMPI) in addit
 ### MPI Example
 
 A ready-to-run configuration at `configs/mpi_demo.yaml` shows two simple channels
-with `use_mpi: true`.
-Execute it using:
+with `use_mpi: true`. The demo expects an encoded FASTA at
+`encoded/message.fasta`. Generate it from any text file:
+
+```bash
+genecli encode --input-files message.txt --output-file encoded/message.fasta
+```
+
+Execute the pipeline using:
 
 ```bash
 mpiexec -n 2 genecli channel run configs/mpi_demo.yaml
 ```
+
+### mpiexec Quickstart
+
+Follow these steps to run the demo configuration under MPI.
+
+1. Install an MPI runtime and the `mpi4py` package:
+
+   ```bash
+   # MPICH
+   sudo apt-get install mpich
+   # or OpenMPI
+   sudo apt-get install openmpi-bin
+   pip install mpi4py
+   ```
+
+2. Launch the pipeline with `mpiexec`:
+
+   ```bash
+   mpiexec -n 2 genecli channel run configs/mpi_demo.yaml
+   ```
+
+   OpenMPI users can instead run:
+
+   ```bash
+   mpirun -np 2 genecli channel run configs/mpi_demo.yaml
+   ```
 


### PR DESCRIPTION
## Summary
- flesh out `mpi_demo.yaml` with input and output fields
- document how to run genecli using `mpiexec`
- include command snippets for MPICH and OpenMPI
- clarify how to create the demo input FASTA

## Testing
- `ruff check .`
- `pytest -k mpi_pipeline -q`
- `pre-commit run markdown-link-check --files docs/parallel.md`


------
https://chatgpt.com/codex/tasks/task_e_688790c783988326b5067b8670e1d784