### PR TITLE
Add NanoporeChannel rate flags

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -12,7 +12,18 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
   `--illumina-sub-rate`, `--illumina-ins-rate` and `--illumina-del-rate`. Depth
   and quality can be adjusted using `--illumina-depth`, `--illumina-quality` and
   `--illumina-context`.
-- **nanopore** — alias for `d2sim`.
+- **nanopore** — alias for `d2sim`. Customize rates with `--nanopore-sub-rate`,
+  `--nanopore-ins-rate` and `--nanopore-del-rate`.
+
+Example YAML:
+
+```yaml
+simulators:
+  - name: nanopore_d2sim
+    substitution_rate: 0.05
+    insertion_rate: 0.01
+    deletion_rate: 0.02
+```
 
 `GENECODER_SIM_SEED` can be set to an integer to reproduce the randomness used
 by these simulators.

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -263,6 +263,9 @@ def register_subcommand(
         target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
         target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
+        target.add_argument("--nanopore-sub-rate", type=float, default=None, help="Substitution rate for Nanopore reads")
+        target.add_argument("--nanopore-ins-rate", type=float, default=None, help="Insertion rate for Nanopore reads")
+        target.add_argument("--nanopore-del-rate", type=float, default=None, help="Deletion rate for Nanopore reads")
         target.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
         target.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
         target.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
@@ -333,6 +336,12 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params.setdefault("quality_profile", opts.nanopore_quality)
             if opts.nanopore_context is not None:
                 new_params.setdefault("context_errors", opts.nanopore_context)
+            if opts.nanopore_sub_rate is not None:
+                new_params.setdefault("substitution_rate", opts.nanopore_sub_rate)
+            if opts.nanopore_ins_rate is not None:
+                new_params.setdefault("insertion_rate", opts.nanopore_ins_rate)
+            if opts.nanopore_del_rate is not None:
+                new_params.setdefault("deletion_rate", opts.nanopore_del_rate)
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -33,6 +33,9 @@ class ChannelOptions:
     illumina_sub_rate: float | None = None
     illumina_ins_rate: float | None = None
     illumina_del_rate: float | None = None
+    nanopore_sub_rate: float | None = None
+    nanopore_ins_rate: float | None = None
+    nanopore_del_rate: float | None = None
 
 
 def _parse_quality(value: str | None) -> Sequence[float] | None:
@@ -187,4 +190,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         illumina_sub_rate=args.illumina_sub_rate,
         illumina_ins_rate=args.illumina_ins_rate,
         illumina_del_rate=args.illumina_del_rate,
+        nanopore_sub_rate=args.nanopore_sub_rate,
+        nanopore_ins_rate=args.nanopore_ins_rate,
+        nanopore_del_rate=args.nanopore_del_rate,
     )

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -32,6 +32,9 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         illumina_sub_rate=None,
         illumina_ins_rate=None,
         illumina_del_rate=None,
+        nanopore_sub_rate=None,
+        nanopore_ins_rate=None,
+        nanopore_del_rate=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -96,6 +96,51 @@ def test_cli_illumina_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert called == [(0.2, 0.3, 0.1)]
 
 
+def test_cli_nanopore_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_np_rates.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_np_rates.fasta"
+    called: list[tuple[float, float, float]] = []
+
+    from genecoder.simulators.nanopore import NanoporeChannel
+
+    def fake_simulate(self: NanoporeChannel, seq: str) -> str:
+        called.append((self.substitution_rate, self.insertion_rate, self.deletion_rate))
+        return seq
+
+    monkeypatch.setattr(NanoporeChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "nanopore_d2sim",
+            "--nanopore-sub-rate",
+            "0.2",
+            "--nanopore-ins-rate",
+            "0.3",
+            "--nanopore-del-rate",
+            "0.1",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == [(0.2, 0.3, 0.1)]
+
+
 def test_channel_cli_yaml(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)


### PR DESCRIPTION
## Summary
- allow setting nanopore substitution, insertion and deletion rates via CLI
- expose new nanopore rate options in ChannelOptions
- document NanoporeChannel rate options with YAML example
- test CLI handling of nanopore rate options

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py tests/test_cli_channel.py tests/test_channel_options_validation.py docs/simulators.md`
- `mypy --config-file pyproject.toml src/genecoder/cli/channel.py src/genecoder/cli/options.py`
- `pytest -q tests/test_cli_channel.py::test_cli_nanopore_rates tests/test_channel_options_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_688797bbb8848326835d541c5ceb18e8