### PR TITLE
Add configurable indel probabilities for channel error simulation

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -4,8 +4,8 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 
 ## Built-in simulators
 
-- **simple** — random substitution errors. Use `genecli channel --sub-prob` or
-  `--simulator simple`.
+- **simple** — random substitutions. Use `genecli channel --sub-prob`
+  (and optionally `--ins-prob`/`--del-prob`) or `--simulator simple`.
 - **indel** — introduces insertions and deletions in addition to substitutions.
 - **none** — disable simulation (the default).
 - **illumina** — simple Illumina read errors. Customize rates with
@@ -94,11 +94,11 @@ sudo make install
 
 ## Command-line usage
 
-Apply simple substitutions with a chosen probability using the ``channel`` command:
+Apply substitutions and indels with chosen probabilities using the ``channel`` command:
 
 ```bash
 genecli channel --input-file input.fasta --output-file corrupted.fasta \
-    --sub-prob 0.02
+    --sub-prob 0.02 --ins-prob 0.01 --del-prob 0.01
 genecli decode corrupted.fasta --output-file decoded.bin <other options>
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,24 +123,24 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
 
 10. **Introduce channel errors before decoding**
 
-   ```bash
-   genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
-       --sub-prob 0.02
-   genecli decode corrupted.fasta --output-file decoded.bin
-   ```
+```bash
+genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
+    --sub-prob 0.02 --ins-prob 0.01 --del-prob 0.01
+genecli decode corrupted.fasta --output-file decoded.bin
+```
 
-   Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
-   simulated substitutions deterministic across runs.
+Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
+simulated substitutions and indels deterministic across runs.
 
 11. **Encode, corrupt and decode a file with automatic extensions**
 
-   ```bash
-   genecli encode --input-files hello.jpg --output-dir encoded \
-       --method base4_direct --auto-ext
-   genecli channel --input-file encoded/hello.jpg.dna --output-file corrupted.dna \
-       --sub-prob 0.01
-   genecli decode corrupted.dna --output-dir decoded --auto-ext
-   ```
+```bash
+genecli encode --input-files hello.jpg --output-dir encoded \
+    --method base4_direct --auto-ext
+genecli channel --input-file encoded/hello.jpg.dna --output-file corrupted.dna \
+    --sub-prob 0.01 --ins-prob 0.01 --del-prob 0.01
+genecli decode corrupted.dna --output-dir decoded --auto-ext
+```
 
    Verify the round-trip checksum:
 

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -4,18 +4,19 @@ This module is deprecated; use :mod:`genecoder.error_simulation` instead.
 """
 from __future__ import annotations
 
+import random
+
 from .error_simulation import (
-    simulate_errors,
     apply_substitutions,
     apply_insertions,
     apply_deletions,
     Channel,
     NUCLEOTIDES,
     register,
+    simulate_errors as _simulate_errors,
 )
 
 __all__ = [
-    "simulate_errors",
     "apply_substitutions",
     "apply_insertions",
     "apply_deletions",
@@ -23,3 +24,38 @@ __all__ = [
     "register",
     "NUCLEOTIDES",
 ]
+
+
+def simulate_errors(
+    sequence: str,
+    substitution_prob: float = 0.0,
+    insertion_prob: float = 0.0,
+    deletion_prob: float = 0.0,
+    rng: random.Random | None = None,
+) -> str:
+    """Introduce substitutions, insertions and deletions into ``sequence``.
+
+    This wrapper mirrors :func:`genecoder.error_simulation.simulate_errors` while
+    keeping the legacy module path. All parameters are forwarded to the new
+    implementation.
+
+    Parameters
+    ----------
+    sequence:
+        Input DNA sequence.
+    substitution_prob, insertion_prob, deletion_prob:
+        Probabilities for each error type. Their sum must not exceed ``1``.
+    rng:
+        Optional random number generator for deterministic behaviour.
+    """
+
+    return _simulate_errors(
+        sequence,
+        substitution_prob=substitution_prob,
+        insertion_prob=insertion_prob,
+        deletion_prob=deletion_prob,
+        rng=rng,
+    )
+
+
+__all__.append("simulate_errors")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -437,6 +437,10 @@ def test_channel_command_probabilities(temp_dir: Path, small_fasta_file: Path) -
         str(out_file),
         "--sub-prob",
         "0.5",
+        "--ins-prob",
+        "0.25",
+        "--del-prob",
+        "0.25",
         "--seed",
         "1",
         "--min-length",
@@ -449,6 +453,7 @@ def test_channel_command_probabilities(temp_dir: Path, small_fasta_file: Path) -
     original_seq = from_fasta(small_fasta_file.read_text())[0][1]
     new_seq = from_fasta(out_file.read_text())[0][1]
     assert new_seq != original_seq
+    assert len(new_seq) != len(original_seq)
 
 
 def test_channel_missing_input(temp_dir: Path) -> None:

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -78,6 +78,26 @@ def test_simulate_errors_empty_sequence():
     )
 
 
+def test_simulate_errors_rate_approximation():
+    """Verify that observed error rates roughly match the configured probabilities."""
+    seq = "ACGT" * 250  # length 1000
+
+    rng = random.Random(0)
+    mutated = simulate_errors(seq, substitution_prob=0.1, rng=rng)
+    subs = sum(1 for a, b in zip(seq, mutated) if a != b)
+    assert abs(subs / len(seq) - 0.1) < 0.03
+
+    rng = random.Random(0)
+    mutated = simulate_errors(seq, insertion_prob=0.05, rng=rng)
+    ins = len(mutated) - len(seq)
+    assert abs(ins / len(seq) - 0.05) < 0.03
+
+    rng = random.Random(0)
+    mutated = simulate_errors(seq, deletion_prob=0.02, rng=rng)
+    dels = len(seq) - len(mutated)
+    assert abs(dels / len(seq) - 0.02) < 0.03
+
+
 @pytest.mark.parametrize(
     "kw,value",
     [


### PR DESCRIPTION
## Summary
- allow configuring insertion and deletion probabilities in `simulate_errors`
- document new `--ins-prob`/`--del-prob` CLI options
- test substitution and indel rates

## Testing
- `pytest tests/test_error_simulation.py tests/test_cli.py::test_channel_command_probabilities -q`
- `SKIP=pytest pre-commit run --files src/genecoder/channel_sim.py tests/test_error_simulation.py tests/test_cli.py docs/simulators.md docs/usage.md`


------
https://chatgpt.com/codex/tasks/task_e_688ec1d0658c832699d78d6e7ef28756