### PR TITLE
Add context-aware DNArSim rates and tests

### DIFF
--- a/configs/dnarsim_rates.yaml
+++ b/configs/dnarsim_rates.yaml
@@ -7,6 +7,12 @@ r9:
     AC: 2.0
   insertion_profile:
     5: 0.9
+  context_insertions:
+    AA:
+      2: 0.9
+  context_deletions:
+    TT:
+      2: 0.9
 "r10.3":
   substitution_rate: 0.06
   insertion_rate: 0.02

--- a/src/genecoder/nanopore_sim.py
+++ b/src/genecoder/nanopore_sim.py
@@ -98,6 +98,8 @@ def _simulate_homopolymer_errors(
     substitution_prob: float = 0.0,
     insertion_prob: float = 0.0,
     deletion_prob: float = 0.0,
+    insertion_profile: Mapping[int, float] | None = None,
+    deletion_profile: Mapping[int, float] | None = None,
     rng: random.Random | None = None,
 ) -> str:
     """Simulate errors with indel rates weighted by homopolymer length."""
@@ -123,8 +125,16 @@ def _simulate_homopolymer_errors(
             j += 1
         run_len = j - i
         factor = run_len / 4.0 if run_len >= 4 else 1.0
-        ins_p = min(1.0, insertion_prob * factor)
-        del_p = min(1.0, deletion_prob * factor)
+        base_ins = insertion_prob * factor
+        base_del = deletion_prob * factor
+        if insertion_profile:
+            ins_p = min(1.0, insertion_profile.get(run_len, base_ins))
+        else:
+            ins_p = min(1.0, base_ins)
+        if deletion_profile:
+            del_p = min(1.0, deletion_profile.get(run_len, base_del))
+        else:
+            del_p = min(1.0, base_del)
         run_seq = sequence[i:j]
         try:
             mutated.append(
@@ -182,17 +192,13 @@ def _simulate_adapter(
     if rng is None:
         rng = make_rng()
     if rate_table:
-        has_profiles = any(
+        insertion_prof = rate_table.get("insertion_profile")
+        deletion_prof = rate_table.get("deletion_profile")
+        has_context_profiles = any(
             key in rate_table
-            for key in (
-                "context_errors",
-                "insertion_profile",
-                "deletion_profile",
-                "context_insertions",
-                "context_deletions",
-            )
+            for key in ("context_errors", "context_insertions", "context_deletions")
         )
-        if has_profiles:
+        if has_context_profiles:
             from .simulators.nanopore import NanoporeChannel, _mutate_read
 
             channel = NanoporeChannel(
@@ -200,8 +206,8 @@ def _simulate_adapter(
                 insertion_rate=float(rate_table.get("insertion_rate", 0.0)),
                 deletion_rate=float(rate_table.get("deletion_rate", 0.0)),
                 context_errors=rate_table.get("context_errors"),
-                insertion_profile=rate_table.get("insertion_profile"),
-                deletion_profile=rate_table.get("deletion_profile"),
+                insertion_profile=insertion_prof,
+                deletion_profile=deletion_prof,
                 context_insertions=rate_table.get("context_insertions"),
                 context_deletions=rate_table.get("context_deletions"),
             )
@@ -211,6 +217,8 @@ def _simulate_adapter(
             float(rate_table.get("substitution_rate", 0.0)),
             float(rate_table.get("insertion_rate", 0.0)),
             float(rate_table.get("deletion_rate", 0.0)),
+            insertion_prof,
+            deletion_prof,
             rng,
         )
     try:

--- a/tests/test_nanopore_sim.py
+++ b/tests/test_nanopore_sim.py
@@ -434,3 +434,57 @@ def test_dnarsim_homopolymer_insertion_profile(monkeypatch):
         if len(mutated) > len(seq):
             ins_prof += 1
     assert ins_prof > ins_base
+
+
+def test_dnarsim_context_insertion_profile(monkeypatch):
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda _: None)
+    seq = "AAT"
+    runs = 200
+    seed = 3
+    orig_ctx = nanopore_sim.DNARSIM_RATE_TABLES["r9"].get("context_insertions")
+    rng1 = random.Random(seed)
+    monkeypatch.setitem(
+        nanopore_sim.DNARSIM_RATE_TABLES["r9"], "context_insertions", {}
+    )
+    ins_base = 0
+    for _ in range(runs):
+        mutated = nanopore_sim.simulate_dnarsim(seq, rng=rng1, profile="r9")
+        if len(mutated) > len(seq):
+            ins_base += 1
+    monkeypatch.setitem(
+        nanopore_sim.DNARSIM_RATE_TABLES["r9"], "context_insertions", orig_ctx
+    )
+    rng2 = random.Random(seed)
+    ins_ctx = 0
+    for _ in range(runs):
+        mutated = nanopore_sim.simulate_dnarsim(seq, rng=rng2, profile="r9")
+        if len(mutated) > len(seq):
+            ins_ctx += 1
+    assert ins_ctx > ins_base
+
+
+def test_dnarsim_context_deletion_profile(monkeypatch):
+    monkeypatch.setattr(nanopore_sim.shutil, "which", lambda _: None)
+    seq = "TTA"
+    runs = 200
+    seed = 4
+    orig_ctx = nanopore_sim.DNARSIM_RATE_TABLES["r9"].get("context_deletions")
+    rng1 = random.Random(seed)
+    monkeypatch.setitem(
+        nanopore_sim.DNARSIM_RATE_TABLES["r9"], "context_deletions", {}
+    )
+    del_base = 0
+    for _ in range(runs):
+        mutated = nanopore_sim.simulate_dnarsim(seq, rng=rng1, profile="r9")
+        if len(mutated) < len(seq):
+            del_base += 1
+    monkeypatch.setitem(
+        nanopore_sim.DNARSIM_RATE_TABLES["r9"], "context_deletions", orig_ctx
+    )
+    rng2 = random.Random(seed)
+    del_ctx = 0
+    for _ in range(runs):
+        mutated = nanopore_sim.simulate_dnarsim(seq, rng=rng2, profile="r9")
+        if len(mutated) < len(seq):
+            del_ctx += 1
+    assert del_ctx > del_base


### PR DESCRIPTION
## Summary
- parse detailed context insertion/deletion rates from `dnarsim_rates.yaml`
- honour homopolymer insertion/deletion profiles in simulator fallback
- add tests covering DNArSim context indel profiles

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/nanopore_sim.py tests/test_nanopore_sim.py configs/dnarsim_rates.yaml`
- `pytest tests/test_nanopore_context_errors.py tests/test_nanopore_dnarsim_channel.py tests/test_nanopore_fallback.py tests/test_nanopore_homopolymer.py tests/test_nanopore_profile_validation.py tests/test_nanopore_sim.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e04de03fc8326bfa0887cff08b17a