### PR TITLE
Add nanopore context error tests

### DIFF
--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -1,0 +1,95 @@
+import random
+
+from genecoder.simulators.nanopore import NanoporeChannel, _mutate_read
+
+
+def _count_substitutions(channel: NanoporeChannel, sequence: str, runs: int, seed: int) -> int:
+    rng = random.Random(seed)
+    subs = 0
+    for _ in range(runs):
+        mutated = _mutate_read(sequence, None, rng, channel)
+        subs += sum(a != b for a, b in zip(mutated, sequence))
+    return subs
+
+
+def _count_ins_del(channel: NanoporeChannel, sequence: str, runs: int, seed: int) -> tuple[int, int]:
+    rng = random.Random(seed)
+    ins = dels = 0
+    for _ in range(runs):
+        mutated = _mutate_read(sequence, None, rng, channel)
+        if len(mutated) > len(sequence):
+            ins += 1
+        elif len(mutated) < len(sequence):
+            dels += 1
+    return ins, dels
+
+
+def test_defaults_without_profiles() -> None:
+    seq = "ACGTACGT"
+    ch_default = NanoporeChannel()
+    ch_empty = NanoporeChannel(context_errors={}, insertion_profile={}, deletion_profile={})
+    rng1 = random.Random(0)
+    rng2 = random.Random(0)
+    mutated_default = _mutate_read(seq, None, rng1, ch_default)
+    mutated_empty = _mutate_read(seq, None, rng2, ch_empty)
+    assert mutated_default == mutated_empty == seq
+    assert ch_default.context_errors == {}
+    assert ch_default.insertion_profile == {}
+    assert ch_default.deletion_profile == {}
+
+
+def test_context_profile_increases_substitutions() -> None:
+    seq = "ACACACAC"
+    base = NanoporeChannel(substitution_rate=0.1, insertion_rate=0.0, deletion_rate=0.0)
+    ctx = NanoporeChannel(
+        substitution_rate=0.1,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_errors={"AC": 2.0},
+    )
+    base_subs = _count_substitutions(base, seq, runs=200, seed=1)
+    ctx_subs = _count_substitutions(ctx, seq, runs=200, seed=1)
+    assert ctx_subs > base_subs
+
+
+def test_homopolymer_profiles_affect_mutation_counts() -> None:
+    seq = "AAAAA"
+    runs = 200
+    seed = 42
+    ins_base, _ = _count_ins_del(
+        NanoporeChannel(substitution_rate=0.0, insertion_rate=0.1, deletion_rate=0.0),
+        seq,
+        runs,
+        seed,
+    )
+    ins_prof, _ = _count_ins_del(
+        NanoporeChannel(
+            substitution_rate=0.0,
+            insertion_rate=0.1,
+            deletion_rate=0.0,
+            insertion_profile={5: 0.9},
+        ),
+        seq,
+        runs,
+        seed,
+    )
+    assert ins_prof > ins_base
+
+    _, del_base = _count_ins_del(
+        NanoporeChannel(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.1),
+        seq,
+        runs,
+        seed,
+    )
+    _, del_prof = _count_ins_del(
+        NanoporeChannel(
+            substitution_rate=0.0,
+            insertion_rate=0.0,
+            deletion_rate=0.1,
+            deletion_profile={5: 0.9},
+        ),
+        seq,
+        runs,
+        seed,
+    )
+    assert del_prof > del_base


### PR DESCRIPTION
## Summary
- add tests for Nanopore context profile behavior
- assert homopolymer-specific insertion/deletion rates modify mutation counts
- ensure defaults unchanged when no profile is supplied

## Testing
- `ruff check tests/test_nanopore_context_errors.py`
- `pytest tests/test_nanopore_context_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68915093c02083268dd0cd146524f381