### PR TITLE
Add decay demo configuration

### DIFF
--- a/configs/decay_demo.yaml
+++ b/configs/decay_demo.yaml
@@ -1,0 +1,15 @@
+# Example channel pipeline applying Illumina sequencing
+# followed by storage decay simulation
+input: encoded/message.fasta
+output: decay_output.fasta
+
+simulators:
+  - illumina
+
+decay:
+  half_life: 1000   # days
+  variation: 0.1
+
+pipeline:
+  illumina_profile: hiseq
+

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -98,7 +98,8 @@ channel step using:
 genecli channel run configs/channel_demo.yaml
 ```
 
-To model storage degradation add a ``decay`` section to the same file:
+The `configs/decay_demo.yaml` file demonstrates storage degradation using
+the new decay channel:
 
 ```yaml
 simulators:
@@ -111,7 +112,7 @@ decay:
 Run the pipeline with:
 
 ```bash
-genecli channel run configs/channel_demo.yaml
+genecli channel run configs/decay_demo.yaml
 ```
 
 ## Encode Example

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -79,6 +79,7 @@ def run_pipeline(
         "max_homopolymer": max_homopolymer,
     }
     if subs is not None:
+        assert ins is not None and dels is not None
         metrics.update({
             "substitutions": subs,
             "insertions": ins,

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -11,6 +11,7 @@ import pytest
 httpx = pytest.importorskip("httpx")
 
 import genecoder.plugin_manager as plugins
+import genecoder.plugin_security as plugin_security
 
 
 class DummyResponse:
@@ -98,7 +99,7 @@ def test_registry_bad_yaml(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCa
     with caplog.at_level(logging.WARNING), pytest.raises(ValueError):
         plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
-    assert "Failed to fetch or parse plugin registry" in caplog.text
+    assert "Failed to parse plugin registry" in caplog.text
 
 
 def test_registry_unreachable(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -171,7 +172,7 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> str:
         assert signature is not None and public_key is not None
         calls.append((data, signature, public_key))
-        return plugins.compute_checksum(data)
+        return plugin_security.compute_checksum(data)
 
     monkeypatch.setenv("GENECODER_CATALOG_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)


### PR DESCRIPTION
## Summary
- add `configs/decay_demo.yaml` showcasing an illumina + decay pipeline
- mention new config in the vertical slice guide
- fix plugin registry tests and mypy failure

## Testing
- `pre-commit run --files configs/decay_demo.yaml docs/vertical_slice.md tests/test_plugin_registry.py src/genecoder/core.py`


------
https://chatgpt.com/codex/tasks/task_e_688cd3e027fc8326b8d0ed4153dbd306