### PR TITLE
Support context-specific indel rates from profile YAMLs

### DIFF
--- a/configs/nanopore.yml
+++ b/configs/nanopore.yml
@@ -10,9 +10,11 @@ minion:
   context_insertions:
     AA:
       1: 0.9
+      2: 0.8
   context_deletions:
     TT:
       1: 0.9
+      2: 0.85
 promethion:
   error_rate: 0.08
   substitution_rate: 0.015
@@ -25,9 +27,11 @@ promethion:
   context_insertions:
     AA:
       1: 0.05
+      2: 0.03
   context_deletions:
     TT:
       1: 0.11
+      2: 0.07
 r10:
   error_rate: 0.05
   substitution_rate: 0.01
@@ -40,6 +44,8 @@ r10:
   context_insertions:
     AA:
       1: 0.04
+      2: 0.02
   context_deletions:
     TT:
       1: 0.08
+      2: 0.05

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -42,84 +42,8 @@ __all__ = [
     "DNARSIM_RATE_TABLES",
 ]
 
-# Preset parameter profiles for :class:`NanoporeChannel` loaded from YAML.
-_DEFAULT_NANOPORE_PROFILES: dict[
-    str, dict[str, float | int | Dict[int, float] | Dict[str, Dict[int, float]]]
-] = {
-    "minion": {
-        "error_rate": 0.12,
-        "substitution_rate": 0.02,
-        "insertion_rate": 0.04,
-        "deletion_rate": 0.06,
-    },
-    "promethion": {
-        "error_rate": 0.08,
-        "substitution_rate": 0.015,
-        "insertion_rate": 0.02,
-        "deletion_rate": 0.045,
-    },
-    "r10": {
-        "error_rate": 0.05,
-        "substitution_rate": 0.01,
-        "insertion_rate": 0.02,
-        "deletion_rate": 0.03,
-    },
-}
-
-try:  # pragma: no cover - optional dependency
-    import yaml
-
-    _cfg_dir = Path(__file__).resolve().parents[3] / "configs"
-    with open(_cfg_dir / "nanopore.yml", "r", encoding="utf-8") as _fh:
-        _data = yaml.safe_load(_fh) or {}
-
-    from typing import Any
-
-    def _parse_profile(params: dict[str, Any]) -> dict[str, Any]:
-        parsed: dict[str, Any] = {}
-        for key, value in params.items():
-            if key in {"insertion_profile", "deletion_profile"} and isinstance(value, dict):
-                parsed[key] = {int(k): float(v) for k, v in value.items()}
-            elif key in {"context_insertions", "context_deletions"} and isinstance(value, dict):
-                parsed[key] = {
-                    str(ctx).upper(): {int(r): float(p) for r, p in prof.items()}
-                    for ctx, prof in value.items()
-                    if isinstance(prof, dict)
-                }
-            else:
-                parsed[key] = value
-        return parsed
-
-    if isinstance(_data, dict):
-        NANOPORE_PROFILES: dict[
-            str,
-            dict[str, float | int | Dict[int, float] | Dict[str, Dict[int, float]]],
-        ] = {
-            str(name): _parse_profile(params)
-            for name, params in _data.items()
-            if isinstance(params, dict)
-        }
-    else:  # pragma: no cover - unexpected structure
-        NANOPORE_PROFILES = _DEFAULT_NANOPORE_PROFILES
-
-    with open(_cfg_dir / "dnarsim_rates.yaml", "r", encoding="utf-8") as _fh:
-        _rates_data = yaml.safe_load(_fh) or {}
-    if isinstance(_rates_data, dict):
-        DNARSIM_RATE_TABLES: dict[str, dict[str, float]] = {
-            str(name): {
-                "substitution_rate": float(tbl.get("substitution_rate", 0.0)),
-                "insertion_rate": float(tbl.get("insertion_rate", 0.0)),
-                "deletion_rate": float(tbl.get("deletion_rate", 0.0)),
-            }
-            for name, tbl in _rates_data.items()
-            if isinstance(tbl, dict)
-        }
-        NANOPORE_PROFILES.update(DNARSIM_RATE_TABLES)  # type: ignore[arg-type]
-    else:  # pragma: no cover - unexpected structure
-        DNARSIM_RATE_TABLES = {}
-except Exception:  # pragma: no cover - fallback when yaml missing
-    NANOPORE_PROFILES = _DEFAULT_NANOPORE_PROFILES
-    DNARSIM_RATE_TABLES = {}
+# ---------------------------------------------------------------------------
+# Validation helpers
 
 
 def _validate_rate(name: str, rate: float | int) -> float:
@@ -156,6 +80,84 @@ def _validate_context_profiles(
             )
         validated[str(ctx).upper()] = _validate_indel_profile(prof, f"{name}[{ctx}]")
     return validated
