### PR TITLE
Cache global random generator

### DIFF
--- a/src/genecoder/random_utils.py
+++ b/src/genecoder/random_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import random
 import logging
+from typing import Optional
 
 __all__ = ["make_rng"]
 
@@ -11,15 +12,29 @@ __all__ = ["make_rng"]
 logger = logging.getLogger(__name__)
 
 
+_RNG: Optional[random.Random] = None
+
+
 def make_rng() -> random.Random:
-    """Return a :class:`~random.Random` seeded from ``GENECODER_SIM_SEED``."""
-    seed_env = os.getenv("GENECODER_SIM_SEED")
-    if seed_env is not None:
-        try:
-            return random.Random(int(seed_env))
-        except ValueError:
-            logger.warning(
-                "Invalid GENECODER_SIM_SEED %r, falling back to default RNG",
-                seed_env,
-            )
-    return random.Random()
+    """Return a module-wide :class:`~random.Random` seeded once.
+
+    The RNG is seeded from the ``GENECODER_SIM_SEED`` environment variable
+    on first invocation and reused for all subsequent calls.  If the
+    environment variable is unset or invalid, a default RNG is created.
+    """
+
+    global _RNG
+    if _RNG is None:
+        seed_env = os.getenv("GENECODER_SIM_SEED")
+        if seed_env is not None:
+            try:
+                _RNG = random.Random(int(seed_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid GENECODER_SIM_SEED %r, falling back to default RNG",
+                    seed_env,
+                )
+                _RNG = random.Random()
+        else:
+            _RNG = random.Random()
+    return _RNG

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,18 +1,21 @@
+import importlib
 import random
 import logging
-from genecoder.random_utils import make_rng
+import genecoder.random_utils as random_utils
 
 
 def test_make_rng_from_env(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "42")
-    rng = make_rng()
+    mod = importlib.reload(random_utils)
+    rng = mod.make_rng()
     assert isinstance(rng, random.Random)
     assert rng.random() == random.Random(42).random()
 
 
 def test_make_rng_without_env(monkeypatch):
     monkeypatch.delenv("GENECODER_SIM_SEED", raising=False)
-    rng = make_rng()
+    mod = importlib.reload(random_utils)
+    rng = mod.make_rng()
     assert isinstance(rng, random.Random)
     assert 0.0 <= rng.random() < 1.0
 
@@ -20,7 +23,8 @@ def test_make_rng_without_env(monkeypatch):
 def test_make_rng_invalid_env(monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     monkeypatch.setenv("GENECODER_SIM_SEED", "invalid")
-    rng = make_rng()
+    mod = importlib.reload(random_utils)
+    rng = mod.make_rng()
     assert isinstance(rng, random.Random)
     assert any(
         "Invalid GENECODER_SIM_SEED" in record.message for record in caplog.records

--- a/tests/test_random_utils_global_rng.py
+++ b/tests/test_random_utils_global_rng.py
@@ -1,0 +1,18 @@
+import importlib
+import genecoder.random_utils as random_utils
+
+
+def test_global_rng_reproducible(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    mod = importlib.reload(random_utils)
+
+    seq1 = [mod.make_rng().random() for _ in range(3)]
+    seq2 = [mod.make_rng().random() for _ in range(3)]
+    assert seq1 != seq2
+
+    mod = importlib.reload(random_utils)
+    seq1_again = [mod.make_rng().random() for _ in range(3)]
+    seq2_again = [mod.make_rng().random() for _ in range(3)]
+
+    assert seq1 == seq1_again
+    assert seq2 == seq2_again


### PR DESCRIPTION
## Summary
- cache a module-wide RNG seeded once from `GENECODER_SIM_SEED`
- refresh random utils tests and add coverage for global RNG sequence behavior

## Testing
- `ruff check src/genecoder/random_utils.py tests/test_random_utils.py tests/test_random_utils_global_rng.py`
- `pytest tests/test_random_utils.py tests/test_random_utils_global_rng.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb0deb1e483268c3bc0a53a1c6efb