### PR TITLE
Add dashboard metrics example

### DIFF
--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -36,3 +36,13 @@ Use the buttons at the bottom of each tab to start the selected operation.
 After encoding completes, GC and homopolymer metrics are shown. If they fall outside recommended ranges, a **Fix Sequence** button allows automatic adjustment. Clicking it displays the fixed DNA snippet and updated metrics.
 
 Example: encode any file, then click **Fix Sequence** when the suggestion text appears to view the corrected sequence.
+
+## Launching the Streamlit Dashboard
+
+GeneCoder also ships with a simple Streamlit dashboard for exploring simulation metrics. After installing the `gui` extras, run:
+
+```bash
+genecli dashboard examples/dashboard_metrics.json
+```
+
+The dashboard visualizes the sample metrics file and plots GC distribution, homopolymer statistics and decode success rates.

--- a/examples/dashboard_metrics.json
+++ b/examples/dashboard_metrics.json
@@ -1,0 +1,14 @@
+{
+  "gc_distribution": [0.1, 0.2, 0.3, 0.4],
+  "gc_content": 0.25,
+  "max_homopolymer": 4,
+  "homopolymer_runs": [1, 2, 1, 0],
+  "ecc_success_rates": {
+    "rs": 0.98,
+    "bch": 0.95
+  },
+  "decode_success_rate": 0.97,
+  "substitutions": 2,
+  "insertions": 1,
+  "deletions": 0
+}


### PR DESCRIPTION
## Summary
- create `dashboard_metrics.json` example file for the dashboard
- document the dashboard command in `gui_tutorial.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d5ece59e48326b5da2f4fc7d1ad29