### PR TITLE
Add offline Docker helper

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,12 +93,21 @@ poetry run pytest -q
 ## Docker Dev Container
 
 The repository ships with a Visual Studio Code Dev Container configuration. You
-can still build the image and run the tests manually:
+can still build the image manually using the included `Dockerfile`:
 
 ```bash
 docker build -t genecoder .
-docker run --rm -e SKIP_PACKAGING_TESTS=1 genecoder poetry run pytest -q
 ```
+
+For a quick offline setup run the helper script which mounts the current
+repository into a container based on that image and disables networking:
+
+```bash
+./scripts/docker_dev.sh
+```
+
+Inside the container you can run commands like `poetry run pytest -q` without
+network access.
 ## Using the Dev Container
 
 Run `devcontainer open` from the repository root to build and launch the configured environment. Alternatively, install the **Dev Containers** extension in VS Code and select **Reopen in Container** when prompted. The container extends the project `Dockerfile` and includes Node and other helpful development tools.

--- a/scripts/docker_dev.sh
+++ b/scripts/docker_dev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build and run the GeneCoder Docker image for offline development
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+IMAGE_NAME="genecoder-dev"
+
+echo "Building $IMAGE_NAME from Dockerfile..."
+docker build -t "$IMAGE_NAME" .
+
+echo "Launching $IMAGE_NAME container..."
+docker run --rm -it --network none \
+  -v "$REPO_ROOT":/workspace \
+  -e GENECODER_PLUGIN_REGISTRY_URL= \
+  -e GENECODER_PROFILE_DIR= \
+  "$IMAGE_NAME" bash


### PR DESCRIPTION
## Summary
- provide `scripts/docker_dev.sh` to build and run the Dockerfile for offline development
- document how to use the helper script in `installation.md`

## Testing
- `pre-commit run --files scripts/docker_dev.sh docs/installation.md` *(with `SKIP=pytest`)*
- `pytest -q tests/test_cli_version.py`


------
https://chatgpt.com/codex/tasks/task_e_688797bc9d088326912aeb1efe1adc94