### PR TITLE
test: add fountain nanopore pipeline

### DIFF
--- a/tests/test_fountain_nanopore_pipeline.py
+++ b/tests/test_fountain_nanopore_pipeline.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import genecoder.simulators.nanopore as nanopore
+from genecoder.core import run_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.api import Codec
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+
+        return decode_base4_direct(encoded)[0]
+
+
+def test_fountain_nanopore_pipeline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pytest.importorskip("pyfinite")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    monkeypatch.setattr(nanopore.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        nanopore,
+        "_run_external",
+        lambda *_: (_ for _ in ()).throw(AssertionError("_run_external called")),
+    )
+
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {
+        "encode": _Base4Codec().encode,
+        "decode": _Base4Codec().decode,
+    }
+    SIMULATOR_REGISTRY["nanopore"] = nanopore.NanoporeChannel(
+        error_rate=0.0,
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+    )
+
+    data = b"nanopore fountain pipeline"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result, metrics = run_pipeline(
+        "base4", "fountain", "nanopore", str(inp), str(outp)
+    )
+
+    assert result == data
+    assert outp.read_bytes() == data
+    assert isinstance(metrics.get("substitutions"), int)
+    assert isinstance(metrics.get("insertions"), int)
+    assert isinstance(metrics.get("deletions"), int)


### PR DESCRIPTION
## Summary
- add fountain/nanopore pipeline test verifying decoding success and metrics

## Testing
- `ruff check tests/test_fountain_nanopore_pipeline.py`
- `pytest tests/test_fountain_nanopore_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896838b7f388326840b30c956afe389