### PR TITLE
Add example visualizer plugin and docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,11 +1,11 @@
 # Plugin System
 
 GeneCoder discovers additional functionality using Python entry points. Any
-package can expose entry points under `genecoder.plugins`, `genecoder.fec` or
-`genecoder.simulators` that point to modules with a `register` function. The
-function receives a callback used to add the implementation to the appropriate
-registry. GeneCoder looks only at packages installed in your current Python
-environment when loading plugins.
+package can expose entry points under `genecoder.plugins`, `genecoder.fec`,
+`genecoder.simulators` or `genecoder.visualizers` that point to modules with a
+`register` function. The function receives a callback used to add the
+implementation to the appropriate registry. GeneCoder looks only at packages
+installed in your current Python environment when loading plugins.
 
 ## Quick Start
 
@@ -67,6 +67,8 @@ The callback passed to `register()` depends on the entry point group used:
   `register_fec(name, FECClass)`.
 - **Simulators** register under `genecoder.simulators` and call
   `register_simulator(name, SimulatorInstance)`.
+- **Visualizers** register under `genecoder.visualizers` and call
+  `register_visualizer(name, VisualizerClass)`.
 
 See the packages in [`plugins-examples`](../plugins-examples/) for working
 implementations of each entry point group.
@@ -141,7 +143,9 @@ the :class:`genecoder.api.Simulator` interface.
 
 Visualizer plugins register under `genecoder.visualizers` with a
 `register_visualizer` callback. The class should implement the
-``genecoder.api.Visualizer`` interface.
+``genecoder.api.Visualizer`` interface. See
+[`plugins-examples/example_visualizer`](../plugins-examples/example_visualizer/)
+for a minimal implementation.
 
 ```toml
 [project.entry-points."genecoder.visualizers"]
@@ -206,6 +210,7 @@ minimal packages showing how each entry point group works:
 - `example_codec` – registers a codec using `register_codec("example", ExampleCodec)`.
 - `example_fec` – registers a FEC backend via `register_fec("example", ExampleFEC)`.
 - `example_simulator` – registers a simulator with `register_simulator("example", PassthroughChannel())`.
+- `example_visualizer` – registers a visualizer with `register_visualizer("example", ExampleVisualizer)`.
 - `advanced_fec` – registers LDPC helper functions under `genecoder.fec`.
 - `example_package_plugin` – demonstrates a small plugin that exposes simple
   encode/decode functions through `genecoder.plugins`.
@@ -228,9 +233,10 @@ Follow these steps to try the example codec plugin:
    print("example" in CODEC_REGISTRY)
    ```
 
-Swap `example_codec` for `example_fec` or `example_simulator` to explore the
-other entry point groups. Install any of these packages with
-`pip install ./plugins-examples/<name>` to experiment locally.
+Swap `example_codec` for `example_fec`, `example_simulator` or
+`example_visualizer` to explore the other entry point groups. Install any of
+these packages with `pip install ./plugins-examples/<name>` to experiment
+locally.
 
 Run `scripts/scaffold_plugin.sh <name>` to create a new plugin project. The
 generated template registers an entry point and includes a README explaining

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,5 +5,5 @@ strict = true
 explicit_package_bases = true
 show_error_codes = true
 enable_error_code = ignore-without-code
-files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec
+files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_visualizer/example_visualizer, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec
 exclude = ^tests/

--- a/plugins-examples/README.md
+++ b/plugins-examples/README.md
@@ -1,13 +1,14 @@
 # Plugin Examples
 
 This directory contains minimal example plugins demonstrating how to integrate
-custom codecs, FEC implementations and read simulators with GeneCoder.
+custom codecs, FEC implementations, visualizers and read simulators with GeneCoder.
 
 Each subdirectory is an installable Python package using PEP 621 metadata:
 
 - `example_codec` – registers a codec named `example`.
 - `example_fec` – registers a FEC backend named `example`.
 - `example_simulator` – registers a simulator named `example`.
