### PR TITLE
feat: verify signed plugin registry entries

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -199,7 +199,8 @@ entry with `pip`. Entries may specify a `spec`, `package` or `url` value that is
 passed directly to `pip install`. **Every entry must now include either a**
 `checksum` **or a** `signature` **field**. When a `checksum` is provided the
 downloaded wheel's SHA256 digest must match. A `signature` is validated using
-the public key referenced by `GENECODER_PLUGIN_PUBLIC_KEY`.
+the public key referenced by `GENECODER_PLUGIN_PUBLIC_KEY` and verified with
+``genecoder.plugin_security.compute_checksum``.
 
 Example registry:
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -31,7 +31,7 @@ import logging
 import pkgutil
 
 from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from .plugin_security import compute_checksum as _compute_checksum
+from . import plugin_security
 from .api import Visualizer
 import base64
 import json
@@ -46,7 +46,7 @@ VISUALIZER_REGISTRY: Dict[str, Callable[..., Any]] = {}
 PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
 
 # re-export for tests
-compute_checksum = _compute_checksum
+compute_checksum = plugin_security.compute_checksum
 
 _SAFE_PKG_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _SAFE_URL_RE = re.compile(r"^(?:https?|file)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$")
@@ -209,7 +209,9 @@ def install_registry_plugins(url: str | None = None) -> None:
                     raise ValueError("Invalid signature")
 
             try:
-                digest = compute_checksum(pkg_bytes, signature=signature, public_key=public_key)
+                digest = plugin_security.compute_checksum(
+                    pkg_bytes, signature=signature, public_key=public_key
+                )
             except Exception:
                 logger.error("Invalid signature for plugin %s", spec)
                 raise ValueError("Invalid signature")

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -1,3 +1,6 @@
+import base64
+from pathlib import Path
+
 import pytest
 
 import genecoder.plugin_manager as plugins
@@ -45,3 +48,72 @@ def test_load_plugins_with_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     plugins.load_plugins()
 
     assert "reverse" in plugins.CODEC_REGISTRY
+
+
+def test_load_plugins_with_signed_registry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pkg = b"PKG"
+    sig_b64 = base64.b64encode(b"sig").decode()
+
+    key = tmp_path / "pub.pem"
+    key.write_bytes(b"PUB")
+
+    calls: list[tuple[bytes, bytes, bytes, str]] = []
+    orig_compute = plugins.plugin_security.compute_checksum
+
+    def fake_compute(
+        data: bytes,
+        *,
+        signature: bytes | None = None,
+        public_key: bytes | None = None,
+        padding_scheme: str = "pkcs1",
+    ) -> str:
+        assert signature is not None and public_key is not None
+        calls.append((data, signature, public_key, padding_scheme))
+        return orig_compute(data)
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    signature: {sig_b64}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    monkeypatch.setenv("GENECODER_PLUGIN_PUBLIC_KEY", str(key))
+    monkeypatch.setattr(plugins.plugin_security, "compute_checksum", fake_compute)
+
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+
+    plugins.load_plugins()
+
+    assert calls == [(pkg, b"sig", b"PUB", "pkcs1")]
+    assert "reverse" in plugins.CODEC_REGISTRY
+
+
+def test_registry_entry_missing_signature_checksum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = "packages:\n  - spec: https://example.com/pkg.whl\n".encode()
+            return DummyResponse(data)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+
+    with pytest.raises(ValueError):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml")


### PR DESCRIPTION
## Summary
- ensure plugin registry installs validate signatures via `plugin_security.compute_checksum`
- document registry signature verification requirements
- test plugin registry loading for signed packages and missing signatures

## Testing
- `ruff check src/genecoder/plugin_manager.py tests/test_plugin_registry_loading.py`
- `pytest tests/test_plugin_registry_loading.py tests/test_plugin_registry.py tests/test_plugin_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_688e2e922f188326a59689efa486e9c4