### PR TITLE
Add simple Illumina simulator

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,11 +183,19 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    Apply multiple simulators and enforce synthesis constraints:
 
    ```bash
-   genecli channel --input-file encoded.fasta \
-       --output-file channel.fasta --simulator simple --simulator indel
-   ```
+    genecli channel --input-file encoded.fasta \
+        --output-file channel.fasta --simulator simple --simulator indel
+    ```
 
-   Named sequencing profiles are available:
+    A built-in Illumina-like model focuses on substitutions and can be
+    configured via ``--sub-rate``:
+
+    ```bash
+    genecli channel --input-file encoded.fasta \
+        --output-file channel.fasta --simulator illumina_builtin --sub-rate 0.01
+    ```
+
+    Named sequencing profiles are available:
 
    - **Illumina** – `miseq`, `hiseq`
    - **Nanopore** – `minion`, `promethion`, `r10`, `r9`, `r10.3`, `r10.4`

--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -58,6 +58,7 @@ def register_builtin_plugins() -> None:
         [
             "genecoder.nanopore_sim",
             "genecoder.error_simulation",
+            "genecoder.illumina_sim",
             "genecoder.simulators.decay",
             "genecoder.simulators.illumina",
             "genecoder.simulators.nanopore",

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -541,6 +541,8 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params["deletion_prob"] = opts.del_rate
         if name == "simple" and opts.sub_rate is not None:
             new_params["error_rate"] = opts.sub_rate
+        if name == "illumina_builtin" and opts.sub_rate is not None:
+            new_params["error_rate"] = opts.sub_rate
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -18,15 +18,20 @@ __all__ = ["run_pipeline"]
 def _levenshtein_counts(original: str, mutated: str) -> tuple[int, int, int]:
     """Return substitution, insertion and deletion counts using Levenshtein ops."""
     try:  # Prefer the optimized python-Levenshtein package if available
-        from Levenshtein import editops  # type: ignore
+        from Levenshtein import editops
 
         ops = editops(original, mutated)
-        get_tag = lambda op: op[0]  # noqa: E731
+
+        def get_tag(op: Any) -> str:  # noqa: D401,ANN401
+            return str(op[0])
+
     except Exception:  # pragma: no cover - fallback to rapidfuzz
         from rapidfuzz.distance import Levenshtein as RF
 
         ops = RF.editops(original, mutated)
-        get_tag = lambda op: op.tag  # noqa: E731
+
+        def get_tag(op: Any) -> str:  # noqa: D401,ANN401
+            return str(op.tag)
 
     subs = ins = dels = 0
     for op in ops:

--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -1,0 +1,66 @@
+"""Built-in Illumina-like sequencing simulator.
+
+This module implements a very small Illumina error model dominated by
+base substitutions.  The overall error ``error_rate`` controls the
+probability of a substitution.  Insertion and deletion probabilities are
+scaled down to one hundredth of this value to approximate the relatively
+low indel rates of Illumina machines.
+"""
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .error_simulation import simulate_errors
+from .random_utils import make_rng
+from .api import Simulator
+from .simulators import register_simulator as _register_simulator
+
+__all__ = ["simulate", "Channel", "register"]
+
+
+def simulate(
+    sequence: str,
+    error_rate: float = 0.001,
+    rng: random.Random | None = None,
+) -> str:
+    """Return ``sequence`` mutated with Illumina-style errors.
+
+    Parameters
+    ----------
+    sequence:
+        Input DNA sequence.
+    error_rate:
+        Probability of substituting each nucleotide.  Insertion and
+        deletion probabilities are ``error_rate / 100``.
+    rng:
+        Optional :class:`random.Random` instance for deterministic
+        behaviour.
+    """
+    insertion_prob = error_rate / 100.0
+    deletion_prob = error_rate / 100.0
+    return simulate_errors(
+        sequence,
+        substitution_prob=error_rate,
+        insertion_prob=insertion_prob,
+        deletion_prob=deletion_prob,
+        rng=rng,
+    )
+
+
+class Channel(Simulator):
+    """Channel applying the built-in Illumina-style error model."""
+
+    def __init__(self, error_rate: float = 0.001) -> None:
+        self.error_rate = error_rate
+
+    def simulate(self, sequence: str) -> str:  # pragma: no cover - thin wrapper
+        return simulate(sequence, self.error_rate, make_rng())
+
+
+def register(
+    registrar: Callable[[str, Simulator], None] = _register_simulator,
+) -> None:
+    """Register the simulator with the global registry."""
+
+    registrar("illumina_builtin", Channel())

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -393,7 +393,7 @@ class NanoporeDNArSimChannel(NanoporeChannel):
         )
         self.profile = profile
         self._profile_rates: dict[str, float] = (
-            DNARSIM_RATE_TABLES.get(profile) if profile else {}
+            DNARSIM_RATE_TABLES.get(profile, {}) if profile else {}
         )
 
     def _simulate_cli(self, sequence: str) -> str:

--- a/tests/test_illumina_builtin_sim.py
+++ b/tests/test_illumina_builtin_sim.py
@@ -1,0 +1,26 @@
+import random
+
+from genecoder import illumina_sim
+from genecoder.random_utils import reset_rng
+
+
+def test_simulate_deterministic_with_rng():
+    seq = "ACGTACGT"
+    rng = random.Random(0)
+    first = illumina_sim.simulate(seq, error_rate=0.1, rng=rng)
+    rng = random.Random(0)
+    second = illumina_sim.simulate(seq, error_rate=0.1, rng=rng)
+    assert first == second
+
+
+def test_channel_respects_seed(monkeypatch):
+    seq = "ACGTACGT"
+    monkeypatch.setenv("GENECODER_SIM_SEED", "7")
+    reset_rng()
+    ch = illumina_sim.Channel(error_rate=0.1)
+    first = ch.simulate(seq)
+    monkeypatch.setenv("GENECODER_SIM_SEED", "7")
+    reset_rng()
+    ch = illumina_sim.Channel(error_rate=0.1)
+    second = ch.simulate(seq)
+    assert first == second


### PR DESCRIPTION
## Summary
- add substitution-focused Illumina simulator and expose via registry and CLI
- document usage of the new `illumina_builtin` simulator
- test deterministic behaviour with seeded RNG
- resolve type-checking failures by providing defaults for nanopore profiles and replacing untyped tag helpers

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/illumina_sim.py src/genecoder/builtin_plugins.py src/genecoder/cli/channel.py tests/test_illumina_builtin_sim.py docs/usage.md src/genecoder/simulators/nanopore.py src/genecoder/core.py`
- `pytest tests/test_illumina_builtin_sim.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c29141fc8326b57881d5a853f801