### PR TITLE
feat: add offline plugin registry

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -252,10 +252,12 @@ Set the `GENECODER_PLUGIN_REGISTRY_URL` environment variable to point to that
 registry file and run the install command below. The path may be an HTTP(S)
 address or a local `file://` URL. When the variable is unset no network
 requests are made and GeneCoder loads only plugins already present in the
-current Python environment.
+current Python environment. Pass `--offline` or set `GENECODER_OFFLINE=1` to
+force offline mode; the registry must then be a local file and any attempt to
+reach the network results in a clear error.
 
 ```bash
-genecli plugin install-registry --allow-registry
+genecli plugin install-registry --allow-registry [--offline]
 ```
 
 The command reads the `packages` array from the YAML document and installs each
@@ -347,7 +349,7 @@ Secure installation with public‑key verification:
 ```bash
 export GENECODER_PLUGIN_REGISTRY_URL=./configs/registry.yaml
 export GENECODER_PLUGIN_PUBLIC_KEY=/path/to/public.pem
-genecli plugin install-registry --allow-registry
+genecli plugin install-registry --allow-registry --offline
 ```
 ## Simulator Environment Variables
 

--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -63,6 +63,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         action="store_true",
         help="Allow downloading and installing packages from the registry",
     )
+    reg_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Read registry from a local file and disable network access",
+    )
     reg_parser.set_defaults(func=_handle_install_registry)
 
 
@@ -179,7 +184,7 @@ def _handle_install_registry(args: argparse.Namespace) -> None:
         logger.error("Registry installation requires --allow-registry")
         raise SystemExit(1)
 
-    plugins.install_registry_plugins()
+    plugins.install_registry_plugins(offline=args.offline)
 
 
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -7,6 +7,7 @@ import os
 import sys
 import subprocess
 import urllib.request
+from urllib.parse import urlparse
 import tempfile
 from pathlib import Path
 import importlib
@@ -124,13 +125,29 @@ def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) ->
 
 
 
-def install_registry_plugins(url: str | None = None) -> None:
-    """Install plugin packages listed in a YAML registry at ``url``."""
+def install_registry_plugins(url: str | None = None, offline: bool | None = None) -> None:
+    """Install plugin packages listed in a YAML registry at ``url``.
+
+    When *offline* is ``True`` or the ``GENECODER_OFFLINE`` environment
+    variable is set, network access is disabled and the registry must point to a
+    local file path or ``file://`` URL. Attempting to access remote resources
+    in offline mode raises :class:`RuntimeError` with a clear message.
+    """
+
+    if offline is None:
+        offline = bool(os.getenv("GENECODER_OFFLINE"))
 
     if url is None:
         url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
     if not url:
         return
+
+    def _is_remote(target: str) -> bool:
+        return target.startswith("http://") or target.startswith("https://")
+
+    def _read_local(path_str: str) -> bytes:
+        path = urlparse(path_str).path if path_str.startswith("file://") else path_str
+        return Path(path).read_bytes()
 
     yaml_module = yaml
     if yaml_module is None:
@@ -147,9 +164,18 @@ def install_registry_plugins(url: str | None = None) -> None:
         return
 
     try:
-        with urllib.request.urlopen(url, timeout=30) as response:
-            raw = response.read()
+        if _is_remote(url):
+            if offline:
+                msg = f"Offline mode forbids fetching registry {url}"
+                logger.error(msg)
+                raise RuntimeError(msg)
+            with urllib.request.urlopen(url, timeout=30) as response:
+                raw = response.read()
+        else:
+            raw = _read_local(url)
     except Exception as exc:
+        if isinstance(exc, RuntimeError):
+            raise
         logger.warning("Failed to fetch plugin registry %s: %s", url, exc)
         return
 
@@ -183,9 +209,21 @@ def install_registry_plugins(url: str | None = None) -> None:
         pkg_path = None
         if checksum or sig_b64:
             try:
-                with urllib.request.urlopen(spec, timeout=30) as resp:
-                    pkg_bytes = resp.read()
+                path = (
+                    urlparse(spec).path if spec.startswith("file://") else spec
+                )
+                if Path(path).exists():
+                    pkg_bytes = _read_local(spec)
+                else:
+                    if offline:
+                        msg = f"Offline mode forbids downloading plugin {spec}"
+                        logger.error(msg)
+                        raise RuntimeError(msg)
+                    with urllib.request.urlopen(spec, timeout=30) as resp:
+                        pkg_bytes = resp.read()
             except Exception as exc:  # pragma: no cover - download error path
