### PR TITLE
Unify InSilicoSeq simulation with Illumina module

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -62,7 +62,6 @@ def register_builtin_plugins() -> None:
             "genecoder.simulators.decay",
             "genecoder.simulators.illumina",
             "genecoder.simulators.nanopore",
-            "genecoder.insilicoseq_adapter",
             "genecoder.desp_adapter",
         ],
         register_simulator,

--- a/src/genecoder/insilicoseq_adapter.py
+++ b/src/genecoder/insilicoseq_adapter.py
@@ -5,20 +5,11 @@ import random
 from typing import Callable
 
 from .api import Simulator
-from .random_utils import make_rng
-from .nanopore_sim import _simulate_adapter, _run_external
+from .simulators.illumina import (
+    IlluminaInSilicoSeqChannel as _IlluminaInSilicoSeqChannel,
+    simulate_insilicoseq as _simulate_insilicoseq,
+)
 from .simulators import register_simulator as _register_simulator
-
-
-class _InSilicoSeq:
-    """Internal helper to invoke the ``iss`` binary."""
-
-    command = "iss"
-
-    @staticmethod
-    def run(sequence: str) -> str:
-        """Run ``iss`` on ``sequence`` via :func:`_run_external`."""
-        return _run_external(_InSilicoSeq.command, sequence)
 
 
 def simulate_insilicoseq(
@@ -26,22 +17,19 @@ def simulate_insilicoseq(
     error_rate: float = 0.05,
     rng: random.Random | None = None,
 ) -> str:
-    """Use ``InSilicoSeq`` if available, else fall back to :func:`simulate_errors`."""
+    """Use ``InSilicoSeq`` if available, else fall back to ``IlluminaChannel``.
 
-    if rng is None:
-        rng = make_rng()
+    The ``rng`` parameter is accepted for API compatibility but ignored.
+    """
 
-    return _simulate_adapter("insilicoseq", sequence, error_rate, rng)
+    return _simulate_insilicoseq(sequence, error_rate=error_rate)
 
 
-class InSilicoSeqChannel(Simulator):
+class InSilicoSeqChannel(_IlluminaInSilicoSeqChannel):
     """Channel wrapper for the optional ``InSilicoSeq`` simulator."""
 
     def __init__(self, error_rate: float = 0.05) -> None:
-        self.error_rate = error_rate
-
-    def simulate(self, sequence: str) -> str:
-        return simulate_insilicoseq(sequence, error_rate=self.error_rate, rng=make_rng())
+        super().__init__(error_rate=error_rate)
 
 
 def register(

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -17,7 +17,6 @@ __all__ = [
     "simulate_dnarsim",
     "simulate_squigulator",
     "simulate_desp",
-    "simulate_insilicoseq",
     "simulate_reads",
     "Channel",
 ]
@@ -115,7 +114,7 @@ def _simulate_adapter(
     if shutil.which(command):
         try:
             cmd_list = [command]
-            if command in {"d2sim", "dnarsim", "squigulator", "desp", "insilicoseq"}:
+            if command in {"d2sim", "dnarsim", "squigulator", "desp"}:
                 cmd_list += ["-e", str(error_rate)]
             if extra_args:
                 cmd_list += list(extra_args)
@@ -207,17 +206,6 @@ def simulate_desp(
     return _simulate_adapter("desp", sequence, error_rate, rng)
 
 
-def simulate_insilicoseq(
-    sequence: str, error_rate: float = 0.05, rng: random.Random | None = None
-) -> str:
-    """Use ``insilicoseq`` if available, else fall back to :func:`simulate_errors`."""
-
-    if rng is None:
-        rng = make_rng()
-
-    return _simulate_adapter("insilicoseq", sequence, error_rate, rng)
-
-
 def simulate_none(
     sequence: str,
     error_rate: float = 0.0,
@@ -238,7 +226,6 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]]
     "dnarsim": simulate_dnarsim,
     "squigulator": simulate_squigulator,
     "desp": simulate_desp,
-    "insilicoseq": simulate_insilicoseq,
     # backward compatibility names
     "nanopore": simulate_d2sim,
     "none": simulate_none,

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -39,6 +39,7 @@ __all__ = [
     "IlluminaChannel",
     "IlluminaD2SimChannel",
     "IlluminaInSilicoSeqChannel",
+    "simulate_insilicoseq",
     "register",
     "ILLUMINA_PROFILES",
 ]
@@ -239,26 +240,31 @@ class IlluminaInSilicoSeqChannel(Simulator):
 
     def __init__(self, error_rate: float = 0.05) -> None:
         self.error_rate = error_rate
-        self._fallback = IlluminaChannel(substitution_rate=error_rate)
 
     def simulate(self, sequence: str) -> str:
-        cmd = "insilicoseq"
-        if shutil.which(cmd):
-            cmd_list = [cmd, "-e", str(self.error_rate)]
-            try:
-                cmd_list += _parse_env_options(cmd)
-                return _run_external(cmd_list, sequence)
-            except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
-                logging.getLogger(__name__).warning(
-                    "%s failed: %s; falling back to simple Illumina model",
-                    cmd,
-                    exc,
-                )
-        else:
+        return simulate_insilicoseq(sequence, error_rate=self.error_rate)
+
+
+def simulate_insilicoseq(sequence: str, error_rate: float = 0.05) -> str:
+    """Use the ``insilicoseq`` CLI if available, else fall back to ``IlluminaChannel``."""
+
+    cmd = "insilicoseq"
+    if shutil.which(cmd):
+        cmd_list = [cmd, "-e", str(error_rate)]
+        try:
+            cmd_list += _parse_env_options(cmd)
+            return _run_external(cmd_list, sequence)
+        except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
             logging.getLogger(__name__).warning(
-                "%s not found; falling back to simple Illumina model", cmd
+                "%s failed: %s; falling back to simple Illumina model",
+                cmd,
+                exc,
             )
-        return self._fallback.simulate(sequence)
+    else:
+        logging.getLogger(__name__).warning(
+            "%s not found; falling back to simple Illumina model", cmd
+        )
+    return IlluminaChannel(substitution_rate=error_rate).simulate(sequence)
 
 
 def register(

--- a/tests/test_builtin_plugin_loading.py
+++ b/tests/test_builtin_plugin_loading.py
@@ -24,7 +24,6 @@ def test_load_builtin_plugins_populates_registries() -> None:
         "dnarsim",
         "squigulator",
         "desp",
-        "insilicoseq",
         "nanopore",
         "none",
         "simple",

--- a/tests/test_error_statistics.py
+++ b/tests/test_error_statistics.py
@@ -10,8 +10,8 @@ def test_insilicoseq_stats(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "1")
     seq = "ACGTACGTACGT"
     out = insilicoseq_adapter.simulate_insilicoseq(seq, error_rate=0.2)
-    assert out == "TCGTACATACGT"
-    assert _sub_rate(seq, out) == 2 / len(seq)
+    assert out == "ACGTCCCTTCGT"
+    assert _sub_rate(seq, out) == 3 / len(seq)
 
 
 def test_desp_stats(monkeypatch):

--- a/tests/test_insilicoseq_desp_adapter.py
+++ b/tests/test_insilicoseq_desp_adapter.py
@@ -4,11 +4,12 @@ import random
 import pytest
 
 from genecoder import insilicoseq_adapter, desp_adapter, nanopore_sim
+import genecoder.simulators.illumina as illumina
 
 ADAPTERS = {
     "insilicoseq": (
         insilicoseq_adapter.simulate_insilicoseq,
-        insilicoseq_adapter._InSilicoSeq,
+        None,
         "insilicoseq",
     ),
     "desp": (
@@ -33,8 +34,12 @@ def test_run_external(monkeypatch, name):
         run_called.append((command, seq))
         return "external"
 
-    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
-    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    if name == "insilicoseq":
+        monkeypatch.setattr(illumina.shutil, "which", fake_which)
+        monkeypatch.setattr(illumina, "_run_external", fake_run)
+    else:
+        monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+        monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
 
     result = func("ACGT")
     assert result == "external"
@@ -48,18 +53,38 @@ def test_fall_back(monkeypatch, name):
     which_called = []
     errors_called = []
 
-    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None)
-    monkeypatch.setattr(
-        nanopore_sim,
-        "simulate_errors",
-        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
-    )
-    monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
+    if name == "insilicoseq":
+        monkeypatch.setattr(
+            illumina.shutil, "which", lambda t: which_called.append(t) or None
+        )
+        monkeypatch.setattr(
+            illumina,
+            "_run_external",
+            lambda *_: (_ for _ in ()).throw(AssertionError("_run_external should not be called")),
+        )
+        monkeypatch.setattr(
+            illumina.IlluminaChannel,
+            "simulate",
+            lambda self, s: errors_called.append((self, s)) or "fallback",
+        )
+    else:
+        monkeypatch.setattr(
+            nanopore_sim.shutil, "which", lambda t: which_called.append(t) or None
+        )
+        monkeypatch.setattr(
+            nanopore_sim,
+            "simulate_errors",
+            lambda seq, rate, rng=None: errors_called.append((seq, rate, rng))
+            or "fallback",
+        )
+        monkeypatch.setattr(nanopore_sim, "_run_external", lambda *_: "boom")
 
     result = func("ACGT", error_rate=0.1)
     assert result == "fallback"
     assert which_called == [cmd]
-    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert errors_called
+    if name != "insilicoseq":
+        assert isinstance(errors_called[0][2], random.Random)
 
 
 @pytest.mark.parametrize("name", ADAPTERS.keys())
@@ -69,18 +94,36 @@ def test_external_error(monkeypatch, caplog, name):
     run_called = []
     errors_called = []
 
-    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t)
+    if name == "insilicoseq":
+        monkeypatch.setattr(
+            illumina.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t
+        )
 
-    def fake_run(command, seq):
-        run_called.append((command, seq))
-        raise subprocess.CalledProcessError(1, command)
+        def fake_run(command, seq):
+            run_called.append((command, seq))
+            raise subprocess.CalledProcessError(1, command)
 
-    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
-    monkeypatch.setattr(
-        nanopore_sim,
-        "simulate_errors",
-        lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
-    )
+        monkeypatch.setattr(illumina, "_run_external", fake_run)
+        monkeypatch.setattr(
+            illumina.IlluminaChannel,
+            "simulate",
+            lambda self, s: errors_called.append((self, s)) or "fallback",
+        )
+    else:
+        monkeypatch.setattr(
+            nanopore_sim.shutil, "which", lambda t: which_called.append(t) or "/usr/bin/" + t
+        )
+
+        def fake_run(command, seq):
+            run_called.append((command, seq))
+            raise subprocess.CalledProcessError(1, command)
+
+        monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+        monkeypatch.setattr(
+            nanopore_sim,
+            "simulate_errors",
+            lambda s, r, rng=None: errors_called.append((s, r, rng)) or "fallback",
+        )
 
     with caplog.at_level(logging.WARNING):
         result = func("ACGT", error_rate=0.2)
@@ -88,7 +131,9 @@ def test_external_error(monkeypatch, caplog, name):
     assert result == "fallback"
     assert which_called == [cmd]
     assert run_called == [([cmd, "-e", "0.2"], "ACGT")]
-    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert errors_called
+    if name != "insilicoseq":
+        assert isinstance(errors_called[0][2], random.Random)
     assert any("falling back" in rec.message for rec in caplog.records)
 
 
@@ -96,23 +141,40 @@ def test_external_error(monkeypatch, caplog, name):
 def test_command_not_found_warning(monkeypatch, caplog, name):
     func, cls, cmd = ADAPTERS[name]
     errors_called = []
-    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: None)
 
-    def boom(*_):
-        raise AssertionError("_run_external should not be called")
+    if name == "insilicoseq":
+        monkeypatch.setattr(illumina.shutil, "which", lambda t: None)
 
-    monkeypatch.setattr(nanopore_sim, "_run_external", boom)
-    monkeypatch.setattr(
-        nanopore_sim,
-        "simulate_errors",
-        lambda seq, rate, rng=None: errors_called.append((seq, rate, rng)) or "fallback",
-    )
+        def boom(*_):
+            raise AssertionError("_run_external should not be called")
+
+        monkeypatch.setattr(illumina, "_run_external", boom)
+        monkeypatch.setattr(
+            illumina.IlluminaChannel,
+            "simulate",
+            lambda self, s: errors_called.append((self, s)) or "fallback",
+        )
+    else:
+        monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: None)
+
+        def boom(*_):
+            raise AssertionError("_run_external should not be called")
+
+        monkeypatch.setattr(nanopore_sim, "_run_external", boom)
+        monkeypatch.setattr(
+            nanopore_sim,
+            "simulate_errors",
+            lambda seq, rate, rng=None: errors_called.append((seq, rate, rng))
+            or "fallback",
+        )
 
     with caplog.at_level(logging.WARNING):
         result = func("ACGT")
 
     assert result == "fallback"
-    assert errors_called and isinstance(errors_called[0][2], random.Random)
+    assert errors_called
+    if name != "insilicoseq":
+        assert isinstance(errors_called[0][2], random.Random)
     assert any(
         rec.levelno == logging.WARNING and "not found" in rec.message for rec in caplog.records
     )
@@ -121,6 +183,8 @@ def test_command_not_found_warning(monkeypatch, caplog, name):
 @pytest.mark.parametrize("name", ADAPTERS.keys())
 def test_class_run(monkeypatch, name):
     func, cls, cmd = ADAPTERS[name]
+    if cls is None:
+        pytest.skip("no direct command helper for insilicoseq")
     called = []
 
     def fake_run_external(c, seq):
@@ -128,7 +192,8 @@ def test_class_run(monkeypatch, name):
         return "ok"
 
     monkeypatch.setattr(cls, "command", cmd)
-    monkeypatch.setattr(insilicoseq_adapter if name == "insilicoseq" else desp_adapter, "_run_external", fake_run_external)
+    target_module = insilicoseq_adapter if name == "insilicoseq" else desp_adapter
+    monkeypatch.setattr(target_module, "_run_external", fake_run_external)
 
     result = cls.run("ACGT")
     assert result == "ok"

--- a/tests/test_simulator_adapters.py
+++ b/tests/test_simulator_adapters.py
@@ -1,6 +1,7 @@
 import pytest
 
 from genecoder import d2sim_adapter, desp_adapter, insilicoseq_adapter, nanopore_sim
+import genecoder.simulators.illumina as illumina
 
 ADAPTERS = {
     "d2sim": d2sim_adapter.simulate_d2sim,
@@ -23,8 +24,12 @@ def test_simulate_adapters_use_run_external(monkeypatch, name):
         run_called.append((cmd, seq))
         return f"{name}-result"
 
-    monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
-    monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+    if name == "insilicoseq":
+        monkeypatch.setattr(illumina.shutil, "which", fake_which)
+        monkeypatch.setattr(illumina, "_run_external", fake_run)
+    else:
+        monkeypatch.setattr(nanopore_sim.shutil, "which", fake_which)
+        monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
 
     result = func("ACGT")
     assert result == f"{name}-result"


### PR DESCRIPTION
## Summary
- Remove standalone `simulate_insilicoseq` adapter and delegate to Illumina simulator
- Drop `insilicoseq_adapter` from builtin plugin list
- Align tests with new InSilicoSeq integration

## Testing
- `ruff check src/genecoder/insilicoseq_adapter.py tests/test_insilicoseq_desp_adapter.py`
- `mypy --follow-imports=skip src/genecoder/api.py src/genecoder/formats.py src/genecoder/channel_sim.py src/genecoder/simulators/__init__.py src/genecoder/simulators/base.py src/genecoder/builtin_plugins.py src/genecoder/insilicoseq_adapter.py src/genecoder/nanopore_sim.py src/genecoder/simulators/illumina.py`
- `pytest tests/test_insilicoseq_desp_adapter.py tests/test_error_statistics.py tests/test_simulator_adapters.py tests/test_builtin_plugin_loading.py tests/test_illumina_insilicoseq_channel.py tests/test_cli_simulator_selection.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea7df64a483269dc977e1f6d91ba2