### PR TITLE
Add fallback test for NanoporeDNArSim

### DIFF
--- a/tests/test_nanopore_fallback.py
+++ b/tests/test_nanopore_fallback.py
@@ -1,0 +1,20 @@
+
+import genecoder.simulators.nanopore as nanopore
+from genecoder.simulators.nanopore import NanoporeDNArSimChannel
+
+
+def test_fallback_output_length(monkeypatch) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "42")
+    monkeypatch.setattr(nanopore.shutil, "which", lambda _: None)
+    # ensure external runner is not used
+    monkeypatch.setattr(
+        nanopore,
+        "_run_external",
+        lambda *_: (_ for _ in ()).throw(AssertionError("_run_external called")),
+    )
+
+    seq = "ACGT" * 10
+    channel = NanoporeDNArSimChannel(error_rate=0.4)
+    result = channel.simulate(seq)
+
+    assert 0.5 * len(seq) <= len(result) <= 1.5 * len(seq)


### PR DESCRIPTION
## Summary
- ensure the fallback path in NanoporeDNArSimChannel returns a sequence
- check that the sequence length remains within 50% of the input when the external tool is absent

## Testing
- `ruff check --fix tests/test_nanopore_fallback.py`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d4a94228832695a685008dc78759