### PR TITLE
Update MPI docs with multi-node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ full test matrix.
 `ChannelPipeline` can execute steps concurrently. Set
 `parallel=True` in `ChannelConfig` and choose a `workers` count. Adding
 `use_mpi=True` enables distributed runs. See
-[docs/parallel.md](docs/parallel.md) for more options and CLI tips.
+[docs/parallel.md](docs/parallel.md) for more options and CLI tips. Multi‑node
+instructions live in [docs/mpi.md](docs/mpi.md). MPI support requires the
+`mpi4py` package and an MPI implementation (MPICH or OpenMPI) but is optional
+for local or offline use.
 
 
 ## Continuous Integration

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,3 +26,5 @@ uvicorn web.main:app --reload
 
 Set `GENECODER_API_TOKEN` to your desired bearer token. When the server is
 running it serves the dashboard from `web/helix-ui/dist` at the root URL.
+
+See [mpi.md](mpi.md) for instructions on running channel simulations across multiple nodes using MPI.

--- a/docs/mpi.md
+++ b/docs/mpi.md
@@ -1,6 +1,7 @@
 # MPI Channel Simulation
 
 GeneCoder can distribute channel simulations across multiple machines using [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface). This relies on the `mpi4py` package and an installed MPI runtime such as MPICH or OpenMPI.
+MPI support is optional; local and offline runs work without it.
 
 ## Quickstart
 
@@ -34,4 +35,21 @@ mpiexec -n 4 genecli channel run config.yml
 ```
 
 Setting `use_mpi: true` automatically selects the MPI executor. The number of workers should match the `-n` argument to `mpiexec`.
+
+## Multi‑node Example
+
+To run the same configuration across several machines create a simple host file listing each node and how many processes it should launch:
+
+```text
+nodeA slots=2
+nodeB slots=2
+```
+
+Copy `config.yml` to every node and start the pipeline with:
+
+```bash
+mpiexec -hostfile hosts -n 4 genecli channel run config.yml
+```
+
+All nodes must have GeneCoder, `mpi4py` and an MPI runtime (MPICH or OpenMPI) installed. MPI support is entirely optional—for local and offline use the pipeline can instead rely on threads or processes as described in [parallel execution](parallel.md).
 


### PR DESCRIPTION
## Summary
- expand `docs/mpi.md` with a basic multi-node example using `mpiexec`
- cross-link MPI docs from the deployment guide and README
- mention that MPI packages are optional

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ac63d70cc8326be157f93e631201c