### PR TITLE
Enforce plugin interface signatures and document API

### DIFF
--- a/plugins-examples/example_codec/example_codec/__init__.py
+++ b/plugins-examples/example_codec/example_codec/__init__.py
@@ -3,10 +3,10 @@ from genecoder.api import Codec
 
 
 class ExampleCodec(Codec):  # type: ignore[misc]
-    def encode(self, data: bytes) -> str:
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
         return data.hex()
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, text: str, /, **kwargs: object) -> bytes:
         return bytes.fromhex(text)
 
 

--- a/plugins-examples/example_fec/example_fec/__init__.py
+++ b/plugins-examples/example_fec/example_fec/__init__.py
@@ -1,12 +1,14 @@
-from typing import Callable, Mapping, Any
+from typing import Callable, Mapping
 from genecoder.api import FEC
 
 
 class ExampleFEC(FEC):  # type: ignore[misc]
-    def encode(self, data: bytes) -> tuple[bytes, Mapping[str, Any]]:
+    def encode(self, data: bytes, /, **kwargs: object) -> tuple[bytes, Mapping[str, object]]:
         return data, {}
 
-    def decode(self, encoded: bytes, info: Mapping[str, Any]) -> tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, object], /, **kwargs: object
+    ) -> tuple[bytes, int]:
         return encoded, 0
 
 

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -28,6 +28,11 @@ class Codec(ABC):
             Raw byte payload to be encoded.
         **kwargs:
             Optional codec specific parameters.
+
+        Returns
+        -------
+        Any
+            Encoded representation of the input bytes.
         """
 
     @abstractmethod
@@ -40,6 +45,11 @@ class Codec(ABC):
             The encoded object returned by :meth:`encode`.
         **kwargs:
             Optional codec specific parameters.
+
+        Returns
+        -------
+        bytes
+            The original byte payload.
         """
 
 
@@ -56,6 +66,11 @@ class FEC(ABC):
             Payload bytes to protect.
         **kwargs:
             Backend specific options.
+
+        Returns
+        -------
+        tuple[bytes, Mapping[str, Any]]
+            Tuple of encoded bytes and auxiliary information.
         """
 
     @abstractmethod
@@ -70,6 +85,11 @@ class FEC(ABC):
             Auxiliary information returned by :meth:`encode`.
         **kwargs:
             Backend specific options.
+
+        Returns
+        -------
+        tuple[bytes, int]
+            The recovered payload and number of corrected errors.
         """
 
 
@@ -78,7 +98,18 @@ class Simulator(ABC):
 
     @abstractmethod
     def simulate(self, sequence: str) -> str:
-        """Return a possibly corrupted version of ``sequence``."""
+        """Return a possibly corrupted version of ``sequence``.
+
+        Parameters
+        ----------
+        sequence:
+            Input DNA sequence.
+
+        Returns
+        -------
+        str
+            Simulated read sequence.
+        """
 
     def with_profile(self, profile: str) -> "Simulator":
         """Return a copy of the simulator configured for ``profile``.
@@ -87,6 +118,16 @@ class Simulator(ABC):
         external error profiles.  The default implementation raises
         :class:`NotImplementedError` to signal that the feature is not
         available.
+
+        Parameters
+        ----------
+        profile:
+            Identifier for the error profile.
+
+        Returns
+        -------
+        Simulator
+            A simulator instance configured with the requested profile.
         """
 
         raise NotImplementedError
@@ -105,5 +146,10 @@ class Visualizer(ABC):
             DNA sequence or other result object to visualise.
         **kwargs:
             Optional visualisation parameters.
