### PR TITLE
Consolidate error simulation into unified module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ nanopore = "genecoder.nanopore_sim"
 d2sim = "genecoder.d2sim_adapter"
 dnarsim = "genecoder.dnarsim_adapter"
 squigulator = "genecoder.squigulator_adapter"
-simple = "genecoder.channel_sim"
+simple = "genecoder.error_simulation"
 indel = "genecoder.error_simulation"
 illumina = "genecoder.simulators.illumina"
 

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -57,7 +57,6 @@ def register_builtin_plugins() -> None:
     _load_and_register(
         [
             "genecoder.nanopore_sim",
-            "genecoder.channel_sim",
             "genecoder.error_simulation",
             "genecoder.simulators.decay",
             "genecoder.simulators.illumina",

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -1,68 +1,25 @@
-"""Simple channel error simulator for DNA sequences."""
+"""Compatibility wrapper for :mod:`genecoder.error_simulation`.
+
+This module is deprecated; use :mod:`genecoder.error_simulation` instead.
+"""
 from __future__ import annotations
 
-import random
-from typing import Callable, Optional, Protocol
+from .error_simulation import (
+    simulate_errors,
+    apply_substitutions,
+    apply_insertions,
+    apply_deletions,
+    Channel,
+    NUCLEOTIDES,
+    register,
+)
 
-from .random_utils import make_rng
-
-from .api import Simulator
-from .simulators import register_simulator as _register_simulator
-
-
-__all__ = ["simulate_errors", "RandomLike", "Channel", "register"]
-
-
-class RandomLike(Protocol):
-    def random(self) -> float: ...
-
-    def choice(self, seq: list[str]) -> str: ...
-
-
-NUCLEOTIDES = ["A", "T", "C", "G"]
-
-
-def simulate_errors(seq: str, p_error: float, rng: Optional[random.Random] = None) -> str:
-
-    """Introduce random substitution errors into *seq* with probability ``p_error``.
-
-    Each nucleotide has an independent chance ``p_error`` of being replaced by a
-    different random nucleotide.  ``p_error`` should be between 0.0 and 1.0.
-    If ``rng`` is given, it will be used for randomness instead of the module
-    :mod:`random` generator.
-    """
-    if not 0.0 <= p_error <= 1.0:
-        raise ValueError("p_error must be between 0 and 1")
-
-    if rng is None:
-        rng = random.Random()
-
-    result = []
-    for nt in seq:
-        if rng.random() < p_error:
-            choices = [n for n in NUCLEOTIDES if n != nt]
-            result.append(rng.choice(choices))
-
-        else:
-            result.append(nt)
-    return "".join(result)
-
-
-
-
-class Channel(Simulator):
-    """Simple substitution error channel."""
-
-    def __init__(self, error_rate: float = 0.05) -> None:
-        self.error_rate = error_rate
-
-    def simulate(self, sequence: str) -> str:
-        return simulate_errors(sequence, self.error_rate, rng=make_rng())
-
-
-def register(
-    registrar: Callable[[str, Simulator], None] = _register_simulator,
-) -> None:
-    """Register the simple substitution error simulator."""
-
-    registrar("simple", Channel())
+__all__ = [
+    "simulate_errors",
+    "apply_substitutions",
+    "apply_insertions",
+    "apply_deletions",
+    "Channel",
+    "register",
+    "NUCLEOTIDES",
+]

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -5,11 +5,18 @@ import random
 from typing import Callable
 
 from .random_utils import make_rng
-
 from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
-__all__ = ["introduce_errors", "apply_substitutions", "apply_insertions", "apply_deletions", "Channel", "register"]
+__all__ = [
+    "simulate_errors",
+    "introduce_errors",
+    "apply_substitutions",
+    "apply_insertions",
+    "apply_deletions",
+    "Channel",
+    "register",
+]
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
 
@@ -20,7 +27,7 @@ def _random_substitution(nucleotide: str, rng: random.Random) -> str:
     return rng.choice(choices)
 
 
-def introduce_errors(
+def simulate_errors(
     sequence: str,
     substitution_prob: float = 0.0,
     insertion_prob: float = 0.0,
@@ -84,19 +91,23 @@ def introduce_errors(
     return "".join(mutated)
 
 
+# Backwards compatibility alias
+introduce_errors = simulate_errors
+
+
 def apply_substitutions(sequence: str, prob: float, rng: random.Random | None = None) -> str:
     """Apply random substitutions to ``sequence`` with probability ``prob``."""
-    return introduce_errors(sequence, substitution_prob=prob, rng=rng)
+    return simulate_errors(sequence, substitution_prob=prob, rng=rng)
 
 
 def apply_insertions(sequence: str, prob: float, rng: random.Random | None = None) -> str:
     """Insert random nucleotides into ``sequence`` with probability ``prob``."""
-    return introduce_errors(sequence, insertion_prob=prob, rng=rng)
+    return simulate_errors(sequence, insertion_prob=prob, rng=rng)
 
 
 def apply_deletions(sequence: str, prob: float, rng: random.Random | None = None) -> str:
     """Delete nucleotides from ``sequence`` with probability ``prob``."""
-    return introduce_errors(sequence, deletion_prob=prob, rng=rng)
+    return simulate_errors(sequence, deletion_prob=prob, rng=rng)
 
 
 
@@ -109,13 +120,25 @@ class Channel(Simulator):
         substitution_prob: float = 0.0,
         insertion_prob: float = 0.0,
         deletion_prob: float = 0.0,
+        error_rate: float | None = None,
     ) -> None:
+        if error_rate is not None:
+            substitution_prob = error_rate
         self.substitution_prob = substitution_prob
         self.insertion_prob = insertion_prob
         self.deletion_prob = deletion_prob
 
+    # compatibility with older API expecting ``error_rate``
+    @property
+    def error_rate(self) -> float:
+        return self.substitution_prob
+
+    @error_rate.setter
+    def error_rate(self, value: float) -> None:
+        self.substitution_prob = value
+
     def simulate(self, sequence: str) -> str:
-        return introduce_errors(
+        return simulate_errors(
             sequence,
             substitution_prob=self.substitution_prob,
             insertion_prob=self.insertion_prob,
@@ -127,6 +150,7 @@ class Channel(Simulator):
 def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
-    """Register the insertion/deletion error simulator."""
+    """Register built-in error simulators."""
 
+    registrar("simple", Channel(substitution_prob=0.05))
     registrar("indel", Channel())

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -28,7 +28,7 @@ from .simulators import register_simulator as _register_simulator
 logger = logging.getLogger(__name__)
 
 from .random_utils import make_rng
-from .channel_sim import simulate_errors
+from .error_simulation import simulate_errors
 from .formats import from_fasta, to_fasta
 
 

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -46,7 +46,9 @@ __all__ = [
 ]
 
 # Preset parameter profiles for :class:`NanoporeChannel` loaded from YAML.
-_DEFAULT_NANOPORE_PROFILES: dict[str, dict[str, float | int]] = {
+_DEFAULT_NANOPORE_PROFILES: dict[
+    str, dict[str, float | int | Dict[int, float]]
+] = {
     "minion": {
         "error_rate": 0.12,
         "substitution_rate": 0.02,
@@ -68,7 +70,7 @@ _DEFAULT_NANOPORE_PROFILES: dict[str, dict[str, float | int]] = {
 }
 
 try:  # pragma: no cover - optional dependency
-    import yaml  # type: ignore
+    import yaml
 
     _cfg_path = Path(__file__).resolve().parents[3] / "configs" / "nanopore.yml"
     with open(_cfg_path, "r", encoding="utf-8") as _fh:

--- a/tests/test_channel_sim.py
+++ b/tests/test_channel_sim.py
@@ -1,15 +1,20 @@
+import random
+
+from genecoder.error_simulation import simulate_errors
 from genecoder.simulators import simulate_reads
 from genecoder.encoders import encode_base4_direct, decode_base4_direct
 from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat
+from genecoder.error_simulation import register as register_error_sim
 
 
-def test_simulate_errors_deterministic(monkeypatch):
-    monkeypatch.setenv("GENECODER_SIM_SEED", "0")
-    assert simulate_reads("AAAA", "simple", error_rate=1.0) == "CGCC"
+def test_simulate_errors_deterministic():
+    rng = random.Random(0)
+    assert simulate_errors("AAAA", substitution_prob=1.0, rng=rng) == "CCTG"
 
 
 def test_decode_recovery_with_triple_repeat(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "42")
+    register_error_sim()
     data = b"hello"
     dna = encode_base4_direct(data)
     dna_tr = encode_triple_repeat(dna)

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -1,11 +1,11 @@
 import random
 import pytest
-from genecoder.error_simulation import introduce_errors
+from genecoder.error_simulation import simulate_errors
 
 
 def test_deterministic_substitutions():
     rng = random.Random(42)
-    result = introduce_errors(
+    result = simulate_errors(
         "AAAA",
         substitution_prob=1.0,
         insertion_prob=0.0,
@@ -17,7 +17,7 @@ def test_deterministic_substitutions():
 
 def test_deterministic_insertions():
     rng = random.Random(0)
-    result = introduce_errors(
+    result = simulate_errors(
         "AT",
         substitution_prob=0.0,
         insertion_prob=1.0,
@@ -29,7 +29,7 @@ def test_deterministic_insertions():
 
 def test_deterministic_deletions():
     rng = random.Random(1)
-    result = introduce_errors(
+    result = simulate_errors(
         "ATGC",
         substitution_prob=0.0,
         insertion_prob=0.0,
@@ -53,9 +53,9 @@ def test_apply_functions_and_edge_cases():
     assert apply_deletions("ATGC", prob=1.0, rng=rng) == ""
 
 
-def test_introduce_errors_combined_operations():
+def test_simulate_errors_combined_operations():
     rng = random.Random(1)
-    result = introduce_errors(
+    result = simulate_errors(
         "AT",
         substitution_prob=0.3,
         insertion_prob=0.3,
@@ -65,9 +65,9 @@ def test_introduce_errors_combined_operations():
     assert result == "TG"
 
 
-def test_introduce_errors_empty_sequence():
+def test_simulate_errors_empty_sequence():
     assert (
-        introduce_errors(
+        simulate_errors(
             "",
             substitution_prob=1.0,
             insertion_prob=0.0,
@@ -89,15 +89,15 @@ def test_introduce_errors_empty_sequence():
         ("deletion_prob", 1.1),
     ],
 )
-def test_introduce_errors_invalid_probabilities(kw: str, value: float) -> None:
+def test_simulate_errors_invalid_probabilities(kw: str, value: float) -> None:
     kwargs = {kw: value, "rng": random.Random(0)}
     with pytest.raises(ValueError):
-        introduce_errors("A", **kwargs)
+        simulate_errors("A", **kwargs)
 
 
-def test_introduce_errors_probability_sum_exceeds_one() -> None:
+def test_simulate_errors_probability_sum_exceeds_one() -> None:
     with pytest.raises(ValueError):
-        introduce_errors(
+        simulate_errors(
             "A",
             substitution_prob=0.6,
             insertion_prob=0.3,


### PR DESCRIPTION
## Summary
- merge substitution-only channel into `error_simulation` and expose `simulate_errors`
- register both `simple` and `indel` simulators from consolidated module
- update plugin loading, entry points and tests for new API
- fix mypy errors in nanopore simulator profile definitions

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/error_simulation.py src/genecoder/channel_sim.py src/genecoder/builtin_plugins.py src/genecoder/nanopore_sim.py src/genecoder/simulators/nanopore.py pyproject.toml tests/test_channel_sim.py tests/test_error_simulation.py`
- `pytest tests/test_channel_sim.py tests/test_error_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb0de1b4c83268f406c0ae76fa63e