### PR TITLE
feat: add profile option for simulators

### DIFF
--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -14,6 +14,8 @@ from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import decode_data_with_hamming
 from genecoder.plugin_manager import FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.simulators.illumina import ILLUMINA_PROFILES
+from genecoder.simulators.nanopore import NANOPORE_PROFILES
 from genecoder.formats import from_fasta
 from genecoder.utils import get_alphabet_maps
 from ..options import DecodingOptions
@@ -229,9 +231,15 @@ def process_single_decode(
                     "%s simulation skipped during decode", args.simulator
                 )
             else:
-                sequence_from_fasta = simulate_reads(
-                    sequence_from_fasta, args.simulator
-                )
+                try:
+                    sequence_from_fasta = simulate_reads(
+                        sequence_from_fasta,
+                        args.simulator,
+                        profile=args.profile,
+                    )
+                except ValueError as exc:
+                    logger.error("%s", exc)
+                    raise SystemExit(1)
                 logger.info(
                     "Applied %s simulator before decoding.", args.simulator
                 )
@@ -373,6 +381,13 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         default="none",
         choices=sim_choices,
         help="Apply an external simulator before decoding (default: none).",
+    )
+    profile_names = sorted(set(ILLUMINA_PROFILES) | set(NANOPORE_PROFILES))
+    parser.add_argument(
+        "--profile",
+        choices=profile_names,
+        default=None,
+        help="Named sequencing profile to use with built-in simulators.",
     )
     parser.add_argument(
         "--d2sim-options",

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -249,7 +249,12 @@ SIMULATOR_ADAPTERS: dict[str, Callable[[str, float, random.Random | None], str]]
 }
 
 
