### PR TITLE
Add sequencing profiles for simulators

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -7,6 +7,8 @@
    - Refine GC-content balancing algorithms for more stable synthesis results.
 3. **Phase 3: Simulation & Analysis**
    - Model sequencing errors in greater detail to mimic real-world conditions.
+   - Provide named sequencing profiles (e.g., `miseq`, `hiseq`, `minion`,
+     `promethion`) selectable via CLI options.
    - Integrate with common bioinformatics tools for downstream analysis.
    - Provide automated reports summarizing encoding accuracy and efficiency.
 4. **Phase 4: Ecosystem & Automation**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,6 +185,11 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file channel.fasta --simulator simple --simulator indel
    ```
 
+   Named sequencing profiles are available. Use `--illumina-profile miseq` or
+   `--illumina-profile hiseq` for Illumina runs and `--nanopore-profile minion`
+   or `--nanopore-profile promethion` for Nanopore data. Individual rate options
+   override the selected profile.
+
    The same configuration can be provided via YAML:
 
    ```yaml

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -19,6 +19,8 @@ from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
 from genecoder.parallel import parallel_map
+from genecoder.simulators.illumina import ILLUMINA_PROFILES
+from genecoder.simulators.nanopore import NANOPORE_PROFILES
 from .options import ChannelOptions, build_channel_options
 from .shared import add_single_io_args
 
@@ -260,12 +262,14 @@ def register_subcommand(
         target.add_argument("--illumina-sub-rate", type=float, default=None, help="Substitution rate for Illumina reads")
         target.add_argument("--illumina-ins-rate", type=float, default=None, help="Insertion rate for Illumina reads")
         target.add_argument("--illumina-del-rate", type=float, default=None, help="Deletion rate for Illumina reads")
+        target.add_argument("--illumina-profile", type=str, default=None, help="Named Illumina profile to use")
         target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
         target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
         target.add_argument("--nanopore-sub-rate", type=float, default=None, help="Substitution rate for Nanopore reads")
         target.add_argument("--nanopore-ins-rate", type=float, default=None, help="Insertion rate for Nanopore reads")
         target.add_argument("--nanopore-del-rate", type=float, default=None, help="Deletion rate for Nanopore reads")
+        target.add_argument("--nanopore-profile", type=str, default=None, help="Named Nanopore profile to use")
         target.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
         target.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
         target.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
@@ -306,8 +310,8 @@ def run_channel(args: argparse.Namespace) -> None:
         workers=opts.processes or opts.threads,
         use_process_pool=opts.processes is not None,
         use_mpi=False,
-        illumina_profile=None,
-        nanopore_profile=None,
+        illumina_profile=opts.illumina_profile,
+        nanopore_profile=opts.nanopore_profile,
     )
     simulators = opts.simulator_specs
     if simulators is None:
@@ -317,31 +321,45 @@ def run_channel(args: argparse.Namespace) -> None:
     for name, params in simulators:
         new_params = dict(params)
         if name == "illumina":
+            if opts.illumina_profile:
+                prof = ILLUMINA_PROFILES.get(opts.illumina_profile)
+                if prof is None:
+                    logger.error("Unknown Illumina profile: %s", opts.illumina_profile)
+                    raise SystemExit(1)
+                for k, v in prof.items():
+                    new_params.setdefault(k, v)
             if opts.illumina_depth is not None:
-                new_params.setdefault("coverage", opts.illumina_depth)
+                new_params["coverage"] = opts.illumina_depth
             if opts.illumina_quality is not None:
-                new_params.setdefault("quality_profile", opts.illumina_quality)
+                new_params["quality_profile"] = opts.illumina_quality
             if opts.illumina_context is not None:
-                new_params.setdefault("context_errors", opts.illumina_context)
+                new_params["context_errors"] = opts.illumina_context
             if opts.illumina_sub_rate is not None:
-                new_params.setdefault("substitution_rate", opts.illumina_sub_rate)
+                new_params["substitution_rate"] = opts.illumina_sub_rate
             if opts.illumina_ins_rate is not None:
-                new_params.setdefault("insertion_rate", opts.illumina_ins_rate)
+                new_params["insertion_rate"] = opts.illumina_ins_rate
             if opts.illumina_del_rate is not None:
-                new_params.setdefault("deletion_rate", opts.illumina_del_rate)
+                new_params["deletion_rate"] = opts.illumina_del_rate
         if name.startswith("nanopore"):
+            if opts.nanopore_profile:
+                prof = NANOPORE_PROFILES.get(opts.nanopore_profile)
+                if prof is None:
+                    logger.error("Unknown Nanopore profile: %s", opts.nanopore_profile)
+                    raise SystemExit(1)
+                for k, v in prof.items():
+                    new_params.setdefault(k, v)
             if opts.nanopore_depth is not None:
