### PR TITLE
refactor: extract simulator helper utilities

### DIFF
--- a/src/genecoder/d2sim_adapter.py
+++ b/src/genecoder/d2sim_adapter.py
@@ -8,7 +8,8 @@ from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 from .random_utils import make_rng
-from .nanopore_sim import _simulate_adapter, _run_external
+from .nanopore_sim import _simulate_adapter
+from .simulator_utils import _run_external
 
 
 class _D2SIM:

--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -6,7 +6,8 @@ from typing import Callable
 
 from .api import Simulator
 from .random_utils import make_rng
-from .nanopore_sim import _simulate_adapter, _run_external
+from .nanopore_sim import _simulate_adapter
+from .simulator_utils import _run_external
 from .simulators import register_simulator as _register_simulator
 
 

--- a/src/genecoder/dnarsim_adapter.py
+++ b/src/genecoder/dnarsim_adapter.py
@@ -6,7 +6,8 @@ from typing import Callable
 
 from .api import Simulator
 from .random_utils import make_rng
-from .nanopore_sim import _simulate_adapter, _run_external
+from .nanopore_sim import _simulate_adapter
+from .simulator_utils import _run_external
 from .simulators import register_simulator as _register_simulator
 
 

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -1,16 +1,13 @@
 """Wrapper for optional nanopore read simulators."""
 from __future__ import annotations
 
-import os
 import random
 import shutil
 import subprocess
-import tempfile
-from pathlib import Path
 import logging
 from typing import Callable, Sequence
 
