### PR TITLE
test: add nanopore context profile coverage

### DIFF
--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -49,6 +49,8 @@ def test_context_profile_increases_substitutions() -> None:
     )
     base_subs = _count_substitutions(base, seq, runs=200, seed=1)
     ctx_subs = _count_substitutions(ctx, seq, runs=200, seed=1)
+    assert base_subs == 164
+    assert ctx_subs == 239
     assert ctx_subs > base_subs
 
 
@@ -73,6 +75,8 @@ def test_homopolymer_profiles_affect_mutation_counts() -> None:
         runs,
         seed,
     )
+    assert ins_base == 86
+    assert ins_prof == 185
     assert ins_prof > ins_base
 
     _, del_base = _count_ins_del(
@@ -92,4 +96,6 @@ def test_homopolymer_profiles_affect_mutation_counts() -> None:
         runs,
         seed,
     )
+    assert del_base == 84
+    assert del_prof == 183
     assert del_prof > del_base


### PR DESCRIPTION
## Summary
- add tests verifying nanopore simulator defaults remain unchanged without profiles
- cover context-based substitution and homopolymer insertion/deletion profile effects using deterministic seeds

## Testing
- `pre-commit run ruff --files tests/test_nanopore_context_errors.py`
- `pre-commit run mypy --files tests/test_nanopore_context_errors.py`
- `pytest tests/test_nanopore_context_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68920a60894c8326b37bebeb61536b72