### PR TITLE
Add Reed-Solomon nanopore pipeline test

### DIFF
--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Mapping, Tuple, Dict
+from difflib import SequenceMatcher
 
 from .gc_constrained_encoder import calculate_gc_content
 from .utils import get_max_homopolymer_length
@@ -12,6 +13,20 @@ from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from .simulators import SIMULATOR_REGISTRY
 
 __all__ = ["run_pipeline"]
+
+
+def _count_errors(original: str, mutated: str) -> tuple[int, int, int]:
+    """Return substitution, insertion and deletion counts."""
+    subs = ins = dels = 0
+    sm = SequenceMatcher(None, original, mutated)
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "replace":
+            subs += max(i2 - i1, j2 - j1)
+        elif tag == "delete":
+            dels += i2 - i1
+        elif tag == "insert":
+            ins += j2 - j1
+    return subs, ins, dels
 
 
 def run_pipeline(
@@ -41,9 +56,11 @@ def run_pipeline(
         data, fec_info = FEC_REGISTRY[fec]["encode"](data)
 
     dna = CODEC_REGISTRY[codec]["encode"](data)
-
+    orig_dna = dna
+    subs = ins = dels = None
     if channel and channel != "none":
         dna = SIMULATOR_REGISTRY[channel].simulate(dna)
+        subs, ins, dels = _count_errors(orig_dna, dna)
 
     gc_content = calculate_gc_content(dna)
     max_homopolymer = get_max_homopolymer_length(dna)
@@ -57,4 +74,14 @@ def run_pipeline(
         decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
 
     Path(output_path).write_bytes(decoded)
-    return decoded, {"gc_content": gc_content, "max_homopolymer": max_homopolymer}
+    metrics: Dict[str, float | int] = {
+        "gc_content": gc_content,
+        "max_homopolymer": max_homopolymer,
+    }
+    if subs is not None:
+        metrics.update({
+            "substitutions": subs,
+            "insertions": ins,
+            "deletions": dels,
+        })
+    return decoded, metrics

--- a/tests/test_rs_nanopore_pipeline.py
+++ b/tests/test_rs_nanopore_pipeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import genecoder.simulators.nanopore as nanopore
+from genecoder.core import run_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.api import Codec
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+        return decode_base4_direct(encoded)[0]
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_rs_nanopore_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    monkeypatch.setattr(nanopore.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        nanopore,
+        "_run_external",
+        lambda *_: (_ for _ in ()).throw(AssertionError("_run_external called")),
+    )
+
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    SIMULATOR_REGISTRY["nanopore"] = nanopore.NanoporeChannel(error_rate=0.1)
+
+    data = b"nanopore rs pipeline"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result, metrics = run_pipeline("base4", "reed_solomon", "nanopore", str(inp), str(outp))
+
+    assert result == data
+    assert outp.read_bytes() == data
+    assert isinstance(metrics.get("substitutions"), int)
+    assert isinstance(metrics.get("insertions"), int)
+    assert isinstance(metrics.get("deletions"), int)


### PR DESCRIPTION
## Summary
- track substitution/indel counts in `run_pipeline`
- add regression test for running the pipeline with ReedSolomonFEC and NanoporeChannel in fallback mode

## Testing
- `ruff check .`
- `pytest tests/test_rs_nanopore_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc288ed1883268306b8efcf5e32c3