### PR TITLE
Update plugin signing docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -237,22 +237,34 @@ genecli plugin install-registry --allow-registry
 
 ### Signing Plugin Packages
 
-Plugin wheels can be signed so GeneCoder verifies them during installation.
-First build the distribution and create a private/public RSA key pair. Sign the
-wheel's SHA256 digest and save the base64 encoded result:
+You can sign plugin wheels so GeneCoder verifies them during installation.
+
+1. **Build the wheel**:
+   ```bash
+   python -m build
+   ```
+2. **Generate a private/public RSA key pair**:
+   ```bash
+   openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+   openssl rsa -in private.pem -pubout -out public.pem
+   ```
+3. **Sign the wheel's SHA256 digest** and save the base64 encoded signature:
+   ```bash
+   openssl dgst -sha256 -sign private.pem -binary dist/*.whl | base64 > signature.txt
+   ```
+4. **Update your registry** with the value from `signature.txt` and share
+   `public.pem` with users so they can verify the download.
+
+Set the `GENECODER_PLUGIN_PUBLIC_KEY` environment variable to point to this
+`public.pem` before running the installation command:
 
 ```bash
-python -m build
-openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
-openssl rsa -in private.pem -pubout -out public.pem
-openssl dgst -sha256 -sign private.pem -binary dist/*.whl | base64 > signature.txt
+export GENECODER_PLUGIN_PUBLIC_KEY=/path/to/public.pem
+genecli plugin install-registry --allow-registry
 ```
 
-Add the `signature` value from ``signature.txt`` to your registry entry and
-provide users with `public.pem` so they can verify the download. Set
-`GENECODER_PLUGIN_PUBLIC_KEY` to this public key before running
-`genecli plugin install-registry --allow-registry`. GeneCoder will read the
-variable and verify the signature automatically during installation.
+GeneCoder will compute the digest of each wheel and validate it against the
+provided signature during installation.
 
 ### Registry Installation Security
 


### PR DESCRIPTION
## Summary
- clarify steps for signing plugin wheels
- show how to verify signatures during `plugin install-registry`

## Testing
- `git commit -m "docs: clarify plugin signing"`

------
https://chatgpt.com/codex/tasks/task_e_688d2e2f003883268f38ac0ee51fff48