### PR TITLE
Use shared RNG for error simulation

### DIFF
--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -70,7 +70,7 @@ def simulate_errors(
         raise ValueError("sum of error probabilities must not exceed 1")
 
     if rng is None:
-        rng = random.Random()
+        rng = make_rng()
 
     mutated: list[str] = []
     for nt in sequence:

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -1,6 +1,22 @@
 import random
 import pytest
 from genecoder.error_simulation import simulate_errors
+from genecoder.random_utils import reset_rng
+
+
+def test_deterministic_default_rng(monkeypatch):
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    reset_rng()
+    try:
+        result = simulate_errors(
+            "AAAA",
+            substitution_prob=1.0,
+            insertion_prob=0.0,
+            deletion_prob=0.0,
+        )
+        assert result == "CCTT"
+    finally:
+        reset_rng()
 
 
 def test_deterministic_substitutions():


### PR DESCRIPTION
## Summary
- replace direct Random() in `simulate_errors` with `make_rng`
- test deterministic behavior of default RNG when `GENECODER_SIM_SEED` is set

## Testing
- `ruff check src/genecoder/error_simulation.py tests/test_error_simulation.py`
- `pytest tests/test_error_simulation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b9feb94083268693597955c72ded