### PR TITLE
Add DNA Chisel constraint fixer

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -140,6 +140,14 @@ project. These are registered when :func:`genecoder.plugins.load_plugins` import
 the :mod:`genecoder.builtin_plugins` module before discovering any third-party
 extensions.
 
+The optional ``dnachisel_fixer`` plugin exposes a GC and homopolymer adjustment
+helper powered by [DNA Chisel](https://github.com/Edinburgh-Genome-Foundry/DNAChisel).
+Install GeneCoder with the ``chisel`` extras to enable it:
+
+```bash
+poetry install --extras chisel --no-interaction
+```
+
 ## Plugin Examples
 
 See the [plugins-examples](../plugins-examples/) directory in the source tree for

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -419,7 +419,8 @@ poetry install --extras chisel --no-interaction
 ```
 
 Pass `--fix-chisel` to `genecli encode` or `genecli analyze` to automatically
-adjust sequences so they satisfy strict GC and homopolymer limits:
+adjust sequences so they satisfy strict GC and homopolymer limits. The option
+uses the ``dnachisel_fixer`` plugin when available:
 
 ```bash
 genecli encode --input-files sample.bin \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ raptorq = {version = ">=2.0,<3.0", optional = true}
 httpx = "<0.28"
 deepdna = {version = "*", optional = true}
 chamaeleo = {version = "*", optional = true}
+dnachisel = {version = "*", optional = true}
 
 [tool.poetry.group.gui.dependencies]
 flet = ">=0.28,<0.29"
@@ -116,6 +117,7 @@ raptorq = ["raptorq", "numpy"]
 bch = ["bchlib"]
 deepdna = ["deepdna", "torch"]
 chamaeleo = ["chamaeleo"]
+chisel = ["dnachisel"]
 
 
 [build-system]

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -35,6 +35,7 @@ def register_builtin_plugins() -> None:
     _load_and_register(
         [
             "genecoder.chamaeleo_codec",
+            "genecoder.dnachisel_fixer",
         ],
         register_codec,
         "builtin",

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -27,7 +27,7 @@ from genecoder.encoders import (
 )
 from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import encode_data_with_hamming
-from genecoder.plugin_manager import FEC_REGISTRY
+from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY
 from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
@@ -302,12 +302,22 @@ def process_single_encode(
         )
 
         if os.getenv("GENECODER_DISABLE_FIX") not in {"1", "true", "True"}:
-            final_encoded_dna_sequence = fix_sequence(
-                final_encoded_dna_sequence,
-                target_gc_min=args.gc_min,
-                target_gc_max=args.gc_max,
-                max_homopolymer=args.max_homopolymer,
-            )
+            if getattr(args, "fix_chisel", False) and "dnachisel_fixer" in CODEC_REGISTRY:
+                from genecoder.dnachisel_fixer import fix_sequence_dnachisel
+
+                final_encoded_dna_sequence = fix_sequence_dnachisel(
+                    final_encoded_dna_sequence,
+                    gc_min=args.gc_min,
+                    gc_max=args.gc_max,
+                    max_homopolymer=args.max_homopolymer,
+                )
+            else:
+                final_encoded_dna_sequence = fix_sequence(
+                    final_encoded_dna_sequence,
+                    target_gc_min=args.gc_min,
+                    target_gc_max=args.gc_max,
+                    max_homopolymer=args.max_homopolymer,
+                )
 
         if checksum:
             fasta_header = f"{fasta_header} checksum={checksum}"
@@ -559,6 +569,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--mirror",
         action="store_true",
         help="Also output the reverse-complement sequence and launch the visualizer.",
+    )
+    parser.add_argument(
+        "--fix-chisel",
+        action="store_true",
+        help="Use DNA Chisel for constraint fixing when available.",
     )
     parser.set_defaults(func=_handle_command)
 

--- a/src/genecoder/dnachisel_fixer.py
+++ b/src/genecoder/dnachisel_fixer.py
@@ -1,0 +1,56 @@
+"""Constraint fixer powered by DNA Chisel."""
+# ruff: noqa: ANN401
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+try:  # optional dependency
+    from dnachisel import DnaOptimizationProblem, EnforceGCContent, AvoidPattern
+except Exception:  # pragma: no cover - optional dependency missing
+    DnaOptimizationProblem = None
+    EnforceGCContent = None
+    AvoidPattern = None
+
+from .api import Codec
+
+__all__ = ["fix_sequence_dnachisel", "register"]
+
+
+def fix_sequence_dnachisel(
+    sequence: str,
+    *,
+    gc_min: float,
+    gc_max: float,
+    max_homopolymer: int,
+) -> str:
+    """Return ``sequence`` fixed for GC and homopolymers using DNA Chisel."""
+    if DnaOptimizationProblem is None:
+        raise ImportError("dnachisel is required for fix_sequence_dnachisel")
+    constraints = [EnforceGCContent(mini=gc_min, maxi=gc_max)]
+    if max_homopolymer >= 1:
+        for base in "ATGC":
+            constraints.append(AvoidPattern(base * (max_homopolymer + 1)))
+    problem = DnaOptimizationProblem(
+        sequence=sequence.upper(),
+        constraints=constraints,
+        logger=None,
+    )
+    problem.resolve_constraints()
+    return str(problem.sequence)
+
+
+class _DummyCodec(Codec):
+    """Minimal codec used only for plugin registration."""
+
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:  # pragma: no cover - unused
+        return ""
+
+    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:  # pragma: no cover - unused
+        return b""
+
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    """Register this module's dummy codec with ``register_codec``."""
+
+    register_codec("dnachisel_fixer", _DummyCodec)

--- a/tests/test_dnachisel_fixer.py
+++ b/tests/test_dnachisel_fixer.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip("dnachisel")
+
+from genecoder.dnachisel_fixer import fix_sequence_dnachisel
+from genecoder.encoders import calculate_gc_content
+from genecoder.utils import get_max_homopolymer_length
+
+
+def test_dnachisel_fix_low_gc() -> None:
+    seq = "A" * 20
+    fixed = fix_sequence_dnachisel(seq, gc_min=0.4, gc_max=0.6, max_homopolymer=3)
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 3
+    assert len(fixed) == len(seq)
+
+
+def test_dnachisel_fix_high_gc() -> None:
+    seq = "G" * 20
+    fixed = fix_sequence_dnachisel(seq, gc_min=0.4, gc_max=0.6, max_homopolymer=2)
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 2
+    assert len(fixed) == len(seq)


### PR DESCRIPTION
## Summary
- add `dnachisel` optional dependency under `chisel` extras
- implement `fix_sequence_dnachisel` plugin using DNA Chisel
- load the plugin from `builtin_plugins`
- support `--fix-chisel` flag in the encode CLI
- add unit tests for the new fixer
- document the plugin and CLI usage

## Testing
- `pytest -q tests/test_dnachisel_fixer.py`
- `ruff check src/genecoder/dnachisel_fixer.py src/genecoder/cli/encode.py src/genecoder/builtin_plugins.py`
- `mypy src/genecoder/dnachisel_fixer.py src/genecoder/cli/encode.py src/genecoder/builtin_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_68893af5ca208326868b1b11eb18436b