### PR TITLE
feat: support offline plugin registry

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -250,11 +250,11 @@ Registered codecs and simulators appear in the respective registries once
 GeneCoder can install a set of third-party packages listed in a YAML registry.
 Set the `GENECODER_PLUGIN_REGISTRY_URL` environment variable to point to that
 registry file and run the install command below. The path may be an HTTP(S)
-address or a local `file://` URL. When the variable is unset no network
-requests are made and GeneCoder loads only plugins already present in the
-current Python environment. Pass `--offline` or set `GENECODER_OFFLINE=1` to
-force offline mode; the registry must then be a local file and any attempt to
-reach the network results in a clear error.
+address, a local `file://` URL or a plain filesystem path. When the variable is
+unset no network requests are made and GeneCoder loads only plugins already
+present in the current Python environment. Pass `--offline` or set
+`GENECODER_OFFLINE=1` to force offline mode; the registry must then reside on
+disk and any attempt to reach the network results in a clear error message.
 
 ```bash
 genecli plugin install-registry --allow-registry [--offline]

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -125,14 +125,21 @@ def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) ->
 
 
 
-def install_registry_plugins(url: str | None = None, offline: bool | None = None) -> None:
+def install_registry_plugins(
+    url: str | os.PathLike[str] | None = None, offline: bool | None = None
+) -> None:
     """Install plugin packages listed in a YAML registry at ``url``.
 
-    When *offline* is ``True`` or the ``GENECODER_OFFLINE`` environment
-    variable is set, network access is disabled and the registry must point to a
-    local file path or ``file://`` URL. Attempting to access remote resources
-    in offline mode raises :class:`RuntimeError` with a clear message.
+    The ``url`` argument may be an HTTP(S) address, a ``file://`` URL or a plain
+    filesystem path. When *offline* is ``True`` or the ``GENECODER_OFFLINE``
+    environment variable is set, all network access is disabled and the
+    registry must reside on the local filesystem. Any attempt to reach a remote
+    resource in offline mode raises :class:`RuntimeError` with a descriptive
+    message.
     """
+
+    if isinstance(url, os.PathLike):
+        url = os.fspath(url)
 
     if offline is None:
         offline = bool(os.getenv("GENECODER_OFFLINE"))

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -145,6 +145,38 @@ def test_registry_install_offline_local(tmp_path: Path, monkeypatch: pytest.Monk
     ]
 
 
+def test_registry_install_offline_local_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pkg_path = tmp_path / "pkg.whl"
+    pkg_bytes = b"PKG"
+    pkg_path.write_bytes(pkg_bytes)
+    checksum = plugins.compute_checksum(pkg_bytes)
+
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        "packages:\n  - spec: {pkg}\n    checksum: {chk}\n".format(
+            pkg=pkg_path.as_uri(), chk=checksum
+        )
+    )
+
+    installs: list[list[str]] = []
+
+    def fake_urlopen(*args, **kwargs):  # pragma: no cover - should not be used
+        raise AssertionError("network access attempted")
+
+    monkeypatch.setenv("GENECODER_OFFLINE", "1")
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", installs.append)
+
+    plugins.install_registry_plugins(registry)
+
+    assert installs and installs[0][:4] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+    ]
+
+
 def test_registry_offline_remote_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
     with pytest.raises(RuntimeError, match="Offline mode forbids fetching registry"):


### PR DESCRIPTION
## Summary
- allow `install_registry_plugins` to read registry files from local paths and block remote access in offline mode
- document `--offline` flag and local file path support
- cover offline and online registry installs in tests

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/plugin_manager.py tests/test_plugin_registry.py docs/plugins.md`
- `pytest tests/test_plugin_registry.py tests/test_cli_plugin_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68912ed171648326b3061203bd32c3cf