### PR TITLE
Add Visualizer plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -75,6 +75,26 @@ Simulator plugins follow the same pattern using the `genecoder.simulators`
 group with a `register_simulator` callback that receives an object implementing
 the :class:`genecoder.api.Simulator` interface.
 
+Visualizer plugins register under `genecoder.visualizers` with a
+`register_visualizer` callback. The class should implement the
+``genecoder.api.Visualizer`` interface.
+
+```toml
+[project.entry-points."genecoder.visualizers"]
+myvis = "my_package.my_vis"
+```
+
+```python
+from genecoder.api import Visualizer
+
+class MyVisualizer(Visualizer):
+    def visualize(self, sequence: str, /, **kwargs):
+        ...
+
+def register(register_visualizer):
+    register_visualizer("myvis", MyVisualizer())
+```
+
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,4 @@ explicit_package_bases = true
 show_error_codes = true
 enable_error_code = ignore-without-code
 files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec
+exclude = ^tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ files = [
     "plugins-examples/example_package_plugin/example_plugin",
     "plugins-examples/advanced_fec/advanced_fec",
 ]
+exclude = "^tests/"
 
 
 [tool.poetry]

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -17,6 +17,7 @@ _LAZY_ATTRS = {
 from .plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
+    VISUALIZER_REGISTRY,
     init_plugins,
     load_plugins,
     install_registry_plugins,
@@ -32,6 +33,7 @@ __all__ = [
     "CODEC_REGISTRY",
     "FEC_REGISTRY",
     "SIMULATOR_REGISTRY",
+    "VISUALIZER_REGISTRY",
     "simulate_reads",
     "init_plugins",
     "load_plugins",

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Mapping, Tuple
 
-__all__ = ["Codec", "FEC", "Simulator"]
+__all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
 
 
 class Codec(ABC):
@@ -39,3 +39,11 @@ class Simulator(ABC):
     @abstractmethod
     def simulate(self, sequence: str) -> str:
         """Return a possibly corrupted version of ``sequence``."""
+
+
+class Visualizer(ABC):
+    """Abstract base class for sequence visualizers."""
+
+    @abstractmethod
+    def visualize(self, sequence: str, /, **kwargs: Any) -> Any:
+        """Return a visualization of ``sequence``."""

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -10,6 +10,7 @@ from .plugin_manager import (
     register_codec,
     register_fec,
     register_simulator,
+    register_visualizer,
     _load_and_register,
 )
 
@@ -63,5 +64,11 @@ def register_builtin_plugins() -> None:
             "genecoder.desp_adapter",
         ],
         register_simulator,
+        "builtin",
+    )
+
+    _load_and_register(
+        ["genecoder.default_visualizer"],
+        register_visualizer,
         "builtin",
     )

--- a/src/genecoder/default_visualizer.py
+++ b/src/genecoder/default_visualizer.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Default Visualizer implementation for GeneCoder."""
+
+from typing import Mapping, Callable
+import base64
+
+from .api import Visualizer
+from .plugin_manager import register_visualizer as _register_visualizer
+from .plotting import (
+    calculate_windowed_gc_content,
+    identify_homopolymer_regions,
+    generate_sequence_analysis_plot,
+)
+
+
+class DefaultVisualizer(Visualizer):
+    """Generate GC distribution and homopolymer plots."""
+
+    def visualize(
+        self,
+        sequence: str,
+        /,
+        *,
+        window_size: int = 50,
+        step_size: int = 10,
+        min_homopolymer_len: int = 4,
+        **_: object,
+    ) -> Mapping[str, str]:
+        """Return base64-encoded PNG plots for ``sequence``."""
+
+        gc_data = calculate_windowed_gc_content(sequence, window_size, step_size)
+        homopolymers = identify_homopolymer_regions(sequence, min_homopolymer_len)
+        buf = generate_sequence_analysis_plot(gc_data, homopolymers, len(sequence))
+        plot_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+        buf.close()
+        return {"sequence_analysis": plot_b64}
+
+
+def register(
+    registrar: Callable[[str, Visualizer], None] = _register_visualizer,
+) -> None:
+    """Register the default visualizer."""
+
+    registrar("default", DefaultVisualizer())

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -27,6 +27,7 @@ import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
 from .plugin_security import compute_checksum as _compute_checksum
+from .api import Visualizer
 import base64
 import json
 
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
+VISUALIZER_REGISTRY: Dict[str, Visualizer] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 # re-export for tests
@@ -94,6 +96,15 @@ def register_simulator(name: str, channel: Simulator) -> None:
         raise TypeError("simulator must subclass Simulator")
 
     _register_simulator(name, channel)
+
+
+def register_visualizer(name: str, visualizer: Visualizer) -> None:
+    """Register a visualizer under ``name``."""
+
+    if not isinstance(visualizer, Visualizer):
+        raise TypeError("visualizer must subclass Visualizer")
+
+    VISUALIZER_REGISTRY[name] = visualizer
 
 
 
@@ -267,6 +278,7 @@ def load_entry_point_plugins() -> list[str]:
         "genecoder.plugins": (register_codec, "codec"),
         "genecoder.fec": (register_fec, "FEC"),
         "genecoder.simulators": (register_simulator, "simulator"),
+        "genecoder.visualizers": (register_visualizer, "visualizer"),
     }
     for group, (registrar, kind) in groups.items():
         try:
@@ -309,6 +321,9 @@ def load_local_plugins() -> list[str]:
             register_s = getattr(module, "register_simulator", None)
             if callable(register_s):
                 register_s(register_simulator)
+            register_v = getattr(module, "register_visualizer", None)
+            if callable(register_v):
+                register_v(register_visualizer)
 
     register = getattr(plugins, "register", None)
     if callable(register):
@@ -319,6 +334,9 @@ def load_local_plugins() -> list[str]:
     register_s = getattr(plugins, "register_simulator", None)
     if callable(register_s):
         register_s(register_simulator)
+    register_v = getattr(plugins, "register_visualizer", None)
+    if callable(register_v):
+        register_v(register_visualizer)
 
     return failures
 

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,12 @@
+import base64
+from genecoder.default_visualizer import DefaultVisualizer
+
+
+def test_default_visualizer_generates_plot() -> None:
+    vis = DefaultVisualizer()
+    result = vis.visualize("ACGT" * 25, window_size=10, step_size=5)
+    assert "sequence_analysis" in result
+    b64 = result["sequence_analysis"]
+    assert isinstance(b64, str)
+    img = base64.b64decode(b64)
+    assert img.startswith(b"\x89PNG")


### PR DESCRIPTION
## Summary
- introduce a `Visualizer` interface and default implementation
- register visualizers in plugin management and builtin plugins
- export `VISUALIZER_REGISTRY`
- document how to create a visualizer plugin
- test the default visualizer
- ensure builtin default visualizer registers itself
- ignore test files in mypy config

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d27dc62083268e33b12b298604d3