### PR TITLE
Add seed option to CLI commands

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,8 +129,9 @@ genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
 genecli decode corrupted.fasta --output-file decoded.bin
 ```
 
-Set the environment variable `GENECODER_SIM_SEED` to an integer to make the
-simulated substitutions and indels deterministic across runs.
+Pass `--seed <int>` to `genecli encode`, `genecli decode`, or `genecli pipeline`
+to seed random components for reproducible runs.  Alternatively set the
+`GENECODER_SIM_SEED` environment variable.
 
 11. **Encode, corrupt and decode a file with automatic extensions**
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -399,6 +399,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         type=str,
         help="Extra command line options forwarded to squigulator.",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for random components to ensure reproducible runs.",
+    )
     parser.set_defaults(func=_handle_command)
 
 
@@ -470,5 +476,7 @@ def decode_files(args: argparse.Namespace) -> None:
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if args.seed is not None:
+        os.environ["GENECODER_SIM_SEED"] = str(args.seed)
     decode_files(args)
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -575,6 +575,12 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         action="store_true",
         help="Use DNA Chisel for constraint fixing when available.",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for random components to ensure reproducible runs.",
+    )
     parser.set_defaults(func=_handle_command)
 
 
@@ -633,5 +639,7 @@ def encode_files(args: argparse.Namespace) -> list[tuple[str, str] | None]:
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if args.seed is not None:
+        os.environ["GENECODER_SIM_SEED"] = str(args.seed)
     encode_files(args)
 

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -128,6 +128,7 @@ def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
         gc_max=args.gc_max,
         max_homopolymer=args.max_homopolymer,
         alphabet=getattr(args, "alphabet", "base4"),
+        seed=getattr(args, "seed", None),
     )
 
 
@@ -140,6 +141,7 @@ def build_decoding_options(args: argparse.Namespace) -> DecodingOptions:
         k_value=args.k_value,
         parity_rule=args.parity_rule,
         alphabet=getattr(args, "alphabet", "base4"),
+        seed=getattr(args, "seed", None),
     )
 
 

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, cast
 
@@ -157,6 +158,12 @@ def register_subcommand(
         help="Deletion rate/probability for the selected channel",
     )
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for random components to ensure reproducible runs.",
+    )
+    parser.add_argument(
         "--mpi-workers",
         type=int,
         default=None,
@@ -167,6 +174,8 @@ def register_subcommand(
 
 
 def _handle_command(args: argparse.Namespace) -> None:
+    if args.seed is not None:
+        os.environ["GENECODER_SIM_SEED"] = str(args.seed)
     cfg_codec = cfg_fec = cfg_channel = None
     cfg_params: Dict[str, Any] = {}
 

--- a/src/genecoder/options.py
+++ b/src/genecoder/options.py
@@ -33,6 +33,7 @@ class EncodingOptions:
     gc_max: float
     max_homopolymer: int
     alphabet: str = "base4"
+    seed: int | None = None
 
 
 @dataclass
@@ -44,3 +45,4 @@ class DecodingOptions:
     k_value: int
     parity_rule: str
     alphabet: str
+    seed: int | None = None

--- a/tests/test_cli_seed.py
+++ b/tests/test_cli_seed.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_pipeline_seed_reproducible(tmp_path: Path) -> None:
+    input_file = tmp_path / "data.bin"
+    input_file.write_bytes(b"seedtest")
+
+    out1 = tmp_path / "out1.bin"
+    out2 = tmp_path / "out2.bin"
+
+    cmd = [
+        "pipeline",
+        str(input_file),
+        str(out1),
+        "--codec",
+        "reverse",
+        "--channel",
+        "simple",
+        "--sub-rate",
+        "0.5",
+        "--seed",
+        "7",
+    ]
+
+    result1 = run_cli_command(cmd)
+    assert result1.returncode == 0, result1.stderr
+
+    cmd[2] = str(out2)
+    result2 = run_cli_command(cmd)
+    assert result2.returncode == 0, result2.stderr
+
+    assert out1.read_bytes() == out2.read_bytes()


### PR DESCRIPTION
## Summary
- allow `genecli encode`, `decode`, and `pipeline` to accept `--seed` and set `GENECODER_SIM_SEED`
- propagate seed through CLI option dataclasses
- document the new CLI seed flag and test deterministic pipeline output

## Testing
- `ruff check src/genecoder/cli/encode.py src/genecoder/cli/decode.py src/genecoder/cli/pipeline.py src/genecoder/cli/options.py src/genecoder/options.py tests/test_cli_seed.py`
- `pytest tests/test_cli_seed.py tests/test_cli_pipeline.py::test_cli_pipeline_indel_rates tests/test_cli_roundtrip.py::test_cli_encode_decode_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_6896547ea3a08326919bcbd2c0f41060