### PR TITLE
feat: add sequencing profile presets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -190,9 +190,17 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    - **Illumina** – `miseq`, `hiseq`
    - **Nanopore** – `minion`, `promethion`
 
-   Select a profile with `--illumina-profile` or `--nanopore-profile`. Individual rate options
-   override the chosen profile. Custom parameters can also be loaded from YAML files
-   using `--illumina-profile-file` or `--nanopore-profile-file`.
+   Use `--profile` to apply a preset without specifying a simulator:
+
+   ```bash
+   genecli channel --profile miseq --input-file encoded.fasta \
+       --output-file channel.fasta
+   ```
+
+   For finer control, select a profile with `--illumina-profile` or
+   `--nanopore-profile`. Individual rate options override the chosen profile.
+   Custom parameters can also be loaded from YAML files using
+   `--illumina-profile-file` or `--nanopore-profile-file`.
 
    The optional `insilicoseq` simulator accepts the same Illumina presets via its
    `--profile` flag, e.g. `--simulator insilicoseq --profile miseq`.

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -29,6 +29,14 @@ from .shared import add_single_io_args
 logger = logging.getLogger(__name__)
 
 
+PROFILE_MAP: dict[str, tuple[str, str]] = {
+    "miseq": ("illumina", "miseq"),
+    "hiseq": ("illumina", "hiseq"),
+    "minion": ("nanopore", "minion"),
+    "promethion": ("nanopore", "promethion"),
+}
+
+
 def _load_config(
     path: str,
 ) -> tuple[
@@ -285,6 +293,13 @@ def register_subcommand(
     run_parser.add_argument("config", type=str, help="Path to channel config")
     illumina_profiles = ", ".join(sorted(ILLUMINA_PROFILES))
     nanopore_profiles = ", ".join(sorted(NANOPORE_PROFILES))
+    profile_names = ", ".join(sorted(PROFILE_MAP))
+    run_parser.add_argument(
+        "--profile",
+        choices=sorted(PROFILE_MAP),
+        default=None,
+        help=f"Named sequencing profile to use. Available profiles: {profile_names}",
+    )
     run_parser.add_argument(
         "--illumina-profile",
         type=str,
@@ -342,6 +357,12 @@ def register_subcommand(
             "--config",
             type=str,
             help="YAML/JSON config defining simulators, synthesis and pipeline",
+        )
+        target.add_argument(
+            "--profile",
+            choices=sorted(PROFILE_MAP),
+            default=None,
+            help="Named sequencing profile to use",
         )
         target.add_argument("--sub-prob", type=float, default=0.0, help="Substitution probability per nucleotide")
         target.add_argument("--ins-prob", type=float, default=0.0, help="Insertion probability after each nucleotide")
@@ -442,7 +463,14 @@ def run_channel(args: argparse.Namespace) -> None:
         nanopore_profile=opts.nanopore_profile,
     )
     simulators = opts.simulator_specs
-    if simulators is None:
+    if opts.profile:
+        sim_name, prof = PROFILE_MAP[opts.profile]
+        simulators = [(sim_name, {})]
+        if sim_name == "illumina":
+            opts.illumina_profile = prof
+        else:
+            opts.nanopore_profile = prof
+    elif simulators is None:
         simulators = [(name, {}) for name in opts.simulators]
 
     if opts.decay_rate is not None:
@@ -536,6 +564,14 @@ def _handle_run(args: argparse.Namespace) -> None:
     except Exception as exc:  # pragma: no cover - config error handling
         logger.error(str(exc))
         raise SystemExit(1)
+
+    if args.profile is not None:
+        sim_name, preset = PROFILE_MAP[args.profile]
+        simulators = [(sim_name, {})]
+        if sim_name == "illumina":
+            cfg.illumina_profile = preset
+        else:
+            cfg.nanopore_profile = preset
 
     if args.illumina_profile is not None:
         cfg.illumina_profile = args.illumina_profile

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -38,6 +38,7 @@ class ChannelOptions:
     nanopore_sub_rate: float | None = None
     nanopore_ins_rate: float | None = None
     nanopore_del_rate: float | None = None
+    profile: str | None = None
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
     illumina_profile_file: str | None = None
@@ -90,18 +91,22 @@ def _parse_context(value: str | None) -> Dict[str, float] | None:
 
 
 def _validate_simulator_prob_args(
-    simulators: Sequence[str], sub_prob: float, ins_prob: float, del_prob: float
+    simulators: Sequence[str],
+    sub_prob: float,
+    ins_prob: float,
+    del_prob: float,
+    profile: str | None,
 ) -> None:
-    """Ensure that simulator and probability arguments are valid."""
+    """Ensure that simulator, profile and probability arguments are valid."""
 
     prob_specified = any([sub_prob, ins_prob, del_prob])
-    if simulators and prob_specified:
+    if (simulators or profile) and prob_specified:
         raise ValueError(
-            "Probability options cannot be combined with --simulator or --config"
+            "Probability options cannot be combined with --simulator, --profile or --config"
         )
-    if not simulators and not prob_specified:
+    if not simulators and not prob_specified and profile is None:
         raise ValueError(
-            "At least one simulator or probability option must be specified"
+            "At least one simulator, profile or probability option must be specified"
         )
 
 
@@ -168,7 +173,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
             args.decay_rate = extra.get("decay_rate")
 
     _validate_simulator_prob_args(
-        simulators, args.sub_prob, args.ins_prob, args.del_prob
+        simulators, args.sub_prob, args.ins_prob, args.del_prob, getattr(args, "profile", None)
     )
     if args.min_length <= 0:
         raise ValueError("min_length must be greater than 0")
@@ -207,6 +212,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_sub_rate=args.nanopore_sub_rate,
         nanopore_ins_rate=args.nanopore_ins_rate,
         nanopore_del_rate=args.nanopore_del_rate,
+        profile=getattr(args, "profile", None),
         illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
         illumina_profile_file=args.illumina_profile_file,


### PR DESCRIPTION
## Summary
- add `--profile` option to channel CLI for miseq, hiseq, minion, and promethion presets
- map `--profile` names to appropriate simulator parameters
- document profile usage example

## Testing
- `ruff check src/genecoder/cli/options.py src/genecoder/cli/channel.py`
- `mypy src/genecoder/cli/options.py src/genecoder/cli/channel.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894cc11be9c8326ba08ab15a4fd2b90