-def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
+def simulate_reads(
+    sequence: str,
+    simulator: str,
+    error_rate: float = 0.05,
+    profile: str | None = None,
+) -> str:
     """Return ``sequence`` processed by the named simulator.
 
     .. deprecated:: 0.2
@@ -266,7 +271,9 @@ def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> s
 
     from .simulators import simulate_reads as _simulate_reads
 
-    return _simulate_reads(sequence, simulator, error_rate=error_rate)
+    return _simulate_reads(
+        sequence, simulator, error_rate=error_rate, profile=profile
+    )
 
 
 class Channel(Simulator):

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -14,8 +14,17 @@ def register_simulator(name: str, channel: Simulator) -> None:
     SIMULATOR_REGISTRY[name] = channel
 
 from .base import BaseChannel, BaseSimulator
-from .illumina import IlluminaChannel, IlluminaInSilicoSeqChannel
-from .nanopore import NanoporeChannel, NanoporeDeSPChannel
+from .illumina import (
+    IlluminaChannel,
+    IlluminaInSilicoSeqChannel,
+    ILLUMINA_PROFILES,
+)
+from .nanopore import (
+    NanoporeChannel,
+    NanoporeDeSPChannel,
+    NanoporeDNArSimChannel,
+    NANOPORE_PROFILES,
+)
 
 __all__ = [
     "SIMULATOR_REGISTRY",
@@ -31,13 +40,39 @@ __all__ = [
 ]
 
 
-def simulate_reads(sequence: str, simulator: str, error_rate: float = 0.05) -> str:
-    """Return ``sequence`` processed by the named simulator."""
+def simulate_reads(
+    sequence: str,
+    simulator: str,
+    error_rate: float = 0.05,
+    profile: str | None = None,
+) -> str:
+    """Return ``sequence`` processed by the named simulator.
+
+    ``profile`` selects a preset for supported simulators.
+    """
 
     try:
         channel = SIMULATOR_REGISTRY[simulator]
     except KeyError as exc:
         raise ValueError(f"Unknown simulator: {simulator}") from exc
+
+    if profile is not None:
+        prof = profile.lower()
+        if isinstance(channel, (IlluminaChannel, IlluminaInSilicoSeqChannel)):
+            if prof not in ILLUMINA_PROFILES:
+                raise ValueError(f"Unknown Illumina profile: {profile}")
+            channel = channel.with_profile(prof)
+        elif isinstance(
+            channel,
+            (NanoporeChannel, NanoporeDeSPChannel, NanoporeDNArSimChannel),
+        ):
+            if prof not in NANOPORE_PROFILES:
+                raise ValueError(f"Unknown Nanopore profile: {profile}")
+            channel = channel.with_profile(prof)
+        else:
+            raise ValueError(
+                f"Simulator '{simulator}' does not support profiles"
+            )
 
     if hasattr(channel, "error_rate"):
         old_rate = getattr(channel, "error_rate")

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -195,3 +195,65 @@ def test_cli_decode_simulator_failure(tmp_path: Path, sim_name: str) -> None:
     out_file = tmp_path / "in.txt_decoded.bin"
     assert out_file.exists()
     assert out_file.read_text().startswith("failure")
+
+
+def test_cli_decode_simulator_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("profile test")
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--fec",
+            "triple_repeat",
+        ],
+        env=env,
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+    fasta_file = tmp_path / "in.txt.fasta"
+    assert fasta_file.exists()
+
+    called: list[str] = []
+
+    import genecoder.simulators.illumina as illumina
+
+    monkeypatch.setattr(illumina.IlluminaChannel, "simulate", lambda self, seq: seq)
+
+    def fake_with_profile(self: illumina.IlluminaChannel, profile: str):
+        called.append(profile)
+        return self
+
+    monkeypatch.setattr(illumina.IlluminaChannel, "with_profile", fake_with_profile)
+
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(fasta_file),
+            "--output-dir",
+            str(tmp_path),
+            "--method",
+            "base4_direct",
+            "--simulator",
+            "illumina",
+            "--profile",
+            "miseq",
+        ],
+        env=env,
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    out_file = tmp_path / "in.txt_decoded.bin"
+    assert out_file.exists()
+    assert out_file.read_text() == "profile test"
+    assert called == ["miseq"]

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -271,8 +271,13 @@ def test_register_returns_channels():
 def test_simulate_reads_wrapper_deprecated(monkeypatch):
     called = []
 
-    def fake_sim(seq: str, sim: str, error_rate: float = 0.05) -> str:
-        called.append((seq, sim, error_rate))
+    def fake_sim(
+        seq: str,
+        sim: str,
+        error_rate: float = 0.05,
+        profile: str | None = None,
+    ) -> str:
+        called.append((seq, sim, error_rate, profile))
         return "wrapped"
 
     monkeypatch.setattr(
@@ -281,10 +286,12 @@ def test_simulate_reads_wrapper_deprecated(monkeypatch):
     )
 
     with pytest.deprecated_call():
-        result = nanopore_sim.simulate_reads("ACGT", "none", error_rate=0.2)
+        result = nanopore_sim.simulate_reads(
+            "ACGT", "none", error_rate=0.2, profile="r9"
+        )
 
     assert result == "wrapped"
-    assert called == [("ACGT", "none", 0.2)]
+    assert called == [("ACGT", "none", 0.2, "r9")]
 
 from genecoder.simulators.nanopore import NanoporeDNArSimChannel
 

--- a/tests/test_simulator_registry.py
+++ b/tests/test_simulator_registry.py
@@ -1,4 +1,7 @@
+import pytest
+
 from genecoder.simulators import SIMULATOR_REGISTRY, simulate_reads
+from genecoder.simulators.illumina import IlluminaChannel, register as illumina_register
 
 
 def test_illumina_registered_and_deterministic(monkeypatch):
@@ -10,4 +13,23 @@ def test_illumina_registered_and_deterministic(monkeypatch):
     second = simulate_reads(seq, "illumina")
     assert first == second
     assert isinstance(first, str)
+
+
+def test_simulate_reads_profile_validation(monkeypatch):
+    illumina_register()
+    called: list[str] = []
+
+    orig = IlluminaChannel.with_profile
+
+    def fake_with_profile(self: IlluminaChannel, profile: str):
+        called.append(profile)
+        return orig(self, profile)
+
+    monkeypatch.setattr(IlluminaChannel, "with_profile", fake_with_profile)
+
+    simulate_reads("ACGT", "illumina", profile="miseq")
+    assert called == ["miseq"]
+
+    with pytest.raises(ValueError, match="Unknown Illumina profile"):
+        simulate_reads("ACGT", "illumina", profile="unknown")
 


### PR DESCRIPTION
## Summary
- allow simulate_reads to accept and validate sequencing profiles
- support `--profile` flag in decode CLI and forward to simulators
- extend nanopore simulator wrapper and tests for profile handling

## Testing
- `ruff check src/genecoder/simulators/__init__.py src/genecoder/cli/decode.py src/genecoder/nanopore_sim.py tests/test_simulator_registry.py tests/test_nanopore_sim.py tests/test_cli_decode.py`
- `pytest tests/test_simulator_registry.py::test_simulate_reads_profile_validation tests/test_nanopore_sim.py::test_simulate_reads_wrapper_deprecated tests/test_cli_decode.py::test_cli_decode_simulator_profile -q`


------
https://chatgpt.com/codex/tasks/task_e_689bd2e9c5dc8326978f4655db4f49e9