### PR TITLE
Add homopolymer deletion test

### DIFF
--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -165,13 +165,27 @@ class NanoporeDNArSimChannel(NanoporeChannel):
         sub_p = error_rate * 0.4
         ins_p = error_rate * 0.3
         del_p = error_rate * 0.3
-        return introduce_errors(
+        base = introduce_errors(
             sequence,
             substitution_prob=sub_p,
             insertion_prob=ins_p,
             deletion_prob=del_p,
             rng=rng,
         )
+        result: list[str] = []
+        run_char = ""
+        run_len = 0
+        for nt in base:
+            if nt == run_char:
+                run_len += 1
+            else:
+                run_char = nt
+                run_len = 1
+            extra_prob = 0.2 if run_len >= 5 else 0.0
+            if rng.random() < extra_prob:
+                continue
+            result.append(nt)
+        return "".join(result)
 
     def simulate(self, sequence: str) -> str:
         rng = make_rng()

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -285,3 +285,24 @@ def test_simulate_reads_wrapper_deprecated(monkeypatch):
 
     assert result == "wrapped"
     assert called == [("ACGT", "none", 0.2)]
+
+from genecoder.simulators.nanopore import NanoporeDNArSimChannel
+
+
+def _avg_deletions(seq: str, channel: NanoporeDNArSimChannel, monkeypatch) -> float:
+    counts = []
+    for i in range(50):
+        monkeypatch.setenv("GENECODER_SIM_SEED", str(i))
+        mutated = channel.simulate(seq)
+        counts.append(len(seq) - len(mutated))
+    return sum(counts) / len(counts)
+
+
+def test_homopolymers_increase_deletions(monkeypatch):
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda _: None)
+    channel = NanoporeDNArSimChannel(error_rate=0.4, deletion_rate=0.1)
+    homopoly = "A" * 50
+    balanced = ("ACGT" * 12) + "AC"
+    homopoly_del = _avg_deletions(homopoly, channel, monkeypatch)
+    balanced_del = _avg_deletions(balanced, channel, monkeypatch)
+    assert homopoly_del > balanced_del


### PR DESCRIPTION
## Summary
- validate fallback behavior for long homopolymers
- bias deletions toward long homopolymer runs

## Testing
- `pre-commit run --files tests/test_nanopore_sim.py src/genecoder/simulators/nanopore.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882b04230c83269c523a3381eb2098