### PR TITLE
Add preset profile configuration examples

### DIFF
--- a/configs/illumina_profile.yaml
+++ b/configs/illumina_profile.yaml
@@ -1,0 +1,5 @@
+simulators:
+  - name: insilicoseq
+    read_length: 150
+pipeline:
+  illumina_profile: hiseq

--- a/configs/vertical_slice_demo.yaml
+++ b/configs/vertical_slice_demo.yaml
@@ -6,5 +6,7 @@ encode:
 simulate:
   simulators:
     - illumina
+  pipeline:
+    illumina_profile: hiseq
 decode:
   method: base4_direct

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -74,7 +74,8 @@ poetry run pytest -q
 ## Bundle Workflow
 
 An example configuration file at `configs/vertical_slice_demo.yaml` demonstrates
-using a simulator and Hamming FEC. Run the bundle with:
+using a simulator and Hamming FEC. The `pipeline` section selects the built-in
+`hiseq` profile for the Illumina simulator. Run the bundle with:
 
 ```bash
 genecli bundle run configs/vertical_slice_demo.yaml --cache-dir runs
@@ -86,8 +87,9 @@ as part of the demo.
 ## Channel Configuration
 
 A unified configuration describing sequencing simulators and synthesis
-constraints is provided at `configs/channel_demo.yaml`.
-Apply the channel step using:
+constraints is provided at `configs/channel_demo.yaml`. Another example at
+`configs/dnarsim_profile.yaml` selects the `r9` Nanopore profile. Apply the
+channel step using:
 
 ```bash
 genecli channel run configs/channel_demo.yaml

--- a/src/genecoder/default_visualizer.py
+++ b/src/genecoder/default_visualizer.py
@@ -38,8 +38,8 @@ class DefaultVisualizer(Visualizer):
 
 
 def register(
-    registrar: Callable[[str, Visualizer], None] = _register_visualizer,
+    registrar: Callable[[str, Visualizer | type[Visualizer]], None] = _register_visualizer,
 ) -> None:
     """Register the default visualizer."""
 
-    registrar("default", DefaultVisualizer())
+    registrar("default", DefaultVisualizer)

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -14,7 +14,7 @@ import re
 
 yaml: ModuleType | None
 try:  # optional dependency
-    import yaml as yaml_module
+    import yaml as yaml_module  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover - optional
     yaml = None
 else:
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-VISUALIZER_REGISTRY: Dict[str, Visualizer] = {}
+VISUALIZER_REGISTRY: Dict[str, Callable[..., Any]] = {}
 
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
@@ -57,7 +57,7 @@ def _validate_spec(spec: str) -> None:
     raise ValueError("Unsafe plugin spec")
 
 
-from .api import Codec, FEC, Simulator, Visualizer
+from .api import Codec, FEC, Simulator
 
 
 def register_codec(name: str, codec: Codec | type[Codec]) -> None:
@@ -99,13 +99,19 @@ def register_simulator(name: str, channel: Simulator) -> None:
     _register_simulator(name, channel)
 
 
-def register_visualizer(name: str, visualizer: Visualizer) -> None:
+def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
     """Register a visualizer under ``name``."""
 
-    if not isinstance(visualizer, Visualizer):
-        raise TypeError("visualizer must subclass Visualizer")
+    if isinstance(visualizer, type):
+        if not issubclass(visualizer, Visualizer):
+            raise TypeError("visualizer must subclass Visualizer")
+        inst = visualizer()
+    else:
+        if not isinstance(visualizer, Visualizer):
+            raise TypeError("visualizer must subclass Visualizer")
+        inst = visualizer
 
-    VISUALIZER_REGISTRY[name] = visualizer
+    VISUALIZER_REGISTRY[name] = inst.visualize
 
 
 


### PR DESCRIPTION
## Summary
- demonstrate pipeline profiles in `vertical_slice_demo.yaml`
- add an InsilicoSeq preset example
- document the new YAML profiles in the walkthrough
- fix visualizer plugin registration for class-based entry points

## Testing
- `ruff check src/genecoder/plugin_manager.py src/genecoder/default_visualizer.py`
- `mypy --config-file pyproject.toml src/genecoder/plugin_manager.py src/genecoder/default_visualizer.py`
- `pytest tests/test_visualizer_plugins.py::test_visualizer_entry_point -q`


------
https://chatgpt.com/codex/tasks/task_e_6887ea9cc4608326b43344fcbb52644e