### PR TITLE
feat: expand dashboard visuals

### DIFF
--- a/docs/images/error_rates.svg
+++ b/docs/images/error_rates.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+  <rect width="200" height="120" fill="white"/>
+  <g fill="steelblue">
+    <rect x="20" y="40" width="30" height="60"/>
+    <rect x="80" y="60" width="30" height="40"/>
+    <rect x="140" y="70" width="30" height="30"/>
+  </g>
+  <text x="35" y="110" font-size="10" text-anchor="middle">Sub</text>
+  <text x="95" y="110" font-size="10" text-anchor="middle">Ins</text>
+  <text x="155" y="110" font-size="10" text-anchor="middle">Del</text>
+</svg>

--- a/docs/images/homopolymer_distribution.svg
+++ b/docs/images/homopolymer_distribution.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+  <rect width="200" height="120" fill="white"/>
+  <g fill="darkorange">
+    <rect x="10" y="80" width="20" height="40"/>
+    <rect x="50" y="60" width="20" height="60"/>
+    <rect x="90" y="40" width="20" height="80"/>
+    <rect x="130" y="70" width="20" height="50"/>
+    <rect x="170" y="90" width="20" height="30"/>
+  </g>
+</svg>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -525,7 +525,11 @@ genecli dashboard examples/pipeline_metrics.json
 This encodes and decodes `examples/pipeline_demo_input.txt`, stores metrics in
 `examples/pipeline_metrics.json` and opens the dashboard with the results.
 
-The interface plots GC content distribution, homopolymer histograms, read-coverage distributions, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion counts are present, they are shown as a simple bar chart. The dashboard additionally charts the total number of constraint violations when provided.
+The interface plots GC content distribution, homopolymer run distributions, read-coverage distributions, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion metrics are present, they are shown as separate rate charts. The dashboard additionally charts the total number of constraint violations when provided.
+
+![Homopolymer distribution screenshot](images/homopolymer_distribution.svg)
+
+![Error rate charts screenshot](images/error_rates.svg)
 
 Example metrics snippet:
 

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -179,6 +179,48 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     else:
         st.write("No ECC success rate data.")
 
+    st.header("Homopolymer Run Distribution")
+    if alt and pd and hasattr(st, "altair_chart"):
+        hp_rows: list[dict[str, Any]] = []
+        for name in selected:
+            runs = datasets[name].get("homopolymer_runs")
+            if isinstance(runs, list) and runs:
+                for i, val in enumerate(runs, 1):
+                    hp_rows.append({"Run Length": i, "Count": val, "Dataset": name})
+        if hp_rows:
+            df = pd.DataFrame(hp_rows)
+            chart = (
+                alt.Chart(df)
+                .mark_bar(opacity=0.5)
+                .encode(x="Run Length:Q", y="Count:Q", color="Dataset:N")
+            )
+            st.altair_chart(chart, use_container_width=True)
+        else:
+            st.write("No homopolymer run data.")
+    else:
+        if len(selected) == 1 and datasets[selected[0]]["homopolymer_runs"]:
+            st.bar_chart(datasets[selected[0]]["homopolymer_runs"])
+        else:
+            st.write("Install pandas and altair for multi-file homopolymer charts.")
+
+    st.header("Error Rates")
+    for label, key in [
+        ("Substitution Rate", "substitutions"),
+        ("Insertion Rate", "insertions"),
+        ("Deletion Rate", "deletions"),
+    ]:
+        rates: dict[str, float] = {}
+        for name in selected:
+            val = datasets[name].get(key)
+            if isinstance(val, (int, float)):
+                rates[name] = float(val)
+        subheader = getattr(st, "subheader", getattr(st, "header", lambda *a, **k: None))
+        subheader(label)
+        if rates:
+            st.bar_chart(rates)
+        else:
+            st.write(f"No {label.lower()} data.")
+
     for name in selected:
         data = datasets[name]
         section = getattr(st, "subheader", getattr(st, "header", lambda *a, **k: None))