+
+        Returns
+        -------
+        Any
+            The visualisation object produced by the implementation.
         """
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -12,6 +12,7 @@ import tempfile
 from pathlib import Path
 import importlib
 import re
+import inspect
 
 yaml: ModuleType | None
 try:  # optional dependency
@@ -68,6 +69,39 @@ from .api import Codec, FEC, Simulator
 T = TypeVar("T")
 
 
+def _check_signature(
+    impl: Callable[..., Any], base: Callable[..., Any], *, kind: str, method: str
+) -> None:
+    """Validate that ``impl`` can accept the parameters of ``base``."""
+
+    base_sig = inspect.signature(base)
+    params = list(base_sig.parameters.values())
+    if params and params[0].name == "self":
+        params = params[1:]
+    base_sig = base_sig.replace(parameters=params)
+
+    impl_sig = inspect.signature(impl)
+
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in impl_sig.parameters.values()):
+            raise TypeError(f"{kind} {method} must accept **kwargs")
+
+    dummy_args = [
+        object()
+        for p in params
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    dummy_kwargs = {
+        p.name: object()
+        for p in params
+        if p.kind == inspect.Parameter.KEYWORD_ONLY
+    }
+    try:
+        impl_sig.bind(*dummy_args, **dummy_kwargs)
+    except TypeError as exc:
+        raise TypeError(f"{kind} {method} has incompatible signature: {exc}") from exc
+
+
 def _coerce_plugin(
     obj: T | type[T], expected: type[T], methods: Iterable[str], kind: str
 ) -> T:
@@ -84,6 +118,9 @@ def _coerce_plugin(
     for method in methods:
         if not callable(getattr(instance, method, None)):
             raise TypeError(f"{kind} missing required method {method}")
+        _check_signature(
+            getattr(instance, method), getattr(expected, method), kind=kind, method=method
+        )
     return instance
 
 

--- a/src/plugins/reverse_codec.py
+++ b/src/plugins/reverse_codec.py
@@ -8,10 +8,10 @@ from genecoder.api import Codec
 class ReverseCodec(Codec):  # type: ignore[misc]
     """Simple byte-reversing codec."""
 
-    def encode(self, data: bytes, /) -> str:
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
         return data[::-1].decode("utf-8")
 
-    def decode(self, encoded: str, /) -> bytes:
+    def decode(self, encoded: str, /, **kwargs: object) -> bytes:
         return encoded[::-1].encode("utf-8")
 
 

--- a/tests/test_plugin_class_registration.py
+++ b/tests/test_plugin_class_registration.py
@@ -9,13 +9,14 @@ def test_class_based_plugins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     codec_mod = tmp_path / "cmod.py"
     codec_mod.write_text(
         """
+from typing import Any
 from genecoder.codecs import BaseCodec
 
 class DummyCodec(BaseCodec):
-    def encode(self, data: bytes, /) -> str:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         return data.decode()[::-1]
 
-    def decode(self, encoded: str, /) -> bytes:
+    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:
         return encoded[::-1].encode()
 
 def register(register_codec):
@@ -30,10 +31,10 @@ from typing import Mapping, Any
 from genecoder.codecs import BaseFEC
 
 class DummyFEC(BaseFEC):
-    def encode(self, data: bytes, /) -> tuple[bytes, Mapping[str, Any]]:
+    def encode(self, data: bytes, /, **kwargs: Any) -> tuple[bytes, Mapping[str, Any]]:
         return data + b'x', {}
 
-    def decode(self, encoded: bytes, info: Mapping[str, Any], /) -> tuple[bytes, int]:
+    def decode(self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any) -> tuple[bytes, int]:
         return encoded[:-1], 0
 
 def register(register_fec):

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -8,14 +8,14 @@ def test_load_plugins_from_local_package(tmp_path, monkeypatch):
     (pkg / "__init__.py").write_text("")
     (pkg / "tmp_codec.py").write_text(
         """
-from typing import Callable
+from typing import Callable, Any
 from genecoder.api import Codec
 
 class TmpCodec(Codec):
-    def encode(self, data: bytes) -> str:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         return 'X'
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, text: str, /, **kwargs: Any) -> bytes:
         return b'X'
 
 def register(register_codec: Callable[[str, type[Codec]], None]):

--- a/tests/test_plugin_failures.py
+++ b/tests/test_plugin_failures.py
@@ -70,14 +70,14 @@ def test_duplicate_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mode: 
     mod1 = tmp_path / "m1.py"
     mod1.write_text(
         """
-from typing import Callable
+from typing import Callable, Any
 from genecoder.api import Codec
 
 class CodecOne(Codec):
-    def encode(self, data: bytes) -> str:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         return "one"
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, text: str, /, **kwargs: Any) -> bytes:
         return b"one"
 
 def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
