### PR TITLE
docs: add decay pipeline examples

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -219,7 +219,8 @@ genecli channel run config.yml
 
    Simulate long‑term storage by including a ``decay`` stage. ``half_life``
    controls how quickly bases are lost and ``variation`` adds random jitter to
-   the process.
+   the process. The stage randomly removes nucleotides from the sequence so
+   lower values or higher variation lead to more dropouts.
 
    ```yaml
    simulators:

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -109,11 +109,16 @@ decay:
   variation: 0.1
 ```
 
+The ``half_life`` value indicates the time required for half the DNA to
+degrade while ``variation`` adds randomness across sequences. This results in
+deletion errors that emulate gradual decay during storage.
+
 Run the pipeline with:
 
 ```bash
 genecli channel run configs/decay_demo.yaml
 ```
+
 
 ## Encode Example
 


### PR DESCRIPTION
## Summary
- show how to configure `decay` in CLI usage docs
- clarify decay parameters in the vertical slice guide

## Testing
- `n/a` (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_688d0de510b883268b6eb4347dae2113