### PR TITLE
Add GC variance metrics and display in reports

### DIFF
--- a/examples/dashboard_metrics.json
+++ b/examples/dashboard_metrics.json
@@ -1,6 +1,7 @@
 {
   "gc_distribution": [0.1, 0.2, 0.3, 0.4],
   "gc_content": 0.25,
+  "gc_variance": 0.0125,
   "max_homopolymer": 4,
   "homopolymer_runs": [1, 2, 1, 0],
   "ecc_success_rates": {

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -127,6 +127,11 @@ def run_pipeline(
     max_homopolymer = get_max_homopolymer_length(dna)
     gc_dist = _gc_distribution(dna)
     hp_runs = _homopolymer_runs(dna)
+    gc_variance = (
+        sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
+        if gc_dist
+        else 0.0
+    )
 
     decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
     assert isinstance(decoded_any, (bytes, bytearray))
@@ -150,6 +155,7 @@ def run_pipeline(
     metrics: Dict[str, Any] = {
         "gc_distribution": gc_dist,
         "gc_content": gc_content,
+        "gc_variance": gc_variance,
         "max_homopolymer": max_homopolymer,
         "homopolymer_runs": hp_runs,
         "ecc_success_rates": {fec: success} if fec else {},

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -13,6 +13,7 @@ import streamlit as st
 _DEF_METRICS: dict[str, Any] = {
     "gc_distribution": [],
     "gc_content": None,
+    "gc_variance": None,
     "max_homopolymer": None,
     "homopolymer_runs": [],
     "ecc_success_rates": {},
@@ -81,8 +82,11 @@ def main(results_path: str | None = None) -> None:
         st.write("No GC distribution data.")
 
     gc_content = data.get("gc_content")
+    gc_variance = data.get("gc_variance")
     if isinstance(gc_content, (int, float)):
-        st.metric("Average GC Content", f"{float(gc_content):.2%}")
+        st.metric("GC Mean", f"{float(gc_content):.2%}")
+    if isinstance(gc_variance, (int, float)):
+        st.metric("GC Variance", f"{float(gc_variance):.4f}")
 
     max_hp = data.get("max_homopolymer")
     if isinstance(max_hp, (int, float)):

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -37,7 +37,12 @@ def generate_html_report(manifest_path: str) -> str:
     gc_content = metrics.get("gc_content")
     if isinstance(gc_content, (int, float)):
         html_lines.append(
-            f"<p><strong>GC Content:</strong> {float(gc_content) * 100:.2f}%</p>"
+            f"<p><strong>GC Mean:</strong> {float(gc_content) * 100:.2f}%</p>"
+        )
+    gc_variance = metrics.get("gc_variance")
+    if isinstance(gc_variance, (int, float)):
+        html_lines.append(
+            f"<p><strong>GC Variance:</strong> {float(gc_variance):.4f}</p>"
         )
 
     max_hp: int | float | None = metrics.get("max_homopolymer")

--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -1,6 +1,7 @@
 {
   "gc_distribution": [0.1, 0.2, 0.3, 0.4],
   "gc_content": 0.25,
+  "gc_variance": 0.0125,
   "max_homopolymer": 4,
   "homopolymer_runs": [1, 2, 1, 0],
   "ecc_success_rates": {

--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -32,8 +32,9 @@ def test_dashboard_metrics() -> None:
         )
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot"}
+    assert set(data) >= {"gc_content", "gc_variance", "max_homopolymer", "error_rate", "plot"}
     assert isinstance(data["gc_content"], float)
+    assert isinstance(data["gc_variance"], float)
     assert isinstance(data["max_homopolymer"], int)
     assert isinstance(data["error_rate"], float)
     assert isinstance(data["plot"], str)

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -15,6 +15,7 @@ def test_dashboard_cli_starts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     data = {
         "gc_distribution": [0.5],
         "gc_content": 0.5,
+        "gc_variance": 0.0,
         "homopolymer_runs": [1],
         "ecc_success_rates": {"hamming": 1.0},
         "decode_success_rate": 1.0,

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -11,6 +11,7 @@ def _make_manifest(path: Path) -> Path:
         "encoding_parameters": {"method": "base4_direct"},
         "metrics": {
             "gc_content": 0.5,
+            "gc_variance": 0.01,
             "max_homopolymer": 4,
             "ecc_success_rates": {"rs": 0.9},
         },
@@ -23,6 +24,7 @@ def test_generate_html_report(tmp_path: Path) -> None:
     manifest = _make_manifest(tmp_path / "m.json")
     html = generate_html_report(str(manifest))
     assert "50.00%" in html
+    assert "GC Variance" in html
     assert "Max Homopolymer Length" in html
     assert "rs" in html
 
@@ -33,3 +35,4 @@ def test_cli_html_report_stdout(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert "GeneCoder Summary Report" in result.stdout
     assert "50.00%" in result.stdout
+    assert "GC Variance" in result.stdout

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -103,5 +103,6 @@ def test_pipeline_manifest_metrics(tmp_path: Path) -> None:
 
     loaded = dashboard._load_metrics(str(manifest_path))
     assert loaded["gc_content"] == metrics["gc_content"]
+    assert loaded["gc_variance"] == metrics["gc_variance"]
     assert loaded["max_homopolymer"] == metrics["max_homopolymer"]
 

--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -169,12 +169,16 @@ def test_homopolymer_weighting_in_fallback() -> None:
                 dels += 1
         return ins, dels
 
-    nanopore_sim.logger.setLevel(logging.ERROR)
-    ins_short, del_short = simulate_many("AAA")
-    ins_long, del_long = simulate_many("AAAAAA")
-    assert ins_short == 45
-    assert del_short == 44
-    assert ins_long == 54
-    assert del_long == 86
-    assert ins_long > ins_short
-    assert del_long > del_short
+    prev_level = nanopore_sim.logger.level
+    try:
+        nanopore_sim.logger.setLevel(logging.ERROR)
+        ins_short, del_short = simulate_many("AAA")
+        ins_long, del_long = simulate_many("AAAAAA")
+        assert ins_short == 45
+        assert del_short == 44
+        assert ins_long == 54
+        assert del_long == 86
+        assert ins_long > ins_short
+        assert del_long > del_short
+    finally:
+        nanopore_sim.logger.setLevel(prev_level)

--- a/web/helix-ui/src/Dashboard.jsx
+++ b/web/helix-ui/src/Dashboard.jsx
@@ -52,7 +52,8 @@ export default function Dashboard() {
       <button onClick={decodeDeepdna}>DeepDNA Decode</button>
       {data && (
         <div>
-          <p>GC Content: {(data.gc_content * 100).toFixed(2)}%</p>
+          <p>GC Mean: {(data.gc_content * 100).toFixed(2)}%</p>
+          <p>GC Variance: {data.gc_variance.toFixed(4)}</p>
           <p>Max Homopolymer: {data.max_homopolymer}</p>
           <p>Error Rate: {(data.error_rate * 100).toFixed(2)}%</p>
           <img src={`data:image/png;base64,${data.plot}`} style={{ maxWidth: '100%' }} />

--- a/web/main.py
+++ b/web/main.py
@@ -311,6 +311,12 @@ async def dashboard_metrics(
     gc = calculate_gc_content(seq)
     max_hp = get_max_homopolymer_length(seq)
     gc_data = calculate_windowed_gc_content(seq, req.window_size, req.step_size)
+    _, gc_values = gc_data
+    gc_var = (
+        sum((v - gc) ** 2 for v in gc_values) / len(gc_values)
+        if gc_values
+        else 0.0
+    )
     hp_regions = identify_homopolymer_regions(seq, req.min_homopolymer_len)
     buf = generate_sequence_analysis_plot(gc_data, hp_regions, len(seq))
     plot_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
@@ -329,6 +335,7 @@ async def dashboard_metrics(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "gc_content": gc,
+        "gc_variance": gc_var,
         "max_homopolymer": max_hp,
         "error_rate": ber,
         "plot": plot_b64,


### PR DESCRIPTION
## Summary
- compute GC content variance during pipeline runs and expose as a metric
- show GC mean/variance and max homopolymer length in Streamlit and HTML reports
- extend dashboard API and React widget to return and display GC variance
- reset nanopore simulator logger level after context error test to avoid suppressing warnings in later tests

## Testing
- `ruff check tests/test_nanopore_context_errors.py tests/test_nanopore_sim.py`
- `pytest tests/test_nanopore_context_errors.py tests/test_nanopore_sim.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8a235db083269d27a747741c72b3