### PR TITLE
Add Reed-Solomon Illumina pipeline test

### DIFF
--- a/tests/test_rs_illumina_pipeline.py
+++ b/tests/test_rs_illumina_pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genecoder.core import run_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.api import Codec
+from genecoder.simulators.illumina import IlluminaChannel
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+        return decode_base4_direct(encoded)[0]
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_rs_illumina_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    SIMULATOR_REGISTRY["illumina"] = IlluminaChannel()
+
+    data = b"illumina rs pipeline"
+    inp = tmp_path / "data.bin"
+    outp = tmp_path / "out.bin"
+    inp.write_bytes(data)
+
+    result, metrics = run_pipeline("base4", "reed_solomon", "illumina", str(inp), str(outp))
+
+    assert result == data
+    assert outp.read_bytes() == data
+    assert metrics["constraint_violations"] == 0


### PR DESCRIPTION
## Summary
- add regression test for running base4 + Reed-Solomon through Illumina channel
- verify decoded output matches input and no constraint violations occur

## Testing
- `ruff check tests/test_rs_illumina_pipeline.py`
- `pytest tests/test_rs_illumina_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896838a99808326a80bbcd6bf2e0770