### PR TITLE
Add MPI example script

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -88,6 +88,15 @@ Execute the pipeline using:
 mpiexec -n 2 genecli channel run configs/mpi_demo.yaml
 ```
 
+You can also run a short Python example:
+
+```bash
+mpiexec -n 2 python scripts/mpi_example.py
+```
+
+The script prints the processed sequence from each MPI rank so you can verify
+distributed execution.
+
 ### mpiexec Quickstart
 
 Follow these steps to run the demo configuration under MPI.

--- a/scripts/mpi_example.py
+++ b/scripts/mpi_example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Demonstrate running ChannelPipeline under MPI."""
+from __future__ import annotations
+
+from genecoder.channel_config import ChannelConfig
+from genecoder.channel_sim import Channel
+from genecoder.simulators.pipeline import ChannelPipeline
+
+try:
+    from mpi4py import MPI
+except Exception as exc:  # pragma: no cover - optional dependency
+    raise SystemExit("mpi4py is required to run this example") from exc
+
+
+def main() -> None:
+    """Run a simple pipeline with MPI and print the result."""
+    rank = MPI.COMM_WORLD.Get_rank()
+    pipeline = ChannelPipeline([Channel(0.1), Channel(0.2)])
+    cfg = ChannelConfig(parallel=True, workers=2, use_mpi=True)
+    result = pipeline.simulate("ACGTACGTACGT", config=cfg)
+    print(f"Rank {rank} result: {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/mpi_example.py` illustrating MPI usage with `ChannelPipeline`
- document example in `docs/parallel.md`

## Testing
- `pre-commit run --files docs/parallel.md scripts/mpi_example.py` *(fails: KeyboardInterrupt? Wait precommit run aborted earlier due to manual break; but we executed ruff, mypy, markdown link check, tests separately)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898387812083269920b37ed6c97d81