### PR TITLE
Add profile support to channel run command

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -253,6 +253,20 @@ def register_subcommand(
         "run", help="Run channel pipeline from a YAML config"
     )
     run_parser.add_argument("config", type=str, help="Path to channel config")
+    illumina_profiles = ", ".join(sorted(ILLUMINA_PROFILES))
+    nanopore_profiles = ", ".join(sorted(NANOPORE_PROFILES))
+    run_parser.add_argument(
+        "--illumina-profile",
+        type=str,
+        default=None,
+        help=f"Named Illumina profile to use. Available profiles: {illumina_profiles}",
+    )
+    run_parser.add_argument(
+        "--nanopore-profile",
+        type=str,
+        default=None,
+        help=f"Named Nanopore profile to use. Available profiles: {nanopore_profiles}",
+    )
     run_parser.set_defaults(func=_handle_run)
 
     apply_parser = channel_sub.add_parser(
@@ -438,6 +452,11 @@ def _handle_run(args: argparse.Namespace) -> None:
     except Exception as exc:  # pragma: no cover - config error handling
         logger.error(str(exc))
         raise SystemExit(1)
+
+    if args.illumina_profile is not None:
+        cfg.illumina_profile = args.illumina_profile
+    if args.nanopore_profile is not None:
+        cfg.nanopore_profile = args.nanopore_profile
 
     input_file = extra.get("input_file")
     output_file = extra.get("output_file")

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -10,8 +10,13 @@ import logging
 try:  # Optional at runtime
     from numba import njit
 except Exception:  # pragma: no cover - fallback when numba missing
-    def njit(*args, **kwargs):
-        def wrapper(func):
+    from typing import Callable, TypeVar, ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
+
+    def njit(*args: object, **kwargs: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
+        def wrapper(func: Callable[P, R]) -> Callable[P, R]:
             return func
 
         return wrapper
@@ -53,7 +58,7 @@ ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
 }
 
 
-@njit(cache=True, forceobj=True)
+@njit(cache=True, forceobj=True)  # type: ignore[misc]
 def _mutate_read_jit(
     read: str,
     quality: Sequence[float] | None,
@@ -113,14 +118,19 @@ class IlluminaChannel(BaseSimulator):
     def _mutate_read(
         self, read: str, quality: Sequence[float] | None, rng: random.Random
     ) -> str:
-        return _mutate_read_jit(
-            read,
-            quality,
-            self.substitution_rate,
-            self.insertion_rate,
-            self.deletion_rate,
-            self.context_errors,
-            rng,
+        from typing import cast
+
+        return cast(
+            str,
+            _mutate_read_jit(
+                read,
+                quality,
+                self.substitution_rate,
+                self.insertion_rate,
+                self.deletion_rate,
+                self.context_errors,
+                rng,
+            ),
         )
 
     @staticmethod

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -10,8 +10,13 @@ import logging
 try:  # Optional at runtime
     from numba import njit
 except Exception:  # pragma: no cover - fallback when numba missing
-    def njit(*args, **kwargs):
-        def wrapper(func):
+    from typing import Callable, TypeVar, ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
+
+    def njit(*args: object, **kwargs: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
+        def wrapper(func: Callable[P, R]) -> Callable[P, R]:
             return func
 
         return wrapper
@@ -56,7 +61,7 @@ NANOPORE_PROFILES: dict[str, dict[str, float | int]] = {
 }
 
 
-@njit(cache=True, forceobj=True)
+@njit(cache=True, forceobj=True)  # type: ignore[misc]
 def _simulate_fallback_jit(sequence: str, error_rate: float, rng: random.Random) -> str:
     sub_p = error_rate * 0.4
     ins_p = error_rate * 0.3
@@ -87,7 +92,7 @@ def _simulate_fallback_jit(sequence: str, error_rate: float, rng: random.Random)
     return "".join(mutated)
 
 
-@njit(cache=True, forceobj=True)
+@njit(cache=True, forceobj=True)  # type: ignore[misc]
 def _mutate_read_jit(
     read: str,
     quality: Sequence[float] | None,
@@ -243,7 +248,9 @@ class NanoporeDNArSimChannel(NanoporeChannel):
 
     @staticmethod
     def _simulate_fallback(sequence: str, error_rate: float, rng: random.Random) -> str:
-        return _simulate_fallback_jit(sequence, error_rate, rng)
+        from typing import cast
+
+        return cast(str, _simulate_fallback_jit(sequence, error_rate, rng))
 
 
     def simulate(self, sequence: str) -> str:
@@ -267,14 +274,19 @@ class NanoporeDNArSimChannel(NanoporeChannel):
 def _mutate_read(
     read: str, quality: Sequence[float] | None, rng: random.Random, channel: NanoporeChannel
 ) -> str:
-    return _mutate_read_jit(
-        read,
-        quality,
-        rng,
-        channel.substitution_rate,
-        channel.insertion_rate,
-        channel.deletion_rate,
-        channel.context_errors,
+    from typing import cast
+
+    return cast(
+        str,
+        _mutate_read_jit(
+            read,
+            quality,
+            rng,
+            channel.substitution_rate,
+            channel.insertion_rate,
+            channel.deletion_rate,
+            channel.context_errors,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- expose `--illumina-profile` and `--nanopore-profile` on `channel run`
- allow overriding profiles in `_handle_run`
- add typed `njit` fallbacks for mypy

## Testing
- `pre-commit run ruff --files src/genecoder/cli/channel.py src/genecoder/simulators/nanopore.py src/genecoder/simulators/illumina.py`
- `pre-commit run mypy --files src/genecoder/cli/channel.py src/genecoder/simulators/nanopore.py src/genecoder/simulators/illumina.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c07ce0a4083268b44b827057efdb4