### PR TITLE
Add GC metrics to pipeline manifest

### DIFF
--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Tuple, Dict
+
+from .gc_constrained_encoder import calculate_gc_content
+from .utils import get_max_homopolymer_length
 
 from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from .simulators import SIMULATOR_REGISTRY
@@ -17,7 +20,7 @@ def run_pipeline(
     channel: str | None,
     input_path: str,
     output_path: str,
-) -> bytes:
+) -> Tuple[bytes, Dict[str, float | int]]:
     """Process ``input_path`` through the selected codec, FEC and channel.
 
     The decoded bytes are written to ``output_path`` and also returned.
@@ -42,6 +45,9 @@ def run_pipeline(
     if channel and channel != "none":
         dna = SIMULATOR_REGISTRY[channel].simulate(dna)
 
+    gc_content = calculate_gc_content(dna)
+    max_homopolymer = get_max_homopolymer_length(dna)
+
     decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
     assert isinstance(decoded_any, (bytes, bytearray))
     decoded = bytes(decoded_any)
@@ -51,4 +57,4 @@ def run_pipeline(
         decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
 
     Path(output_path).write_bytes(decoded)
-    return decoded
+    return decoded, {"gc_content": gc_content, "max_homopolymer": max_homopolymer}

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -13,6 +13,7 @@ import streamlit as st
 _DEF_METRICS: dict[str, Any] = {
     "gc_distribution": [],
     "gc_content": None,
+    "max_homopolymer": None,
     "homopolymer_runs": [],
     "ecc_success_rates": {},
     "decode_success_rate": None,
@@ -76,6 +77,10 @@ def main(results_path: str | None = None) -> None:
     gc_content = data.get("gc_content")
     if isinstance(gc_content, (int, float)):
         st.metric("Average GC Content", f"{float(gc_content):.2%}")
+
+    max_hp = data.get("max_homopolymer")
+    if isinstance(max_hp, (int, float)):
+        st.metric("Max Homopolymer Length", f"{int(max_hp)}")
 
     st.header("Homopolymer Runs")
     if data["homopolymer_runs"]:

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -34,6 +34,7 @@ def test_roundtrip_rs_simple(tmp_path: Path) -> None:
     data = b"pipeline test"
     inp.write_bytes(data)
 
-    result = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
+    result, metrics = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
     assert result == data
+    assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,6 +3,10 @@ import pytest
 from dataclasses import dataclass
 
 from genecoder.manifest import generate_manifest
+from genecoder.core import run_pipeline
+from genecoder.api import Codec
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+import json
 from genecoder.cli import EncodingOptions
 from pathlib import Path
 import os
@@ -69,4 +73,35 @@ def test_generate_manifest_missing_required_key_dataclass() -> None:
 
     with pytest.raises(ValueError, match="Missing required encoding parameter\(s\): method"):
         generate_manifest("bad.txt", NoMethod(), {"dna_length": 1})
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+        return decode_base4_direct(encoded)[0]
+
+
+def test_pipeline_manifest_metrics(tmp_path: Path) -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(b"ACGTACGT")
+
+    result, metrics = run_pipeline("base4", None, "none", str(inp), str(outp))
+    assert result == b"ACGTACGT"
+
+    manifest = generate_manifest(inp.name, {"method": "base4"}, metrics)
+    manifest_path = tmp_path / "m.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    from genecoder import dashboard
+
+    loaded = dashboard._load_metrics(str(manifest_path))
+    assert loaded["gc_content"] == metrics["gc_content"]
+    assert loaded["max_homopolymer"] == metrics["max_homopolymer"]
 

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -42,8 +42,9 @@ def test_pipeline_roundtrip_reed_solomon(tmp_path: Path) -> None:
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
+    result, metrics = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
     assert result == data
+    assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data
 
 
@@ -58,8 +59,9 @@ def test_pipeline_roundtrip_fountain(tmp_path: Path) -> None:
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result = run_pipeline("base4", "fountain", "simple", str(inp), str(outp))
+    result, metrics = run_pipeline("base4", "fountain", "simple", str(inp), str(outp))
     assert result == data
+    assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data
 
 
@@ -76,7 +78,7 @@ def test_pipeline_roundtrip_rs_illumina(
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result = run_pipeline(
+    result, _ = run_pipeline(
         "base4",
         "reed_solomon",
         "illumina",
@@ -100,7 +102,7 @@ def test_pipeline_roundtrip_fountain_nanopore(
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result = run_pipeline(
+    result, _ = run_pipeline(
         "base4",
         "fountain",
         "nanopore",


### PR DESCRIPTION
## Summary
- compute GC content and maximum homopolymer length in `run_pipeline`
- surface these metrics in `generate_manifest`
- show metrics in dashboard if present
- test manifest metric parsing and adapt pipeline tests

## Testing
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895cd3a4a883269961c8331655e806