### PR TITLE
feat(simulators): add with_profile API for profile-aware simulators

### DIFF
--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -41,6 +41,16 @@ class Simulator(ABC):
     def simulate(self, sequence: str) -> str:
         """Return a possibly corrupted version of ``sequence``."""
 
+    def with_profile(self, profile: str) -> "Simulator":
+        """Return a copy of the simulator configured for ``profile``.
+
+        Implementations should override this method if they support
+        applying external error profiles. The default implementation
+        raises :class:`NotImplementedError`.
+        """
+
+        raise NotImplementedError
+
 
 class Visualizer(ABC):
     """Abstract base class for sequence visualizers."""

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -52,6 +52,11 @@ class DNArSimChannel(Simulator):
             profile=self.profile,
         )
 
+    def with_profile(self, profile: str) -> "DNArSimChannel":
+        """Return a new channel configured to use ``profile``."""
+
+        return type(self)(error_rate=self.error_rate, profile=profile)
+
 
 def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,

--- a/src/genecoder/insilicoseq_adapter.py
+++ b/src/genecoder/insilicoseq_adapter.py
@@ -16,20 +16,23 @@ def simulate_insilicoseq(
     sequence: str,
     error_rate: float = 0.05,
     rng: random.Random | None = None,
+    profile: str | None = None,
 ) -> str:
     """Use ``InSilicoSeq`` if available, else fall back to ``IlluminaChannel``.
 
     The ``rng`` parameter is accepted for API compatibility but ignored.
     """
 
-    return _simulate_insilicoseq(sequence, error_rate=error_rate)
+    return _simulate_insilicoseq(sequence, error_rate=error_rate, profile=profile)
 
 
 class InSilicoSeqChannel(_IlluminaInSilicoSeqChannel):
     """Channel wrapper for the optional ``InSilicoSeq`` simulator."""
 
-    def __init__(self, error_rate: float = 0.05) -> None:
-        super().__init__(error_rate=error_rate)
+    def __init__(
+        self, error_rate: float = 0.05, profile: str | None = None
+    ) -> None:
+        super().__init__(error_rate=error_rate, profile=profile)
 
 
 def register(

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -238,19 +238,31 @@ class IlluminaD2SimChannel(Simulator):
 class IlluminaInSilicoSeqChannel(Simulator):
     """Use the ``insilicoseq`` CLI with a simple fallback."""
 
-    def __init__(self, error_rate: float = 0.05) -> None:
+    def __init__(self, error_rate: float = 0.05, profile: str | None = None) -> None:
         self.error_rate = error_rate
+        self.profile = profile
 
     def simulate(self, sequence: str) -> str:
-        return simulate_insilicoseq(sequence, error_rate=self.error_rate)
+        return simulate_insilicoseq(
+            sequence, error_rate=self.error_rate, profile=self.profile
+        )
+
+    def with_profile(self, profile: str) -> "IlluminaInSilicoSeqChannel":
+        """Return a new channel configured to use ``profile``."""
+
+        return type(self)(error_rate=self.error_rate, profile=profile)
 
 
-def simulate_insilicoseq(sequence: str, error_rate: float = 0.05) -> str:
+def simulate_insilicoseq(
+    sequence: str, error_rate: float = 0.05, profile: str | None = None
+) -> str:
     """Use the ``insilicoseq`` CLI if available, else fall back to ``IlluminaChannel``."""
 
     cmd = "insilicoseq"
     if shutil.which(cmd):
         cmd_list = [cmd, "-e", str(error_rate)]
+        if profile:
+            cmd_list += ["-p", profile]
         try:
             cmd_list += _parse_env_options(cmd)
             return _run_external(cmd_list, sequence)

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -309,6 +309,20 @@ class NanoporeDNArSimChannel(NanoporeChannel):
             )
         raise RuntimeError("fallback")
 
+    def with_profile(self, profile: str) -> "NanoporeDNArSimChannel":
+        """Return a new channel configured to use ``profile``."""
+
+        return type(self)(
+            self.error_rate,
+            profile,
+            substitution_rate=self.substitution_rate,
+            insertion_rate=self.insertion_rate,
+            deletion_rate=self.deletion_rate,
+            coverage=self.coverage,
+            quality_profile=self.quality_profile,
+            context_errors=self.context_errors,
+        )
+
     @staticmethod
     def _simulate_fallback(sequence: str, error_rate: float, rng: random.Random) -> str:
         from typing import cast

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -41,26 +41,19 @@ class ChannelPipeline(BaseChannel):
         use_process_pool = config.use_process_pool
         use_mpi = config.use_mpi
 
+        from ..dnarsim_adapter import DNArSimChannel
+        from ..insilicoseq_adapter import InSilicoSeqChannel
+
         channels = []
         for ch in self.channels:
