### PR TITLE
Add simulator profile presets

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -197,7 +197,7 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
 
     Named sequencing profiles are available:
 
-   - **Illumina** – `miseq`, `hiseq`
+   - **Illumina** – `miseq`, `hiseq`, `novaseq` (alias `nova`)
    - **Nanopore** – `minion`, `promethion`, `r10`, `r9`, `r10.3`, `r10.4`
 
    Use `--profile` to apply a preset without specifying a simulator:

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 PROFILE_MAP: dict[str, tuple[str, str]] = {
     "miseq": ("illumina", "miseq"),
     "hiseq": ("illumina", "hiseq"),
+    "novaseq": ("illumina", "novaseq"),
+    "nova": ("illumina", "nova"),
     "minion": ("nanopore", "minion"),
     "promethion": ("nanopore", "promethion"),
 }

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -140,6 +140,13 @@ ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
         "read_length": 150,
         "coverage": 1,
     },
+    "nova": {
+        "substitution_rate": 0.0003,
+        "insertion_rate": 0.00003,
+        "deletion_rate": 0.00003,
+        "read_length": 150,
+        "coverage": 1,
+    },
 }
 
 
@@ -187,8 +194,23 @@ class IlluminaChannel(BaseSimulator):
         read_length: int = 150,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
+        profile: str | None = None,
         profile_path: str | None = None,
     ) -> None:
+        if profile is not None:
+            params = ILLUMINA_PROFILES.get(profile.lower())
+            if params is not None:
+                substitution_rate = float(
+                    params.get("substitution_rate", substitution_rate)
+                )
+                insertion_rate = float(
+                    params.get("insertion_rate", insertion_rate)
+                )
+                deletion_rate = float(
+                    params.get("deletion_rate", deletion_rate)
+                )
+                read_length = int(params.get("read_length", read_length))
+                coverage = int(params.get("coverage", coverage))
         if profile_path is not None:
             try:
                 import yaml
@@ -286,6 +308,20 @@ class IlluminaChannel(BaseSimulator):
         if coverage == 1:
             return reads[0]
         return self._consensus(reads)
+
+    def with_profile(self, profile: str) -> "IlluminaChannel":
+        """Return a new channel configured to use ``profile``.
+
+        Unknown profiles leave the channel unchanged.
+        """
+
+        if profile.lower() not in ILLUMINA_PROFILES:
+            return self
+        return type(self)(
+            profile=profile,
+            quality_profile=self.quality_profile,
+            context_errors=dict(self.context_errors),
+        )
 
 
 class IlluminaD2SimChannel(Simulator):

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -262,8 +262,19 @@ class NanoporeChannel(BaseChannel):
         context_deletions: Dict[str, Dict[int, float]] | None = None,
         insertion_profile: Dict[int, float] | None = None,
         deletion_profile: Dict[int, float] | None = None,
+        profile: str | None = None,
         profile_path: str | None = None,
     ) -> None:
+        if profile is not None:
+            params = NANOPORE_PROFILES.get(profile.lower())
+            if params is not None:
+                error_rate = float(params.get("error_rate", error_rate))
+                substitution_rate = float(
+                    params.get("substitution_rate", substitution_rate)
+                )
+                insertion_rate = float(params.get("insertion_rate", insertion_rate))
+                deletion_rate = float(params.get("deletion_rate", deletion_rate))
+                coverage = int(params.get("coverage", coverage))
         if profile_path is not None:
             try:
                 import yaml
@@ -341,6 +352,24 @@ class NanoporeChannel(BaseChannel):
             return reads[0]
         return _consensus(reads)
 
+    def with_profile(self, profile: str) -> "NanoporeChannel":
+        """Return a new channel configured to use ``profile``.
+
+        Unknown profiles leave the channel unchanged.
+        """
+
+        if profile.lower() not in NANOPORE_PROFILES:
+            return self
+        return type(self)(
+            profile=profile,
+            quality_profile=self.quality_profile,
+            context_errors=dict(self.context_errors),
+            context_insertions=self.context_insertions,
+            context_deletions=self.context_deletions,
+            insertion_profile=self.insertion_profile,
+            deletion_profile=self.deletion_profile,
+        )
+
 
 class NanoporeDeSPChannel(NanoporeChannel):
     """Channel wrapper using the external ``desp`` simulator."""
