### PR TITLE
feat: support custom illumina profiles

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -115,24 +115,25 @@ def _load_config(
 
 
 def _load_profile_file(path: str) -> Dict[str, Any]:
-    """Return parameters from YAML ``path``."""
+    """Return parameters from JSON or YAML ``path``."""
+    text = Path(path).read_text(encoding="utf-8")
     try:
-        import yaml
-    except Exception:  # pragma: no cover - optional dependency
-        from genecoder.plugin_manager import yaml as yaml_module
-        if yaml_module is None:
-            raise
-        yaml = yaml_module
-
-    with open(path, "r", encoding="utf-8") as fh:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError:
+        try:  # Optional at runtime
+            import yaml
+        except Exception:  # pragma: no cover - optional dependency
+            from genecoder.plugin_manager import yaml as yaml_module
+            if yaml_module is None:
+                raise
+            yaml = yaml_module
         try:
-            data = yaml.safe_load(fh) or {}
+            data = yaml.safe_load(text)
         except Exception as exc:  # pragma: no cover - invalid YAML path
-            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
-
+            raise ValueError(f"Invalid profile in {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError("Profile file must map keys to values")
-    return data
+    return data or {}
 
 
 def _apply_simulators(
@@ -307,13 +308,10 @@ def register_subcommand(
         "--illumina-profile",
         type=str,
         default=None,
-        help=f"Named Illumina profile to use. Available profiles: {illumina_profiles}",
-    )
-    run_parser.add_argument(
-        "--illumina-profile-file",
-        type=str,
-        default=None,
-        help="YAML file with Illumina simulator parameters",
+        help=(
+            "Named Illumina profile or path to JSON/YAML file. "
+            f"Available profiles: {illumina_profiles}"
+        ),
     )
     run_parser.add_argument(
         "--nanopore-profile",
@@ -406,8 +404,12 @@ def register_subcommand(
         target.add_argument("--illumina-sub-rate", type=float, default=None, help="Substitution rate for Illumina reads")
         target.add_argument("--illumina-ins-rate", type=float, default=None, help="Insertion rate for Illumina reads")
         target.add_argument("--illumina-del-rate", type=float, default=None, help="Deletion rate for Illumina reads")
-        target.add_argument("--illumina-profile", type=str, default=None, help="Named Illumina profile to use")
-        target.add_argument("--illumina-profile-file", type=str, default=None, help="YAML file with Illumina simulator parameters")
+        target.add_argument(
+            "--illumina-profile",
+            type=str,
+            default=None,
+            help="Named Illumina profile or path to JSON/YAML file",
+        )
         target.add_argument("--nanopore-depth", type=int, default=None, help="Coverage depth for Nanopore reads")
         target.add_argument("--nanopore-quality", type=str, default=None, help="Comma-separated quality profile or path to JSON")
         target.add_argument("--nanopore-context", type=str, default=None, help="Path to JSON/YAML context error map")
@@ -585,7 +587,15 @@ def _handle_run(args: argparse.Namespace) -> None:
             cfg.nanopore_profile = preset
 
     if args.illumina_profile is not None:
-        cfg.illumina_profile = args.illumina_profile
+        path = Path(args.illumina_profile)
+        if path.is_file():
+            prof = _load_profile_file(str(path))
+            for name, params in simulators:
+                if name == "illumina":
+                    for k, v in prof.items():
+                        params.setdefault(k, v)
+        else:
+            cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
     if args.indel_profile is not None:
@@ -595,12 +605,6 @@ def _handle_run(args: argparse.Namespace) -> None:
         for name, params in simulators:
             if name == "indel":
                 params.setdefault("profile", args.indel_profile)
-    if args.illumina_profile_file is not None:
-        prof = _load_profile_file(args.illumina_profile_file)
-        for name, params in simulators:
-            if name == "illumina":
-                for k, v in prof.items():
-                    params.setdefault(k, v)
     if args.nanopore_profile_file is not None:
         prof = _load_profile_file(args.nanopore_profile_file)
         for name, params in simulators:

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -188,6 +188,13 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("Cannot specify both --threads and --processes")
     if args.batch_workers is not None and args.batch_workers <= 0:
         raise ValueError("batch_workers must be greater than 0")
+    illumina_profile = args.illumina_profile
+    illumina_profile_file = None
+    if illumina_profile is not None:
+        from pathlib import Path
+        if Path(illumina_profile).is_file():
+            illumina_profile_file = illumina_profile
+            illumina_profile = None
 
     return ChannelOptions(
         simulators=simulators,
@@ -216,10 +223,10 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_ins_rate=args.nanopore_ins_rate,
         nanopore_del_rate=args.nanopore_del_rate,
         profile=getattr(args, "profile", None),
-        illumina_profile=args.illumina_profile,
+        illumina_profile=illumina_profile,
         nanopore_profile=args.nanopore_profile,
         indel_profile=getattr(args, "indel_profile", None),
-        illumina_profile_file=args.illumina_profile_file,
+        illumina_profile_file=illumina_profile_file,
         nanopore_profile_file=args.nanopore_profile_file,
         sub_rate=args.sub_rate,
         ins_rate=args.ins_rate,

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -117,6 +117,29 @@ def _validate_profile(data: Mapping[str, Any]) -> IlluminaProfile:
     )
 
 
+# Load profile parameters from a JSON or YAML file
+def _load_profile_file(path: str | Path) -> Mapping[str, Any]:
+    """Return profile parameters loaded from ``path``.
+
+    The file may be JSON or YAML and must map keys to values.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError:
+        try:  # Optional at runtime
+            import yaml
+        except Exception:  # pragma: no cover - optional dependency
+            from genecoder.plugin_manager import yaml as yaml_module
+            if yaml_module is None:
+                raise
+            yaml = yaml_module
+        data = yaml.safe_load(text) or {}
+    if not isinstance(data, Mapping):
+        raise ValueError("Profile file must map keys to values")
+    return data
+
+
 # Preset parameter profiles for :class:`IlluminaChannel`.
 ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
     "miseq": {
@@ -212,18 +235,7 @@ class IlluminaChannel(BaseSimulator):
                 read_length = int(params.get("read_length", read_length))
                 coverage = int(params.get("coverage", coverage))
         if profile_path is not None:
-            try:
-                import yaml
-            except Exception:  # pragma: no cover - optional dependency
-                from genecoder.plugin_manager import yaml as yaml_module
-                if yaml_module is None:
-                    raise
-                yaml = yaml_module
-
-            with open(profile_path, "r", encoding="utf-8") as fh:
-                data = yaml.safe_load(fh) or {}
-            if not isinstance(data, dict):
-                raise ValueError("Profile file must map keys to values")
+            data = _load_profile_file(profile_path) or {}
             profile = _validate_profile(data)
             substitution_rate = profile.substitution_rate
             insertion_rate = profile.insertion_rate

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -1,6 +1,6 @@
-import json
 import os
 import argparse
+import json
 from pathlib import Path
 
 import pytest
@@ -97,6 +97,130 @@ def test_cli_illumina_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     )
     assert result.returncode == 0, result.stderr
     assert called == [(0.2, 0.3, 0.1)]
+
+
+def test_cli_illumina_profile_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_profile_path.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_profile_path.fasta"
+    profile = tmp_path / "illumina.json"
+    params = {
+        "substitution_rate": 0.11,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.03,
+        "read_length": 110,
+        "coverage": 2,
+    }
+    profile.write_text(json.dumps(params))
+    called: list[tuple[float, float, float, int, int]] = []
+
+    from genecoder.simulators.illumina import IlluminaChannel
+
+    def fake_simulate(self: IlluminaChannel, seq: str) -> str:
+        called.append(
+            (
+                self.substitution_rate,
+                self.insertion_rate,
+                self.deletion_rate,
+                self.read_length,
+                self.coverage,
+            )
+        )
+        return seq
+
+    monkeypatch.setattr(IlluminaChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "illumina",
+            "--illumina-profile",
+            str(profile),
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert called == [
+        (
+            params["substitution_rate"],
+            params["insertion_rate"],
+            params["deletion_rate"],
+            params["read_length"],
+            params["coverage"],
+        )
+    ]
+
+
+def test_cli_illumina_profile_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    input_fasta = tmp_path / "in_profile_name.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_profile_name.fasta"
+    called: list[tuple[float, float, float, int, int]] = []
+
+    from genecoder.simulators.illumina import IlluminaChannel, ILLUMINA_PROFILES
+
+    def fake_simulate(self: IlluminaChannel, seq: str) -> str:
+        called.append(
+            (
+                self.substitution_rate,
+                self.insertion_rate,
+                self.deletion_rate,
+                self.read_length,
+                self.coverage,
+            )
+        )
+        return seq
+
+    monkeypatch.setattr(IlluminaChannel, "simulate", fake_simulate)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "illumina",
+            "--illumina-profile",
+            "miseq",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    params = ILLUMINA_PROFILES["miseq"]
+    assert called == [
+        (
+            params["substitution_rate"],
+            params["insertion_rate"],
+            params["deletion_rate"],
+            params["read_length"],
+            params["coverage"],
+        )
+    ]
 
 
 def test_cli_nanopore_rates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_illumina_profile_validation.py
+++ b/tests/test_illumina_profile_validation.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 import yaml
 from pathlib import Path
 
@@ -18,6 +19,21 @@ def test_valid_profile_file(tmp_path: Path) -> None:
     ch = IlluminaChannel(profile_path=str(prof))
     assert ch.read_length == 100
     assert ch.coverage == 2
+
+
+def test_valid_profile_file_json(tmp_path: Path) -> None:
+    params = {
+        "substitution_rate": 0.01,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.03,
+        "read_length": 120,
+        "coverage": 3,
+    }
+    prof = tmp_path / "good.json"
+    prof.write_text(json.dumps(params))
+    ch = IlluminaChannel(profile_path=str(prof))
+    assert ch.read_length == 120
+    assert ch.coverage == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- allow IlluminaChannel to load JSON or YAML profile files
- add --illumina-profile flag that accepts a profile name or file path
- extend channel options builder and tests for custom Illumina profiles

## Testing
- `ruff check src/genecoder/simulators/illumina.py src/genecoder/cli/channel.py src/genecoder/cli/options.py tests/test_cli_channel.py tests/test_illumina_profile_validation.py`
- `pytest tests/test_illumina_profile_validation.py::test_valid_profile_file_json tests/test_cli_channel.py::test_cli_illumina_profile_path tests/test_cli_channel.py::test_cli_illumina_profile_name tests/test_cli_channel.py::test_cli_illumina_rates -q`


------
https://chatgpt.com/codex/tasks/task_e_689c93517548832689f4378430cbd9b4