### PR TITLE
Add error count metrics for dashboard

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -394,7 +394,17 @@ poetry install --with gui --no-interaction
 genecli dashboard results.json
 ```
 
-The interface plots GC content distribution, homopolymer histograms, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file.
+The interface plots GC content distribution, homopolymer histograms, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion counts are present, they are shown as a simple bar chart.
+
+Example metrics snippet:
+
+```json
+{
+  "substitutions": 12,
+  "insertions": 3,
+  "deletions": 1
+}
+```
 
 ### Constraint Fix Suggestions
 

--- a/src/genecoder/bundle_metrics.py
+++ b/src/genecoder/bundle_metrics.py
@@ -25,6 +25,9 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
     total_files = 0
     total_bytes = 0
     total_nt = 0
+    total_subs = 0
+    total_ins = 0
+    total_dels = 0
     bpn_values: list[float] = []
     for manifest in parse_manifests(root):
         total_files += 1
@@ -39,10 +42,22 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
             bpn = metrics.get("bits_per_nt")
             if isinstance(bpn, (int, float)):
                 bpn_values.append(float(bpn))
+            s = metrics.get("substitutions")
+            if isinstance(s, int):
+                total_subs += s
+            i = metrics.get("insertions")
+            if isinstance(i, int):
+                total_ins += i
+            d = metrics.get("deletions")
+            if isinstance(d, int):
+                total_dels += d
     avg_bpn = sum(bpn_values) / len(bpn_values) if bpn_values else 0.0
     return {
         "files": total_files,
         "total_original_size": total_bytes,
         "total_dna_length": total_nt,
         "avg_bits_per_nt": avg_bpn,
+        "total_substitutions": total_subs,
+        "total_insertions": total_ins,
+        "total_deletions": total_dels,
     }

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -9,6 +9,7 @@ import os
 import random
 from pathlib import Path
 from typing import Sequence, Dict, Any
+from difflib import SequenceMatcher
 
 
 from genecoder.formats import from_fasta, to_fasta
@@ -125,6 +126,20 @@ def _apply_simulators(
     return result
 
 
+def _count_errors(original: str, mutated: str) -> tuple[int, int, int]:
+    """Return substitution, insertion and deletion counts."""
+    subs = ins = dels = 0
+    sm = SequenceMatcher(None, original, mutated)
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "replace":
+            subs += max(i2 - i1, j2 - j1)
+        elif tag == "delete":
+            dels += i2 - i1
+        elif tag == "insert":
+            ins += j2 - j1
+    return subs, ins, dels
+
+
 def process_channel(
     input_file: str,
     output_file: str,
@@ -156,8 +171,9 @@ def process_channel(
     headers = [h for h, _ in records]
     sequences = [s for _, s in records]
 
-    def _process(item: tuple[int, str]) -> str:
+    def _process(item: tuple[int, str]) -> tuple[str, tuple[int, int, int]]:
         idx, seq = item
+        original = seq
         if simulators:
             cfg = config or ChannelConfig()
             seq = _apply_simulators(seq, simulators, config=cfg)
@@ -174,18 +190,25 @@ def process_channel(
         if not validate_sequence(seq, synth):
             raise ValueError("Sequence violates synthesis constraints")
         logger.info("Sequence satisfies synthesis constraints")
-        return seq
+        return seq, _count_errors(original, seq)
 
     if batch_workers and len(sequences) > 1:
-        processed_seqs = parallel_map(
+        processed = parallel_map(
             _process,
             list(enumerate(sequences)),
             workers=batch_workers,
         )
     else:
-        processed_seqs = [_process(p) for p in enumerate(sequences)]
+        processed = [_process(p) for p in enumerate(sequences)]
 
-    processed_records = list(zip(headers, processed_seqs))
+    processed_records: list[tuple[str, str]] = []
+    sub_total = ins_total = del_total = 0
+    for header, (seq, stats) in zip(headers, processed):
+        s, i, d = stats
+        sub_total += s
+        ins_total += i
+        del_total += d
+        processed_records.append((header, seq))
 
     fasta_out = "".join(
         to_fasta(seq, header, line_width=80) for header, seq in processed_records
@@ -204,7 +227,12 @@ def process_channel(
             "del_prob": del_prob,
         },
         "constraints": constraints,
-        "metrics": {"length": total_len},
+        "metrics": {
+            "length": total_len,
+            "substitutions": sub_total,
+            "insertions": ins_total,
+            "deletions": del_total,
+        },
     }
     manifest_path = os.path.splitext(output_file)[0] + ".manifest.json"
     with open(manifest_path, "w", encoding="utf-8") as m_out:

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -17,6 +17,9 @@ _DEF_METRICS: dict[str, Any] = {
     "homopolymer_runs": [],
     "ecc_success_rates": {},
     "decode_success_rate": None,
+    "substitutions": None,
+    "insertions": None,
+    "deletions": None,
 }
 
 
@@ -100,6 +103,22 @@ def main(results_path: str | None = None) -> None:
         st.metric("Decode Success", f"{decode_rate:.2%}")
     else:
         st.write("No decode success metric.")
+
+    st.header("Error Counts")
+    subs = data.get("substitutions")
+    ins = data.get("insertions")
+    dels = data.get("deletions")
+    counts = {}
+    if isinstance(subs, int):
+        counts["Substitutions"] = subs
+    if isinstance(ins, int):
+        counts["Insertions"] = ins
+    if isinstance(dels, int):
+        counts["Deletions"] = dels
+    if counts:
+        st.bar_chart(counts)
+    else:
+        st.write("No error count data.")
 
 
 def launch(results_path: str) -> None:

--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -6,5 +6,8 @@
     "rs": 0.98,
     "bch": 0.95
   },
-  "decode_success_rate": 0.97
+  "decode_success_rate": 0.97,
+  "substitutions": 2,
+  "insertions": 1,
+  "deletions": 0
 }

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -49,6 +49,9 @@ def test_channel_cli_simulator(tmp_path: Path) -> None:
     data = json.loads(manifest.read_text())
     assert data["simulators"] == ["simple"]
     assert isinstance(data["metrics"].get("length"), int)
+    assert "substitutions" in data["metrics"]
+    assert "insertions" in data["metrics"]
+    assert "deletions" in data["metrics"]
 
 
 def test_cli_illumina_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -375,6 +378,9 @@ def test_channel_cli_parallel_variants(
     data = json.loads(manifest.read_text())
     assert data["simulators"] == ["simple"]
     assert data["metrics"]["length"] == len(seq)
+    assert "substitutions" in data["metrics"]
+    assert "insertions" in data["metrics"]
+    assert "deletions" in data["metrics"]
 
 
 def test_channel_cli_bad_yaml(tmp_path: Path) -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -66,6 +66,9 @@ def test_display_ecc_and_decode_metric(
 ) -> None:
     data = {
         "ecc_success_rates": {"rs": 0.8, "bch": 0.9},
+        "substitutions": 5,
+        "insertions": 1,
+        "deletions": 2,
     }
     path = tmp_path / "metrics.json"
     path.write_text(json.dumps(data))
@@ -77,6 +80,13 @@ def test_display_ecc_and_decode_metric(
     assert dummy_streamlit["bar_chart"], "bar_chart not called"
     ecc_args, _ = dummy_streamlit["bar_chart"][0]
     assert {"rs": 0.8, "bch": 0.9} == ecc_args[0]
+    assert len(dummy_streamlit["bar_chart"]) >= 2
+    err_args, _ = dummy_streamlit["bar_chart"][1]
+    assert {
+        "Substitutions": 5,
+        "Insertions": 1,
+        "Deletions": 2,
+    } == err_args[0]
 
     # Decode success metric averages ECC rates
     assert dummy_streamlit["metric"], "metric not called"

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -29,7 +29,14 @@ def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
         json.dumps({
             "file": "x",
             "encoding_parameters": {"method": "base4_direct"},
-            "metrics": {"original_size": 10, "dna_length": 20, "bits_per_nt": 1.5},
+            "metrics": {
+                "original_size": 10,
+                "dna_length": 20,
+                "bits_per_nt": 1.5,
+                "substitutions": 2,
+                "insertions": 1,
+                "deletions": 1,
+            },
         })
     )
     r = _request("GET", "/bundle-metrics")
@@ -39,4 +46,7 @@ def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     assert data["total_original_size"] == 10
     assert data["total_dna_length"] == 20
     assert abs(data["avg_bits_per_nt"] - 1.5) < 1e-6
+    assert data["total_substitutions"] == 2
+    assert data["total_insertions"] == 1
+    assert data["total_deletions"] == 1
 


### PR DESCRIPTION
## Summary
- include substitution/insertion/deletion counts in dashboard metrics
- compute error statistics during channel simulation
- aggregate counts in bundle metrics
- document new dashboard output
- adjust tests for updated metrics

## Testing
- `pre-commit run --files src/genecoder/dashboard.py src/genecoder/cli/channel.py src/genecoder/bundle_metrics.py tests/test_dashboard.py tests/test_cli_channel.py tests/test_web_bundle_metrics.py tests/data/metrics.json docs/usage.md`
- `pytest tests/test_dashboard.py tests/test_cli_channel.py tests/test_web_bundle_metrics.py -k 'test_display_ecc_and_decode_metric or test_channel_cli_simulator or test_channel_cli_threads_and_processes_error or test_bundle_metrics' -q`

------
https://chatgpt.com/codex/tasks/task_e_68897ca3b3a88326a4b08f3f24cf4597