### PR TITLE
test: add profile ratio and pipeline cli tests

### DIFF
--- a/tests/test_cli_pipeline_profile_roundtrip.py
+++ b/tests/test_cli_pipeline_profile_roundtrip.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+import yaml
+import pytest
+
+from tests.test_cli import run_cli_command
+from genecoder.simulators.nanopore import NanoporeDNArSimChannel
+
+
+def test_pipeline_cli_profile_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "msg.txt"
+    input_file.write_text("hi")
+    output_file = tmp_path / "out.txt"
+
+    config = {
+        "codec": "reverse",
+        "channel": {"name": "nanopore_dnarsim", "profile": "r10.3"},
+    }
+    cfg_path = tmp_path / "pipe.yml"
+    cfg_path.write_text(yaml.safe_dump(config))
+
+    called: list[str | None] = []
+
+    def fake_simulate(self: NanoporeDNArSimChannel, seq: str) -> str:
+        called.append(self.profile)
+        return seq
+
+    monkeypatch.setattr(NanoporeDNArSimChannel, "simulate", fake_simulate)
+
+    result = run_cli_command(
+        ["pipeline", str(input_file), str(output_file), "--config", str(cfg_path)], env=env
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == ["r10.3"]
+    assert output_file.read_text() == "hi"

--- a/tests/test_dnarsim_profile_ratio_hypothesis.py
+++ b/tests/test_dnarsim_profile_ratio_hypothesis.py
@@ -1,0 +1,45 @@
+import pytest
+
+pytest.importorskip("hypothesis")
+
+from difflib import SequenceMatcher
+
+from hypothesis import given, strategies as st
+
+from genecoder.error_simulation import NUCLEOTIDES
+from genecoder.simulators.nanopore import (
+    NanoporeDNArSimChannel,
+    DNARSIM_RATE_TABLES,
+)
+
+
+def _error_counts(original: str, mutated: str) -> tuple[int, int, int]:
+    matcher = SequenceMatcher(a=original, b=mutated)
+    subs = ins = dele = 0
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "replace":
+            subs += max(i2 - i1, j2 - j1)
+        elif tag == "insert":
+            ins += j2 - j1
+        elif tag == "delete":
+            dele += i2 - i1
+    return subs, ins, dele
+
+
+@given(seq=st.text(alphabet=st.sampled_from(NUCLEOTIDES), min_size=200, max_size=400))
+@pytest.mark.parametrize("profile", list(DNARSIM_RATE_TABLES.keys()))
+def test_dnarsim_profile_sub_indel_ratio(seq: str, profile: str) -> None:
+    channel = NanoporeDNArSimChannel(profile=profile)
+    mutated = channel.simulate(seq)
+    subs, ins, dele = _error_counts(seq, mutated)
+    assert subs + ins + dele > 0
+    observed_ratio = subs / (ins + dele)
+
+    rates = DNARSIM_RATE_TABLES[profile]
+    base_sub = 0.4 * channel.error_rate
+    base_ins = base_del = 0.3 * channel.error_rate
+    expected_sub = base_sub + rates["substitution_rate"]
+    expected_indel = base_ins + rates["insertion_rate"] + base_del + rates["deletion_rate"]
+    expected_ratio = expected_sub / expected_indel
+
+    assert observed_ratio == pytest.approx(expected_ratio, rel=0.3)


### PR DESCRIPTION
## Summary
- verify DNArSim profile substitution/indel ratios with property-based tests
- ensure pipeline CLI honors profile selection

## Testing
- `ruff check tests/test_dnarsim_profile_ratio_hypothesis.py tests/test_cli_pipeline_profile_roundtrip.py`
- `pytest tests/test_dnarsim_profile_ratio_hypothesis.py tests/test_cli_pipeline_profile_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8a2415b48326874268a85cb797c6