### PR TITLE
feat: add custom Illumina profile support

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -492,16 +492,7 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params.setdefault("quality_profile", opts.quality_profile)
         if name == "illumina":
             if opts.illumina_profile:
-                prof = ILLUMINA_PROFILES.get(opts.illumina_profile)
-                if prof is None:
-                    logger.error("Unknown Illumina profile: %s", opts.illumina_profile)
-                    raise SystemExit(1)
-                for k, v in prof.items():
-                    new_params.setdefault(k, v)
-            if opts.illumina_profile_file:
-                file_params = _load_profile_file(opts.illumina_profile_file)
-                for k, v in file_params.items():
-                    new_params.setdefault(k, v)
+                new_params.setdefault("profile", opts.illumina_profile)
             if opts.illumina_depth is not None:
                 new_params["coverage"] = opts.illumina_depth
             if opts.illumina_quality is not None:
@@ -587,15 +578,7 @@ def _handle_run(args: argparse.Namespace) -> None:
             cfg.nanopore_profile = preset
 
     if args.illumina_profile is not None:
-        path = Path(args.illumina_profile)
-        if path.is_file():
-            prof = _load_profile_file(str(path))
-            for name, params in simulators:
-                if name == "illumina":
-                    for k, v in prof.items():
-                        params.setdefault(k, v)
-        else:
-            cfg.illumina_profile = args.illumina_profile
+        cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
     if args.indel_profile is not None:

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -42,7 +42,6 @@ class ChannelOptions:
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
     indel_profile: str | None = None
-    illumina_profile_file: str | None = None
     nanopore_profile_file: str | None = None
     sub_rate: float | None = None
     ins_rate: float | None = None
@@ -188,14 +187,6 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("Cannot specify both --threads and --processes")
     if args.batch_workers is not None and args.batch_workers <= 0:
         raise ValueError("batch_workers must be greater than 0")