-from .utils import get_temp_dir
+from .simulator_utils import _parse_env_options, _run_external
 
 __all__ = [
     "simulate_d2sim",
@@ -28,78 +25,6 @@ logger = logging.getLogger(__name__)
 
 from .random_utils import make_rng
 from .error_simulation import simulate_errors
-from .formats import from_fasta, to_fasta
-
-
-def _parse_env_options(command: str) -> list[str]:
-    """Return additional options for ``command`` parsed from the environment.
-
-    The environment variable ``GENECODER_<CMD>_OPTIONS`` allows forwarding extra
-    command line arguments to the external simulators.  For security reasons
-    only a limited set of characters is permitted.  If ``raw`` contains
-    potentially dangerous characters a ``ValueError`` is raised.
-    """
-
-    env_var = f"GENECODER_{command.upper()}_OPTIONS"
-    raw = os.getenv(env_var)
-    if not raw:
-        return []
-
-    import re
-
-    # Reject characters outside a conservative whitelist to avoid
-    # command injection via shell metacharacters.
-    if not raw.isprintable() or not re.fullmatch(r"[A-Za-z0-9_\-./=:'\"\s]*", raw):
-        raise ValueError(f"Unsafe characters in {env_var}")
-
-    import shlex
-
-    try:
-        options = shlex.split(raw)
-    except ValueError as exc:  # pragma: no cover - error path
-        logger.warning("Invalid %s value: %s", env_var, exc)
-        return []
-
-    flag_re = re.compile(r"^-{1,2}[A-Za-z0-9][A-Za-z0-9_-]*(=.+)?$")
-    arg_re = re.compile(r"^[A-Za-z0-9./:_-]+$")
-
-    for opt in options:
-        if opt.startswith("-"):
-            if not flag_re.fullmatch(opt):
-                raise ValueError(f"Invalid option {opt!r} in {env_var}")
-        else:
-            if not arg_re.fullmatch(opt):
-                raise ValueError(f"Invalid argument {opt!r} in {env_var}")
-
-    logger.debug("Using %s=%r", env_var, options)
-    return options
-
-
-
-
-def _run_external(command: Sequence[str] | str, sequence: str) -> str:
-    """Run an external simulator command on ``sequence``.
-
-    The command must accept an input FASTA file and output FASTA to a
-    second file: ``command <in> <out>``.
-    """
-    with tempfile.TemporaryDirectory(dir=get_temp_dir()) as tmpdir:
-        input_path = Path(tmpdir) / "input.fasta"
-        output_path = Path(tmpdir) / "output.fasta"
-        input_path.write_text(to_fasta(sequence, "seq"))
-        cmd_list = [command] if isinstance(command, str) else list(command)
-        full_cmd = cmd_list + [str(input_path), str(output_path)]
-        logger.debug("Running external command: %s", " ".join(full_cmd))
-        try:
-            subprocess.run(full_cmd, check=True)
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
-            raise RuntimeError(
-                f"{cmd_list[0]} failed with exit code {exc.returncode}"
-            ) from exc
-        records = from_fasta(output_path.read_text())
-        if not records:
-            raise RuntimeError(f"{cmd_list[0]} produced no FASTA output")
-        return records[0][1]
 
 
 def _simulate_adapter(

--- a/src/genecoder/simulator_utils.py
+++ b/src/genecoder/simulator_utils.py
@@ -1,0 +1,86 @@
+"""Utility functions for external simulators."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+from .formats import from_fasta, to_fasta
+from .utils import get_temp_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_env_options(command: str) -> list[str]:
+    """Return additional options for ``command`` parsed from the environment.
+
+    The environment variable ``GENECODER_<CMD>_OPTIONS`` allows forwarding extra
+    command line arguments to the external simulators.  For security reasons
+    only a limited set of characters is permitted.  If ``raw`` contains
+    potentially dangerous characters a ``ValueError`` is raised.
+    """
+
+    env_var = f"GENECODER_{command.upper()}_OPTIONS"
+    raw = os.getenv(env_var)
+    if not raw:
+        return []
+
+    import re
+
+    # Reject characters outside a conservative whitelist to avoid
+    # command injection via shell metacharacters.
+    if not raw.isprintable() or not re.fullmatch(r"[A-Za-z0-9_\-./=:'\"\s]*", raw):
+        raise ValueError(f"Unsafe characters in {env_var}")
+
+    import shlex
+
+    try:
+        options = shlex.split(raw)
+    except ValueError as exc:  # pragma: no cover - error path
+        logger.warning("Invalid %s value: %s", env_var, exc)
+        return []
+
+    flag_re = re.compile(r"^-{1,2}[A-Za-z0-9][A-Za-z0-9_-]*(=.+)?$")
+    arg_re = re.compile(r"^[A-Za-z0-9./:_-]+$")
+
+    for opt in options:
+        if opt.startswith("-"):
+            if not flag_re.fullmatch(opt):
+                raise ValueError(f"Invalid option {opt!r} in {env_var}")
+        else:
+            if not arg_re.fullmatch(opt):
+                raise ValueError(f"Invalid argument {opt!r} in {env_var}")
+
+    logger.debug("Using %s=%r", env_var, options)
+    return options
+
+
+def _run_external(command: Sequence[str] | str, sequence: str) -> str:
+    """Run an external simulator command on ``sequence``.
+
+    The command must accept an input FASTA file and output FASTA to a
+    second file: ``command <in> <out>``.
+    """
+
+    with tempfile.TemporaryDirectory(dir=get_temp_dir()) as tmpdir:
+        input_path = Path(tmpdir) / "input.fasta"
+        output_path = Path(tmpdir) / "output.fasta"
+        input_path.write_text(to_fasta(sequence, "seq"))
+        cmd_list = [command] if isinstance(command, str) else list(command)
+        full_cmd = cmd_list + [str(input_path), str(output_path)]
+        logger.debug("Running external command: %s", " ".join(full_cmd))
+        try:
+            subprocess.run(full_cmd, check=True)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - error path
+            raise RuntimeError(
+                f"{cmd_list[0]} failed with exit code {exc.returncode}"
+            ) from exc
+        records = from_fasta(output_path.read_text())
+        if not records:
+            raise RuntimeError(f"{cmd_list[0]} produced no FASTA output")
+        return records[0][1]
+

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -28,11 +28,8 @@ from .base import BaseSimulator
 from ..random_utils import make_rng
 from ..api import Simulator
 from ..error_simulation import _random_substitution, NUCLEOTIDES
-from ..nanopore_sim import (
-    simulate_d2sim,
-    _run_external,
-    _parse_env_options,
-)
+from ..nanopore_sim import simulate_d2sim
+from ..simulator_utils import _run_external, _parse_env_options
 from . import register_simulator as _register_simulator
 
 __all__ = [

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -23,12 +23,8 @@ except Exception:  # pragma: no cover - fallback when numba missing
         return wrapper
 
 from ..random_utils import make_rng
-from ..nanopore_sim import (
-    simulate_d2sim,
-    simulate_desp,
-    _run_external,
-    _parse_env_options,
-)
+from ..nanopore_sim import simulate_d2sim, simulate_desp
+from ..simulator_utils import _run_external, _parse_env_options
 from ..api import Simulator
 from .base import BaseChannel
 from ..error_simulation import (

--- a/src/genecoder/squigulator_adapter.py
+++ b/src/genecoder/squigulator_adapter.py
@@ -6,7 +6,8 @@ from typing import Callable
 
 from .api import Simulator
 from .random_utils import make_rng
-from .nanopore_sim import _simulate_adapter, _run_external
+from .nanopore_sim import _simulate_adapter
+from .simulator_utils import _run_external
 from .simulators import register_simulator as _register_simulator
 
 

--- a/tests/test_env_option_parsing.py
+++ b/tests/test_env_option_parsing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from genecoder.nanopore_sim import _parse_env_options
+from genecoder.simulator_utils import _parse_env_options
 
 
 def test_valid_options(monkeypatch):

--- a/tests/test_simulator_adapters.py
+++ b/tests/test_simulator_adapters.py
@@ -2,6 +2,7 @@ import pytest
 
 from genecoder import d2sim_adapter, desp_adapter, insilicoseq_adapter, nanopore_sim
 import genecoder.simulators.illumina as illumina
+import genecoder.random_utils as random_utils
 
 ADAPTERS = {
     "d2sim": d2sim_adapter.simulate_d2sim,
@@ -15,6 +16,7 @@ def test_simulate_adapters_use_run_external(monkeypatch, name):
     func = ADAPTERS[name]
     which_called = []
     run_called = []
+    monkeypatch.setattr(random_utils, "_RNG", None)
 
     def fake_which(target: str) -> str:
         which_called.append(target)
@@ -35,4 +37,28 @@ def test_simulate_adapters_use_run_external(monkeypatch, name):
     assert result == f"{name}-result"
     assert which_called == [name]
     assert run_called == [([name, "-e", "0.05"], "ACGT")]
+
+
+@pytest.mark.parametrize("name", ADAPTERS.keys())
+def test_simulate_adapters_env_options(monkeypatch, name):
+    func = ADAPTERS[name]
+    run_called = []
+    env_var = f"GENECODER_{name.upper()}_OPTIONS"
+    monkeypatch.setenv(env_var, "--foo bar")
+    monkeypatch.setattr(random_utils, "_RNG", None)
+
+    def fake_run(cmd, seq):
+        run_called.append((cmd, seq))
+        return "ok"
+
+    if name == "insilicoseq":
+        monkeypatch.setattr(illumina.shutil, "which", lambda t: "/usr/bin/" + t)
+        monkeypatch.setattr(illumina, "_run_external", fake_run)
+    else:
+        monkeypatch.setattr(nanopore_sim.shutil, "which", lambda t: "/usr/bin/" + t)
+        monkeypatch.setattr(nanopore_sim, "_run_external", fake_run)
+
+    result = func("ACGT")
+    assert result == "ok"
+    assert run_called == [([name, "-e", "0.05", "--foo", "bar"], "ACGT")]
 


### PR DESCRIPTION
## Summary
- add shared `_parse_env_options` and `_run_external` to new `simulator_utils`
- update simulators and adapters to use the shared utilities
- test env option forwarding across simulator adapters

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/simulator_utils.py src/genecoder/nanopore_sim.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py src/genecoder/d2sim_adapter.py src/genecoder/dnarsim_adapter.py src/genecoder/desp_adapter.py src/genecoder/squigulator_adapter.py tests/test_env_option_parsing.py tests/test_simulator_adapters.py`
- `pytest tests/test_env_option_parsing.py tests/test_simulator_adapters.py tests/test_nanopore_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8adb86d4832694cd843f8124f363