### PR TITLE
Add plugin interface abstractions and checks

### DIFF
--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -11,15 +11,36 @@ __all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
 
 
 class Codec(ABC):
-    """Abstract base class for simple codecs."""
+    """Abstract base class for stateless codecs.
+
+    Implementations must provide :meth:`encode` and :meth:`decode`
+    methods.  Extra keyword arguments are accepted to allow codecs to
+    expose optional behaviour without changing the interface.
+    """
 
     @abstractmethod
     def encode(self, data: bytes, /, **kwargs: Any) -> Any:
-        """Encode ``data`` and return the encoded representation."""
+        """Return an encoded representation of ``data``.
+
+        Parameters
+        ----------
+        data:
+            Raw byte payload to be encoded.
+        **kwargs:
+            Optional codec specific parameters.
+        """
 
     @abstractmethod
     def decode(self, encoded: Any, /, **kwargs: Any) -> bytes:
-        """Decode ``encoded`` data back into bytes."""
+        """Decode ``encoded`` back into the original byte sequence.
+
+        Parameters
+        ----------
+        encoded:
+            The encoded object returned by :meth:`encode`.
+        **kwargs:
+            Optional codec specific parameters.
+        """
 
 
 class FEC(ABC):
@@ -27,11 +48,29 @@ class FEC(ABC):
 
     @abstractmethod
     def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, Any]]:
-        """Encode ``data`` returning encoded bytes and associated info."""
+        """Return FEC protected data and metadata.
+
+        Parameters
+        ----------
+        data:
+            Payload bytes to protect.
+        **kwargs:
+            Backend specific options.
+        """
 
     @abstractmethod
     def decode(self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any) -> Tuple[bytes, int]:
-        """Decode ``encoded`` bytes using ``info`` returning the original data and number of corrections."""
+        """Recover the original data from ``encoded`` using ``info``.
+
+        Parameters
+        ----------
+        encoded:
+            Bytes produced by :meth:`encode`.
+        info:
+            Auxiliary information returned by :meth:`encode`.
+        **kwargs:
+            Backend specific options.
+        """
 
 
 class Simulator(ABC):
@@ -44,9 +83,10 @@ class Simulator(ABC):
     def with_profile(self, profile: str) -> "Simulator":
         """Return a copy of the simulator configured for ``profile``.
 
-        Implementations should override this method if they support
-        applying external error profiles. The default implementation
-        raises :class:`NotImplementedError`.
+        Implementations may override this method to support applying
+        external error profiles.  The default implementation raises
+        :class:`NotImplementedError` to signal that the feature is not
+        available.
         """
 
         raise NotImplementedError
@@ -57,5 +97,13 @@ class Visualizer(ABC):
 
     @abstractmethod
     def visualize(self, sequence: str, /, **kwargs: Any) -> Any:
-        """Return a visualization of ``sequence``."""
+        """Produce a visualization of ``sequence``.
+
+        Parameters
+        ----------
+        sequence:
+            DNA sequence or other result object to visualise.
+        **kwargs:
+            Optional visualisation parameters.
+        """
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, Any, Iterable
+from typing import Callable, Dict, Any, Iterable, TypeVar
 from types import ModuleType
 
 import os
@@ -65,58 +65,53 @@ def _validate_spec(spec: str) -> None:
 
 from .api import Codec, FEC, Simulator
 
+T = TypeVar("T")
+
+
+def _coerce_plugin(
+    obj: T | type[T], expected: type[T], methods: Iterable[str], kind: str
+) -> T:
+    """Return ``obj`` as an instance of ``expected`` ensuring required methods."""
+
+    if isinstance(obj, type):
+        if not issubclass(obj, expected):
+            raise TypeError(f"{kind} must subclass {expected.__name__}")
+        instance: T = obj()
+    else:
+        if not isinstance(obj, expected):
+            raise TypeError(f"{kind} must subclass {expected.__name__}")
+        instance = obj
+    for method in methods:
+        if not callable(getattr(instance, method, None)):
+            raise TypeError(f"{kind} missing required method {method}")
+    return instance
+
 
 def register_codec(name: str, codec: Codec | type[Codec]) -> None:
     """Register a codec implementation under ``name``."""
 
-    if isinstance(codec, type):
-        if not issubclass(codec, Codec):
-            raise TypeError("codec must subclass Codec")
-        inst = codec()
-    else:
-        if not isinstance(codec, Codec):
-            raise TypeError("codec must subclass Codec")
-        inst = codec
-
+    inst = _coerce_plugin(codec, Codec, ("encode", "decode"), "codec")
     CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
 def register_fec(name: str, fec: FEC | type[FEC]) -> None:
     """Register a FEC backend under ``name``."""
 
-    if isinstance(fec, type):
-        if not issubclass(fec, FEC):
-            raise TypeError("FEC must subclass FEC")
-        inst = fec()
-    else:
-        if not isinstance(fec, FEC):
-            raise TypeError("FEC must subclass FEC")
-        inst = fec
-
+    inst = _coerce_plugin(fec, FEC, ("encode", "decode"), "FEC")
     FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
-def register_simulator(name: str, channel: Simulator) -> None:
+def register_simulator(name: str, channel: Simulator | type[Simulator]) -> None:
     """Register a read simulator under ``name``."""
 
-    if not isinstance(channel, Simulator):
-        raise TypeError("simulator must subclass Simulator")
-
-    _register_simulator(name, channel)
+    inst = _coerce_plugin(channel, Simulator, ("simulate",), "simulator")
+    _register_simulator(name, inst)
 
 
 def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
     """Register a visualizer under ``name``."""
 
-    if isinstance(visualizer, type):
-        if not issubclass(visualizer, Visualizer):
-            raise TypeError("visualizer must subclass Visualizer")
-        inst = visualizer()
-    else:
-        if not isinstance(visualizer, Visualizer):
-            raise TypeError("visualizer must subclass Visualizer")
-        inst = visualizer
-
+    inst = _coerce_plugin(visualizer, Visualizer, ("visualize",), "visualizer")
     VISUALIZER_REGISTRY[name] = inst.visualize
 
 


### PR DESCRIPTION
## Summary
- document abstract plugin interfaces with detailed method signatures
- validate plugin implementations during registration via a common helper

## Testing
- `ruff check src/genecoder/api.py src/genecoder/plugin_manager.py`
- `pytest tests/test_plugin_abc_validation.py tests/test_plugin_class_registration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b55d1ce1083268de82e90048065c2