### PR TITLE
Add checksum verification for plugin registry downloads

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -293,9 +293,15 @@ def install_registry_plugins(
                 logger.error("Invalid signature for plugin %s", spec)
                 raise ValueError("Invalid signature")
 
-            if checksum and digest != str(checksum):
-                logger.error("Checksum mismatch for plugin %s", spec)
-                raise ValueError("Checksum mismatch")
+            if checksum:
+                try:
+                    expected = plugin_security.decode_checksum(str(checksum))
+                except ValueError:
+                    logger.error("Invalid checksum for plugin %s", spec)
+                    raise ValueError("Invalid checksum")
+                if digest != expected:
+                    logger.error("Checksum mismatch for plugin %s", spec)
+                    raise ValueError("Checksum mismatch")
 
             tmp = tempfile.NamedTemporaryFile(delete=False)
             pkg_path = tmp.name

--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -1,8 +1,31 @@
-from __future__ import annotations
-
 """Utilities for verifying plugin packages."""
 
+from __future__ import annotations
+
+import base64
+
 from .security import compute_checksum as _compute_checksum
+
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def decode_checksum(checksum: str) -> str:
+    """Return a hex digest for *checksum* encoded as hex or Base64.
+
+    The input may either be a hexadecimal string or a Base64 encoded digest.
+    The returned value is always a lowercase hexadecimal string.
+    ``ValueError`` is raised if *checksum* cannot be decoded.
+    """
+
+    text = checksum.strip()
+    if len(text) % 2 == 0 and all(ch in _HEX_DIGITS for ch in text):
+        return text.lower()
+    try:
+        raw = base64.b64decode(text, validate=True)
+    except Exception as exc:  # pragma: no cover - decoding failure
+        raise ValueError("Invalid checksum encoding") from exc
+    return raw.hex()
 
 
 def compute_checksum(

--- a/tests/test_plugin_checksum_decode.py
+++ b/tests/test_plugin_checksum_decode.py
@@ -1,0 +1,17 @@
+import base64
+import pytest
+
+from genecoder.plugin_security import compute_checksum, decode_checksum
+
+
+def test_decode_checksum_hex_and_base64() -> None:
+    data = b"ABC"
+    digest = compute_checksum(data)
+    assert decode_checksum(digest) == digest
+    b64 = base64.b64encode(bytes.fromhex(digest)).decode()
+    assert decode_checksum(b64) == digest
+
+
+def test_decode_checksum_invalid() -> None:
+    with pytest.raises(ValueError):
+        decode_checksum("not$$valid")

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -1,5 +1,6 @@
 import base64
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -117,3 +118,54 @@ def test_registry_entry_missing_signature_checksum(
 
     with pytest.raises(ValueError):
         plugins.install_registry_plugins("https://example.com/plugins.yaml")
+
+
+def test_load_plugins_with_base64_checksum(monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg = b"PKG"
+    hex_digest = plugins.compute_checksum(pkg)
+    checksum_b64 = base64.b64encode(bytes.fromhex(hex_digest)).decode()
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum_b64}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+
+    plugins.install_registry_plugins("https://example.com/plugins.yaml")
+
+
+def test_registry_base64_checksum_mismatch(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pkg = b"PKG"
+    wrong_checksum = base64.b64encode(b"WRONG").decode()
+
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}\n"
+            ).encode()
+            return DummyResponse(data)
+        elif url == "https://example.com/pkg.whl":
+            return DummyResponse(pkg)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        with caplog.at_level(logging.ERROR):
+            plugins.install_registry_plugins("https://example.com/plugins.yaml")
+    assert "Checksum mismatch for plugin https://example.com/pkg.whl" in caplog.text


### PR DESCRIPTION
## Summary
- support hex or Base64 `checksum` entries in plugin registries
- add checksum decoding helpers in `plugin_security`
- test successful and failing checksum verifications

## Testing
- `ruff check src/genecoder/plugin_manager.py src/genecoder/plugin_security.py tests/test_plugin_registry_loading.py tests/test_plugin_checksum_decode.py`
- `pytest tests/test_plugin_registry_loading.py tests/test_plugin_checksum_decode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd7444a4c8326b7136c8b2112ff7c