### PR TITLE
Support context-specific indel profiles

### DIFF
--- a/configs/nanopore.yml
+++ b/configs/nanopore.yml
@@ -9,9 +9,11 @@ minion:
     5: 0.12
   context_insertions:
     AA:
+      1: 0.05
       5: 0.09
   context_deletions:
     TT:
+      1: 0.07
       5: 0.13
 promethion:
   error_rate: 0.08
@@ -24,9 +26,11 @@ promethion:
     5: 0.09
   context_insertions:
     AA:
+      1: 0.03
       5: 0.05
   context_deletions:
     TT:
+      1: 0.06
       5: 0.11
 r10:
   error_rate: 0.05
@@ -39,7 +43,9 @@ r10:
     5: 0.06
   context_insertions:
     AA:
+      1: 0.02
       5: 0.04
   context_deletions:
     TT:
+      1: 0.05
       5: 0.08

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -71,12 +71,30 @@ try:  # pragma: no cover - optional dependency
     _cfg_path = Path(__file__).resolve().parents[3] / "configs" / "nanopore.yml"
     with open(_cfg_path, "r", encoding="utf-8") as _fh:
         _data = yaml.safe_load(_fh) or {}
+
+    from typing import Any
+
+    def _parse_profile(params: dict[str, Any]) -> dict[str, Any]:
+        parsed: dict[str, Any] = {}
+        for key, value in params.items():
+            if key in {"insertion_profile", "deletion_profile"} and isinstance(value, dict):
+                parsed[key] = {int(k): float(v) for k, v in value.items()}
+            elif key in {"context_insertions", "context_deletions"} and isinstance(value, dict):
+                parsed[key] = {
+                    str(ctx).upper(): {int(r): float(p) for r, p in prof.items()}
+                    for ctx, prof in value.items()
+                    if isinstance(prof, dict)
+                }
+            else:
+                parsed[key] = value
+        return parsed
+
     if isinstance(_data, dict):
         NANOPORE_PROFILES: dict[
             str,
             dict[str, float | int | Dict[int, float] | Dict[str, Dict[int, float]]],
         ] = {
-            str(name): params
+            str(name): _parse_profile(params)
             for name, params in _data.items()
             if isinstance(params, dict)
         }

--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -93,3 +93,51 @@ def test_homopolymer_profiles_affect_mutation_counts() -> None:
         seed,
     )
     assert del_prof > del_base
+
+
+def test_context_insertion_profile_affect_counts() -> None:
+    seq = "AAT"
+    runs = 200
+    seed = 7
+    ins_base, _ = _count_ins_del(
+        NanoporeChannel(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0),
+        seq,
+        runs,
+        seed,
+    )
+    ins_ctx, _ = _count_ins_del(
+        NanoporeChannel(
+            substitution_rate=0.0,
+            insertion_rate=0.0,
+            deletion_rate=0.0,
+            context_insertions={"AA": {1: 0.9}},
+        ),
+        seq,
+        runs,
+        seed,
+    )
+    assert ins_ctx > ins_base
+
+
+def test_context_deletion_profile_affect_counts() -> None:
+    seq = "TTA"
+    runs = 200
+    seed = 8
+    _, del_base = _count_ins_del(
+        NanoporeChannel(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0),
+        seq,
+        runs,
+        seed,
+    )
+    _, del_ctx = _count_ins_del(
+        NanoporeChannel(
+            substitution_rate=0.0,
+            insertion_rate=0.0,
+            deletion_rate=0.0,
+            context_deletions={"TT": {1: 0.9}},
+        ),
+        seq,
+        runs,
+        seed,
+    )
+    assert del_ctx > del_base


### PR DESCRIPTION
## Summary
- parse context-specific insertion and deletion profiles from `nanopore.yml`
- handle homopolymer length mappings in simulator
- add sample context profiles and tests

## Testing
- `pre-commit run --files src/genecoder/simulators/nanopore.py configs/nanopore.yml tests/test_nanopore_context_errors.py`
- `pytest tests/test_nanopore_context_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_6892031c790c832692706f3043986973