### PR TITLE
Add README info on pipeline parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,16 @@ poetry install --with dev --no-interaction
 poetry run pytest -q
 ```
 
+
 The helper script above installs every extras group, enabling the
 full test matrix.
+
+## Parallel Execution
+
+`ChannelPipeline` can execute steps concurrently. Set
+`parallel=True` in `ChannelConfig` and choose a `workers` count. Adding
+`use_mpi=True` enables distributed runs. See
+[docs/parallel.md](docs/parallel.md) for more options and CLI tips.
 
 
 ## Continuous Integration


### PR DESCRIPTION
## Summary
- document how `ChannelPipeline` can run threads and MPI

## Testing
- `pre-commit run markdown-link-check --files README.md`

------
https://chatgpt.com/codex/tasks/task_e_68881be838848326b2f96f02cc79469d