### PR TITLE
Add MPI docs and integration test

### DIFF
--- a/docs/mpi.md
+++ b/docs/mpi.md
@@ -1,0 +1,37 @@
+# MPI Channel Simulation
+
+GeneCoder can distribute channel simulations across multiple machines using [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface). This relies on the `mpi4py` package and an installed MPI runtime such as MPICH or OpenMPI.
+
+## Quickstart
+
+1. Install an MPI implementation and `mpi4py`:
+
+```bash
+# MPICH
+sudo apt-get install mpich
+# or OpenMPI
+sudo apt-get install openmpi-bin
+pip install mpi4py
+```
+
+2. Enable MPI in your pipeline configuration:
+
+```yaml
+simulators:
+  - simple
+synthesis:
+  min_length: 1
+pipeline:
+  parallel: true
+  workers: 4
+  use_mpi: true
+```
+
+3. Execute the pipeline with `mpiexec`:
+
+```bash
+mpiexec -n 4 genecli channel run config.yml
+```
+
+Setting `use_mpi: true` automatically selects the MPI executor. The number of workers should match the `-n` argument to `mpiexec`.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - Local Execution Only: cloud.md
       - Helix Frontend: helix_frontend.md
       - Parallel Pipeline: parallel.md
+      - MPI Channel Simulation: mpi.md
   - Archived:
       - Full Development Vision: archived/DEVELOPMENT_VISION.md
   - Technology Stack: technology_stack.md

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -14,7 +14,7 @@ import re
 
 yaml: ModuleType | None
 try:  # optional dependency
-    import yaml as yaml_module  # type: ignore[import-untyped]
+    import yaml as yaml_module
 except Exception:  # pragma: no cover - optional
     yaml = None
 else:

--- a/tests/test_mpi_channel.py
+++ b/tests/test_mpi_channel.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+from tests.test_cli_channel import create_fasta
+
+
+class _DummyFuture:
+    def __init__(self, result: str) -> None:
+        self._result = result
+
+    def result(self) -> str:
+        return self._result
+
+
+class _DummyExecutor:
+    called = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        _DummyExecutor.called = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def submit(self, fn, *args, **kwargs):
+        return _DummyFuture(fn(*args, **kwargs))
+
+
+def test_channel_cli_mpi(tmp_path: Path, monkeypatch) -> None:
+    input_fasta = tmp_path / "in.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out.fasta"
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text(
+        f"""input: {input_fasta}\noutput: {output_fasta}\nsimulators:\n  - simple\n  - simple\nsynthesis:\n  min_length: 1\npipeline:\n  parallel: true\n  workers: 2\n  use_mpi: true\n"""
+    )
+
+    mpimod = types.ModuleType("mpi4py")
+    futures_mod = types.ModuleType("mpi4py.futures")
+    futures_mod.MPIPoolExecutor = _DummyExecutor
+    mpimod.futures = futures_mod
+    monkeypatch.setitem(sys.modules, "mpi4py", mpimod)
+    monkeypatch.setitem(sys.modules, "mpi4py.futures", futures_mod)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(["channel", "run", str(cfg)], env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert _DummyExecutor.called
+    assert output_fasta.exists()


### PR DESCRIPTION
## Summary
- document MPI execution setup in new `docs/mpi.md`
- reference MPI guide in MkDocs navigation
- mock `MPIPoolExecutor` in new `tests/test_mpi_channel.py`
- tidy plugin manager import for mypy

## Testing
- `ruff check tests/test_mpi_channel.py src/genecoder/plugin_manager.py`
- `mypy --config-file pyproject.toml src/genecoder/plugin_manager.py`
- `pytest -q tests/test_mpi_channel.py`


------
https://chatgpt.com/codex/tasks/task_e_6887f981a32883269561f5ab927e8c6b