### PR TITLE
Add Visualizer plugin architecture

### DIFF
--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -17,6 +17,7 @@ _LAZY_ATTRS = {
 from .plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
+    VISUALIZER_REGISTRY,
     init_plugins,
     load_plugins,
     install_registry_plugins,
@@ -31,6 +32,7 @@ __all__ = [
     "__version__",
     "CODEC_REGISTRY",
     "FEC_REGISTRY",
+    "VISUALIZER_REGISTRY",
     "SIMULATOR_REGISTRY",
     "simulate_reads",
     "init_plugins",

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 """Public abstract interfaces for GeneCoder plugins."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping, Tuple, TYPE_CHECKING
 
-__all__ = ["Codec", "FEC", "Simulator"]
+if TYPE_CHECKING:  # pragma: no cover - for type checkers
+    from .app_helpers import EncodeResult, DecodeResult
+
+__all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
 
 
 class Codec(ABC):
@@ -39,3 +42,13 @@ class Simulator(ABC):
     @abstractmethod
     def simulate(self, sequence: str) -> str:
         """Return a possibly corrupted version of ``sequence``."""
+
+
+class Visualizer(ABC):
+    """Base class for result visualizers."""
+
+    @abstractmethod
+    def visualize(
+        self, result: "EncodeResult | DecodeResult", /, **kwargs: Any
+    ) -> None:
+        """Visualize ``result`` using optional keyword arguments."""

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -10,6 +10,7 @@ from .plugin_manager import (
     register_codec,
     register_fec,
     register_simulator,
+    register_visualizer,
     _load_and_register,
 )
 
@@ -65,3 +66,19 @@ def register_builtin_plugins() -> None:
         register_simulator,
         "builtin",
     )
+
+    try:
+        vis_mod = import_module("plugins.helix_visualizer")
+    except ModuleNotFoundError:
+        vis_spec = spec_from_file_location(
+            "plugins.helix_visualizer",
+            Path(__file__).resolve().parents[1]
+            / "plugins"
+            / "helix_visualizer.py",
+        )
+        assert vis_spec and vis_spec.loader
+        vis_mod = module_from_spec(vis_spec)
+        vis_spec.loader.exec_module(vis_mod)
+    vis_register = getattr(vis_mod, "register", None)
+    if callable(vis_register):
+        vis_register(register_visualizer)

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
+VISUALIZER_REGISTRY: Dict[str, Callable[..., Any]] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 # re-export for tests
@@ -54,7 +55,7 @@ def _validate_spec(spec: str) -> None:
     raise ValueError("Unsafe plugin spec")
 
 
-from .api import Codec, FEC, Simulator
+from .api import Codec, FEC, Simulator, Visualizer
 
 
 def register_codec(name: str, codec: Codec | type[Codec]) -> None:
@@ -94,6 +95,21 @@ def register_simulator(name: str, channel: Simulator) -> None:
         raise TypeError("simulator must subclass Simulator")
 
     _register_simulator(name, channel)
+
+
+def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
+    """Register a result visualizer under ``name``."""
+
+    if isinstance(visualizer, type):
+        if not issubclass(visualizer, Visualizer):
+            raise TypeError("visualizer must subclass Visualizer")
+        inst = visualizer()
+    else:
+        if not isinstance(visualizer, Visualizer):
+            raise TypeError("visualizer must subclass Visualizer")
+        inst = visualizer
+
+    VISUALIZER_REGISTRY[name] = inst.visualize
 
 
 
@@ -250,6 +266,7 @@ def load_builtin_plugins() -> None:
 
     CODEC_REGISTRY.clear()
     FEC_REGISTRY.clear()
+    VISUALIZER_REGISTRY.clear()
     SIMULATOR_REGISTRY.clear()
 
     builtin = importlib.import_module("genecoder.builtin_plugins")
@@ -267,6 +284,7 @@ def load_entry_point_plugins() -> list[str]:
         "genecoder.plugins": (register_codec, "codec"),
         "genecoder.fec": (register_fec, "FEC"),
         "genecoder.simulators": (register_simulator, "simulator"),
+        "genecoder.visualizers": (register_visualizer, "visualizer"),
     }
     for group, (registrar, kind) in groups.items():
         try:
@@ -309,6 +327,9 @@ def load_local_plugins() -> list[str]:
             register_s = getattr(module, "register_simulator", None)
             if callable(register_s):
                 register_s(register_simulator)
+            register_v = getattr(module, "register_visualizer", None)
+            if callable(register_v):
+                register_v(register_visualizer)
 
     register = getattr(plugins, "register", None)
     if callable(register):
@@ -319,6 +340,9 @@ def load_local_plugins() -> list[str]:
     register_s = getattr(plugins, "register_simulator", None)
     if callable(register_s):
         register_s(register_simulator)
+    register_v = getattr(plugins, "register_visualizer", None)
+    if callable(register_v):
+        register_v(register_visualizer)
 
     return failures
 

--- a/src/plugins/helix_visualizer.py
+++ b/src/plugins/helix_visualizer.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from genecoder.api import Visualizer
+from genecoder.app_helpers import EncodeResult, DecodeResult
+from genecoder.helix_view import show_helix_ui
+
+
+class HelixVisualizer(Visualizer):  # type: ignore[misc]
+    """Simple visualizer showing a helix view for encoded DNA."""
+
+    def visualize(
+        self, result: EncodeResult | DecodeResult, /, **kwargs: object
+    ) -> None:
+        if isinstance(result, EncodeResult):
+            show_helix_ui(result.encoded_dna, **kwargs)
+        else:
+            raise TypeError("HelixVisualizer supports EncodeResult only")
+
+
+def register(register_visualizer: Callable[[str, type[Visualizer]], None]) -> None:
+    """Register the helix visualizer."""
+
+    register_visualizer("helix", HelixVisualizer)

--- a/tests/test_visualizer_plugins.py
+++ b/tests/test_visualizer_plugins.py
@@ -1,0 +1,52 @@
+from importlib.metadata import EntryPoint
+from pathlib import Path
+
+import pytest
+
+import genecoder.plugin_manager as plugins
+from genecoder.app_helpers import EncodeResult
+
+
+def test_visualizer_entry_point(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mod = tmp_path / "vmod.py"
+    mod.write_text(
+        """
+class DummyBase:
+    def visualize(self, result, **kw):
+        pass
+
+def register(register_visualizer):
+    from genecoder.api import Visualizer
+    from genecoder.app_helpers import EncodeResult, DecodeResult
+
+    class DummyViz(DummyBase, Visualizer):
+        def visualize(self, result: EncodeResult | DecodeResult, **kw) -> None:
+            super().visualize(result, **kw)
+
+    register_visualizer('dummy_vis', DummyViz)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    src_path = Path(__file__).resolve().parents[1] / "src"
+    monkeypatch.syspath_prepend(str(src_path))
+    ep = EntryPoint(name="dummy_vis", value="vmod", group="genecoder.visualizers")
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda *, group=None: [ep] if group == "genecoder.visualizers" else [],
+    )
+    monkeypatch.setattr(plugins, "load_builtin_plugins", lambda: None)
+    monkeypatch.setattr(plugins, "load_local_plugins", lambda: [])
+
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    failures = plugins.load_entry_point_plugins()
+
+    assert failures == []
+    assert "dummy_vis" in plugins.VISUALIZER_REGISTRY
+    plugins.VISUALIZER_REGISTRY["dummy_vis"](
+        EncodeResult(fasta="", encoded_dna="AC", metrics={}, info_messages=[])
+    )


### PR DESCRIPTION
## Summary
- define `Visualizer` protocol in `genecoder.api`
- extend plugin manager with a `VISUALIZER_REGISTRY`
- register a built-in helix visualizer plugin
- expose the new registry via `genecoder.__init__`
- add tests for loading visualizer entry point plugins

## Testing
- `ruff check src/genecoder/api.py src/genecoder/plugin_manager.py src/genecoder/builtin_plugins.py src/plugins/helix_visualizer.py tests/test_visualizer_plugins.py src/genecoder/__init__.py --fix`
- `mypy`
- `pytest -q tests/test_visualizer_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_6887d27d5404832698aa74a7d887a4f2