### PR TITLE
Add pipeline metrics config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GeneCoder is an educational toolkit for exploring DNA-based data storage. It pro
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
+The configuration at `configs/pipeline_metrics.yaml` shows how to run the pipeline while recording metrics.
 For deployment instructions including building the React dashboard see the
 [deployment guide](docs/deployment.md).
 

--- a/configs/pipeline_metrics.yaml
+++ b/configs/pipeline_metrics.yaml
@@ -1,0 +1,19 @@
+# Sample pipeline configuration demonstrating metric collection.
+# Set GENECODER_METRICS_PATH to specify the metrics file before running:
+#   GENECODER_METRICS_PATH=metrics.json genecli bundle run configs/pipeline_metrics.yaml
+encode:
+  input_files:
+    - tests/data/vertical_slice.txt
+  method: base4_direct
+  fec: hamming_7_4
+simulate:
+  simulators:
+    - name: simple
+      error_rate: 0.01
+  pipeline:
+    parallel: false
+    workers: null
+    use_process_pool: false
+    use_mpi: false
+decode:
+  method: base4_direct

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -81,6 +81,9 @@ using a simulator and Hamming FEC. The `pipeline` section selects the built-in
 genecli bundle run configs/vertical_slice_demo.yaml --cache-dir runs
 ```
 
+For a pipeline run that records usage statistics see
+`configs/pipeline_metrics.yaml`.
+
 The `scripts/vertical_slice.sh` helper executes the same command automatically
 as part of the demo.
 

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -37,6 +37,9 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         nanopore_del_rate=None,
         illumina_profile=None,
         nanopore_profile=None,
+        sub_rate=None,
+        ins_rate=None,
+        del_rate=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)


### PR DESCRIPTION
## Summary
- add pipeline metrics YAML example
- reference new config in vertical slice guide and readme
- update CLI options unit test to include new rate fields

## Testing
- `ruff check tests/test_channel_options_validation.py`
- `mypy src/genecoder/metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895cd4597c8326a5a71b27d8117428