### PR TITLE
feat: weight nanopore indel errors by homopolymer

### DIFF
--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -50,6 +50,52 @@ except Exception:  # pragma: no cover - fallback when yaml missing
     DNARSIM_RATE_TABLES = {}
 
 
+def _simulate_homopolymer_errors(
+    sequence: str,
+    substitution_prob: float = 0.0,
+    insertion_prob: float = 0.0,
+    deletion_prob: float = 0.0,
+    rng: random.Random | None = None,
+) -> str:
+    """Simulate errors with indel rates weighted by homopolymer length."""
+
+    if rng is None:
+        rng = make_rng()
+
+    if insertion_prob == 0.0 and deletion_prob == 0.0:
+        try:
+            return simulate_errors(sequence, substitution_prob, rng=rng)
+        except TypeError:
+            return simulate_errors(
+                sequence, substitution_prob=substitution_prob, rng=rng
+            )
+
+    mutated: list[str] = []
+    i = 0
+    seq_len = len(sequence)
+    while i < seq_len:
+        nt = sequence[i]
+        j = i + 1
+        while j < seq_len and sequence[j] == nt:
+            j += 1
+        run_len = j - i
+        factor = run_len / 4.0 if run_len >= 4 else 1.0
+        ins_p = min(1.0, insertion_prob * factor)
+        del_p = min(1.0, deletion_prob * factor)
+        run_seq = sequence[i:j]
+        mutated.append(
+            simulate_errors(
+                run_seq,
+                substitution_prob,
+                ins_p,
+                del_p,
+                rng=rng,
+            )
+        )
+        i = j
+    return "".join(mutated)
+
+
 def _simulate_adapter(
     command: str,
     sequence: str,
@@ -86,17 +132,19 @@ def _simulate_adapter(
     if rng is None:
         rng = make_rng()
     if rate_table:
-        return simulate_errors(
+        return _simulate_homopolymer_errors(
             sequence,
             rate_table.get("substitution_rate", 0.0),
             rate_table.get("insertion_rate", 0.0),
             rate_table.get("deletion_rate", 0.0),
-            rng=rng,
+            rng,
         )
     try:
-        return simulate_errors(sequence, error_rate, rng=rng)
+        return _simulate_homopolymer_errors(sequence, error_rate, rng=rng)
     except TypeError:
-        return simulate_errors(sequence, substitution_prob=error_rate, rng=rng)
+        return _simulate_homopolymer_errors(
+            sequence, substitution_prob=error_rate, rng=rng
+        )
 
 
 

--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -1,6 +1,8 @@
 import random
+import logging
 
 from genecoder.simulators.nanopore import NanoporeChannel, _mutate_read
+from genecoder import nanopore_sim
 
 
 def _count_substitutions(channel: NanoporeChannel, sequence: str, runs: int, seed: int) -> int:
@@ -147,3 +149,32 @@ def test_context_deletion_profile_affect_counts() -> None:
         seed,
     )
     assert del_ctx > del_base
+
+
+def test_homopolymer_weighting_in_fallback() -> None:
+    runs = 200
+    seed = 21
+    table = {"substitution_rate": 0.0, "insertion_rate": 0.1, "deletion_rate": 0.1}
+
+    def simulate_many(seq: str) -> tuple[int, int]:
+        rng = random.Random(seed)
+        ins = dels = 0
+        for _ in range(runs):
+            mutated = nanopore_sim._simulate_adapter(
+                "dnarsim", seq, 0.0, rng, rate_table=table
+            )
+            if len(mutated) > len(seq):
+                ins += 1
+            elif len(mutated) < len(seq):
+                dels += 1
+        return ins, dels
+
+    nanopore_sim.logger.setLevel(logging.ERROR)
+    ins_short, del_short = simulate_many("AAA")
+    ins_long, del_long = simulate_many("AAAAAA")
+    assert ins_short == 45
+    assert del_short == 44
+    assert ins_long == 54
+    assert del_long == 86
+    assert ins_long > ins_short
+    assert del_long > del_short


### PR DESCRIPTION
## Summary
- weight nanopore indel rates by homopolymer length in fallback simulator
- add regression test for homopolymer-driven indel weighting

## Testing
- `SKIP=pytest,mypy pre-commit run --files src/genecoder/nanopore_sim.py tests/test_nanopore_context_errors.py`
- `pytest tests/test_nanopore_context_errors.py`
- `pytest tests/test_nanopore_sim.py tests/test_simulate_reads_dispatch.py`


------
https://chatgpt.com/codex/tasks/task_e_6896bd893b68832685bf10cdbb237e9e