@@ -390,6 +419,7 @@ class NanoporeDNArSimChannel(NanoporeChannel):
             context_errors=context_errors,
             context_insertions=context_insertions,
             context_deletions=context_deletions,
+            profile=profile,
         )
         self.profile = profile
         self._profile_rates: dict[str, float] = (

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -43,15 +43,19 @@ class ChannelPipeline(BaseChannel):
 
         from ..dnarsim_adapter import DNArSimChannel
         from ..insilicoseq_adapter import InSilicoSeqChannel
+        from ..simulators.illumina import IlluminaChannel
+        from ..simulators.nanopore import NanoporeChannel
 
         channels = []
         for ch in self.channels:
-            if config.illumina_profile is not None and isinstance(
-                ch, InSilicoSeqChannel
+            if (
+                config.illumina_profile is not None
+                and isinstance(ch, (InSilicoSeqChannel, IlluminaChannel))
             ):
                 ch = ch.with_profile(config.illumina_profile)
-            elif config.nanopore_profile is not None and isinstance(
-                ch, DNArSimChannel
+            elif (
+                config.nanopore_profile is not None
+                and isinstance(ch, (DNArSimChannel, NanoporeChannel))
             ):
                 ch = ch.with_profile(config.nanopore_profile)
             channels.append(ch)

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -149,7 +149,7 @@ def test_adapters_external_error(monkeypatch, caplog, name):
         lambda s, **kwargs: errors_called.append((s, kwargs.get("rng"))) or "fallback",
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger=nanopore_sim.__name__):
         result = func("ACGT", error_rate=0.2)
 
     assert result == "fallback"
@@ -178,7 +178,7 @@ def test_adapters_invalid_output(monkeypatch, caplog, name):
         lambda s, **kwargs: errors_called.append((s, kwargs.get("rng"))) or "fallback",
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger=nanopore_sim.__name__):
         result = func("ACGT")
 
     assert result == "fallback"
@@ -205,7 +205,7 @@ def test_adapters_command_not_found_warning(monkeypatch, caplog, name):
         or "fallback",
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger=nanopore_sim.__name__):
         result = func("ACGT")
 
     assert result == "fallback"

--- a/tests/test_simulator_profiles.py
+++ b/tests/test_simulator_profiles.py
@@ -55,3 +55,23 @@ def test_nanopore_profile_file(tmp_path: Path) -> None:
     assert ch.deletion_rate == params["deletion_rate"]
     assert ch.coverage == params["coverage"]
 
+
+def test_named_profiles() -> None:
+    illumina_params = ILLUMINA_PROFILES["hiseq"]
+    illumina = IlluminaChannel(profile="hiseq")
+    assert illumina.substitution_rate == illumina_params["substitution_rate"]
+    assert illumina.insertion_rate == illumina_params["insertion_rate"]
+    nanopore_params = NANOPORE_PROFILES["minion"]
+    nanopore = NanoporeChannel(profile="minion")
+    assert nanopore.error_rate == nanopore_params["error_rate"]
+    assert nanopore.insertion_rate == nanopore_params["insertion_rate"]
+
+
+def test_profile_fallback() -> None:
+    default_illumina = IlluminaChannel()
+    unknown_illumina = IlluminaChannel(profile="unknown")
+    assert unknown_illumina.substitution_rate == default_illumina.substitution_rate
+    default_nanopore = NanoporeChannel()
+    unknown_nanopore = NanoporeChannel(profile="unknown")
+    assert unknown_nanopore.error_rate == default_nanopore.error_rate
+


### PR DESCRIPTION
## Summary
- support `profile` names for Illumina and Nanopore simulators
- pipe profile options through the simulator pipeline and CLI
- document and test new profile presets

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8a21fd3083269f130f1a708f781a