### PR TITLE
Add profiles listing command

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -402,3 +402,26 @@ def _handle_run(args: argparse.Namespace) -> None:
         config=cfg,
         batch_workers=extra.get("batch_workers"),
     )
+
+
+def _handle_list_profiles(_: argparse.Namespace) -> None:
+    """Print available Illumina and Nanopore profiles."""
+
+    print("Illumina profiles:")
+    for name in sorted(ILLUMINA_PROFILES):
+        print(f"  {name}")
+
+    print("Nanopore profiles:")
+    for name in sorted(NANOPORE_PROFILES):
+        print(f"  {name}")
+
+
+def register_profiles_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the ``profiles`` subcommand."""
+
+    parser = subparsers.add_parser(
+        "profiles", help="List available sequencing profiles"
+    )
+    parser.set_defaults(func=_handle_list_profiles)

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -116,6 +116,7 @@ def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     analyze.register_subcommand(subparsers)
     report.register_subcommand(subparsers)
     channel.register_subcommand(subparsers)
+    channel.register_profiles_subcommand(subparsers)
     bundle.register_subcommand(subparsers)
     plugin.register_subcommand(subparsers)
     benchmark.register_subcommand(subparsers)

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -1,0 +1,11 @@
+from tests.test_cli import run_cli_command
+
+
+def test_cli_profiles_lists() -> None:
+    result = run_cli_command(["profiles"])
+    assert result.returncode == 0
+    out = result.stdout
+    assert "Illumina" in out
+    assert "Nanopore" in out
+    assert "miseq" in out
+    assert "minion" in out


### PR DESCRIPTION
## Summary
- expose a new `profiles` CLI command for listing built-in Illumina and Nanopore profiles
- hook the command into CLI parser
- test the new command

## Testing
- `ruff check --fix src/genecoder/cli/channel.py src/genecoder/cli/cli.py tests/test_cli_profiles.py`
- `mypy --config-file pyproject.toml src/genecoder/cli/channel.py src/genecoder/cli/cli.py`
- `pytest -q tests/test_cli_profiles.py`


------
https://chatgpt.com/codex/tasks/task_e_688825adf654832698166120a79f74a3