-    illumina_profile = args.illumina_profile
-    illumina_profile_file = None
-    if illumina_profile is not None:
-        from pathlib import Path
-        if Path(illumina_profile).is_file():
-            illumina_profile_file = illumina_profile
-            illumina_profile = None
-
     return ChannelOptions(
         simulators=simulators,
         constraints=constraints,
@@ -223,10 +214,9 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         nanopore_ins_rate=args.nanopore_ins_rate,
         nanopore_del_rate=args.nanopore_del_rate,
         profile=getattr(args, "profile", None),
-        illumina_profile=illumina_profile,
+        illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
         indel_profile=getattr(args, "indel_profile", None),
-        illumina_profile_file=illumina_profile_file,
         nanopore_profile_file=args.nanopore_profile_file,
         sub_rate=args.sub_rate,
         ins_rate=args.ins_rate,

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -210,55 +210,63 @@ class IlluminaChannel(BaseSimulator):
 
     def __init__(
         self,
-        substitution_rate: float = 0.001,
-        insertion_rate: float = 0.0001,
-        deletion_rate: float = 0.0001,
-        coverage: int = 1,
-        read_length: int = 150,
+        substitution_rate: float | None = None,
+        insertion_rate: float | None = None,
+        deletion_rate: float | None = None,
+        coverage: int | None = None,
+        read_length: int | None = None,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
         profile: str | None = None,
-        profile_path: str | None = None,
     ) -> None:
+        profile_data: Mapping[str, Any] = {}
         if profile is not None:
-            params = ILLUMINA_PROFILES.get(profile.lower())
-            if params is not None:
-                substitution_rate = float(
-                    params.get("substitution_rate", substitution_rate)
-                )
-                insertion_rate = float(
-                    params.get("insertion_rate", insertion_rate)
-                )
-                deletion_rate = float(
-                    params.get("deletion_rate", deletion_rate)
-                )
-                read_length = int(params.get("read_length", read_length))
-                coverage = int(params.get("coverage", coverage))
-        if profile_path is not None:
-            data = _load_profile_file(profile_path) or {}
-            profile = _validate_profile(data)
-            substitution_rate = profile.substitution_rate
-            insertion_rate = profile.insertion_rate
-            deletion_rate = profile.deletion_rate
-            read_length = profile.read_length
-            coverage = profile.coverage
-            quality_profile = data.get("quality_profile", quality_profile)
-            context_errors = data.get("context_errors", context_errors)
-        else:
-            profile = _validate_profile(
-                {
-                    "substitution_rate": substitution_rate,
-                    "insertion_rate": insertion_rate,
-                    "deletion_rate": deletion_rate,
-                    "read_length": read_length,
-                    "coverage": coverage,
-                }
-            )
-            substitution_rate = profile.substitution_rate
-            insertion_rate = profile.insertion_rate
-            deletion_rate = profile.deletion_rate
-            read_length = profile.read_length
-            coverage = profile.coverage
+            path = Path(profile)
+            if path.is_file():
+                profile_data = _load_profile_file(path) or {}
+            else:
+                profile_data = ILLUMINA_PROFILES.get(profile.lower(), {})
+
+        substitution_rate = float(
+            substitution_rate
+            if substitution_rate is not None
+            else profile_data.get("substitution_rate", 0.001)
+        )
+        insertion_rate = float(
+            insertion_rate
+            if insertion_rate is not None
+            else profile_data.get("insertion_rate", 0.0001)
+        )
+        deletion_rate = float(
+            deletion_rate
+            if deletion_rate is not None
+            else profile_data.get("deletion_rate", 0.0001)
+        )
+        read_length = int(
+            read_length
+            if read_length is not None
+            else profile_data.get("read_length", 150)
+        )
+        coverage = int(
+            coverage if coverage is not None else profile_data.get("coverage", 1)
+        )
+        quality_profile = profile_data.get("quality_profile", quality_profile)
+        context_errors = profile_data.get("context_errors", context_errors)
+
+        profile_obj = _validate_profile(
+            {
+                "substitution_rate": substitution_rate,
+                "insertion_rate": insertion_rate,
+                "deletion_rate": deletion_rate,
+                "read_length": read_length,
+                "coverage": coverage,
+            }
+        )
+        substitution_rate = profile_obj.substitution_rate
+        insertion_rate = profile_obj.insertion_rate
+        deletion_rate = profile_obj.deletion_rate
+        read_length = profile_obj.read_length
+        coverage = profile_obj.coverage
 
         if isinstance(quality_profile, str):
             quality_profile = _parse_quality_profile(quality_profile)
@@ -327,12 +335,18 @@ class IlluminaChannel(BaseSimulator):
         Unknown profiles leave the channel unchanged.
         """
 
-        if profile.lower() not in ILLUMINA_PROFILES:
+        path = Path(profile)
+        if not path.is_file() and profile.lower() not in ILLUMINA_PROFILES:
             return self
         return type(self)(
-            profile=profile,
+            substitution_rate=self.substitution_rate,
+            insertion_rate=self.insertion_rate,
+            deletion_rate=self.deletion_rate,
+            coverage=self.coverage,
+            read_length=self.read_length,
             quality_profile=self.quality_profile,
             context_errors=dict(self.context_errors),
+            profile=profile,
         )
 
 

--- a/tests/test_channel_options_validation.py
+++ b/tests/test_channel_options_validation.py
@@ -39,7 +39,6 @@ def _make_args(**kwargs: object) -> argparse.Namespace:
         nanopore_del_rate=None,
         illumina_profile=None,
         nanopore_profile=None,
-        illumina_profile_file=None,
         nanopore_profile_file=None,
         sub_rate=None,
         ins_rate=None,

--- a/tests/test_simulator_profiles.py
+++ b/tests/test_simulator_profiles.py
@@ -30,7 +30,7 @@ def test_illumina_profile_file(tmp_path: Path) -> None:
     }
     prof = tmp_path / "illumina.yml"
     prof.write_text(yaml.safe_dump(params))
-    ch = IlluminaChannel(profile_path=str(prof))
+    ch = IlluminaChannel(profile=str(prof))
     assert ch.substitution_rate == params["substitution_rate"]
     assert ch.insertion_rate == params["insertion_rate"]
     assert ch.deletion_rate == params["deletion_rate"]


### PR DESCRIPTION
## Summary
- allow IlluminaChannel to load parameters from custom JSON/YAML profile files
- pass `--illumina-profile` values directly to IlluminaChannel in CLI
- update tests for profile loading and CLI option handling

## Testing
- `ruff check src/genecoder/simulators/illumina.py src/genecoder/cli/options.py src/genecoder/cli/channel.py tests/test_simulator_profiles.py tests/test_channel_options_validation.py tests/test_cli_channel.py`
- `pytest tests/test_simulator_profiles.py tests/test_cli_channel.py tests/test_channel_options_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccb6ddd74832697f413be8e132ef7