+                if isinstance(exc, RuntimeError):
+                    raise
                 logger.warning("Failed to download plugin %s: %s", spec, exc)
                 raise
 
@@ -226,6 +264,10 @@ def install_registry_plugins(url: str | None = None) -> None:
             tmp.close()
             install_target = pkg_path
 
+        if offline and not (spec.startswith("file://") or Path(spec).exists()):
+            msg = f"Offline mode forbids installing plugin {spec}"
+            logger.error(msg)
+            raise RuntimeError(msg)
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", install_target])
             version_req = entry.get("version") if isinstance(entry, dict) else None

--- a/tests/test_cli_plugin_registry.py
+++ b/tests/test_cli_plugin_registry.py
@@ -5,7 +5,11 @@ import genecoder.plugin_manager as plugins
 def test_install_registry_requires_flag(monkeypatch):
     calls = []
     monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
-    monkeypatch.setattr(plugins, "install_registry_plugins", lambda url=None: calls.append(url))
+    monkeypatch.setattr(
+        plugins,
+        "install_registry_plugins",
+        lambda url=None, offline=None: calls.append((url, offline)),
+    )
 
     result = run_cli_command(["plugin", "install-registry"])
     assert result.returncode != 0
@@ -15,9 +19,29 @@ def test_install_registry_requires_flag(monkeypatch):
 def test_install_registry_with_flag(monkeypatch):
     calls = []
     monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
-    monkeypatch.setattr(plugins, "install_registry_plugins", lambda url=None: calls.append(url))
+    monkeypatch.setattr(
+        plugins,
+        "install_registry_plugins",
+        lambda url=None, offline=None: calls.append((url, offline)),
+    )
 
     result = run_cli_command(["plugin", "install-registry", "--allow-registry"])
     assert result.returncode == 0
-    assert calls == [None]
+    assert calls == [(None, False)]
+
+
+def test_install_registry_offline_flag(monkeypatch):
+    calls = []
+    monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "./plugins.yaml")
+    monkeypatch.setattr(
+        plugins,
+        "install_registry_plugins",
+        lambda url=None, offline=None: calls.append((url, offline)),
+    )
+
+    result = run_cli_command(
+        ["plugin", "install-registry", "--allow-registry", "--offline"]
+    )
+    assert result.returncode == 0
+    assert calls == [(None, True)]
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -114,6 +114,43 @@ def test_registry_unreachable(monkeypatch: pytest.MonkeyPatch, caplog: pytest.Lo
     assert "Failed to fetch plugin registry" in caplog.text
 
 
+def test_registry_install_offline_local(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg_path = tmp_path / "pkg.whl"
+    pkg_bytes = b"PKG"
+    pkg_path.write_bytes(pkg_bytes)
+    checksum = plugins.compute_checksum(pkg_bytes)
+
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        "packages:\n  - spec: {pkg}\n    checksum: {chk}\n".format(
+            pkg=pkg_path.as_uri(), chk=checksum
+        )
+    )
+
+    installs: list[list[str]] = []
+
+    def fake_urlopen(*args, **kwargs):  # pragma: no cover - should not be used
+        raise AssertionError("network access attempted")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+
+    plugins.install_registry_plugins(str(registry), offline=True)
+
+    assert installs and installs[0][:4] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+    ]
+
+
+def test_registry_offline_remote_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    with pytest.raises(RuntimeError, match="Offline mode forbids fetching registry"):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml", offline=True)
+
+
 def _urlopen_via_httpx(client: httpx.Client) -> Callable[[str], DummyResponse]:
     """Return a urlopen replacement using ``client``."""
 


### PR DESCRIPTION
## Summary
- support offline installation for plugin registries with new `--offline` flag or `GENECODER_OFFLINE`
- add CLI flag and documentation for offline registry use
- cover offline and online registry installation scenarios with tests

## Testing
- `ruff check src/genecoder/plugin_manager.py src/genecoder/cli/plugin.py tests/test_plugin_registry.py tests/test_cli_plugin_registry.py`
- `mypy src/genecoder/plugin_manager.py src/genecoder/cli/plugin.py`
- `pytest tests/test_plugin_registry.py tests/test_cli_plugin_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890cf1a81f88326a9943ab7457584da