### PR TITLE
Document pipeline profiles

### DIFF
--- a/docs/cli_tutorial.md
+++ b/docs/cli_tutorial.md
@@ -56,3 +56,8 @@ FASTA sequences:
 genecli channel apply --input-file seq.fasta --output-file corrupted.fasta \
     --simulator indel --sub-rate 0.1 --ins-rate 0.02 --del-rate 0.05 --min-length 1
 ```
+
+Built-in channel profiles include:
+
+- **Illumina** – `miseq`, `hiseq`
+- **Nanopore** – `minion`, `promethion`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -185,10 +185,13 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-file channel.fasta --simulator simple --simulator indel
    ```
 
-   Named sequencing profiles are available. Use `--illumina-profile miseq` or
-   `--illumina-profile hiseq` for Illumina runs and `--nanopore-profile minion`
-   or `--nanopore-profile promethion` for Nanopore data. Individual rate options
-   override the selected profile.
+   Named sequencing profiles are available:
+
+   - **Illumina** – `miseq`, `hiseq`
+   - **Nanopore** – `minion`, `promethion`
+
+   Select a profile with `--illumina-profile` or `--nanopore-profile`. Individual rate options
+   override the chosen profile.
 
    The same configuration can be provided via YAML:
 

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -7,6 +7,9 @@ import logging
 from pathlib import Path
 from typing import Any, Dict
 
+from genecoder.simulators.illumina import ILLUMINA_PROFILES
+from genecoder.simulators.nanopore import NANOPORE_PROFILES
+
 from genecoder.core import run_pipeline
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
@@ -120,6 +123,8 @@ def register_subcommand(
     codec_choices = sorted(CODEC_REGISTRY.keys()) or None
     fec_choices = sorted(FEC_REGISTRY.keys())
     chan_choices = ["none", *sorted(SIMULATOR_REGISTRY.keys())]
+    illumina_profiles = ", ".join(sorted(ILLUMINA_PROFILES))
+    nanopore_profiles = ", ".join(sorted(NANOPORE_PROFILES))
 
     parser.add_argument("input", help="Path to input file")
     parser.add_argument("output", help="Path to output file")
@@ -131,7 +136,15 @@ def register_subcommand(
         parser.add_argument("--fec", choices=fec_choices, default=None)
     else:
         parser.add_argument("--fec", default=None)
-    parser.add_argument("--channel", choices=chan_choices, default=None)
+    parser.add_argument(
+        "--channel",
+        choices=chan_choices,
+        default=None,
+        help=(
+            "Channel simulator to apply. Illumina profiles: "
+            f"{illumina_profiles}. Nanopore profiles: {nanopore_profiles}."
+        ),
+    )
     parser.add_argument(
         "--sub-rate",
         type=float,

--- a/tests/test_profiles_cli.py
+++ b/tests/test_profiles_cli.py
@@ -1,0 +1,11 @@
+from tests.test_cli import run_cli_command
+
+
+def test_pipeline_profiles_listed() -> None:
+    result = run_cli_command(["pipeline", "--help"])
+    assert result.returncode == 0
+    out = result.stdout
+    assert "miseq" in out
+    assert "hiseq" in out
+    assert "minion" in out
+    assert "promethion" in out


### PR DESCRIPTION
## Summary
- mention Illumina and Nanopore profile names in docs
- expose profile information in `pipeline` command help
- test help text for profile names

## Testing
- `ruff check .`
- `pytest -k test_profiles_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_6889631edddc832680a11b89b757e6ec