@@ -87,14 +87,14 @@ def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
     mod2 = tmp_path / "m2.py"
     mod2.write_text(
         """
-from typing import Callable
+from typing import Callable, Any
 from genecoder.api import Codec
 
 class CodecTwo(Codec):
-    def encode(self, data: bytes) -> str:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         return "two"
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, text: str, /, **kwargs: Any) -> bytes:
         return b"two"
 
 def register(register_codec: Callable[[str, type[Codec]], None]) -> None:

--- a/tests/test_plugin_interface_enforcement.py
+++ b/tests/test_plugin_interface_enforcement.py
@@ -1,0 +1,35 @@
+from importlib.metadata import EntryPoint
+from pathlib import Path
+
+import pytest
+import genecoder.plugin_manager as plugins
+
+
+def test_plugin_signature_validation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    codec_mod = tmp_path / "bad_codec.py"
+    codec_mod.write_text(
+        """
+from genecoder.codecs import BaseCodec
+
+class BadCodec(BaseCodec):
+    def encode(self, data: bytes, extra: int, /, **kwargs) -> bytes:
+        return b""
+
+    def decode(self, encoded: bytes, /, **kwargs) -> bytes:
+        return b""
+
+def register(register_codec):
+    register_codec("bad", BadCodec)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="bad", value="bad_codec", group="genecoder.plugins")
+    monkeypatch.setattr(
+        plugins, "entry_points", lambda *, group=None: [ep] if group == "genecoder.plugins" else []
+    )
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
+    with pytest.raises(TypeError):
+        plugins.load_plugins()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -11,21 +11,23 @@ def test_external_plugin_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     (pkg / "__init__.py").write_text("")
     (pkg / "ext.py").write_text(
         """
-from typing import Callable, Mapping, Tuple
+from typing import Callable, Mapping, Tuple, Any
 from genecoder.api import Codec, FEC
 
 class ExtCodec(Codec):
-    def encode(self, data: bytes) -> str:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         return 'Y'
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, text: str, /, **kwargs: Any) -> bytes:
         return b'Y'
 
 class ExtFEC(FEC):
-    def encode(self, data: bytes) -> Tuple[bytes, Mapping[str, int]]:
+    def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, int]]:
         return data + b'ZZ', {'n': 2}
 
-    def decode(self, encoded: bytes, info: Mapping[str, int]) -> Tuple[bytes, int]:
+    def decode(
+        self, encoded: bytes, info: Mapping[str, int], /, **kwargs: Any
+    ) -> Tuple[bytes, int]:
         return encoded[:-info['n']], info['n']
 
 def register(register_codec: Callable[[str, type[Codec]], None]):


### PR DESCRIPTION
## Summary
- document plugin API abstract methods with explicit parameter and return docs
- validate plugin method signatures during registration
- update built-in and example plugins to accept flexible keyword arguments
- add tests covering signature enforcement

## Testing
- `ruff check src/genecoder/plugin_manager.py src/genecoder/api.py src/plugins/reverse_codec.py plugins-examples/example_codec/example_codec/__init__.py plugins-examples/example_fec/example_fec/__init__.py tests/test_plugin_interface_enforcement.py tests/test_plugin_class_registration.py tests/test_plugin_discovery.py tests/test_plugin_failures.py tests/test_plugins.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689baab8502883268c9b2aa609c5eb08