+- `example_visualizer` – registers a visualizer named `example`.
 - `advanced_fec` – registers an LDPC FEC backend named `advanced_ldpc`.
 
 Install any of the packages with `pip` to experiment locally, e.g.:

--- a/plugins-examples/example_visualizer/example_visualizer/__init__.py
+++ b/plugins-examples/example_visualizer/example_visualizer/__init__.py
@@ -1,0 +1,16 @@
+from typing import Callable
+
+from genecoder.api import Visualizer
+
+
+class ExampleVisualizer(Visualizer):  # type: ignore[misc]
+    """Trivial visualizer returning the input sequence unchanged."""
+
+    def visualize(self, sequence: str, /, **kwargs: object) -> str:
+        return sequence
+
+
+def register(register_visualizer: Callable[[str, type[Visualizer]], None]) -> None:
+    """Register the example visualizer."""
+
+    register_visualizer("example", ExampleVisualizer)

--- a/plugins-examples/example_visualizer/pyproject.toml
+++ b/plugins-examples/example_visualizer/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-example-visualizer"
+version = "0.1.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.visualizers"]
+example = "example_visualizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ files = [
     "plugins-examples/example_codec/example_codec",
     "plugins-examples/example_fec/example_fec",
     "plugins-examples/example_simulator/example_simulator",
+    "plugins-examples/example_visualizer/example_visualizer",
     "plugins-examples/example_package_plugin/example_plugin",
     "plugins-examples/advanced_fec/advanced_fec",
 ]

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -43,6 +43,7 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.syspath_prepend(str(root / "example_codec"))
     monkeypatch.syspath_prepend(str(root / "example_fec"))
     monkeypatch.syspath_prepend(str(root / "example_simulator"))
+    monkeypatch.syspath_prepend(str(root / "example_visualizer"))
 
     def fake_entry_points(*, group: str | None = None) -> list[EntryPoint]:
         if group == "genecoder.plugins":
@@ -51,6 +52,8 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
             return [EntryPoint(name="example", value="example_fec", group=group)]
         if group == "genecoder.simulators":
             return [EntryPoint(name="example", value="example_simulator", group=group)]
+        if group == "genecoder.visualizers":
+            return [EntryPoint(name="example", value="example_visualizer", group=group)]
         return []
 
     monkeypatch.setattr(plugins, "entry_points", fake_entry_points)
@@ -58,6 +61,7 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     plugins.CODEC_REGISTRY.clear()
     plugins.FEC_REGISTRY.clear()
     plugins.SIMULATOR_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
 
     plugins.load_plugins()
 
@@ -65,6 +69,7 @@ def test_example_plugins_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "example" in plugins.CODEC_REGISTRY
     assert "example" in plugins.FEC_REGISTRY
     assert "example" in plugins.SIMULATOR_REGISTRY
+    assert "example" in plugins.VISUALIZER_REGISTRY
 
 
 def test_load_plugins_idempotent() -> None:


### PR DESCRIPTION
## Summary
- add example visualizer plugin package
- document visualizer entry point and reference example
- test discovery of example visualizer plugin

## Testing
- `pre-commit run --files plugins-examples/example_visualizer/example_visualizer/__init__.py plugins-examples/example_visualizer/pyproject.toml plugins-examples/README.md docs/plugins.md tests/test_plugin_loading.py pyproject.toml mypy.ini` (skipping mypy, pytest)
- `ruff check plugins-examples/example_visualizer/example_visualizer/__init__.py tests/test_plugin_loading.py`
- `mypy plugins-examples/example_visualizer/example_visualizer/__init__.py tests/test_plugin_loading.py`
- `pytest tests/test_plugin_loading.py::test_example_plugins_registered tests/test_visualizer_plugins.py::test_visualizer_entry_point -q`

------
https://chatgpt.com/codex/tasks/task_e_6896bd89ddc08326b93cdee425945109