### PR TITLE
Add per-channel rate options

### DIFF
--- a/docs/cli_tutorial.md
+++ b/docs/cli_tutorial.md
@@ -38,3 +38,21 @@ genecli bundle run bundle.yaml --cache-dir runs/
 
 Results are written to `runs/<hash>/<timestamp>/` and skipped when the same
 configuration is executed again.
+
+## Simulating channel errors
+
+The `pipeline` command can apply a sequencing simulator between encoding and
+decoding. Pass per-channel rates directly on the command line:
+
+```bash
+genecli pipeline input.bin output.bin --codec base4_direct --channel indel \
+    --sub-rate 0.1 --ins-rate 0.02 --del-rate 0.05
+```
+
+The same parameters work with the `channel` command when applying simulators to
+FASTA sequences:
+
+```bash
+genecli channel apply --input-file seq.fasta --output-file corrupted.fasta \
+    --simulator indel --sub-rate 0.1 --ins-rate 0.02 --del-rate 0.05 --min-length 1
+```

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -256,6 +256,24 @@ def register_subcommand(
         target.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
         target.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
         target.add_argument("--del-prob", type=float, default=0.0, help="Deletion probability per nucleotide")
+        target.add_argument(
+            "--sub-rate",
+            type=float,
+            default=None,
+            help="Substitution rate for generic simulators",
+        )
+        target.add_argument(
+            "--ins-rate",
+            type=float,
+            default=None,
+            help="Insertion rate for generic simulators",
+        )
+        target.add_argument(
+            "--del-rate",
+            type=float,
+            default=None,
+            help="Deletion rate for generic simulators",
+        )
         target.add_argument("--illumina-depth", type=int, default=None, help="Coverage depth for Illumina reads")
         target.add_argument("--illumina-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--illumina-context", type=str, default=None, help="Path to JSON/YAML context error map")
@@ -360,6 +378,15 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params["insertion_rate"] = opts.nanopore_ins_rate
             if opts.nanopore_del_rate is not None:
                 new_params["deletion_rate"] = opts.nanopore_del_rate
+        if name == "indel":
+            if opts.sub_rate is not None:
+                new_params["substitution_prob"] = opts.sub_rate
+            if opts.ins_rate is not None:
+                new_params["insertion_prob"] = opts.ins_rate
+            if opts.del_rate is not None:
+                new_params["deletion_prob"] = opts.del_rate
+        if name == "simple" and opts.sub_rate is not None:
+            new_params["error_rate"] = opts.sub_rate
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -38,6 +38,9 @@ class ChannelOptions:
     nanopore_del_rate: float | None = None
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    sub_rate: float | None = None
+    ins_rate: float | None = None
+    del_rate: float | None = None
 
 
 def _parse_quality(value: str | None) -> Sequence[float] | None:
@@ -197,4 +200,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_del_rate=args.nanopore_del_rate,
         illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
+        sub_rate=args.sub_rate,
+        ins_rate=args.ins_rate,
+        del_rate=args.del_rate,
     )

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -132,6 +132,24 @@ def register_subcommand(
     else:
         parser.add_argument("--fec", default=None)
     parser.add_argument("--channel", choices=chan_choices, default=None)
+    parser.add_argument(
+        "--sub-rate",
+        type=float,
+        default=None,
+        help="Substitution rate/probability for the selected channel",
+    )
+    parser.add_argument(
+        "--ins-rate",
+        type=float,
+        default=None,
+        help="Insertion rate/probability for the selected channel",
+    )
+    parser.add_argument(
+        "--del-rate",
+        type=float,
+        default=None,
+        help="Deletion rate/probability for the selected channel",
+    )
 
     parser.set_defaults(func=_handle_command)
 
@@ -147,6 +165,24 @@ def _handle_command(args: argparse.Namespace) -> None:
     fec = args.fec if args.fec is not None else cfg_fec
     channel = args.channel or cfg_channel
     channel_params = cfg_params if channel == cfg_channel else {}
+    if channel is not None and channel != "none":
+        if args.sub_rate is not None:
+            if channel == "indel":
+                channel_params["substitution_prob"] = args.sub_rate
+            elif channel != "simple":
+                channel_params["substitution_rate"] = args.sub_rate
+            else:
+                channel_params["error_rate"] = args.sub_rate
+        if args.ins_rate is not None:
+            if channel == "indel":
+                channel_params["insertion_prob"] = args.ins_rate
+            elif channel != "simple":
+                channel_params["insertion_rate"] = args.ins_rate
+        if args.del_rate is not None:
+            if channel == "indel":
+                channel_params["deletion_prob"] = args.del_rate
+            elif channel != "simple":
+                channel_params["deletion_rate"] = args.del_rate
 
     if codec is None:
         logger.error("Codec must be specified via --codec or config")

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -141,6 +141,51 @@ def test_cli_nanopore_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert called == [(0.2, 0.3, 0.1)]
 
 
+def test_cli_indel_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_indel.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_indel.fasta"
+    called: list[tuple[float, float, float]] = []
+
+    from genecoder.error_simulation import Channel as IndelChannel
+
+    def fake_simulate(self: IndelChannel, seq: str) -> str:
+        called.append((self.substitution_prob, self.insertion_prob, self.deletion_prob))
+        return seq
+
+    monkeypatch.setattr(IndelChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "indel",
+            "--sub-rate",
+            "0.1",
+            "--ins-rate",
+            "0.2",
+            "--del-rate",
+            "0.05",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == [(0.1, 0.2, 0.05)]
+
+
 def test_channel_cli_yaml(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+import pytest
+from tests.test_cli import run_cli_command
+
+
+def test_cli_pipeline_indel_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_file = tmp_path / "data.bin"
+    input_file.write_bytes(b"abc")
+    output_file = tmp_path / "out.bin"
+
+    called: list[tuple[float, float, float]] = []
+
+    from genecoder.error_simulation import Channel as IndelChannel
+
+    def fake_simulate(self: IndelChannel, seq: str) -> str:
+        called.append((self.substitution_prob, self.insertion_prob, self.deletion_prob))
+        return seq
+
+    monkeypatch.setattr(IndelChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "pipeline",
+            str(input_file),
+            str(output_file),
+            "--codec",
+            "reverse",
+            "--channel",
+            "indel",
+            "--sub-rate",
+            "0.1",
+            "--ins-rate",
+            "0.2",
+            "--del-rate",
+            "0.05",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == [(0.1, 0.2, 0.05)]
+    assert output_file.read_bytes() == b"abc"


### PR DESCRIPTION
## Summary
- extend CLI pipeline and channel commands with per-channel rate options
- implement rate argument handling for indel and simple simulators
- document usage with examples in cli tutorial
- ensure CLI tests cover new options using built-in reverse codec

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/cli/pipeline.py tests/test_cli_channel.py tests/test_cli_pipeline.py --fix`
- `pre-commit run mypy --files src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/cli/pipeline.py tests/test_cli_channel.py tests/test_cli_pipeline.py`
- `pytest -q tests/test_cli_channel.py tests/test_cli_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6888e23406688326928235b95fad8280