-            if (
-                config.illumina_profile is not None
-                and hasattr(ch, "profile")
-                and ch.__class__.__name__ == "InsilicoSeqChannel"
+            if config.illumina_profile is not None and isinstance(
+                ch, InSilicoSeqChannel
             ):
-                ch = type(ch)(
-                    read_length=getattr(ch, "read_length", 150),
-                    profile=config.illumina_profile,
-                )  # type: ignore[call-arg]
-            elif (
-                config.nanopore_profile is not None
-                and hasattr(ch, "profile")
-                and ch.__class__.__name__ == "DNArSimChannel"
+                ch = ch.with_profile(config.illumina_profile)
+            elif config.nanopore_profile is not None and isinstance(
+                ch, DNArSimChannel
             ):
-                ch = type(ch)(
-                    error_rate=getattr(ch, "error_rate", 0.05),
-                    profile=config.nanopore_profile,
-                )  # type: ignore[call-arg]
+                ch = ch.with_profile(config.nanopore_profile)
             channels.append(ch)
 
         if use_mpi:

--- a/tests/test_channel_sim.py
+++ b/tests/test_channel_sim.py
@@ -5,6 +5,9 @@ from genecoder.simulators import simulate_reads
 from genecoder.encoders import encode_base4_direct, decode_base4_direct
 from genecoder.error_correction import encode_triple_repeat, decode_triple_repeat
 from genecoder.error_simulation import register as register_error_sim
+from genecoder.channel_config import ChannelConfig
+from genecoder.simulators.pipeline import ChannelPipeline
+import genecoder.dnarsim_adapter as dnarsim_adapter
 
 
 def test_simulate_errors_deterministic():
@@ -22,3 +25,29 @@ def test_decode_recovery_with_triple_repeat(monkeypatch):
     corrected, _, _ = decode_triple_repeat(corrupted)
     recovered, _ = decode_base4_direct(corrected)
     assert recovered == data
+
+
+def test_pipeline_profile_application(monkeypatch):
+    called_profiles: list[str | None] = []
+
+    def fake_sim(seq: str, error_rate: float = 0.05, rng=None, profile: str | None = None) -> str:
+        called_profiles.append(profile)
+        return seq
+
+    monkeypatch.setattr(dnarsim_adapter, "simulate_dnarsim", fake_sim)
+
+    with_calls: list[str] = []
+
+    def fake_with_profile(self, profile: str):
+        with_calls.append(profile)
+        self.profile = profile
+        return self
+
+    monkeypatch.setattr(dnarsim_adapter.DNArSimChannel, "with_profile", fake_with_profile)
+
+    pipeline = ChannelPipeline([dnarsim_adapter.DNArSimChannel()])
+    config = ChannelConfig(nanopore_profile="r9")
+    pipeline.simulate("ACGT", config=config)
+
+    assert with_calls == ["r9"]
+    assert called_profiles == ["r9"]

--- a/tests/test_illumina_insilicoseq_channel.py
+++ b/tests/test_illumina_insilicoseq_channel.py
@@ -1,14 +1,17 @@
 
 from genecoder.simulators.illumina import IlluminaInSilicoSeqChannel
 import genecoder.simulators.illumina as illumina
+import genecoder.random_utils as random_utils
 
 
 def test_fallback_deterministic(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "1")
     monkeypatch.setattr(illumina.shutil, "which", lambda _: None)
+    random_utils._RNG = None
     channel = IlluminaInSilicoSeqChannel(error_rate=0.2)
     first = channel.simulate("ACGTACGTACGT")
     monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    random_utils._RNG = None
     second = channel.simulate("ACGTACGTACGT")
     assert first == second == "ACGTCCCTTCGT"
 

--- a/tests/test_nanopore_dnarsim_channel.py
+++ b/tests/test_nanopore_dnarsim_channel.py
@@ -1,5 +1,6 @@
 from genecoder.simulators.nanopore import NanoporeDNArSimChannel
 import genecoder.simulators.nanopore as nanopore
+import genecoder.random_utils as random_utils
 import logging
 import random
 
@@ -7,9 +8,11 @@ import random
 def test_fallback_deterministic(monkeypatch):
     monkeypatch.setenv("GENECODER_SIM_SEED", "1")
     monkeypatch.setattr(nanopore.shutil, "which", lambda _: None)
+    random_utils._RNG = None
     ch = NanoporeDNArSimChannel(error_rate=0.2)
     first = ch.simulate("ACGTACGTACGT")
     monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    random_utils._RNG = None
     second = ch.simulate("ACGTACGTACGT")
     assert first == second == "ACGAGTACCGT"
 


### PR DESCRIPTION
## Summary
- add `with_profile` method to simulator base and profile-capable channels
- use `isinstance`/`with_profile` in `ChannelPipeline` instead of class-name checks
- extend tests to cover profile application and reset RNG in deterministic cases

## Testing
- `ruff check src/genecoder/api.py src/genecoder/dnarsim_adapter.py src/genecoder/insilicoseq_adapter.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py src/genecoder/simulators/pipeline.py tests/test_channel_sim.py`
- `ruff check tests/test_illumina_insilicoseq_channel.py tests/test_nanopore_dnarsim_channel.py`
- `pytest tests/test_channel_sim.py tests/test_illumina_insilicoseq_channel.py tests/test_nanopore_dnarsim_channel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ec1cff53c83268a911829f9dd5aa6