### PR TITLE
feat: add coverage distribution chart to dashboard

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -463,7 +463,7 @@ genecli dashboard examples/pipeline_metrics.json
 This encodes and decodes `examples/pipeline_demo_input.txt`, stores metrics in
 `examples/pipeline_metrics.json` and opens the dashboard with the results.
 
-The interface plots GC content distribution, homopolymer histograms, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion counts are present, they are shown as a simple bar chart.
+The interface plots GC content distribution, homopolymer histograms, read-coverage distributions, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion counts are present, they are shown as a simple bar chart. The dashboard additionally charts the total number of constraint violations when provided.
 
 Example metrics snippet:
 
@@ -471,7 +471,9 @@ Example metrics snippet:
 {
   "substitutions": 12,
   "insertions": 3,
-  "deletions": 1
+  "deletions": 1,
+  "coverage_distribution": [1, 3, 2],
+  "constraint_violations": 2
 }
 ```
 

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -21,6 +21,7 @@ _DEF_METRICS: dict[str, Any] = {
     "insertions": None,
     "deletions": None,
     "coverage": None,
+    "coverage_distribution": [],
     "constraint_violations": None,
 }
 
@@ -122,12 +123,16 @@ def main(results_path: str | None = None) -> None:
     else:
         st.write("No error count data.")
 
-    st.header("Coverage")
-    coverage = data.get("coverage")
-    if isinstance(coverage, int):
-        st.bar_chart({"Coverage": coverage})
+    st.header("Read Coverage")
+    cov_dist = data.get("coverage_distribution")
+    if isinstance(cov_dist, list) and cov_dist:
+        st.bar_chart(cov_dist)
     else:
-        st.write("No coverage data.")
+        coverage = data.get("coverage")
+        if isinstance(coverage, int):
+            st.bar_chart({"Coverage": coverage})
+        else:
+            st.write("No coverage data.")
 
     st.header("Constraint Violations")
     violations = data.get("constraint_violations")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -99,7 +99,7 @@ def test_display_coverage_and_constraint_metrics(
     tmp_path: Path, dummy_streamlit: dict[str, list]
 ) -> None:
     data = {
-        "coverage": 7,
+        "coverage_distribution": [1, 3, 2],
         "constraint_violations": 2,
     }
     path = tmp_path / "metrics.json"
@@ -108,8 +108,8 @@ def test_display_coverage_and_constraint_metrics(
     mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
     mod.main(str(path))
 
-    # Ensure coverage and constraint violation charts are rendered
+    # Ensure coverage distribution and constraint violation charts are rendered
     assert dummy_streamlit["bar_chart"], "bar_chart not called"
     charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
-    assert {"Coverage": 7} in charts
+    assert [1, 3, 2] in charts
     assert {"Violations": 2} in charts


### PR DESCRIPTION
## Summary
- render read coverage distributions and display constraint violation counts in the dashboard
- extend dashboard tests to cover coverage distributions and constraint violation charts
- document coverage distribution and constraint violation metrics in usage guide

## Testing
- `ruff check src/genecoder/dashboard.py tests/test_dashboard.py`
- `pytest tests/test_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c29175d08326bba138902954d767