### PR TITLE
Add selectable indel error profiles

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -22,6 +22,7 @@ from genecoder.metrics import metrics
 from genecoder.parallel import parallel_map
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
+from genecoder.error_simulation import INDEL_PROFILES
 from genecoder.simulators.decay import DegradationChannel
 from .options import ChannelOptions, build_channel_options
 from .shared import add_single_io_args
@@ -415,6 +416,7 @@ def register_subcommand(
         target.add_argument("--nanopore-del-rate", type=float, default=None, help="Deletion rate for Nanopore reads")
         target.add_argument("--nanopore-profile", type=str, default=None, help="Named Nanopore profile to use")
         target.add_argument("--nanopore-profile-file", type=str, default=None, help="YAML file with Nanopore simulator parameters")
+        target.add_argument("--indel-profile", type=str, default=None, help="Named indel profile to use")
         target.add_argument(
             "--decay-rate",
             type=float,
@@ -535,6 +537,11 @@ def run_channel(args: argparse.Namespace) -> None:
             if opts.nanopore_del_rate is not None:
                 new_params["deletion_rate"] = opts.nanopore_del_rate
         if name == "indel":
+            if opts.indel_profile is not None:
+                if opts.indel_profile not in INDEL_PROFILES:
+                    logger.error("Unknown indel profile: %s", opts.indel_profile)
+                    raise SystemExit(1)
+                new_params.setdefault("profile", opts.indel_profile)
             if opts.sub_rate is not None:
                 new_params["substitution_prob"] = opts.sub_rate
             if opts.ins_rate is not None:
@@ -581,6 +588,13 @@ def _handle_run(args: argparse.Namespace) -> None:
         cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
+    if args.indel_profile is not None:
+        if args.indel_profile not in INDEL_PROFILES:
+            logger.error("Unknown indel profile: %s", args.indel_profile)
+            raise SystemExit(1)
+        for name, params in simulators:
+            if name == "indel":
+                params.setdefault("profile", args.indel_profile)
     if args.illumina_profile_file is not None:
         prof = _load_profile_file(args.illumina_profile_file)
         for name, params in simulators:
@@ -627,6 +641,10 @@ def _handle_list_profiles(_: argparse.Namespace) -> None:
 
     print("Nanopore profiles:")
     for name in sorted(NANOPORE_PROFILES):
+        print(f"  {name}")
+
+    print("Indel profiles:")
+    for name in sorted(INDEL_PROFILES):
         print(f"  {name}")
 
 

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -41,6 +41,7 @@ class ChannelOptions:
     profile: str | None = None
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    indel_profile: str | None = None
     illumina_profile_file: str | None = None
     nanopore_profile_file: str | None = None
     sub_rate: float | None = None
@@ -217,6 +218,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         profile=getattr(args, "profile", None),
         illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
+        indel_profile=getattr(args, "indel_profile", None),
         illumina_profile_file=args.illumina_profile_file,
         nanopore_profile_file=args.nanopore_profile_file,
         sub_rate=args.sub_rate,

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -16,9 +16,27 @@ __all__ = [
     "apply_deletions",
     "Channel",
     "register",
+    "INDEL_PROFILES",
 ]
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
+
+
+# Preset substitution/indel probability profiles for :class:`Channel`.
+INDEL_PROFILES: dict[str, dict[str, float]] = {
+    # Typical Illumina error characteristics favour substitutions over indels.
+    "illumina": {
+        "substitution_prob": 0.002,
+        "insertion_prob": 0.0001,
+        "deletion_prob": 0.0001,
+    },
+    # Nanopore devices tend to produce higher indel rates.
+    "nanopore": {
+        "substitution_prob": 0.01,
+        "insertion_prob": 0.02,
+        "deletion_prob": 0.02,
+    },
+}
 
 
 def _random_substitution(nucleotide: str, rng: random.Random) -> str:
@@ -121,7 +139,14 @@ class Channel(Simulator):
         insertion_prob: float = 0.0,
         deletion_prob: float = 0.0,
         error_rate: float | None = None,
+        profile: str | None = None,
     ) -> None:
+        if profile is not None:
+            params = INDEL_PROFILES.get(profile.lower())
+            if params is not None:
+                substitution_prob = params["substitution_prob"]
+                insertion_prob = params["insertion_prob"]
+                deletion_prob = params["deletion_prob"]
         if error_rate is not None:
             substitution_prob = error_rate
         self.substitution_prob = substitution_prob
@@ -145,6 +170,17 @@ class Channel(Simulator):
             deletion_prob=self.deletion_prob,
             rng=make_rng(),
         )
+
+    def with_profile(self, profile: str) -> "Channel":
+        """Return a new channel configured to use ``profile``."""
+
+        if profile.lower() not in INDEL_PROFILES:
+            return type(self)(
+                substitution_prob=self.substitution_prob,
+                insertion_prob=self.insertion_prob,
+                deletion_prob=self.deletion_prob,
+            )
+        return type(self)(profile=profile)
 
 
 def register(

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -189,6 +189,52 @@ def test_cli_indel_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert called == [(0.1, 0.2, 0.05)]
 
 
+def test_cli_indel_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_indel_profile.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_indel_profile.fasta"
+    called: list[tuple[float, float, float]] = []
+
+    from genecoder.error_simulation import Channel as IndelChannel, INDEL_PROFILES
+
+    def fake_simulate(self: IndelChannel, seq: str) -> str:
+        called.append((self.substitution_prob, self.insertion_prob, self.deletion_prob))
+        return seq
+
+    monkeypatch.setattr(IndelChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "indel",
+            "--indel-profile",
+            "illumina",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    prof = INDEL_PROFILES["illumina"]
+    assert called == [(
+        prof["substitution_prob"],
+        prof["insertion_prob"],
+        prof["deletion_prob"],
+    )]
+
+
 def test_channel_cli_yaml(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)


### PR DESCRIPTION
## Summary
- add preset substitution/indel profiles to generic Channel
- allow `--indel-profile` CLI option and propagate via ChannelOptions
- test CLI profile selection

## Testing
- `ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/error_simulation.py tests/test_cli_channel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcbf76fac83268103ca38cc5b7931