### PR TITLE
Add parallel threads pipeline test

### DIFF
--- a/tests/test_pipeline_parallel.py
+++ b/tests/test_pipeline_parallel.py
@@ -97,3 +97,17 @@ def test_channel_pipeline_mpi(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result == expected
     assert _DummyExecutor.called
     assert calls == ["oligos_simulated"]
+
+def test_channel_pipeline_parallel_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(pipeline_module.metrics, "increment", lambda k: calls.append(k))
+
+    pipeline = ChannelPipeline([_AppendChannel("A"), _AppendChannel("B")])
+    expected = pipeline.simulate("X")
+    calls.clear()
+
+    cfg = ChannelConfig(parallel=True, workers=2, use_process_pool=False)
+    result = pipeline.simulate("X", config=cfg)
+
+    assert result == expected
+    assert calls == ["oligos_simulated"]


### PR DESCRIPTION
## Summary
- add a test for ChannelPipeline when using threads

## Testing
- `ruff check tests/test_pipeline_parallel.py`
- `mypy --config-file pyproject.toml --show-error-codes src`
- `pytest tests/test_pipeline_parallel.py::test_channel_pipeline_parallel_threads -q`


------
https://chatgpt.com/codex/tasks/task_e_688d59a3013c8326845d8759d1f64810