### PR TITLE
Add NanoporeDNArSimChannel missing dnarsim test

### DIFF
--- a/tests/test_nanopore_dnarsim_channel.py
+++ b/tests/test_nanopore_dnarsim_channel.py
@@ -1,5 +1,7 @@
 from genecoder.simulators.nanopore import NanoporeDNArSimChannel
 import genecoder.simulators.nanopore as nanopore
+import logging
+import random
 
 
 def test_fallback_deterministic(monkeypatch):
@@ -26,4 +28,26 @@ def test_cli_invocation(monkeypatch):
     result = ch.simulate("ACGT")
     assert result == "ok"
     assert called == [(["dnarsim", "-e", "0.1", "-p", "r9"], "ACGT")]
+
+
+def test_missing_executable_warning(monkeypatch, caplog):
+    called = []
+    monkeypatch.setattr(nanopore.shutil, "which", lambda _: None)
+
+    def fake_fallback(seq: str, rate: float, rng):
+        called.append((seq, rate, rng))
+        return "fallback"
+
+    monkeypatch.setattr(
+        nanopore.NanoporeDNArSimChannel,
+        "_simulate_fallback",
+        staticmethod(fake_fallback),
+    )
+    ch = NanoporeDNArSimChannel(error_rate=0.1)
+    with caplog.at_level(logging.WARNING):
+        result = ch.simulate("ACGT")
+
+    assert result == "fallback"
+    assert called and isinstance(called[0][2], random.Random)
+    assert any("not found" in rec.message for rec in caplog.records)
 


### PR DESCRIPTION
## Summary
- test NanoporeDNArSimChannel fallback warning when dnarsim not installed

## Testing
- `pre-commit run --files tests/test_nanopore_dnarsim_channel.py`
- `pytest tests/test_nanopore_dnarsim_channel.py::test_missing_executable_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_6889791409748326b9fa062dd3a6b038