### PR TITLE
test: add CLI profile selection tests

### DIFF
--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -442,3 +442,49 @@ def test_channel_cli_wrong_type(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "'simulators' must be a list" in result.stderr
 
+
+def test_cli_channel_profile_selection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_profile.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_profile.fasta"
+
+    from genecoder.simulators.illumina import IlluminaChannel, ILLUMINA_PROFILES
+
+    called: list[tuple[float, float, float]] = []
+
+    def fake_simulate(self: IlluminaChannel, seq: str) -> str:
+        called.append((self.substitution_rate, self.insertion_rate, self.deletion_rate))
+        return seq
+
+    monkeypatch.setattr(IlluminaChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--profile",
+            "miseq",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    expected = ILLUMINA_PROFILES["miseq"]
+    assert called == [
+        (
+            expected["substitution_rate"],
+            expected["insertion_rate"],
+            expected["deletion_rate"],
+        )
+    ]

--- a/tests/test_cli_pipeline_profile_roundtrip.py
+++ b/tests/test_cli_pipeline_profile_roundtrip.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.test_cli import run_cli_command
 from genecoder.simulators.nanopore import NanoporeDNArSimChannel
+from genecoder.simulators.illumina import IlluminaChannel, ILLUMINA_PROFILES
 
 
 def test_pipeline_cli_profile_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,4 +39,45 @@ def test_pipeline_cli_profile_roundtrip(tmp_path: Path, monkeypatch: pytest.Monk
     )
     assert result.returncode == 0, result.stderr
     assert called == ["r10.3"]
+    assert output_file.read_text() == "hi"
+
+def test_pipeline_cli_illumina_profile_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "msg2.txt"
+    input_file.write_text("hi")
+    output_file = tmp_path / "out2.txt"
+
+    config = {
+        "codec": "reverse",
+        "channel": {"name": "illumina", "profile": "miseq"},
+    }
+    cfg_path = tmp_path / "pipe2.yml"
+    cfg_path.write_text(yaml.safe_dump(config))
+
+    called: list[tuple[float, float, float]] = []
+
+    def fake_simulate(self: IlluminaChannel, seq: str) -> str:
+        called.append((self.substitution_rate, self.insertion_rate, self.deletion_rate))
+        return seq
+
+    monkeypatch.setattr(IlluminaChannel, "simulate", fake_simulate)
+
+    result = run_cli_command(
+        ["pipeline", str(input_file), str(output_file), "--config", str(cfg_path)], env=env
+    )
+    assert result.returncode == 0, result.stderr
+    expected = ILLUMINA_PROFILES["miseq"]
+    assert called == [
+        (
+            expected["substitution_rate"],
+            expected["insertion_rate"],
+            expected["deletion_rate"],
+        )
+    ]
     assert output_file.read_text() == "hi"


### PR DESCRIPTION
## Summary
- test channel profile flag applies Illumina presets
- check pipeline round-trip works with Illumina profile config

## Testing
- `SKIP=pytest pre-commit run --files tests/test_cli_channel.py tests/test_cli_pipeline_profile_roundtrip.py`
- `pytest tests/test_cli_channel.py::test_cli_channel_profile_selection tests/test_cli_pipeline_profile_roundtrip.py::test_pipeline_cli_profile_roundtrip tests/test_cli_pipeline_profile_roundtrip.py::test_pipeline_cli_illumina_profile_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_689b55ce98fc8326bf733ad506b75128