### PR TITLE
Support RSA-PSS verification

### DIFF
--- a/src/genecoder/plugin_checks.py
+++ b/src/genecoder/plugin_checks.py
@@ -24,6 +24,7 @@ def verify_package(
     checksum: str | None = None,
     signature: bytes | None = None,
     public_key: bytes | None = None,
+    padding_scheme: str = "pkcs1",
     compute_fn: Callable[..., str] | None = None,
 ) -> str:
     """Return the SHA256 digest of ``data`` after optional verification.
@@ -34,7 +35,12 @@ def verify_package(
     """
     if compute_fn is None:
         compute_fn = compute_checksum
-    digest = compute_fn(data, signature=signature, public_key=public_key)
+    digest = compute_fn(
+        data,
+        signature=signature,
+        public_key=public_key,
+        padding_scheme=padding_scheme,
+    )
     if checksum is not None and digest != checksum:
         raise ValueError("Checksum mismatch")
     return digest

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -407,8 +407,9 @@ def load_plugin_catalog(url: str | None = None) -> None:
 
     if isinstance(data, dict):
         signature = data.get("signature")
+        scheme = data.get("signature_scheme") or data.get("scheme")
         if signature:
-            if not _verify_catalog_signature(raw, signature):
+            if not _verify_catalog_signature(raw, signature, padding_scheme=scheme):
                 logger.warning("Invalid catalog signature for %s", url)
                 return
         plugins_data = data.get("plugins", data.get("entries", {}))
@@ -457,7 +458,9 @@ def init_plugins() -> None:
     _initialized = True
 
 
-def _verify_catalog_signature(data: bytes, signature_b64: str) -> bool:
+def _verify_catalog_signature(
+    data: bytes, signature_b64: str, *, padding_scheme: str | None = None
+) -> bool:
     """Return ``True`` if ``signature_b64`` verifies ``data`` using the public key.
 
     The key path is read from the ``GENECODER_CATALOG_PUBLIC_KEY`` environment
@@ -479,7 +482,12 @@ def _verify_catalog_signature(data: bytes, signature_b64: str) -> bool:
         return False
 
     try:
-        compute_checksum(data, signature=signature, public_key=public_key)
+        compute_checksum(
+            data,
+            signature=signature,
+            public_key=public_key,
+            padding_scheme=padding_scheme or "pkcs1",
+        )
     except Exception:
         return False
     return True

--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -10,11 +10,24 @@ def compute_checksum(
     *,
     signature: bytes | None = None,
     public_key: bytes | None = None,
+    padding_scheme: str = "pkcs1",
 ) -> str:
     """Return the SHA256 checksum of *data*."""
-    return _compute_checksum(data, signature=signature, public_key=public_key)
+    return _compute_checksum(
+        data,
+        signature=signature,
+        public_key=public_key,
+        padding_scheme=padding_scheme,
+    )
 
 
-def verify_signature(data: bytes, signature: bytes, public_key: bytes) -> None:
+def verify_signature(
+    data: bytes, signature: bytes, public_key: bytes, *, padding_scheme: str = "pkcs1"
+) -> None:
     """Raise if *signature* does not verify *data* with *public_key*."""
-    _compute_checksum(data, signature=signature, public_key=public_key)
+    _compute_checksum(
+        data,
+        signature=signature,
+        public_key=public_key,
+        padding_scheme=padding_scheme,
+    )

--- a/src/genecoder/security.py
+++ b/src/genecoder/security.py
@@ -52,12 +52,14 @@ def compute_checksum(
     *,
     signature: bytes | None = None,
     public_key: bytes | None = None,
+    padding_scheme: str = "pkcs1",
 ) -> str:
     """Return a hexadecimal SHA256 checksum for ``data``.
 
     If ``signature`` and ``public_key`` are provided, verify that the signature
     matches ``data`` using RSA or ECDSA with a SHA256 hash. ``InvalidSignature``
