### PR TITLE
Add pipeline metrics JSON output

### DIFF
--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 """CLI helpers for the core encode/ECC/channel/decode pipeline."""
 
 import argparse
+import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
@@ -70,8 +71,8 @@ def _run_with_params(
     channel_params: Dict[str, Any],
     input_path: str,
     output_path: str,
-) -> None:
-    """Run pipeline with optional ``channel_params``."""
+) -> Dict[str, Any]:
+    """Run pipeline with optional ``channel_params`` and return metrics."""
 
     init_plugins()
 
@@ -85,33 +86,24 @@ def _run_with_params(
         logger.error("Unknown channel: %s", channel)
         raise SystemExit(1)
 
-    data = Path(input_path).read_bytes()
-
-    fec_info: Any | None = None
-    if fec:
-        data, fec_info = FEC_REGISTRY[fec]["encode"](data)
-
-    dna = CODEC_REGISTRY[codec]["encode"](data)
-
-    if channel and channel != "none":
-        ch = SIMULATOR_REGISTRY[channel]
+    chan_name = channel or "none"
+    temp_name = chan_name
+    if chan_name != "none":
+        ch = SIMULATOR_REGISTRY[chan_name]
         if channel_params:
             try:
                 ch = type(ch)(**channel_params)
             except Exception as exc:
-                logger.error("Invalid channel parameters for %s: %s", channel, exc)
+                logger.error("Invalid channel parameters for %s: %s", chan_name, exc)
                 raise SystemExit(1)
-        dna = ch.simulate(dna)
-
-    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
-    assert isinstance(decoded_any, (bytes, bytearray))
-    decoded = bytes(decoded_any)
-
-    if fec:
-        assert fec_info is not None
-        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
-
-    Path(output_path).write_bytes(decoded)
+        temp_name = f"_tmp_{chan_name}"
+        SIMULATOR_REGISTRY[temp_name] = ch
+    try:
+        _, metrics_any = run_pipeline(codec, fec, temp_name, input_path, output_path)
+    finally:
+        if temp_name != chan_name and temp_name in SIMULATOR_REGISTRY:
+            del SIMULATOR_REGISTRY[temp_name]
+    return cast(Dict[str, Any], metrics_any)
 
 
 def register_subcommand(
@@ -205,6 +197,11 @@ def _handle_command(args: argparse.Namespace) -> None:
         channel = "none"
 
     if channel_params:
-        _run_with_params(codec, fec, channel, channel_params, args.input, args.output)
+        metrics = _run_with_params(
+            codec, fec, channel, channel_params, args.input, args.output
+        )
     else:
-        run_pipeline(codec, fec, channel, args.input, args.output)
+        _, metrics = run_pipeline(codec, fec, channel, args.input, args.output)
+
+    metrics_path = Path(str(args.output) + ".json")
+    metrics_path.write_text(json.dumps({"metrics": metrics}))

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
 from pathlib import Path
-from typing import Any, Mapping, Tuple, Dict
+from typing import Any, Mapping, Tuple, Dict, List
 from difflib import SequenceMatcher
 
 from .gc_constrained_encoder import calculate_gc_content
@@ -29,13 +29,46 @@ def _count_errors(original: str, mutated: str) -> tuple[int, int, int]:
     return subs, ins, dels
 
 
+def _gc_distribution(sequence: str, window: int = 50) -> List[float]:
+    """Return GC content for non-overlapping windows in ``sequence``."""
+
+    values: List[float] = []
+    for i in range(0, len(sequence), window):
+        chunk = sequence[i : i + window]
+        if not chunk:
+            break
+        gc = sum(1 for base in chunk if base in "GCgc") / len(chunk)
+        values.append(gc)
+    return values
+
+
+def _homopolymer_runs(sequence: str) -> List[int]:
+    """Return counts of homopolymer runs by length for ``sequence``."""
+
+    if not sequence:
+        return []
+    counts: Dict[int, int] = {}
+    current = sequence[0]
+    run = 1
+    for base in sequence[1:]:
+        if base == current:
+            run += 1
+        else:
+            counts[run] = counts.get(run, 0) + 1
+            current = base
+            run = 1
+    counts[run] = counts.get(run, 0) + 1
+    max_run = max(counts)
+    return [counts.get(i, 0) for i in range(1, max_run + 1)]
+
+
 def run_pipeline(
     codec: str,
     fec: str | None,
     channel: str | None,
     input_path: str,
     output_path: str,
-) -> Tuple[bytes, Dict[str, float | int]]:
+) -> Tuple[bytes, Dict[str, Any]]:
     """Process ``input_path`` through the selected codec, FEC and channel.
 
     The decoded bytes are written to ``output_path`` and also returned.
@@ -49,7 +82,8 @@ def run_pipeline(
     if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
         raise ValueError(f"Unknown channel: {channel}")
 
-    data = Path(input_path).read_bytes()
+    original_data = Path(input_path).read_bytes()
+    data = original_data
 
     fec_info: Mapping[str, Any] | None = None
     if fec:
@@ -64,6 +98,8 @@ def run_pipeline(
 
     gc_content = calculate_gc_content(dna)
     max_homopolymer = get_max_homopolymer_length(dna)
+    gc_dist = _gc_distribution(dna)
+    hp_runs = _homopolymer_runs(dna)
 
     decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
     assert isinstance(decoded_any, (bytes, bytearray))
@@ -74,15 +110,21 @@ def run_pipeline(
         decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
 
     Path(output_path).write_bytes(decoded)
-    metrics: Dict[str, float | int] = {
+    success = 1.0 if decoded == original_data else 0.0
+    metrics: Dict[str, Any] = {
+        "gc_distribution": gc_dist,
         "gc_content": gc_content,
         "max_homopolymer": max_homopolymer,
+        "homopolymer_runs": hp_runs,
+        "ecc_success_rates": {fec: success} if fec else {},
+        "decode_success_rate": success,
     }
     if subs is not None and ins is not None and dels is not None:
-
-        metrics.update({
-            "substitutions": subs,
-            "insertions": ins,
-            "deletions": dels,
-        })
+        metrics.update(
+            {
+                "substitutions": subs,
+                "insertions": ins,
+                "deletions": dels,
+            }
+        )
     return decoded, metrics

--- a/tests/test_pipeline_metrics_output.py
+++ b/tests/test_pipeline_metrics_output.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_pipeline_outputs_metrics(tmp_path: Path) -> None:
+    inp = tmp_path / "in.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(b"hello")
+
+    result = run_cli_command(["pipeline", str(inp), str(outp), "--codec", "reverse"])
+    assert result.returncode == 0, result.stderr
+    metrics_path = outp.with_suffix(outp.suffix + ".json")
+    data = json.loads(metrics_path.read_text())
+    metrics = data.get("metrics", data)
+    assert isinstance(metrics.get("gc_distribution"), list)
+    assert isinstance(metrics.get("homopolymer_runs"), list)
+    assert isinstance(metrics.get("ecc_success_rates"), dict)


### PR DESCRIPTION
## Summary
- record GC distribution, homopolymer runs, and ECC success in core pipeline
- emit metrics JSON in pipeline CLI for dashboard consumption
- add integration test ensuring metrics file generation

## Testing
- `pre-commit run --files src/genecoder/core.py src/genecoder/cli/pipeline.py tests/test_pipeline_metrics_output.py` *(fails: Unused "type: ignore" comment and incompatible assignment in nanopore simulator)*
- `ruff check src/genecoder/core.py src/genecoder/cli/pipeline.py tests/test_pipeline_metrics_output.py`
- `pytest tests/test_pipeline_metrics_output.py tests/test_pipeline_roundtrip.py`

------
https://chatgpt.com/codex/tasks/task_e_688e5683bcd483269cd3d454ac25bb08