### PR TITLE
feat: add coverage and quality options to builtin Illumina sim

### DIFF
--- a/configs/illumina_profile.yaml
+++ b/configs/illumina_profile.yaml
@@ -3,3 +3,5 @@ simulators:
     read_length: 150
 pipeline:
   illumina_profile: hiseq
+  illumina_depth: 1
+  illumina_quality: null

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -218,6 +218,14 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
         --output-file channel.fasta --simulator illumina_builtin --sub-rate 0.01
     ```
 
+    Coverage depth and per-base quality probabilities may also be provided:
+
+    ```bash
+    genecli channel --input-file encoded.fasta \
+        --output-file channel.fasta --simulator illumina_builtin \
+        --sub-rate 0.01 --illumina-depth 5 --illumina-quality 0.01,0.02
+    ```
+
    Named sequencing profiles are available:
 
    - **Illumina** – `miseq`, `hiseq`, `novaseq` (alias `nova`)

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -543,8 +543,13 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params["deletion_prob"] = opts.del_rate
         if name == "simple" and opts.sub_rate is not None:
             new_params["error_rate"] = opts.sub_rate
-        if name == "illumina_builtin" and opts.sub_rate is not None:
-            new_params["error_rate"] = opts.sub_rate
+        if name == "illumina_builtin":
+            if opts.sub_rate is not None:
+                new_params["error_rate"] = opts.sub_rate
+            if opts.illumina_depth is not None:
+                new_params["coverage"] = opts.illumina_depth
+            if opts.illumina_quality is not None:
+                new_params["quality_profile"] = opts.illumina_quality
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -9,9 +9,9 @@ low indel rates of Illumina machines.
 from __future__ import annotations
 
 import random
-from typing import Callable
+from typing import Callable, Sequence
 
-from .error_simulation import simulate_errors
+from .error_simulation import NUCLEOTIDES, _random_substitution
 from .random_utils import make_rng
 from .api import Simulator
 from .simulators import register_simulator as _register_simulator
@@ -19,10 +19,59 @@ from .simulators import register_simulator as _register_simulator
 __all__ = ["simulate", "Channel", "register"]
 
 
+def _mutate_read(
+    sequence: str,
+    substitution_prob: float,
+    insertion_prob: float,
+    deletion_prob: float,
+    quality: Sequence[float] | None,
+    rng: random.Random,
+) -> str:
+    """Return ``sequence`` mutated using the provided probabilities."""
+
+    mutated: list[str] = []
+    for idx, nt in enumerate(sequence):
+        if rng.random() < deletion_prob:
+            continue
+
+        sub_prob = (
+            quality[idx] if quality is not None and idx < len(quality) else substitution_prob
+        )
+        if rng.random() < sub_prob:
+            nt = _random_substitution(nt, rng)
+
+        mutated.append(nt)
+
+        if rng.random() < insertion_prob:
+            mutated.append(rng.choice(NUCLEOTIDES))
+
+    return "".join(mutated)
+
+
+def _consensus(reads: Sequence[str]) -> str:
+    """Return the per-base majority sequence from ``reads``."""
+
+    if not reads:
+        return ""
+    length = max(len(r) for r in reads)
+    result: list[str] = []
+    for i in range(length):
+        counts: dict[str, int] = {}
+        for r in reads:
+            if i < len(r):
+                base = r[i]
+                counts[base] = counts.get(base, 0) + 1
+        if counts:
+            result.append(max(counts, key=counts.get))
+    return "".join(result)
+
+
 def simulate(
     sequence: str,
     error_rate: float = 0.001,
     rng: random.Random | None = None,
+    coverage: int = 1,
+    quality_profile: Sequence[float] | None = None,
 ) -> str:
     """Return ``sequence`` mutated with Illumina-style errors.
 
@@ -34,28 +83,59 @@ def simulate(
         Probability of substituting each nucleotide.  Insertion and
         deletion probabilities are ``error_rate / 100``.
     rng:
-        Optional :class:`random.Random` instance for deterministic
-        behaviour.
+        Optional :class:`random.Random` instance for deterministic behaviour.
+    coverage:
+        Number of independent reads to generate. A majority vote consensus
+        is returned when ``coverage`` is greater than one.
+    quality_profile:
+        Optional list of per-base substitution probabilities. When provided,
+        values override ``error_rate`` at the corresponding positions.
     """
+
     insertion_prob = error_rate / 100.0
     deletion_prob = error_rate / 100.0
-    return simulate_errors(
-        sequence,
-        substitution_prob=error_rate,
-        insertion_prob=insertion_prob,
-        deletion_prob=deletion_prob,
-        rng=rng,
-    )
+    if rng is None:
+        rng = make_rng()
+
+    reads = [
+        _mutate_read(
+            sequence,
+            error_rate,
+            insertion_prob,
+            deletion_prob,
+            quality_profile,
+            rng,
+        )
+        for _ in range(max(1, coverage))
+    ]
+    if coverage <= 1:
+        return reads[0]
+    return _consensus(reads)
 
 
 class Channel(Simulator):
     """Channel applying the built-in Illumina-style error model."""
 
-    def __init__(self, error_rate: float = 0.001) -> None:
+    def __init__(
+        self,
+        error_rate: float = 0.001,
+        coverage: int = 1,
+        quality_profile: Sequence[float] | None = None,
+    ) -> None:
         self.error_rate = error_rate
+        self.coverage = coverage
+        self.quality_profile = (
+            tuple(quality_profile) if quality_profile is not None else None
+        )
 
     def simulate(self, sequence: str) -> str:  # pragma: no cover - thin wrapper
-        return simulate(sequence, self.error_rate, make_rng())
+        return simulate(
+            sequence,
+            self.error_rate,
+            make_rng(),
+            coverage=self.coverage,
+            quality_profile=self.quality_profile,
+        )
 
 
 def register(

--- a/tests/test_illumina_coverage_quality.py
+++ b/tests/test_illumina_coverage_quality.py
@@ -1,0 +1,33 @@
+import random
+
+from genecoder import illumina_sim
+
+
+def _hamming(a: str, b: str) -> int:
+    length = min(len(a), len(b))
+    dist = sum(1 for i in range(length) if a[i] != b[i])
+    return dist + abs(len(a) - len(b))
+
+
+def test_coverage_reduces_errors() -> None:
+    seq = "A" * 50
+    rng1 = random.Random(0)
+    out1 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng1, coverage=1)
+    rng2 = random.Random(0)
+    out5 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng2, coverage=5)
+    assert _hamming(seq, out5) <= _hamming(seq, out1)
+
+
+def test_quality_profile_position_specific() -> None:
+    seq = "ACGTAC"
+    rng = random.Random(0)
+    out = illumina_sim.simulate(
+        seq,
+        error_rate=0.0,
+        rng=rng,
+        coverage=1,
+        quality_profile=[0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+    )
+    assert out[1] != seq[1]
+    assert out[:1] + out[2:] == seq[:1] + seq[2:]
+


### PR DESCRIPTION
## Summary
- extend builtin Illumina simulator with coverage depth and per-base quality profile
- document new CLI flags and default config entries
- test coverage and quality behaviour

## Testing
- `pytest tests/test_illumina_builtin_sim.py tests/test_illumina_coverage_quality.py`
- `SKIP=mypy,pytest pre-commit run --files configs/illumina_profile.yaml docs/usage.md src/genecoder/cli/channel.py src/genecoder/illumina_sim.py tests/test_illumina_coverage_quality.py`

------
https://chatgpt.com/codex/tasks/task_e_689d3bbaf184832694121cf1b1683522