### PR TITLE
Ensure ruff lint passes

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -11,7 +11,6 @@ import pytest
 httpx = pytest.importorskip("httpx")
 
 import genecoder.plugin_manager as plugins
-import genecoder.plugin_security as plugin_security
 
 
 class DummyResponse:


### PR DESCRIPTION
## Summary
- cleanup unused import in plugin registry test

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml --show-error-codes`
- `pytest tests/test_plugin_registry.py::test_registry_install -q`


------
https://chatgpt.com/codex/tasks/task_e_688d0de4da8083269e3cc146aa0c3d71