### PR TITLE
feat: add GC constraints to synthesis

### DIFF
--- a/src/genecoder/synthesis.py
+++ b/src/genecoder/synthesis.py
@@ -14,6 +14,8 @@ class SynthesisConstraints:
     min_length: int = 25
     max_length: int = 300
     max_homopolymer: int = 4
+    gc_min: float = 0.0
+    gc_max: float = 1.0
 
     def __post_init__(self) -> None:
         if self.min_length <= 0:
@@ -22,6 +24,12 @@ class SynthesisConstraints:
             raise ValueError("max_length must be greater than 0")
         if self.min_length > self.max_length:
             raise ValueError("min_length cannot be greater than max_length")
+        if not 0.0 <= self.gc_min <= 1.0:
+            raise ValueError("gc_min must be between 0.0 and 1.0")
+        if not 0.0 <= self.gc_max <= 1.0:
+            raise ValueError("gc_max must be between 0.0 and 1.0")
+        if self.gc_min > self.gc_max:
+            raise ValueError("gc_min cannot be greater than gc_max")
 
 
 def validate_sequence(seq: str, constraints: SynthesisConstraints | None = None) -> bool:
@@ -34,5 +42,9 @@ def validate_sequence(seq: str, constraints: SynthesisConstraints | None = None)
     if length < constraints.min_length or length > constraints.max_length:
         return False
     if get_max_homopolymer_length(seq) > constraints.max_homopolymer:
+        return False
+    seq_upper = seq.upper()
+    gc_content = (seq_upper.count("G") + seq_upper.count("C")) / length if length else 0.0
+    if gc_content < constraints.gc_min or gc_content > constraints.gc_max:
         return False
     return True

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -37,6 +37,22 @@ def test_validate_sequence_fail_homopolymer() -> None:
     assert not validate_sequence("AAACCC", constraints)
 
 
+def test_validate_sequence_gc_boundaries_accept() -> None:
+    constraints = SynthesisConstraints(
+        min_length=5, max_length=10, max_homopolymer=2, gc_min=0.4, gc_max=0.6
+    )
+    assert validate_sequence("GCATA", constraints)  # 40% GC
+    assert validate_sequence("GCCAT", constraints)  # 60% GC
+
+
+def test_validate_sequence_gc_outside_reject() -> None:
+    constraints = SynthesisConstraints(
+        min_length=5, max_length=10, max_homopolymer=2, gc_min=0.4, gc_max=0.6
+    )
+    assert not validate_sequence("GAATT", constraints)  # 20% GC
+    assert not validate_sequence("GGCCA", constraints)  # 80% GC
+
+
 def test_constraints_invalid_min_length() -> None:
     with pytest.raises(ValueError):
         SynthesisConstraints(min_length=0, max_length=10)


### PR DESCRIPTION
## Summary
- allow configuring GC content in `SynthesisConstraints`
- validate sequences against GC percentage limits
- test sequences at GC boundary limits

## Testing
- `ruff check src/genecoder/synthesis.py tests/test_synthesis.py`
- `pytest tests/test_synthesis.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea7dd653c8326a7fdbd4a03b82766