### PR TITLE
Update docs for plugin verification and simulator environment variables

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -225,3 +225,19 @@ local packages. The CLI and GUI behave the same way when these variables are
 unset or empty, making this the recommended configuration for air‑gapped
 systems.
 
+## Plugin Verification
+
+Plugin registries record a `checksum` or `signature` for every wheel. The
+installer computes the SHA256 digest of each download and compares it against
+this information before proceeding. Provide the verification key via the
+`GENECODER_PLUGIN_PUBLIC_KEY` environment variable so signatures are checked
+automatically. Installation fails if the digest or signature does not match.
+See [Plugin Security](plugins.md#plugin-security) for more details.
+
+## Configuring Optional Simulators
+
+External simulators accept additional flags through environment variables. Set
+`GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
+`GENECODER_SQUIGULATOR_OPTIONS` to pass options to the respective tool. Use
+`GENECODER_SIM_SEED` to make runs reproducible.
+

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,7 +107,8 @@ wheel's digital signature with
 :func:`genecoder.security.compute_checksum` and raises ``InvalidSignature`` if
 verification fails. Set the ``GENECODER_PLUGIN_PUBLIC_KEY`` environment variable
 to the path of a PEM encoded key so the installer can perform this check
-automatically.
+automatically. Every wheel is hashed and the digest compared against the
+``checksum`` or ``signature`` listed in the registry before installation.
 
 When installing a signed wheel the file is downloaded and its SHA256 digest
 computed. The signature from the registry entry is base64 decoded and verified
@@ -212,7 +213,13 @@ export GENECODER_PLUGIN_REGISTRY_URL=./configs/registry.yaml
 export GENECODER_PLUGIN_PUBLIC_KEY=/path/to/public.pem
 genecli plugin install-registry --allow-registry
 ```
+## Simulator Environment Variables
 
+External simulator plugins can forward additional flags to their underlying
+tools. Set `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
+`GENECODER_SQUIGULATOR_OPTIONS` to pass options to the respective simulator.
+Use `GENECODER_SIM_SEED` to make runs reproducible. The CLI automatically
+includes these values when invoking the simulator plugin.
 
 ## Plugin Catalogs
 


### PR DESCRIPTION
## Summary
- clarify plugin security verification in plugin docs
- document simulator plugin environment variables
- document plugin verification and simulator env vars in installation guide

## Testing
- `PYTHONPATH=. poetry run mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6888d4a9e148832683daac9f51d4b178