### PR TITLE
Fix homopolymer deletion threshold

### DIFF
--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -17,7 +17,6 @@ from ..nanopore_sim import (
 from ..api import Simulator
 from .base import BaseChannel
 from ..error_simulation import (
-    introduce_errors,
     _random_substitution,
     NUCLEOTIDES,
 )
@@ -176,7 +175,9 @@ class NanoporeDNArSimChannel(NanoporeChannel):
                 run_len = 1
                 prev = nt
 
-            del_p = base_del_p * (2 if run_len > 3 else 1)
+            # Double the deletion probability only for very long runs to
+            # prevent excessive trimming of shorter homopolymers.
+            del_p = base_del_p * (2 if run_len >= 5 else 1)
             del_p = min(1.0, del_p)
             if rng.random() < del_p:
                 continue


### PR DESCRIPTION
## Summary
- restrict deletion increase in `NanoporeDNArSimChannel._simulate_fallback` to runs >=5

## Testing
- `ruff check src/genecoder/simulators/nanopore.py`
- `pytest tests/test_nanopore_homopolymer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68891989d1dc8326aa4478d11faabd92