### PR TITLE
Use shared RNG in constraint fixer for deterministic behaviour

### DIFF
--- a/src/genecoder/constraint_fixer.py
+++ b/src/genecoder/constraint_fixer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import random
 
+from .random_utils import make_rng
+
 __all__ = ["adjust_gc_balance", "limit_homopolymers", "fix_sequence"]
 
 
@@ -15,8 +17,12 @@ def adjust_gc_balance(
     rng: random.Random | None = None,
 ) -> str:
     """Return ``sequence`` adjusted so its GC content falls within bounds."""
+    if target_gc_min > target_gc_max:
+        msg = "target_gc_min cannot exceed target_gc_max"
+        raise ValueError(msg)
+
     if rng is None:
-        rng = random.Random()
+        rng = make_rng()
     seq = list(sequence.upper())
     length = len(seq)
     gc_count = sum(1 for b in seq if b in {"G", "C"})
@@ -47,10 +53,12 @@ def limit_homopolymers(
     rng: random.Random | None = None,
 ) -> str:
     """Return ``sequence`` with runs longer than ``max_len`` disrupted."""
-    if rng is None:
-        rng = random.Random()
     if max_len < 1:
-        return sequence
+        msg = "max_len must be at least 1"
+        raise ValueError(msg)
+
+    if rng is None:
+        rng = make_rng()
     seq = list(sequence.upper())
     i = 0
     while i < len(seq):
@@ -82,6 +90,16 @@ def fix_sequence(
     rng: random.Random | None = None,
 ) -> str:
     """Return ``sequence`` adjusted for GC content and homopolymers."""
+    if target_gc_min > target_gc_max:
+        msg = "target_gc_min cannot exceed target_gc_max"
+        raise ValueError(msg)
+    if max_homopolymer < 1:
+        msg = "max_homopolymer must be at least 1"
+        raise ValueError(msg)
+
+    if rng is None:
+        rng = make_rng()
+
     seq = adjust_gc_balance(sequence, target_gc_min, target_gc_max, rng=rng)
     seq = limit_homopolymers(seq, max_homopolymer, rng=rng)
     # Breaking up long homopolymers can skew the GC ratio slightly. Run a final

--- a/tests/test_constraint_fixer.py
+++ b/tests/test_constraint_fixer.py
@@ -1,7 +1,10 @@
 import random
 
+import pytest
+
 from genecoder.constraint_fixer import adjust_gc_balance, limit_homopolymers, fix_sequence
 from genecoder.gc_constrained_encoder import calculate_gc_content
+from genecoder.random_utils import reset_rng
 from genecoder.utils import get_max_homopolymer_length
 
 
@@ -74,4 +77,51 @@ def test_fix_sequence_handles_long_input() -> None:
     assert 0.4 <= calculate_gc_content(fixed) <= 0.6
     assert get_max_homopolymer_length(fixed) <= 4
     assert len(fixed) == len(seq)
+
+
+def test_adjust_gc_balance_seed_reproducible(monkeypatch) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    seq = "AAAAAA"
+    reset_rng()
+    fixed1 = adjust_gc_balance(seq, 0.4, 0.6)
+    reset_rng()
+    fixed2 = adjust_gc_balance(seq, 0.4, 0.6)
+    assert fixed1 == fixed2
+
+
+def test_limit_homopolymers_seed_reproducible(monkeypatch) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    seq = "AAAAAA"
+    reset_rng()
+    fixed1 = limit_homopolymers(seq, 2)
+    reset_rng()
+    fixed2 = limit_homopolymers(seq, 2)
+    assert fixed1 == fixed2
+
+
+def test_fix_sequence_seed_reproducible(monkeypatch) -> None:
+    monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+    seq = "A" * 12
+    reset_rng()
+    fixed1 = fix_sequence(
+        seq,
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=3,
+    )
+    reset_rng()
+    fixed2 = fix_sequence(
+        seq,
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=3,
+    )
+    assert fixed1 == fixed2
+
+
+def test_fix_sequence_invalid_parameters() -> None:
+    with pytest.raises(ValueError):
+        fix_sequence("AT", target_gc_min=0.6, target_gc_max=0.4, max_homopolymer=1)
+    with pytest.raises(ValueError):
+        fix_sequence("AT", target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=0)
 


### PR DESCRIPTION
## Summary
- replace ad-hoc random generators with `make_rng` in constraint fixer
- validate GC and homopolymer bounds
- test deterministic outputs when seeding the RNG

## Testing
- `ruff check src/genecoder/constraint_fixer.py tests/test_constraint_fixer.py`
- `pytest tests/test_constraint_fixer.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd74367cc83269fbb95fe289a8aeb