### PR TITLE
Ensure seeded pipeline reproducibility

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,6 +134,29 @@ Pass `--seed <int>` to `genecli encode`, `genecli decode`, `genecli channel`, or
 `genecli pipeline` to seed random components for reproducible runs.
 Alternatively set the `GENECODER_SIM_SEED` environment variable.
 
+### Reproducible pipelines
+
+Setting `GENECODER_SIM_SEED` ensures that every random component—from
+constraint fixers to Illumina and Nanopore simulators—uses the same seed.
+Running the same encode→channel→decode command twice with the variable set
+produces byte‑identical results.
+
+```bash
+export GENECODER_SIM_SEED=123
+genecli pipeline input.bin out1.bin --codec base4_direct --channel illumina --profile miseq
+genecli pipeline input.bin out2.bin --codec base4_direct --channel illumina --profile miseq
+cmp out1.bin out2.bin   # files match
+```
+
+The same seed works across other profiles, for example Nanopore's `minion`:
+
+```bash
+export GENECODER_SIM_SEED=123
+genecli pipeline input.bin out1.bin --codec base4_direct --channel nanopore --profile minion
+genecli pipeline input.bin out2.bin --codec base4_direct --channel nanopore --profile minion
+cmp out1.bin out2.bin   # files match
+```
+
 11. **Encode, corrupt and decode a file with automatic extensions**
 
 ```bash

--- a/tests/test_seeded_pipeline.py
+++ b/tests/test_seeded_pipeline.py
@@ -1,0 +1,65 @@
+import pytest
+
+from genecoder.constraint_fixer import fix_sequence
+from genecoder.random_utils import reset_rng
+from genecoder.encoders import encode_base4_direct, decode_base4_direct
+from genecoder.simulators.illumina import IlluminaChannel
+import genecoder.simulators.nanopore as nanopore
+
+
+def _nanopore_profile() -> nanopore.NanoporeChannel:
+    channel = nanopore.NanoporeChannel(profile="minion")
+    channel.error_rate = 0.0
+    channel.substitution_rate = 0.1
+    channel.insertion_rate = 0.0
+    channel.deletion_rate = 0.0
+    channel.insertion_profile = {}
+    channel.deletion_profile = {}
+    channel.context_errors = {}
+    channel.context_insertions = {}
+    channel.context_deletions = {}
+    return channel
+
+
+@pytest.mark.parametrize(
+    "channel_factory, patch",
+    [
+        (
+            lambda: IlluminaChannel(
+                profile="miseq",
+                substitution_rate=0.1,
+                insertion_rate=0.0,
+                deletion_rate=0.0,
+            ),
+            lambda monkeypatch: None,
+        ),
+        (
+            lambda: _nanopore_profile(),
+            lambda monkeypatch: (
+                monkeypatch.setattr(nanopore.shutil, "which", lambda _: None),
+                monkeypatch.setattr(
+                    nanopore,
+                    "_run_external",
+                    lambda *_: (_ for _ in ()).throw(AssertionError("_run_external called")),
+                ),
+            ),
+        ),
+    ],
+)
+def test_seeded_pipeline(monkeypatch: pytest.MonkeyPatch, channel_factory, patch) -> None:
+    data = b"\x00" * 8
+    patch(monkeypatch)
+
+    def run() -> bytes:
+        monkeypatch.setenv("GENECODER_SIM_SEED", "123")
+        reset_rng()
+        dna = encode_base4_direct(data)
+        dna = fix_sequence(dna, target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=3)
+        channel = channel_factory()
+        mutated = channel.simulate(dna)
+        decoded, _ = decode_base4_direct(mutated)
+        return decoded
+
+    out1 = run()
+    out2 = run()
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- Document how to use `GENECODER_SIM_SEED` for deterministic encode→channel→decode runs across Illumina and Nanopore profiles
- Add regression test verifying seeded pipelines yield identical outputs for Illumina and Nanopore channels

## Testing
- `ruff check tests/test_seeded_pipeline.py`
- `pytest tests/test_seeded_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d00e71de48326b558d8217b76e6f5