-                new_params.setdefault("coverage", opts.nanopore_depth)
+                new_params["coverage"] = opts.nanopore_depth
             if opts.nanopore_quality is not None:
-                new_params.setdefault("quality_profile", opts.nanopore_quality)
+                new_params["quality_profile"] = opts.nanopore_quality
             if opts.nanopore_context is not None:
-                new_params.setdefault("context_errors", opts.nanopore_context)
+                new_params["context_errors"] = opts.nanopore_context
             if opts.nanopore_sub_rate is not None:
-                new_params.setdefault("substitution_rate", opts.nanopore_sub_rate)
+                new_params["substitution_rate"] = opts.nanopore_sub_rate
             if opts.nanopore_ins_rate is not None:
-                new_params.setdefault("insertion_rate", opts.nanopore_ins_rate)
+                new_params["insertion_rate"] = opts.nanopore_ins_rate
             if opts.nanopore_del_rate is not None:
-                new_params.setdefault("deletion_rate", opts.nanopore_del_rate)
+                new_params["deletion_rate"] = opts.nanopore_del_rate
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -36,6 +36,8 @@ class ChannelOptions:
     nanopore_sub_rate: float | None = None
     nanopore_ins_rate: float | None = None
     nanopore_del_rate: float | None = None
+    illumina_profile: str | None = None
+    nanopore_profile: str | None = None
 
 
 def _parse_quality(value: str | None) -> Sequence[float] | None:
@@ -193,4 +195,6 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_sub_rate=args.nanopore_sub_rate,
         nanopore_ins_rate=args.nanopore_ins_rate,
         nanopore_del_rate=args.nanopore_del_rate,
+        illumina_profile=args.illumina_profile,
+        nanopore_profile=args.nanopore_profile,
     )

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -19,7 +19,29 @@ from ..nanopore_sim import (
 )
 from . import register_simulator as _register_simulator
 
-__all__ = ["IlluminaChannel", "IlluminaD2SimChannel", "IlluminaInSilicoSeqChannel", "register"]
+__all__ = [
+    "IlluminaChannel",
+    "IlluminaD2SimChannel",
+    "IlluminaInSilicoSeqChannel",
+    "register",
+    "ILLUMINA_PROFILES",
+]
+
+# Preset parameter profiles for :class:`IlluminaChannel`.
+ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
+    "miseq": {
+        "substitution_rate": 0.001,
+        "insertion_rate": 0.0001,
+        "deletion_rate": 0.0001,
+        "read_length": 250,
+    },
+    "hiseq": {
+        "substitution_rate": 0.0005,
+        "insertion_rate": 0.00005,
+        "deletion_rate": 0.00005,
+        "read_length": 150,
+    },
+}
 
 
 class IlluminaChannel(BaseSimulator):

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -28,7 +28,24 @@ __all__ = [
     "NanoporeDeSPChannel",
     "NanoporeDNArSimChannel",
     "register",
+    "NANOPORE_PROFILES",
 ]
+
+# Preset parameter profiles for :class:`NanoporeChannel`.
+NANOPORE_PROFILES: dict[str, dict[str, float | int]] = {
+    "minion": {
+        "error_rate": 0.12,
+        "substitution_rate": 0.02,
+        "insertion_rate": 0.04,
+        "deletion_rate": 0.06,
+    },
+    "promethion": {
+        "error_rate": 0.08,
+        "substitution_rate": 0.015,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.045,
+    },
+}
 
 
 class NanoporeChannel(BaseChannel):

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -35,6 +35,8 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         nanopore_sub_rate=None,
         nanopore_ins_rate=None,
         nanopore_del_rate=None,
+        illumina_profile=None,
+        nanopore_profile=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/test_simulator_profiles.py
+++ b/tests/test_simulator_profiles.py
@@ -1,0 +1,17 @@
+from genecoder.simulators.illumina import IlluminaChannel, ILLUMINA_PROFILES
+from genecoder.simulators.nanopore import NanoporeChannel, NANOPORE_PROFILES
+
+
+def test_illumina_profiles() -> None:
+    for name, params in ILLUMINA_PROFILES.items():
+        ch = IlluminaChannel(**params)
+        for key, value in params.items():
+            assert getattr(ch, key) == value
+
+
+def test_nanopore_profiles() -> None:
+    for name, params in NANOPORE_PROFILES.items():
+        ch = NanoporeChannel(**params)
+        for key, value in params.items():
+            assert getattr(ch, key) == value
+


### PR DESCRIPTION
## Summary
- add profile dictionaries for Illumina and Nanopore simulators
- allow `--illumina-profile` and `--nanopore-profile` on CLI
- document new profiles and options
- test profile initialization

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py tests/test_channel_options_validation.py tests/test_simulator_profiles.py`
- `mypy src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py tests/test_channel_options_validation.py tests/test_simulator_profiles.py`
- `pytest tests/test_simulator_profiles.py tests/test_channel_options_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ea9c41e48326b8b93342c95e948e