### PR TITLE
Add novaseq and r10 simulator presets

### DIFF
--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -50,6 +50,12 @@ ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
         "deletion_rate": 0.00005,
         "read_length": 150,
     },
+    "novaseq": {
+        "substitution_rate": 0.0003,
+        "insertion_rate": 0.00003,
+        "deletion_rate": 0.00003,
+        "read_length": 150,
+    },
 }
 
 

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -53,6 +53,12 @@ NANOPORE_PROFILES: dict[str, dict[str, float | int]] = {
         "insertion_rate": 0.02,
         "deletion_rate": 0.045,
     },
+    "r10": {
+        "error_rate": 0.05,
+        "substitution_rate": 0.01,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.03,
+    },
 }
 
 

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -9,3 +9,5 @@ def test_cli_profiles_lists() -> None:
     assert "Nanopore" in out
     assert "miseq" in out
     assert "minion" in out
+    assert "novaseq" in out
+    assert "r10" in out

--- a/tests/test_profiles_cli.py
+++ b/tests/test_profiles_cli.py
@@ -9,3 +9,5 @@ def test_pipeline_profiles_listed() -> None:
     assert "hiseq" in out
     assert "minion" in out
     assert "promethion" in out
+    assert "novaseq" in out
+    assert "r10" in out


### PR DESCRIPTION
## Summary
- add a novaseq preset to the Illumina simulator
- add a r10 preset to the Nanopore simulator
- show these profiles in the `channel profiles` command
- test that the CLI lists the new profiles

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c07ce0e20832685aceccf28ccd1a4