@@ -197,34 +239,12 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         if isinstance(max_hp, (int, float)):
             st.metric("Max Homopolymer Length", f"{int(max_hp)}")
 
-        subheader = getattr(st, "subheader", getattr(st, "header", lambda *a, **k: None))
-        subheader("Homopolymer Runs")
-        if data["homopolymer_runs"]:
-            st.bar_chart(data["homopolymer_runs"])
-        else:
-            st.write("No homopolymer data.")
-
         decode_rate = _calc_decode_success(data)
         if decode_rate is not None:
             st.metric("Decode Success", f"{decode_rate:.2%}")
         else:
             st.write("No decode success metric.")
 
-        subheader("Error Counts")
-        subs = data.get("substitutions")
-        ins = data.get("insertions")
-        dels = data.get("deletions")
-        counts: dict[str, int] = {}
-        if isinstance(subs, int):
-            counts["Substitutions"] = subs
-        if isinstance(ins, int):
-            counts["Insertions"] = ins
-        if isinstance(dels, int):
-            counts["Deletions"] = dels
-        if counts:
-            st.bar_chart(counts)
-        else:
-            st.write("No error count data.")
 
         subheader("Read Coverage")
         cov_dist = data.get("coverage_distribution")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,5 @@
-import json
 import importlib
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -78,21 +78,31 @@ def test_display_ecc_and_decode_metric(
 
     # ECC success rates should be plotted
     assert dummy_streamlit["bar_chart"], "bar_chart not called"
-    ecc_args, _ = dummy_streamlit["bar_chart"][0]
-    assert {"rs": 0.8, "bch": 0.9} == ecc_args[0]
-    assert len(dummy_streamlit["bar_chart"]) >= 2
-    err_args, _ = dummy_streamlit["bar_chart"][1]
-    assert {
-        "Substitutions": 5,
-        "Insertions": 1,
-        "Deletions": 2,
-    } == err_args[0]
+    charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
+    assert {"rs": 0.8, "bch": 0.9} in charts
+    assert {"metrics": 5.0} in charts
+    assert {"metrics": 1.0} in charts
+    assert {"metrics": 2.0} in charts
 
     # Decode success metric averages ECC rates
     assert dummy_streamlit["metric"], "metric not called"
     label, value = dummy_streamlit["metric"][0][0][:2]
     assert label == "Decode Success"
     assert value == "85.00%"
+
+
+def test_homopolymer_distribution_chart(
+    tmp_path: Path, dummy_streamlit: dict[str, list]
+) -> None:
+    data = {"homopolymer_runs": [1, 2, 1]}
+    path = tmp_path / "metrics.json"
+    path.write_text(json.dumps(data))
+
+    mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
+    mod.main(str(path))
+
+    charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
+    assert [1, 2, 1] in charts
 
 
 def test_display_coverage_and_constraint_metrics(

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -37,7 +37,7 @@ def test_dashboard_cli_starts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert called
 
 
-def test_dashboard_error_counts_rendered(
+def test_dashboard_error_rates_rendered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     metrics_file = Path(__file__).parent / "data" / "metrics.json"
@@ -56,4 +56,4 @@ def test_dashboard_error_counts_rendered(
     dash.main(str(results))
 
     assert charts
-    assert charts[-1] == {"Substitutions": 2, "Insertions": 0, "Deletions": 0}
+    assert charts[-3:] == [{"results": 2}, {"results": 0}, {"results": 0}]


### PR DESCRIPTION
## Summary
- add homopolymer run distribution and per-error rate charts to dashboard
- document new dashboard visuals with svg examples
- test dashboard metric extraction and rendering

## Testing
- `pre-commit run --files docs/usage.md docs/images/error_rates.svg docs/images/homopolymer_distribution.svg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d40795f88832682f5dab31a82da0d