### PR TITLE
Add pipeline demo config and dashboard docs

### DIFF
--- a/configs/pipeline_demo.yaml
+++ b/configs/pipeline_demo.yaml
@@ -1,0 +1,20 @@
+# Pipeline demonstration configuration that performs encoding, simulated sequencing,
+# decoding and metrics export. Set GENECODER_METRICS_PATH before running to capture
+# metrics:
+#   GENECODER_METRICS_PATH=examples/pipeline_metrics.json genecli bundle run configs/pipeline_demo.yaml
+encode:
+  input_files:
+    - examples/pipeline_demo_input.txt
+  method: base4_direct
+  fec: hamming_7_4
+simulate:
+  simulators:
+    - name: simple
+      error_rate: 0.01
+  pipeline:
+    parallel: false
+    workers: null
+    use_process_pool: false
+    use_mpi: false
+decode:
+  method: base4_direct

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -417,12 +417,19 @@ The GUI exposes encoding options, error correction choices and displays metrics 
 
 ### Launching the Streamlit Dashboard
 
-The dashboard visualizes simulation output stored in a JSON file. Install the `gui` group and run:
+The dashboard visualizes simulation output stored in a JSON file.
+Generate a sample set of metrics by running the provided pipeline demo
+configuration and then launch the Streamlit interface:
 
 ```bash
 poetry install --with gui --no-interaction
-genecli dashboard results.json
+GENECODER_METRICS_PATH=examples/pipeline_metrics.json \
+    genecli bundle run configs/pipeline_demo.yaml
+genecli dashboard examples/pipeline_metrics.json
 ```
+
+This encodes and decodes `examples/pipeline_demo_input.txt`, stores metrics in
+`examples/pipeline_metrics.json` and opens the dashboard with the results.
 
 The interface plots GC content distribution, homopolymer histograms, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion counts are present, they are shown as a simple bar chart.
 

--- a/examples/pipeline_demo_input.txt
+++ b/examples/pipeline_demo_input.txt
@@ -1,0 +1,1 @@
+GeneCoder pipeline demo input.


### PR DESCRIPTION
## Summary
- add `pipeline_demo.yaml` showing encode/simulate/decode with metrics export
- document running Streamlit dashboard against generated metrics
- include tiny sample input file for reproducible demo

## Testing
- `pre-commit run markdown-link-check --files docs/usage.md`
- `pytest tests/test_cli_simulator_roundtrip.py::test_encode_decode_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a7d64554832680c1ea1d4bef5b80