### PR TITLE
Optimize GC balancing and add long-sequence tests

### DIFF
--- a/src/genecoder/constraint_fixer.py
+++ b/src/genecoder/constraint_fixer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import random
-from .gc_constrained_encoder import calculate_gc_content
 
 __all__ = ["adjust_gc_balance", "limit_homopolymers", "fix_sequence"]
 
@@ -19,21 +18,25 @@ def adjust_gc_balance(
     if rng is None:
         rng = random.Random()
     seq = list(sequence.upper())
-    gc = calculate_gc_content("".join(seq))
+    length = len(seq)
+    gc_count = sum(1 for b in seq if b in {"G", "C"})
+    gc = gc_count / length if length else 0.0
     while gc < target_gc_min:
         idxs = [i for i, b in enumerate(seq) if b in {"A", "T"}]
         if not idxs:
             break
         i = rng.choice(idxs)
         seq[i] = rng.choice(["G", "C"])
-        gc = calculate_gc_content("".join(seq))
+        gc_count += 1
+        gc = gc_count / length
     while gc > target_gc_max:
         idxs = [i for i, b in enumerate(seq) if b in {"G", "C"}]
         if not idxs:
             break
         i = rng.choice(idxs)
         seq[i] = rng.choice(["A", "T"])
-        gc = calculate_gc_content("".join(seq))
+        gc_count -= 1
+        gc = gc_count / length
     return "".join(seq)
 
 

--- a/tests/test_constraint_fixer.py
+++ b/tests/test_constraint_fixer.py
@@ -11,6 +11,13 @@ def test_adjust_gc_balance_increases_gc():
     assert calculate_gc_content(fixed) >= 0.4
 
 
+def test_adjust_gc_balance_long_sequence():
+    seq = "AT" * 5000
+    fixed = adjust_gc_balance(seq, 0.4, 0.6, rng=random.Random(0))
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert len(fixed) == len(seq)
+
+
 def test_limit_homopolymers_breaks_runs():
     seq = "AAAAAA"
     fixed = limit_homopolymers(seq, 2, rng=random.Random(0))
@@ -52,5 +59,19 @@ def test_fix_sequence_enforces_gc_and_homopolymer_limits_high_gc() -> None:
     )
     assert 0.4 <= calculate_gc_content(fixed) <= 0.6
     assert get_max_homopolymer_length(fixed) <= 2
+    assert len(fixed) == len(seq)
+
+
+def test_fix_sequence_handles_long_input() -> None:
+    seq = "A" * 1000
+    fixed = fix_sequence(
+        seq,
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=4,
+        rng=random.Random(0),
+    )
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 4
     assert len(fixed) == len(seq)
 


### PR DESCRIPTION
## Summary
- track GC counts incrementally in `adjust_gc_balance`
- add long-sequence tests for constraint fixer utilities

## Testing
- `ruff check src/genecoder/constraint_fixer.py tests/test_constraint_fixer.py`
- `pytest tests/test_constraint_fixer.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8adbca5c83268e4e56878df2e4cc