### PR TITLE
Update docs for MyPy stub setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,8 @@ issues they report before merging.
 ### Running `mypy` Manually
 
 Install the development extras so stub packages like `types-PyYAML` are
-available, then invoke `mypy`:
+available. `mypy` relies on this stub package for YAML type checking, so
+ensure it is installed before running:
 
 ```bash
 python -m pip install -e .[dev]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,8 @@ python -m pip install -e .[gui,web,dev]
 ```
 This command installs the optional GUI, web, and development dependencies in
 editable mode. The `dev` group pulls in stub packages like `types-PyYAML` so
-`mypy` runs without additional steps.
+`mypy` runs without additional steps. Make sure this stub package is
+installed whenever you run the type checker.
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary
- clarify that the `types-PyYAML` stub must be available when running MyPy
- note the same requirement in developer installation docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b8a86284c83268367678ab30e9e3c