### PR TITLE
test: validate streamlit error metrics

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -269,6 +269,7 @@ jobs:
     - name: Run unit tests
       env:
         SKIP_PACKAGING_TESTS: "1"
+        STREAMLIT_SERVER_HEADLESS: "1"
       run: |
         poetry run pytest -n auto --cov=src --cov-config=.coveragerc -vv
         coverage xml

--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -1,6 +1,7 @@
 {
   "gc_distribution": [0.1, 0.2, 0.3, 0.4],
   "gc_content": 0.25,
+  "max_homopolymer": 4,
   "homopolymer_runs": [1, 2, 1, 0],
   "ecc_success_rates": {
     "rs": 0.98,
@@ -8,6 +9,6 @@
   },
   "decode_success_rate": 0.97,
   "substitutions": 2,
-  "insertions": 1,
+  "insertions": 0,
   "deletions": 0
 }

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -34,3 +34,25 @@ def test_dashboard_cli_starts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     res = run_cli_command(["dashboard", str(results)])
     assert res.returncode == 0, res.stderr
     assert called
+
+
+def test_dashboard_error_counts_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    metrics_file = Path(__file__).parent / "data" / "metrics.json"
+    results = tmp_path / "results.json"
+    results.write_text(metrics_file.read_text())
+
+    charts: list[object] = []
+
+    def capture_bar_chart(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        charts.append(data)
+
+    monkeypatch.setattr(streamlit, "bar_chart", capture_bar_chart)
+
+    from genecoder import dashboard as dash
+
+    dash.main(str(results))
+
+    assert charts
+    assert charts[-1] == {"Substitutions": 2, "Insertions": 0, "Deletions": 0}


### PR DESCRIPTION
## Summary
- extend Streamlit dashboard tests to assert error counts are graphed
- add metrics fixture with max homopolymer and zero-count error metrics
- run unit tests in headless Streamlit mode in CI

## Testing
- `ruff check tests/test_dashboard_streamlit.py`
- `pytest tests/test_dashboard_streamlit.py tests/test_dashboard_render.py tests/test_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e568489a4832688ff038a263a4728