### PR TITLE
docs: add plugin packaging tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,6 @@ GeneCoder has been enhanced with new encoding strategies, error correction, batc
 
 For more details, explore the sections below.
 
-* [Plugin System](plugins.md) – Extend GeneCoder with custom codecs and viewers.
 * [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo.
 * [n8n Overview](n8n_overview.md) – Automate workflows with n8n.
 * [Simulators](simulators.md) – Available read simulators and how to install external tools.
@@ -26,3 +25,9 @@ For more details, explore the sections below.
 * [Introductory Notebooks](../notebooks) – Encoding, channel simulation and decoding examples.
 * [Lesson Notebooks](../notebooks/lessons) – Step-by-step guides for encoding basics, FEC, simulation and analysis.
 * [MPI Pipeline Execution](mpi.md) – Run the channel pipeline across multiple nodes.
+
+## Extending GeneCoder
+
+* [Plugin System](plugins.md) – Step-by-step guide to writing codecs, FEC modules and simulators.
+* [Plugin Packaging Tutorial](../notebooks/lessons/6_plugin_packaging.ipynb) – Interactive walkthrough of entry points.
+* [Example Plugins](../plugins-examples) – Installable packages demonstrating each entry point group.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,8 +160,27 @@ minimal packages showing how each entry point group works:
 - `example_package_plugin` – demonstrates a small plugin that exposes simple
   encode/decode functions through `genecoder.plugins`.
 
-Install any of these packages with `pip install ./plugins-examples/<name>` to
-experiment locally.
+Follow these steps to try the example codec plugin:
+
+1. From the repository root install it with:
+
+   ```bash
+   pip install ./plugins-examples/example_codec
+   ```
+2. Inspect `plugins-examples/example_codec/pyproject.toml` to see the
+   `genecoder.plugins` entry and review the plugin module.
+3. Load plugins and confirm the entry point registered:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import CODEC_REGISTRY
+   print("example" in CODEC_REGISTRY)
+   ```
+
+Swap `example_codec` for `example_fec` or `example_simulator` to explore the
+other entry point groups. Install any of these packages with
+`pip install ./plugins-examples/<name>` to experiment locally.
 
 Run `scripts/scaffold_plugin.sh <name>` to create a new plugin project. The
 generated template registers an entry point and includes a README explaining

--- a/notebooks/lessons/6_plugin_packaging.ipynb
+++ b/notebooks/lessons/6_plugin_packaging.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Plugin Packaging & Entry Points\n",
+    "This lesson demonstrates how GeneCoder discovers plugins via Python entry points.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "steps",
+   "metadata": {},
+   "source": [
+    "1. Install the example codec from `plugins-examples/example_codec`.\n",
+    "2. Examine its `pyproject.toml` to see the `genecoder.plugins` entry.\n",
+    "3. Use `load_plugins()` to register entry points and inspect the codec registry.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from genecoder.plugins import load_plugins\n",
+    "load_plugins()\n",
+    "from genecoder import CODEC_REGISTRY\n",
+    "list(CODEC_REGISTRY)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- guide through installing and verifying example plugins in the docs
- add notebook showing plugin packaging and entry point discovery
- surface plugin resources in a new "Extending GeneCoder" section of the docs index

## Testing
- `pre-commit run --hook-stage manual --files docs/plugins.md docs/index.md notebooks/lessons/6_plugin_packaging.ipynb` *(failed: tests/test_channel_options_validation.py::test_only_simulators_ok - AttributeError: 'Namespace' object has no attribute 'illumina_profile_file'; tests/test_channel_options_validation.py::test_only_probabilities_ok - AttributeError: 'Namespace' object has no attribute 'illumina_profile_file')*

------
https://chatgpt.com/codex/tasks/task_e_688e2e92c0388326b9baa4b53919fa5f