### PR TITLE
Add decay-rate option to channel CLI

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -163,5 +163,7 @@ decay_rate: 0.05
 ```
 
 Invoke the pipeline with ``genecli channel apply --decay-rate 0.05`` or include
-the ``decay_rate`` field in a YAML config as shown above.
+the ``decay_rate`` field in a YAML config as shown above. When using
+``genecli channel run`` the same field can be specified in the configuration
+file to enable the simulator.
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -97,6 +97,8 @@ def _load_config(
         "seed": data.get("seed"),
         "batch_workers": data.get("batch_workers"),
     }
+    if "decay_rate" in data:
+        extra["decay_rate"] = float(data["decay_rate"])
 
     return simulators, {k: int(v) for k, v in synth_section.items()}, cfg, extra
 
@@ -273,6 +275,12 @@ def register_subcommand(
         type=str,
         default=None,
         help=f"Named Nanopore profile to use. Available profiles: {nanopore_profiles}",
+    )
+    run_parser.add_argument(
+        "--decay-rate",
+        type=float,
+        default=None,
+        help="Probability of strand loss and damage",
     )
     run_parser.set_defaults(func=_handle_run)
 
@@ -480,8 +488,9 @@ def _handle_run(args: argparse.Namespace) -> None:
         logger.error("Config must define 'input' and 'output' paths")
         raise SystemExit(1)
 
-    if args.decay_rate is not None:
-        simulators.append(DegradationChannel(deletion_prob=args.decay_rate))
+    decay_rate = args.decay_rate if args.decay_rate is not None else extra.get("decay_rate")
+    if decay_rate is not None:
+        simulators.append(DegradationChannel(deletion_prob=decay_rate))
 
     process_channel(
         input_file,

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -148,7 +148,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
 
     sim_specs: list[tuple[str, dict[str, object]]] | None = None
     if args.config:
-        cfg_sim, cfg_con, cfg_pipeline, _ = _load_config(args.config)
+        cfg_sim, cfg_con, cfg_pipeline, extra = _load_config(args.config)
         if cfg_sim:
             sim_specs = cfg_sim
             simulators = [name for name, _ in cfg_sim]
@@ -160,6 +160,8 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
                 args.threads = cfg_pipeline.workers
         if cfg_pipeline.use_process_pool:
             args.processes = args.threads
+        if getattr(args, "decay_rate", None) is None:
+            args.decay_rate = extra.get("decay_rate")
 
     _validate_simulator_prob_args(
         simulators, args.sub_prob, args.ins_prob, args.del_prob


### PR DESCRIPTION
## Summary
- support `--decay-rate` for `genecli channel run`
- parse `decay_rate` from YAML configs
- mention YAML field for the decay simulator in workflow docs

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2bb2e8648326b64a9fedd51b98cd