+
+# ---------------------------------------------------------------------------
+# Preset parameter profiles for :class:`NanoporeChannel` loaded from YAML.
+_DEFAULT_NANOPORE_PROFILES: dict[
+    str, dict[str, float | int | Dict[int, float] | Dict[str, Dict[int, float]]]
+] = {
+    "minion": {
+        "error_rate": 0.12,
+        "substitution_rate": 0.02,
+        "insertion_rate": 0.04,
+        "deletion_rate": 0.06,
+    },
+    "promethion": {
+        "error_rate": 0.08,
+        "substitution_rate": 0.015,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.045,
+    },
+    "r10": {
+        "error_rate": 0.05,
+        "substitution_rate": 0.01,
+        "insertion_rate": 0.02,
+        "deletion_rate": 0.03,
+    },
+}
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+
+    _cfg_dir = Path(__file__).resolve().parents[3] / "configs"
+    with open(_cfg_dir / "nanopore.yml", "r", encoding="utf-8") as _fh:
+        _data = yaml.safe_load(_fh) or {}
+
+    from typing import Any
+
+    def _parse_profile(params: dict[str, Any]) -> dict[str, Any]:
+        parsed: dict[str, Any] = {}
+        for key, value in params.items():
+            if key in {"insertion_profile", "deletion_profile"}:
+                prof = value if isinstance(value, Mapping) else None
+                parsed[key] = _validate_indel_profile(prof, key)
+            elif key in {"context_insertions", "context_deletions"}:
+                prof = value if isinstance(value, Mapping) else None
+                parsed[key] = _validate_context_profiles(prof, key)
+            else:
+                parsed[key] = value
+        return parsed
+
+    if isinstance(_data, dict):
+        NANOPORE_PROFILES: dict[
+            str,
+            dict[str, float | int | Dict[int, float] | Dict[str, Dict[int, float]]],
+        ] = {
+            str(name): _parse_profile(params)
+            for name, params in _data.items()
+            if isinstance(params, dict)
+        }
+    else:  # pragma: no cover - unexpected structure
+        NANOPORE_PROFILES = _DEFAULT_NANOPORE_PROFILES
+
+    with open(_cfg_dir / "dnarsim_rates.yaml", "r", encoding="utf-8") as _fh:
+        _rates_data = yaml.safe_load(_fh) or {}
+    if isinstance(_rates_data, dict):
+        DNARSIM_RATE_TABLES: dict[str, dict[str, float]] = {
+            str(name): {
+                "substitution_rate": float(tbl.get("substitution_rate", 0.0)),
+                "insertion_rate": float(tbl.get("insertion_rate", 0.0)),
+                "deletion_rate": float(tbl.get("deletion_rate", 0.0)),
+            }
+            for name, tbl in _rates_data.items()
+            if isinstance(tbl, dict)
+        }
+        NANOPORE_PROFILES.update(DNARSIM_RATE_TABLES)  # type: ignore[arg-type]
+    else:  # pragma: no cover - unexpected structure
+        DNARSIM_RATE_TABLES = {}
+except Exception:  # pragma: no cover - fallback when yaml missing
+    NANOPORE_PROFILES = _DEFAULT_NANOPORE_PROFILES
+    DNARSIM_RATE_TABLES = {}
 
 
 @njit(cache=True, forceobj=True)  # type: ignore[misc]

--- a/tests/test_nanopore_context_errors.py
+++ b/tests/test_nanopore_context_errors.py
@@ -155,6 +155,50 @@ def test_context_deletion_profile_affect_counts() -> None:
     assert del_ctx > del_base
 
 
+def test_context_insertion_run_length_specific() -> None:
+    seq = "AAT"
+    runs = 50
+    seed = 9
+    ch_high = NanoporeChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_insertions={"AA": {2: 1.0}},
+    )
+    ch_low = NanoporeChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_insertions={"AA": {2: 0.0}},
+    )
+    ins_high, _ = _count_ins_del(ch_high, seq, runs, seed)
+    ins_low, _ = _count_ins_del(ch_low, seq, runs, seed)
+    assert ins_high == runs
+    assert ins_low == 0
+
+
+def test_context_deletion_run_length_specific() -> None:
+    seq = "TTA"
+    runs = 50
+    seed = 10
+    ch_high = NanoporeChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_deletions={"TT": {2: 1.0}},
+    )
+    ch_low = NanoporeChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_deletions={"TT": {2: 0.0}},
+    )
+    _, del_high = _count_ins_del(ch_high, seq, runs, seed)
+    _, del_low = _count_ins_del(ch_low, seq, runs, seed)
+    assert del_high == runs
+    assert del_low == 0
+
+
 def test_profile_context_insertion_affects_counts() -> None:
     seq = "AAT"
     runs = 200

--- a/tests/test_parallel_pipeline.py
+++ b/tests/test_parallel_pipeline.py
@@ -42,7 +42,7 @@ class _DelayChannel(BaseChannel):
 def test_parallel_pipeline_concurrent(tmp_path: Path) -> None:
     pipeline = ChannelPipeline([_DelayChannel(0.1)])
     os.environ["GENECODER_METRICS_PATH"] = str(tmp_path / "m.json")
-    seqs = ["AAAA", "TTTT"]
+    seqs = ["AAAA", "TTTT", "CCCC", "GGGG"]
 
     start = time.perf_counter()
     for s in seqs:
@@ -62,7 +62,7 @@ def test_parallel_pipeline_multi_channel_concurrent(tmp_path: Path) -> None:
     """Ensure multiple sequences run concurrently when parallel=True."""
     pipeline = ChannelPipeline([_DelayChannel(0.1)])
     os.environ["GENECODER_METRICS_PATH"] = str(tmp_path / "m.json")
-    seqs = ["AAAA", "CCCC", "GGGG"]
+    seqs = ["AAAA", "CCCC", "GGGG", "TTTT", "ACAC", "TGTG"]
 
     start = time.perf_counter()
     for s in seqs:


### PR DESCRIPTION
## Summary
- validate and parse context-specific insertion/deletion profiles from YAML
- demonstrate context-aware indel probabilities in `configs/nanopore.yml`
- test run-length specific context insertions and deletions
- harden parallel pipeline concurrency tests

## Testing
- `ruff check src/genecoder/simulators/nanopore.py tests/test_nanopore_context_errors.py tests/test_parallel_pipeline.py tests/test_simulator_profiles.py`
- `pytest tests/test_parallel_pipeline.py::test_parallel_pipeline_concurrent tests/test_parallel_pipeline.py::test_parallel_pipeline_multi_channel_concurrent tests/test_nanopore_context_errors.py tests/test_simulator_profiles.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689ccb6ecbd483269b556583b40f52ef