### PR TITLE
Add plugin registry version validation

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -21,7 +21,12 @@ else:
     yaml = yaml_module
 
 
-from importlib.metadata import entry_points, EntryPoints
+from importlib.metadata import (
+    entry_points,
+    EntryPoints,
+    version as get_pkg_version,
+    PackageNotFoundError,
+)
 import logging
 import pkgutil
 
@@ -221,8 +226,29 @@ def install_registry_plugins(url: str | None = None) -> None:
 
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", install_target])
+            version_req = entry.get("version") if isinstance(entry, dict) else None
+            if version_req:
+                pkg_name = str(entry.get("package") or spec).split("==")[0]
+                if _SAFE_PKG_RE.fullmatch(pkg_name):
+                    try:
+                        installed_version = get_pkg_version(pkg_name)
+                    except PackageNotFoundError:
+                        logger.error("Version mismatch for plugin %s", pkg_name)
+                        raise ValueError("Version mismatch")
+                    if installed_version != str(version_req):
+                        logger.error(
+                            "Version mismatch for plugin %s (expected %s, got %s)",
+                            pkg_name,
+                            version_req,
+                            installed_version,
+                        )
+                        raise ValueError("Version mismatch")
         except Exception as exc:  # pragma: no cover - install error path
-            logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
+            if isinstance(exc, ValueError):
+                raise
+            logger.warning(
+                "Failed to install plugin %s from registry: %s", spec, exc
+            )
         finally:
             if pkg_path is not None:
                 try:

--- a/tests/data/plugin_registry_version.yaml
+++ b/tests/data/plugin_registry_version.yaml
@@ -1,0 +1,4 @@
+packages:
+  - spec: example_pkg
+    checksum: 45095df41e6342cabf37e17e4d88855c15b0a186469716949153a53367706787
+    version: "1.0.0"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -219,3 +219,46 @@ def test_registry_network_failure(
     assert (
         "Failed to install plugin https://example.com/pkgD.whl from registry" in caplog.text
     )
+
+
+def test_registry_version_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = Path("tests/data/plugin_registry_version.yaml").read_bytes()
+            return DummyResponse(data)
+        elif url == "example_pkg":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    installs: list[list[str]] = []
+
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins, "get_pkg_version", lambda name: "1.0.0")
+
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
+
+    assert installs and installs[0][:4] == [sys.executable, "-m", "pip", "install"]
+
+
+def test_registry_version_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = Path("tests/data/plugin_registry_version.yaml").read_bytes()
+            return DummyResponse(data)
+        elif url == "example_pkg":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins, "get_pkg_version", lambda name: "0.9.0")
+
+    with pytest.raises(ValueError, match="Version mismatch"):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")


### PR DESCRIPTION
## Summary
- validate registry plugin versions using importlib.metadata.version
- add sample registry YAML with version
- test version checks in plugin registry

## Testing
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_registry.py`
- `mypy --config-file pyproject.toml src/genecoder/plugin_manager.py`
- `pytest tests/test_plugin_registry.py tests/test_plugin_registry_loading.py tests/test_plugin_install_malformed.py tests/test_plugin_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d59a20940832697a3e52ff8410533