### PR TITLE
Expose InSilicoSeq presets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,6 +194,9 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    override the chosen profile. Custom parameters can also be loaded from YAML files
    using `--illumina-profile-file` or `--nanopore-profile-file`.
 
+   The optional `insilicoseq` simulator accepts the same Illumina presets via its
+   `--profile` flag, e.g. `--simulator insilicoseq --profile miseq`.
+
    The same configuration can be provided via YAML:
 
    ```yaml

--- a/src/genecoder/insilicoseq_adapter.py
+++ b/src/genecoder/insilicoseq_adapter.py
@@ -12,6 +12,16 @@ from .simulators.illumina import (
 from .simulators import register_simulator as _register_simulator
 
 
+MISEQ_PROFILE = "MiSeq"
+HISEQ_PROFILE = "HiSeq"
+
+# Mapping of user friendly preset names to ``insilicoseq`` profile strings.
+INSILICOSEQ_PROFILES = {
+    "miseq": MISEQ_PROFILE,
+    "hiseq": HISEQ_PROFILE,
+}
+
+
 def simulate_insilicoseq(
     sequence: str,
     error_rate: float = 0.05,
@@ -23,6 +33,8 @@ def simulate_insilicoseq(
     The ``rng`` parameter is accepted for API compatibility but ignored.
     """
 
+    if profile:
+        profile = INSILICOSEQ_PROFILES.get(profile.lower(), profile)
     return _simulate_insilicoseq(sequence, error_rate=error_rate, profile=profile)
 
 
@@ -32,6 +44,8 @@ class InSilicoSeqChannel(_IlluminaInSilicoSeqChannel):
     def __init__(
         self, error_rate: float = 0.05, profile: str | None = None
     ) -> None:
+        if profile:
+            profile = INSILICOSEQ_PROFILES.get(profile.lower(), profile)
         super().__init__(error_rate=error_rate, profile=profile)
 
 

--- a/tests/test_illumina_quality_profile.py
+++ b/tests/test_illumina_quality_profile.py
@@ -142,3 +142,22 @@ def test_context_specific_errors_mutation_rates() -> None:
     context_counts = _count_mutations(context, seq)
     assert all(c == 0 for c in context_counts[1:])
     assert all(c > 0 for c in base_counts[1:])
+
+
+@pytest.mark.parametrize(
+    "preset, expected",
+    [("miseq", "MiSeq"), ("hiseq", "HiSeq")],
+)
+def test_insilicoseq_presets(monkeypatch: pytest.MonkeyPatch, preset: str, expected: str) -> None:
+    from genecoder import insilicoseq_adapter
+
+    called: list[str | None] = []
+
+    def fake_sim(seq: str, error_rate: float = 0.05, profile: str | None = None) -> str:
+        called.append(profile)
+        return seq
+
+    monkeypatch.setattr(insilicoseq_adapter, "_simulate_insilicoseq", fake_sim)
+
+    insilicoseq_adapter.simulate_insilicoseq("ACGT", profile=preset)
+    assert called == [expected]


### PR DESCRIPTION
## Summary
- expose MiSeq/HiSeq profiles in InSilicoSeq adapter and map friendly names
- document insilicoseq preset usage in CLI docs
- test profile selection for insilicoseq presets

## Testing
- `ruff check src/genecoder/insilicoseq_adapter.py tests/test_illumina_quality_profile.py`
- `pytest tests/test_illumina_quality_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6fd3aa08326b5e02d47441b8f80