### PR TITLE
Add dev extra for stub packages

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -156,7 +156,7 @@ jobs:
         key: pre-commit-3.11-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Install package for mypy
-      run: pip install .[dev]
+      run: pip install -e .[dev]
 
     - name: Run mypy
       run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary
@@ -220,7 +220,7 @@ jobs:
       run: ruff check .
 
     - name: Install package for mypy
-      run: pip install .[dev]
+      run: pip install -e .[dev]
 
     - name: Run mypy
       run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,16 @@ The hook also runs automatically on each commit if installed.
 CI runs `ruff check` and `mypy` on pull requests that modify code. Fix any
 issues they report before merging.
 
+### Running `mypy` Manually
+
+Install the development extras so stub packages like `types-PyYAML` are
+available, then invoke `mypy`:
+
+```bash
+python -m pip install -e .[dev]
+mypy --config-file pyproject.toml --show-error-codes
+```
+
 An additional `check-glossary-terms` hook verifies that every term in
 `docs/glossary.json` appears in at least one Markdown file. The commit
 will fail if any terms are missing.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ test suite:
 |---------------|-------------------------------------------------|
 | `gui`         | Flet GUI and helix viewer dependencies          |
 | `web`         | FastAPI server for the web dashboard            |
-| `dev`         | Pytest, Ruff, MyPy and Playwright tools         |
+| `dev`         | Pytest, Ruff, MyPy, types-PyYAML and Playwright tools |
 | `ldpc`        | Low-density parity-check codes                  |
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
@@ -153,6 +153,14 @@ Install the development dependencies before executing the test suite:
 ```bash
 poetry install --with dev --no-interaction
 poetry run pytest -q
+```
+
+Run MyPy after installing the same `dev` extras so stub packages like
+`types-PyYAML` are available:
+
+```bash
+python -m pip install -e .[dev]
+mypy --config-file pyproject.toml --show-error-codes
 ```
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,9 +65,11 @@ If you prefer `pip`, ensure you are using **Python 3.11+** and install the
 repository in editable mode so changes take effect immediately:
 
 ```bash
-python -m pip install -e .[gui,web]
+python -m pip install -e .[gui,web,dev]
 ```
-This command installs the optional GUI and web dependencies in editable mode.
+This command installs the optional GUI, web, and development dependencies in
+editable mode. The `dev` group pulls in stub packages like `types-PyYAML` so
+`mypy` runs without additional steps.
 
 ## Development Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ bch = ["bchlib"]
 deepdna = ["deepdna", "torch"]
 chamaeleo = ["chamaeleo"]
 chisel = ["dnachisel"]
+dev = ["types-PyYAML"]
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `dev` extra with types-PyYAML
- document installing dev extras with pip for stub packages
- mention types-PyYAML in README extras table
- describe running mypy manually in CONTRIBUTING
- ensure CI installs dev extras in editable mode
- show how to run mypy in README

## Testing
- `SKIP=pytest pre-commit run --files pyproject.toml docs/installation.md README.md CONTRIBUTING.md .github/workflows/python-ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ac63e41448326b0fb157021ba3560