### PR TITLE
Document offline plugin registry installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,6 +232,22 @@ local packages. The CLI and GUI behave the same way when these variables are
 unset or empty, making this the recommended configuration for air‑gapped
 systems.
 
+## Installing Registry Plugins Offline
+
+Use the :func:`genecoder.plugin_manager.install_registry_plugins` helper with
+``offline=True`` to install plugins from a local registry without network
+access. Supplying a remote URL in this mode raises ``RuntimeError`` to prevent
+accidental downloads.
+
+```python
+from genecoder import plugin_manager as plugins
+
+plugins.install_registry_plugins("/path/to/registry.yaml", offline=True)
+```
+
+This flag is also honored when the ``GENECODER_OFFLINE`` environment variable
+is set.
+
 ## Plugin Verification
 
 Plugin registries record a `checksum` or `signature` for every wheel. The

--- a/tests/test_plugin_registry_offline.py
+++ b/tests/test_plugin_registry_offline.py
@@ -1,0 +1,11 @@
+import pytest
+
+import genecoder.plugin_manager as plugins
+
+
+def test_remote_registry_rejected_in_offline_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remote registries are blocked when offline is true."""
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    with pytest.raises(RuntimeError, match="Offline mode forbids fetching registry"):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml", offline=True)
+


### PR DESCRIPTION
## Summary
- document using `install_registry_plugins(..., offline=True)` for local plugin registries
- test that remote registry URLs are rejected when offline mode is enabled

## Testing
- `ruff check tests/test_plugin_registry_offline.py`
- `mypy tests/test_plugin_registry_offline.py`
- `pytest tests/test_plugin_registry_offline.py::test_remote_registry_rejected_in_offline_mode -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b9ff4a2083269be44a6c5d42518e