-    or ``ValueError`` is raised on failure.
+    or ``ValueError`` is raised on failure. RSA signatures default to PKCS#1
+    padding. Specify ``padding_scheme="pss"`` to require RSA-PSS verification.
     """
 
     digest = hashlib.sha256(data).hexdigest()
@@ -72,7 +74,18 @@ def compute_checksum(
 
         key = serialization.load_pem_public_key(public_key)
         if isinstance(key, rsa.RSAPublicKey):
-            key.verify(signature, data, padding.PKCS1v15(), hashes.SHA256())
+            if padding_scheme == "pss":
+                key.verify(
+                    signature,
+                    data,
+                    padding.PSS(
+                        mgf=padding.MGF1(hashes.SHA256()),
+                        salt_length=padding.PSS.MAX_LENGTH,
+                    ),
+                    hashes.SHA256(),
+                )
+            else:
+                key.verify(signature, data, padding.PKCS1v15(), hashes.SHA256())
         elif isinstance(key, ec.EllipticCurvePublicKey):
             key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
         else:  # pragma: no cover - unsupported key type

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -31,32 +31,44 @@ def test_challenge_endpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 def test_load_catalog_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     import genecoder.plugin_manager as plugins
 
-    catalog = {"plugins": {"demo": {"description": "Demo"}}, "signature": "sig"}
+    catalog = {
+        "plugins": {"demo": {"description": "Demo"}},
+        "signature": "sig",
+        "signature_scheme": "pss",
+    }
     path = tmp_path / "cat.json"
     path.write_text(json.dumps(catalog))
 
-    calls: list[tuple[bytes, str]] = []
+    calls: list[tuple[bytes, str, str | None]] = []
 
-    def fake_verify(data: bytes, sig: str) -> bool:
-        calls.append((data, sig))
+    def fake_verify(data: bytes, sig: str, *, padding_scheme: str | None = None) -> bool:
+        calls.append((data, sig, padding_scheme))
         return True
 
     monkeypatch.setattr(plugins, "_verify_catalog_signature", fake_verify)
     plugins.PLUGIN_CATALOG.clear()
     plugins.load_plugin_catalog(f"file://{path}")
 
-    assert calls == [(path.read_bytes(), "sig")]
+    assert calls == [(path.read_bytes(), "sig", "pss")]
     assert "demo" in plugins.PLUGIN_CATALOG
 
 
 def test_load_catalog_bad_signature(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
     import genecoder.plugin_manager as plugins
 
-    catalog = {"plugins": {"demo": {"description": "Demo"}}, "signature": "sig"}
+    catalog = {
+        "plugins": {"demo": {"description": "Demo"}},
+        "signature": "sig",
+        "signature_scheme": "pss",
+    }
     path = tmp_path / "cat.json"
     path.write_text(json.dumps(catalog))
 
-    monkeypatch.setattr(plugins, "_verify_catalog_signature", lambda d, s: False)
+    monkeypatch.setattr(
+        plugins,
+        "_verify_catalog_signature",
+        lambda d, s, *, padding_scheme=None: False,
+    )
     plugins.PLUGIN_CATALOG.clear()
     with caplog.at_level(logging.WARNING):
         plugins.load_plugin_catalog(f"file://{path}")

--- a/tests/test_plugin_checks.py
+++ b/tests/test_plugin_checks.py
@@ -23,9 +23,42 @@ def test_decode_signature_invalid():
 
 
 def test_verify_package_signature_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_compute(data: bytes, *, signature: bytes | None = None, public_key: bytes | None = None) -> str:
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+        padding_scheme: str = "pkcs1",
+    ) -> str:
         raise ValueError("bad sig")
 
     monkeypatch.setattr(pc, "compute_checksum", fake_compute)
     with pytest.raises(ValueError, match="bad sig"):
         pc.verify_package(b"DATA", signature=b"sig", public_key=b"PUB")
+
+
+def test_verify_package_rsa_pss() -> None:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    data = b"SIGNED"
+    signature = key.sign(
+        data,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+
+    checksum = compute_checksum(
+        data, signature=signature, public_key=pub, padding_scheme="pss"
+    )
+    assert (
+        pc.verify_package(
+            data, signature=signature, public_key=pub, padding_scheme="pss"
+        )
+        == checksum
+    )

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -161,7 +161,7 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
     key.write_text("PUB")
 
     sig_b64 = base64.b64encode(b"sig").decode()
-    calls: list[tuple[bytes, bytes, bytes]] = []
+    calls: list[tuple[bytes, bytes, bytes, str]] = []
 
     orig_compute = plugins.compute_checksum
 
@@ -170,17 +170,18 @@ def test_catalog_signature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
         *,
         signature: bytes | None = None,
         public_key: bytes | None = None,
+        padding_scheme: str = "pkcs1",
     ) -> str:
         assert signature is not None and public_key is not None
-        calls.append((data, signature, public_key))
+        calls.append((data, signature, public_key, padding_scheme))
         return orig_compute(data)
 
 
     monkeypatch.setenv("GENECODER_CATALOG_PUBLIC_KEY", str(key))
     monkeypatch.setattr(plugins, "compute_checksum", fake_compute)
 
-    assert plugins._verify_catalog_signature(b"DATA", sig_b64)
-    assert calls == [(b"DATA", b"sig", b"PUB")]
+    assert plugins._verify_catalog_signature(b"DATA", sig_b64, padding_scheme="pss")
+    assert calls == [(b"DATA", b"sig", b"PUB", "pss")]
 
 
 def test_registry_network_failure(


### PR DESCRIPTION
## Summary
- support an optional RSA-PSS padding scheme in `compute_checksum`
- allow plugin signature utilities to pass along the padding scheme
- read `signature_scheme` from plugin catalogs
- extend unit tests for RSA-PSS support and update existing tests

## Testing
- `ruff check src/genecoder/security.py src/genecoder/plugin_security.py src/genecoder/plugin_manager.py src/genecoder/plugin_checks.py tests/test_plugin_catalog.py tests/test_plugin_checks.py tests/test_plugin_registry.py`
- `mypy --config-file pyproject.toml --show-error-codes src/genecoder/security.py src/genecoder/plugin_security.py src/genecoder/plugin_manager.py src/genecoder/plugin_checks.py`
- `pytest -q tests/test_plugin_catalog.py tests/test_plugin_checks.py tests/test_plugin_registry.py`

------
https://chatgpt.com/codex/tasks/task_e_688d5ecddd5083269dc62d95c3e1baf6