### PR TITLE
Fix channel_sim import order

### DIFF
--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import random
-from typing import Protocol, Callable
+from typing import Callable, Optional, Protocol
 
 from .random_utils import make_rng
 
@@ -18,7 +18,6 @@ class RandomLike(Protocol):
 
     def choice(self, seq: list[str]) -> str: ...
 
-from typing import Optional
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
 


### PR DESCRIPTION
## Summary
- organize imports in `channel_sim`

## Testing
- `ruff check`
- `pytest -q` *(tests interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd09cff483268ff39f3f23ca4b10