### PR TITLE
feat: add coverage depth and quality distribution to illumina simulator

### DIFF
--- a/configs/illumina_profile.yaml
+++ b/configs/illumina_profile.yaml
@@ -4,4 +4,4 @@ simulators:
 pipeline:
   illumina_profile: hiseq
   illumina_depth: 1
-  illumina_quality: null
+  illumina_quality_distribution: null

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -10,8 +10,8 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 - **none** — disable simulation (the default).
 - **illumina** — simple Illumina read errors. Customize rates with
   `--illumina-sub-rate`, `--illumina-ins-rate` and `--illumina-del-rate`. Depth
-  and quality can be adjusted using `--illumina-depth`, `--illumina-quality` and
-  `--illumina-context`.
+  and the base-quality distribution can be adjusted using `--illumina-depth`,
+  `--illumina-quality` and `--illumina-context`.
 - **nanopore** — alias for `d2sim`. Customize rates with `--nanopore-sub-rate`,
   `--nanopore-ins-rate` and `--nanopore-del-rate`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -218,7 +218,7 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
         --output-file channel.fasta --simulator illumina_builtin --sub-rate 0.01
     ```
 
-    Coverage depth and per-base quality probabilities may also be provided:
+    Coverage depth and a base-quality distribution may also be provided:
 
     ```bash
     genecli channel --input-file encoded.fasta \

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -547,9 +547,9 @@ def run_channel(args: argparse.Namespace) -> None:
             if opts.sub_rate is not None:
                 new_params["error_rate"] = opts.sub_rate
             if opts.illumina_depth is not None:
-                new_params["coverage"] = opts.illumina_depth
+                new_params["coverage_depth"] = opts.illumina_depth
             if opts.illumina_quality is not None:
-                new_params["quality_profile"] = opts.illumina_quality
+                new_params["quality_distribution"] = opts.illumina_quality
         updated.append((name, new_params))
     simulators = updated
 

--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -24,7 +24,8 @@ def _mutate_read(
     substitution_prob: float,
     insertion_prob: float,
     deletion_prob: float,
-    quality: Sequence[float] | None,
+    quality_profile: Sequence[float] | None,
+    quality_distribution: Sequence[float] | None,
     rng: random.Random,
 ) -> str:
     """Return ``sequence`` mutated using the provided probabilities."""
@@ -34,9 +35,12 @@ def _mutate_read(
         if rng.random() < deletion_prob:
             continue
 
-        sub_prob = (
-            quality[idx] if quality is not None and idx < len(quality) else substitution_prob
-        )
+        if quality_profile is not None and idx < len(quality_profile):
+            sub_prob = quality_profile[idx]
+        elif quality_distribution is not None and len(quality_distribution) > 0:
+            sub_prob = rng.choice(quality_distribution)
+        else:
+            sub_prob = substitution_prob
         if rng.random() < sub_prob:
             nt = _random_substitution(nt, rng)
 
@@ -70,8 +74,9 @@ def simulate(
     sequence: str,
     error_rate: float = 0.001,
     rng: random.Random | None = None,
-    coverage: int = 1,
+    coverage_depth: int = 1,
     quality_profile: Sequence[float] | None = None,
+    quality_distribution: Sequence[float] | None = None,
 ) -> str:
     """Return ``sequence`` mutated with Illumina-style errors.
 
@@ -84,12 +89,14 @@ def simulate(
         deletion probabilities are ``error_rate / 100``.
     rng:
         Optional :class:`random.Random` instance for deterministic behaviour.
-    coverage:
+    coverage_depth:
         Number of independent reads to generate. A majority vote consensus
-        is returned when ``coverage`` is greater than one.
+        is returned when ``coverage_depth`` is greater than one.
     quality_profile:
-        Optional list of per-base substitution probabilities. When provided,
-        values override ``error_rate`` at the corresponding positions.
+        Optional list of position-specific substitution probabilities.
+    quality_distribution:
+        Optional list describing a distribution of substitution probabilities
+        to sample for each base when ``quality_profile`` is not provided.
     """
 
     insertion_prob = error_rate / 100.0
@@ -104,11 +111,12 @@ def simulate(
             insertion_prob,
             deletion_prob,
             quality_profile,
+            quality_distribution,
             rng,
         )
-        for _ in range(max(1, coverage))
+        for _ in range(max(1, coverage_depth))
     ]
-    if coverage <= 1:
+    if coverage_depth <= 1:
         return reads[0]
     return _consensus(reads)
 
@@ -119,13 +127,17 @@ class Channel(Simulator):
     def __init__(
         self,
         error_rate: float = 0.001,
-        coverage: int = 1,
+        coverage_depth: int = 1,
         quality_profile: Sequence[float] | None = None,
+        quality_distribution: Sequence[float] | None = None,
     ) -> None:
         self.error_rate = error_rate
-        self.coverage = coverage
+        self.coverage_depth = coverage_depth
         self.quality_profile = (
             tuple(quality_profile) if quality_profile is not None else None
+        )
+        self.quality_distribution = (
+            tuple(quality_distribution) if quality_distribution is not None else None
         )
 
     def simulate(self, sequence: str) -> str:  # pragma: no cover - thin wrapper
@@ -133,8 +145,9 @@ class Channel(Simulator):
             sequence,
             self.error_rate,
             make_rng(),
-            coverage=self.coverage,
+            coverage_depth=self.coverage_depth,
             quality_profile=self.quality_profile,
+            quality_distribution=self.quality_distribution,
         )
 
 

--- a/tests/test_illumina_coverage_quality.py
+++ b/tests/test_illumina_coverage_quality.py
@@ -12,22 +12,30 @@ def _hamming(a: str, b: str) -> int:
 def test_coverage_reduces_errors() -> None:
     seq = "A" * 50
     rng1 = random.Random(0)
-    out1 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng1, coverage=1)
+    out1 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng1, coverage_depth=1)
     rng2 = random.Random(0)
-    out5 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng2, coverage=5)
+    out5 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng2, coverage_depth=5)
     assert _hamming(seq, out5) <= _hamming(seq, out1)
 
 
-def test_quality_profile_position_specific() -> None:
+def test_quality_distribution_controls_errors() -> None:
     seq = "ACGTAC"
-    rng = random.Random(0)
-    out = illumina_sim.simulate(
+    rng1 = random.Random(0)
+    out_none = illumina_sim.simulate(
         seq,
         error_rate=0.0,
-        rng=rng,
-        coverage=1,
-        quality_profile=[0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        rng=rng1,
+        coverage_depth=1,
+        quality_distribution=[0.0],
     )
-    assert out[1] != seq[1]
-    assert out[:1] + out[2:] == seq[:1] + seq[2:]
+    rng2 = random.Random(0)
+    out_all = illumina_sim.simulate(
+        seq,
+        error_rate=0.0,
+        rng=rng2,
+        coverage_depth=1,
+        quality_distribution=[1.0],
+    )
+    assert out_none == seq
+    assert _hamming(seq, out_all) == len(seq)
 


### PR DESCRIPTION
## Summary
- extend illumina simulator to support coverage depth and base-quality distributions
- wire coverage/quality options through CLI and default configs
- test that higher coverage and quality distributions affect mutation rates

## Testing
- `ruff check src/genecoder/illumina_sim.py src/genecoder/cli/channel.py tests/test_illumina_coverage_quality.py`
- `pytest tests/test_illumina_coverage_quality.py tests/test_illumina_builtin_sim.py -q`
- `pytest tests/test_cli_channel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e04deeb48832697d158d910f5755c