### PR TITLE
Add HTML manifest report

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -328,6 +328,13 @@ Example snippet:
 
 See [Manifest Format](manifest.md) for the full structure and required keys.
 
+Generate a standalone HTML summary from a manifest:
+
+```bash
+genecli html-report --manifest encoded/example.txt.manifest.json \
+    --output-file summary.html
+```
+
 
 
 ### Capsule output

--- a/src/genecoder/cli/report.py
+++ b/src/genecoder/cli/report.py
@@ -4,8 +4,9 @@ import argparse
 import json
 import sys
 
-from genecoder.app_helpers import EncodeResult, DecodeResult
+from genecoder.app_helpers import DecodeResult, EncodeResult
 from genecoder import report as report_module
+from genecoder.html_report import generate_html_report
 
 
 def register_subcommand(
@@ -29,6 +30,23 @@ def register_subcommand(
     )
     parser.add_argument("--output-file", type=str, help="Path to write the report. Defaults to stdout")
     parser.set_defaults(func=_handle_command)
+
+    html_parser = subparsers.add_parser(
+        "html-report",
+        help="Generate an HTML summary report from a manifest JSON.",
+    )
+    html_parser.add_argument(
+        "--manifest",
+        type=str,
+        required=True,
+        help="Path to manifest JSON file",
+    )
+    html_parser.add_argument(
+        "--output-file",
+        type=str,
+        help="Path to write the HTML report. Defaults to stdout",
+    )
+    html_parser.set_defaults(func=_handle_html_command)
 
 
 def _handle_command(args: argparse.Namespace) -> None:
@@ -54,3 +72,12 @@ def _handle_command(args: argparse.Namespace) -> None:
             fh.write(report_text)
     else:
         sys.stdout.write(report_text)
+
+
+def _handle_html_command(args: argparse.Namespace) -> None:
+    html = generate_html_report(args.manifest)
+    if args.output_file:
+        with open(args.output_file, "w", encoding="utf-8") as fh:
+            fh.write(html)
+    else:
+        sys.stdout.write(html)

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -78,7 +78,7 @@ def run_pipeline(
         "gc_content": gc_content,
         "max_homopolymer": max_homopolymer,
     }
-    if subs is not None:
+    if subs is not None and ins is not None and dels is not None:
         metrics.update({
             "substitutions": subs,
             "insertions": ins,

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Simple HTML summary generation for manifest metrics."""
+
+from html import escape
+import json
+from typing import Any
+
+__all__ = ["generate_html_report"]
+
+
+def _calc_decode_success(data: dict[str, Any]) -> float | None:
+    rate = data.get("decode_success_rate")
+    if isinstance(rate, (int, float)):
+        return float(rate)
+    ecc = data.get("ecc_success_rates")
+    if isinstance(ecc, dict) and ecc:
+        values = []
+        for val in ecc.values():
+            try:
+                values.append(float(val))
+            except Exception:
+                pass
+        if values:
+            return sum(values) / len(values)
+    return None
+
+
+def generate_html_report(manifest_path: str) -> str:
+    """Return HTML summary for the manifest at ``manifest_path``."""
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    metrics = data.get("metrics", data)
+    html_lines: list[str] = ["<html>", "<body>", "<h1>GeneCoder Summary Report</h1>"]
+
+    gc_content = metrics.get("gc_content")
+    if isinstance(gc_content, (int, float)):
+        html_lines.append(
+            f"<p><strong>GC Content:</strong> {float(gc_content) * 100:.2f}%</p>"
+        )
+
+    max_hp: int | float | None = metrics.get("max_homopolymer")
+    if not isinstance(max_hp, (int, float)):
+        hp_runs = metrics.get("homopolymer_runs")
+        if isinstance(hp_runs, list) and hp_runs:
+            max_hp = len(hp_runs) - 1
+    if isinstance(max_hp, (int, float)):
+        html_lines.append(
+            f"<p><strong>Max Homopolymer Length:</strong> {int(max_hp)}</p>"
+        )
+
+    ecc = metrics.get("ecc_success_rates")
+    if isinstance(ecc, dict) and ecc:
+        html_lines.append("<h2>ECC Success Rates</h2>")
+        html_lines.append("<ul>")
+        for name, val in ecc.items():
+            try:
+                value = float(val) * 100
+                html_lines.append(
+                    f"<li>{escape(str(name))}: {value:.2f}%</li>"
+                )
+            except Exception:
+                pass
+        html_lines.append("</ul>")
+
+    decode_rate = _calc_decode_success(metrics)
+    if decode_rate is not None:
+        html_lines.append(
+            f"<p><strong>Overall Decode Success:</strong> {decode_rate * 100:.2f}%</p>"
+        )
+
+    html_lines.extend(["</body>", "</html>"])
+    return "\n".join(html_lines)

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from genecoder.html_report import generate_html_report
+from tests.test_cli import run_cli_command
+
+
+def _make_manifest(path: Path) -> Path:
+    data = {
+        "file": "test.bin",
+        "encoding_parameters": {"method": "base4_direct"},
+        "metrics": {
+            "gc_content": 0.5,
+            "max_homopolymer": 4,
+            "ecc_success_rates": {"rs": 0.9},
+        },
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_generate_html_report(tmp_path: Path) -> None:
+    manifest = _make_manifest(tmp_path / "m.json")
+    html = generate_html_report(str(manifest))
+    assert "50.00%" in html
+    assert "Max Homopolymer Length" in html
+    assert "rs" in html
+
+
+def test_cli_html_report_stdout(tmp_path: Path) -> None:
+    manifest = _make_manifest(tmp_path / "m.json")
+    result = run_cli_command(["html-report", "--manifest", str(manifest)])
+    assert result.returncode == 0
+    assert "GeneCoder Summary Report" in result.stdout
+    assert "50.00%" in result.stdout

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -98,7 +98,7 @@ def test_registry_bad_yaml(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCa
     with caplog.at_level(logging.WARNING), pytest.raises(ValueError):
         plugins.install_registry_plugins("https://example.com/plugins.yaml")
 
-    assert "Failed to fetch or parse plugin registry" in caplog.text
+    assert "Failed to parse plugin registry" in caplog.text
 
 
 def test_registry_unreachable(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -163,6 +163,8 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     sig_b64 = base64.b64encode(b"sig").decode()
     calls: list[tuple[bytes, bytes, bytes]] = []
 
+    orig_compute = plugins.compute_checksum
+
     def fake_compute(
         data: bytes,
         *,
@@ -171,7 +173,7 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> str:
         assert signature is not None and public_key is not None
         calls.append((data, signature, public_key))
-        return plugins.compute_checksum(data)
+        return orig_compute(data)
 
     monkeypatch.setenv("GENECODER_CATALOG_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)


### PR DESCRIPTION
## Summary
- generate an HTML summary report from manifest JSON
- expose `genecli html-report` command
- document HTML report usage
- fix mypy issue in core
- test html report generation
- fix plugin registry tests

## Testing
- `pre-commit run --files tests/test_plugin_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdc1bf6888326a8a218691fef41cb