### PR TITLE
Validate Illumina profile parameters

### DIFF
--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -1,7 +1,8 @@
 """Simple Illumina sequencing simulator."""
 from __future__ import annotations
 
-from typing import Callable, Sequence, Dict, Iterable
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Mapping, Sequence
 from pathlib import Path
 import json
 import random
@@ -34,6 +35,7 @@ from . import register_simulator as _register_simulator
 
 __all__ = [
     "IlluminaChannel",
+    "IlluminaProfile",
     "IlluminaD2SimChannel",
     "IlluminaInSilicoSeqChannel",
     "simulate_insilicoseq",
@@ -68,6 +70,53 @@ def _parse_quality_profile(value: str) -> Sequence[float]:
     return [float(x) for x in value.split(",") if x]
 
 
+@dataclass
+class IlluminaProfile:
+    """Parameters controlling Illumina simulation behaviour."""
+
+    substitution_rate: float
+    insertion_rate: float
+    deletion_rate: float
+    read_length: int
+    coverage: int
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("substitution_rate", self.substitution_rate),
+            ("insertion_rate", self.insertion_rate),
+            ("deletion_rate", self.deletion_rate),
+        ):
+            if not 0 <= value <= 1:
+                raise ValueError(f"{name} must be between 0 and 1")
+        if self.read_length <= 0:
+            raise ValueError("read_length must be positive")
+        if self.coverage <= 0:
+            raise ValueError("coverage must be positive")
+
+
+_REQUIRED_KEYS = {
+    "substitution_rate",
+    "insertion_rate",
+    "deletion_rate",
+    "read_length",
+    "coverage",
+}
+
+
+def _validate_profile(data: Mapping[str, Any]) -> IlluminaProfile:
+    missing = _REQUIRED_KEYS - data.keys()
+    if missing:
+        keys = ", ".join(sorted(missing))
+        raise ValueError(f"Illumina profile missing required key(s): {keys}")
+    return IlluminaProfile(
+        substitution_rate=float(data["substitution_rate"]),
+        insertion_rate=float(data["insertion_rate"]),
+        deletion_rate=float(data["deletion_rate"]),
+        read_length=int(data["read_length"]),
+        coverage=int(data["coverage"]),
+    )
+
+
 # Preset parameter profiles for :class:`IlluminaChannel`.
 ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
     "miseq": {
@@ -75,18 +124,21 @@ ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
         "insertion_rate": 0.0001,
         "deletion_rate": 0.0001,
         "read_length": 250,
+        "coverage": 1,
     },
     "hiseq": {
         "substitution_rate": 0.0005,
         "insertion_rate": 0.00005,
         "deletion_rate": 0.00005,
         "read_length": 150,
+        "coverage": 1,
     },
     "novaseq": {
         "substitution_rate": 0.0003,
         "insertion_rate": 0.00003,
         "deletion_rate": 0.00003,
         "read_length": 150,
+        "coverage": 1,
     },
 }
 
@@ -150,16 +202,30 @@ class IlluminaChannel(BaseSimulator):
                 data = yaml.safe_load(fh) or {}
             if not isinstance(data, dict):
                 raise ValueError("Profile file must map keys to values")
-            substitution_rate = float(data.get("substitution_rate", substitution_rate))
-            insertion_rate = float(data.get("insertion_rate", insertion_rate))
-            deletion_rate = float(data.get("deletion_rate", deletion_rate))
-            read_length = int(data.get("read_length", read_length))
-            coverage = int(data.get("coverage", coverage))
+            profile = _validate_profile(data)
+            substitution_rate = profile.substitution_rate
+            insertion_rate = profile.insertion_rate
+            deletion_rate = profile.deletion_rate
+            read_length = profile.read_length
+            coverage = profile.coverage
             quality_profile = data.get("quality_profile", quality_profile)
             context_errors = data.get("context_errors", context_errors)
+        else:
+            profile = _validate_profile(
+                {
+                    "substitution_rate": substitution_rate,
+                    "insertion_rate": insertion_rate,
+                    "deletion_rate": deletion_rate,
+                    "read_length": read_length,
+                    "coverage": coverage,
+                }
+            )
+            substitution_rate = profile.substitution_rate
+            insertion_rate = profile.insertion_rate
+            deletion_rate = profile.deletion_rate
+            read_length = profile.read_length
+            coverage = profile.coverage
 
-        if isinstance(coverage, str):
-            coverage = int(coverage)
         if isinstance(quality_profile, str):
             quality_profile = _parse_quality_profile(quality_profile)
 

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -349,12 +349,9 @@ class NanoporeDNArSimChannel(NanoporeChannel):
             context_deletions=context_deletions,
         )
         self.profile = profile
