### PR TITLE
Add DegradationChannel simulator

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -59,6 +59,7 @@ def register_builtin_plugins() -> None:
             "genecoder.nanopore_sim",
             "genecoder.channel_sim",
             "genecoder.error_simulation",
+            "genecoder.simulators.decay",
             "genecoder.simulators.illumina",
             "genecoder.simulators.nanopore",
             "genecoder.insilicoseq_adapter",

--- a/src/genecoder/simulators/decay.py
+++ b/src/genecoder/simulators/decay.py
@@ -1,0 +1,44 @@
+"""Simple strand degradation simulator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from ..api import Simulator
+from ..random_utils import make_rng
+from ..error_simulation import _random_substitution
+from . import register_simulator as _register_simulator
+
+__all__ = ["DegradationChannel", "register"]
+
+
+@dataclass
+class DegradationChannel(Simulator):
+    """Channel modeling strand loss and base damage."""
+
+    deletion_prob: float = 0.0
+    substitution_prob: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.deletion_prob <= 1.0:
+            raise ValueError("deletion_prob must be between 0 and 1")
+        if not 0.0 <= self.substitution_prob <= 1.0:
+            raise ValueError("substitution_prob must be between 0 and 1")
+
+    def simulate(self, sequence: str) -> str:
+        rng = make_rng()
+        if rng.random() < self.deletion_prob:
+            return ""
+        mutated = [
+            _random_substitution(nt, rng) if rng.random() < self.substitution_prob else nt
+            for nt in sequence
+        ]
+        return "".join(mutated)
+
+
+def register(
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
+) -> None:
+    """Register the degradation simulator."""
+
+    registrar("decay", DegradationChannel())

--- a/tests/test_builtin_plugin_loading.py
+++ b/tests/test_builtin_plugin_loading.py
@@ -34,6 +34,7 @@ def test_load_builtin_plugins_populates_registries() -> None:
         "illumina_insilicoseq",
         "nanopore_d2sim",
         "nanopore_desp",
+        "decay",
     }
     assert sim_names <= set(plugins.SIMULATOR_REGISTRY)
 

--- a/tests/test_decay_channel.py
+++ b/tests/test_decay_channel.py
@@ -1,0 +1,17 @@
+from genecoder.simulators.decay import DegradationChannel
+
+
+def test_decay_deterministic_seed(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    ch = DegradationChannel(deletion_prob=0.0, substitution_prob=0.5)
+    first = ch.simulate("ACGTACGT")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    ch2 = DegradationChannel(deletion_prob=0.0, substitution_prob=0.5)
+    second = ch2.simulate("ACGTACGT")
+    assert first == second == "CACACCGC"
+
+
+def test_decay_strand_loss(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    ch = DegradationChannel(deletion_prob=1.0, substitution_prob=0.0)
+    assert ch.simulate("ACGT") == ""


### PR DESCRIPTION
## Summary
- implement new `DegradationChannel` simulator
- register the simulator via builtin plugins
- test deterministic behavior for the new simulator
- update builtin plugin loading test for the new entry

## Testing
- `ruff check src/genecoder/simulators/decay.py src/genecoder/builtin_plugins.py tests/test_decay_channel.py tests/test_builtin_plugin_loading.py`
- `pytest -q tests/test_decay_channel.py tests/test_builtin_plugin_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_688cb90cf2c483269a4a439477660631