### PR TITLE
Add MPI pipeline guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,4 @@ For more details, explore the sections below.
 * [Usage Metrics](metrics.md) – Track encode and simulation counts.
 * [Introductory Notebooks](../notebooks) – Encoding, channel simulation and decoding examples.
 * [Lesson Notebooks](../notebooks/lessons) – Step-by-step guides for encoding basics, FEC, simulation and analysis.
+* [MPI Pipeline Execution](mpi.md) – Run the channel pipeline across multiple nodes.

--- a/docs/mpi.md
+++ b/docs/mpi.md
@@ -1,7 +1,6 @@
-# MPI Channel Simulation
+# MPI Pipeline Execution
 
-GeneCoder can distribute channel simulations across multiple machines using [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface). This relies on the `mpi4py` package and an installed MPI runtime such as MPICH or OpenMPI.
-MPI support is optional; local and offline runs work without it.
+GeneCoder can distribute channel pipelines across multiple machines using [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface). This requires the `mpi4py` package and an installed MPI runtime such as MPICH or OpenMPI. MPI support is optional; local and offline runs work without it.
 
 ## Quickstart
 
@@ -15,28 +14,24 @@ sudo apt-get install openmpi-bin
 pip install mpi4py
 ```
 
-2. Enable MPI in your pipeline configuration:
+2. Enable MPI in your pipeline configuration by setting `pipeline.use_mpi: true` and choosing the number of workers. The sample configuration [`configs/mpi_demo.yaml`](../configs/mpi_demo.yaml) demonstrates this:
 
 ```yaml
-simulators:
-  - simple
-synthesis:
-  min_length: 1
 pipeline:
   parallel: true
-  workers: 4
+  workers: 2
   use_mpi: true
 ```
 
 3. Execute the pipeline with `mpiexec`:
 
 ```bash
-mpiexec -n 4 genecli channel run config.yml
+mpiexec -n 2 genecli channel run configs/mpi_demo.yaml
 ```
 
 Setting `use_mpi: true` automatically selects the MPI executor. The number of workers should match the `-n` argument to `mpiexec`.
 
-## Multi‑node Example
+## Multi-node Example
 
 To run the same configuration across several machines create a simple host file listing each node and how many processes it should launch:
 
@@ -45,11 +40,10 @@ nodeA slots=2
 nodeB slots=2
 ```
 
-Copy `config.yml` to every node and start the pipeline with:
+Copy `configs/mpi_demo.yaml` to every node and start the pipeline with:
 
 ```bash
-mpiexec -hostfile hosts -n 4 genecli channel run config.yml
+mpiexec -hostfile hosts -n 4 genecli channel run configs/mpi_demo.yaml
 ```
 
 All nodes must have GeneCoder, `mpi4py` and an MPI runtime (MPICH or OpenMPI) installed. MPI support is entirely optional—for local and offline use the pipeline can instead rely on threads or processes as described in [parallel execution](parallel.md).
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
       - Local Execution Only: cloud.md
       - Helix Frontend: helix_frontend.md
       - Parallel Pipeline: parallel.md
-      - MPI Channel Simulation: mpi.md
+      - MPI Pipeline Execution: mpi.md
   - Archived:
       - Full Development Vision: archived/DEVELOPMENT_VISION.md
   - Technology Stack: technology_stack.md


### PR DESCRIPTION
## Summary
- add MPI pipeline execution documentation referencing `configs/mpi_demo.yaml`
- link MPI guide from index and mkdocs navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d33a8cb788326a44a34e04bb99c4a