-        if profile:
-            rates = DNARSIM_RATE_TABLES.get(profile)
-            if rates:
-                self.substitution_rate = rates.get("substitution_rate", self.substitution_rate)
-                self.insertion_rate = rates.get("insertion_rate", self.insertion_rate)
-                self.deletion_rate = rates.get("deletion_rate", self.deletion_rate)
+        self._profile_rates: dict[str, float] = (
+            DNARSIM_RATE_TABLES.get(profile) if profile else {}
+        )
 
     def _simulate_cli(self, sequence: str) -> str:
         cmd = "dnarsim"
@@ -395,6 +392,8 @@ class NanoporeDNArSimChannel(NanoporeChannel):
 
 
     def simulate(self, sequence: str) -> str:
+        from typing import cast
+
         rng = make_rng()
         quality = self.quality_profile
         coverage = max(1, self.get_coverage(sequence))
@@ -403,9 +402,33 @@ class NanoporeDNArSimChannel(NanoporeChannel):
         for _ in range(coverage):
             try:
                 base = self._simulate_cli(sequence)
+                sub = self.substitution_rate
+                ins = self.insertion_rate
+                dele = self.deletion_rate
             except Exception:
                 base = self._simulate_fallback(sequence, self.error_rate, rng)
-            reads.append(_mutate_read(base, quality, rng, self))
+                rates = self._profile_rates
+                sub = rates.get("substitution_rate", self.substitution_rate)
+                ins = rates.get("insertion_rate", self.insertion_rate)
+                dele = rates.get("deletion_rate", self.deletion_rate)
+            reads.append(
+                cast(
+                    str,
+                    _mutate_read_jit(
+                        base,
+                        quality,
+                        rng,
+                        sub,
+                        ins,
+                        dele,
+                        self.context_errors,
+                        self.insertion_profile,
+                        self.deletion_profile,
+                        self.context_insertions,
+                        self.context_deletions,
+                    ),
+                )
+            )
 
         if coverage == 1:
             return reads[0]

--- a/tests/test_illumina_profile_validation.py
+++ b/tests/test_illumina_profile_validation.py
@@ -1,0 +1,76 @@
+import pytest
+import yaml
+from pathlib import Path
+
+from genecoder.simulators.illumina import IlluminaChannel
+
+
+def test_valid_profile_file(tmp_path: Path) -> None:
+    params = {
+        "substitution_rate": 0.01,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.03,
+        "read_length": 100,
+        "coverage": 2,
+    }
+    prof = tmp_path / "good.yml"
+    prof.write_text(yaml.safe_dump(params))
+    ch = IlluminaChannel(profile_path=str(prof))
+    assert ch.read_length == 100
+    assert ch.coverage == 2
+
+
+@pytest.mark.parametrize(
+    "bad_params, msg",
+    [
+        (
+            {
+                "substitution_rate": 0.01,
+                "insertion_rate": 0.02,
+                "deletion_rate": 0.03,
+                "read_length": 100,
+            },
+            "missing required key\(s\): coverage",
+        ),
+        (
+            {
+                "substitution_rate": -0.1,
+                "insertion_rate": 0.02,
+                "deletion_rate": 0.03,
+                "read_length": 100,
+                "coverage": 2,
+            },
+            "substitution_rate must be between 0 and 1",
+        ),
+        (
+            {
+                "substitution_rate": 0.01,
+                "insertion_rate": 0.02,
+                "deletion_rate": 0.03,
+                "read_length": 0,
+                "coverage": 2,
+            },
+            "read_length must be positive",
+        ),
+        (
+            {
+                "substitution_rate": 0.01,
+                "insertion_rate": 0.02,
+                "deletion_rate": 0.03,
+                "read_length": 100,
+                "coverage": 0,
+            },
+            "coverage must be positive",
+        ),
+    ],
+)
+def test_invalid_profile_file(tmp_path: Path, bad_params: dict, msg: str) -> None:
+    prof = tmp_path / "bad.yml"
+    prof.write_text(yaml.safe_dump(bad_params))
+    with pytest.raises(ValueError, match=msg):
+        IlluminaChannel(profile_path=str(prof))
+
+
+def test_invalid_direct_params() -> None:
+    with pytest.raises(ValueError):
+        IlluminaChannel(substitution_rate=2.0)


### PR DESCRIPTION
## Summary
- add `IlluminaProfile` dataclass and validation helper
- ensure `IlluminaChannel` validates profile inputs
- include coverage in built-in Illumina profiles
- add tests for valid and invalid Illumina profiles
- prevent double mutation of reads when `NanoporeDNArSimChannel` uses the `dnarsim` CLI, applying profile rates only for fallback

## Testing
- `ruff check src/genecoder/simulators/nanopore.py`
- `pytest tests/test_nanopore_dnarsim_channel.py::test_cli_invocation -q`
- `pytest tests/test_illumina_profile_validation.py tests/test_simulator_profiles.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68964b519a288326a5fc0ea81a693568