### PR TITLE
Add YAML profile loading to simulators

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,7 +191,8 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    - **Nanopore** – `minion`, `promethion`
 
    Select a profile with `--illumina-profile` or `--nanopore-profile`. Individual rate options
-   override the chosen profile.
+   override the chosen profile. Custom parameters can also be loaded from YAML files
+   using `--illumina-profile-file` or `--nanopore-profile-file`.
 
    The same configuration can be provided via YAML:
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -103,6 +103,27 @@ def _load_config(
     return simulators, {k: int(v) for k, v in synth_section.items()}, cfg, extra
 
 
+def _load_profile_file(path: str) -> Dict[str, Any]:
+    """Return parameters from YAML ``path``."""
+    try:
+        import yaml
+    except Exception:  # pragma: no cover - optional dependency
+        from genecoder.plugin_manager import yaml as yaml_module
+        if yaml_module is None:
+            raise
+        yaml = yaml_module
+
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            data = yaml.safe_load(fh) or {}
+        except Exception as exc:  # pragma: no cover - invalid YAML path
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Profile file must map keys to values")
+    return data
+
+
 def _apply_simulators(
     sequence: str,
     simulators: Sequence[
@@ -271,10 +292,22 @@ def register_subcommand(
         help=f"Named Illumina profile to use. Available profiles: {illumina_profiles}",
     )
     run_parser.add_argument(
+        "--illumina-profile-file",
+        type=str,
+        default=None,
+        help="YAML file with Illumina simulator parameters",
+    )
+    run_parser.add_argument(
         "--nanopore-profile",
         type=str,
         default=None,
         help=f"Named Nanopore profile to use. Available profiles: {nanopore_profiles}",
+    )
+    run_parser.add_argument(
+        "--nanopore-profile-file",
+        type=str,
+        default=None,
+        help="YAML file with Nanopore simulator parameters",
     )
     run_parser.add_argument(
         "--decay-rate",
@@ -338,6 +371,7 @@ def register_subcommand(
         target.add_argument("--illumina-ins-rate", type=float, default=None, help="Insertion rate for Illumina reads")
         target.add_argument("--illumina-del-rate", type=float, default=None, help="Deletion rate for Illumina reads")
         target.add_argument("--illumina-profile", type=str, default=None, help="Named Illumina profile to use")
+        target.add_argument("--illumina-profile-file", type=str, default=None, help="YAML file with Illumina simulator parameters")
         target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
         target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
@@ -345,6 +379,7 @@ def register_subcommand(
         target.add_argument("--nanopore-ins-rate", type=float, default=None, help="Insertion rate for Nanopore reads")
         target.add_argument("--nanopore-del-rate", type=float, default=None, help="Deletion rate for Nanopore reads")
         target.add_argument("--nanopore-profile", type=str, default=None, help="Named Nanopore profile to use")
+        target.add_argument("--nanopore-profile-file", type=str, default=None, help="YAML file with Nanopore simulator parameters")
         target.add_argument(
             "--decay-rate",
             type=float,
@@ -412,6 +447,10 @@ def run_channel(args: argparse.Namespace) -> None:
                     raise SystemExit(1)
                 for k, v in prof.items():
                     new_params.setdefault(k, v)
+            if opts.illumina_profile_file:
+                file_params = _load_profile_file(opts.illumina_profile_file)
+                for k, v in file_params.items():
+                    new_params.setdefault(k, v)
             if opts.illumina_depth is not None:
                 new_params["coverage"] = opts.illumina_depth
             if opts.illumina_quality is not None:
@@ -431,6 +470,10 @@ def run_channel(args: argparse.Namespace) -> None:
                     logger.error("Unknown Nanopore profile: %s", opts.nanopore_profile)
                     raise SystemExit(1)
                 for k, v in prof.items():
+                    new_params.setdefault(k, v)
+            if opts.nanopore_profile_file:
+                file_params = _load_profile_file(opts.nanopore_profile_file)
+                for k, v in file_params.items():
                     new_params.setdefault(k, v)
             if opts.nanopore_depth is not None:
                 new_params["coverage"] = opts.nanopore_depth
@@ -481,6 +524,18 @@ def _handle_run(args: argparse.Namespace) -> None:
         cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
+    if args.illumina_profile_file is not None:
+        prof = _load_profile_file(args.illumina_profile_file)
+        for name, params in simulators:
+            if name == "illumina":
+                for k, v in prof.items():
+                    params.setdefault(k, v)
+    if args.nanopore_profile_file is not None:
+        prof = _load_profile_file(args.nanopore_profile_file)
+        for name, params in simulators:
+            if name.startswith("nanopore"):
+                for k, v in prof.items():
+                    params.setdefault(k, v)
 
     input_file = extra.get("input_file")
     output_file = extra.get("output_file")

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -38,6 +38,8 @@ class ChannelOptions:
     nanopore_del_rate: float | None = None
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    illumina_profile_file: str | None = None
+    nanopore_profile_file: str | None = None
     sub_rate: float | None = None
     ins_rate: float | None = None
     del_rate: float | None = None
@@ -203,6 +205,8 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_del_rate=args.nanopore_del_rate,
         illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
+        illumina_profile_file=args.illumina_profile_file,
+        nanopore_profile_file=args.nanopore_profile_file,
         sub_rate=args.sub_rate,
         ins_rate=args.ins_rate,
         del_rate=args.del_rate,

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -108,7 +108,29 @@ class IlluminaChannel(BaseSimulator):
         read_length: int = 150,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
+        profile_path: str | None = None,
     ) -> None:
+        if profile_path is not None:
+            try:
+                import yaml
+            except Exception:  # pragma: no cover - optional dependency
+                from genecoder.plugin_manager import yaml as yaml_module
+                if yaml_module is None:
+                    raise
+                yaml = yaml_module
+
+            with open(profile_path, "r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            if not isinstance(data, dict):
+                raise ValueError("Profile file must map keys to values")
+            substitution_rate = float(data.get("substitution_rate", substitution_rate))
+            insertion_rate = float(data.get("insertion_rate", insertion_rate))
+            deletion_rate = float(data.get("deletion_rate", deletion_rate))
+            read_length = int(data.get("read_length", read_length))
+            coverage = int(data.get("coverage", coverage))
+            quality_profile = data.get("quality_profile", quality_profile)
+            context_errors = data.get("context_errors", context_errors)
+
         super().__init__(
             substitution_rate=substitution_rate,
             insertion_rate=insertion_rate,

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -153,7 +153,29 @@ class NanoporeChannel(BaseChannel):
         coverage: int = 1,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
+        profile_path: str | None = None,
     ) -> None:
+        if profile_path is not None:
+            try:
+                import yaml
+            except Exception:  # pragma: no cover - optional dependency
+                from genecoder.plugin_manager import yaml as yaml_module
+                if yaml_module is None:
+                    raise
+                yaml = yaml_module
+
+            with open(profile_path, "r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            if not isinstance(data, dict):
+                raise ValueError("Profile file must map keys to values")
+            error_rate = float(data.get("error_rate", error_rate))
+            substitution_rate = float(data.get("substitution_rate", substitution_rate))
+            insertion_rate = float(data.get("insertion_rate", insertion_rate))
+            deletion_rate = float(data.get("deletion_rate", deletion_rate))
+            coverage = int(data.get("coverage", coverage))
+            quality_profile = data.get("quality_profile", quality_profile)
+            context_errors = data.get("context_errors", context_errors)
+
         super().__init__(
             substitution_rate=substitution_rate,
             insertion_rate=insertion_rate,

--- a/tests/test_simulator_profiles.py
+++ b/tests/test_simulator_profiles.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import yaml
+
 from genecoder.simulators.illumina import IlluminaChannel, ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NanoporeChannel, NANOPORE_PROFILES
 
@@ -14,4 +18,40 @@ def test_nanopore_profiles() -> None:
         ch = NanoporeChannel(**params)
         for key, value in params.items():
             assert getattr(ch, key) == value
+
+
+def test_illumina_profile_file(tmp_path: Path) -> None:
+    params = {
+        "substitution_rate": 0.01,
+        "insertion_rate": 0.002,
+        "deletion_rate": 0.003,
+        "coverage": 2,
+        "read_length": 100,
+    }
+    prof = tmp_path / "illumina.yml"
+    prof.write_text(yaml.safe_dump(params))
+    ch = IlluminaChannel(profile_path=str(prof))
+    assert ch.substitution_rate == params["substitution_rate"]
+    assert ch.insertion_rate == params["insertion_rate"]
+    assert ch.deletion_rate == params["deletion_rate"]
+    assert ch.coverage == params["coverage"]
+    assert ch.read_length == params["read_length"]
+
+
+def test_nanopore_profile_file(tmp_path: Path) -> None:
+    params = {
+        "error_rate": 0.15,
+        "substitution_rate": 0.02,
+        "insertion_rate": 0.03,
+        "deletion_rate": 0.04,
+        "coverage": 3,
+    }
+    prof = tmp_path / "nanopore.yml"
+    prof.write_text(yaml.safe_dump(params))
+    ch = NanoporeChannel(profile_path=str(prof))
+    assert ch.error_rate == params["error_rate"]
+    assert ch.substitution_rate == params["substitution_rate"]
+    assert ch.insertion_rate == params["insertion_rate"]
+    assert ch.deletion_rate == params["deletion_rate"]
+    assert ch.coverage == params["coverage"]
 


### PR DESCRIPTION
## Summary
- allow IlluminaChannel and NanoporeChannel to load parameters from YAML files
- expose `--illumina-profile-file` and `--nanopore-profile-file` CLI options
- document new CLI flags in usage guide
- test YAML profile loading

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py tests/test_simulator_profiles.py`
- `mypy --config-file pyproject.toml --show-error-codes src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py tests/test_simulator_profiles.py`
- `pytest tests/test_simulator_profiles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d33a933608326a108d6cfea7aa77e