### PR TITLE
feat: add auto fix flag and tests

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -302,22 +302,28 @@ def process_single_encode(
         )
 
         if getattr(args, "auto_fix", False) and os.getenv("GENECODER_DISABLE_FIX") not in {"1", "true", "True"}:
+            target_dna = raw_encoded_dna
             if getattr(args, "fix_chisel", False) and "dnachisel_fixer" in CODEC_REGISTRY:
                 from genecoder.dnachisel_fixer import fix_sequence_dnachisel
 
-                final_encoded_dna_sequence = fix_sequence_dnachisel(
-                    final_encoded_dna_sequence,
+                target_dna = fix_sequence_dnachisel(
+                    target_dna,
                     gc_min=args.gc_min,
                     gc_max=args.gc_max,
                     max_homopolymer=args.max_homopolymer,
                 )
             else:
-                final_encoded_dna_sequence = fix(
-                    final_encoded_dna_sequence,
+                target_dna = fix(
+                    target_dna,
                     gc_min=args.gc_min,
                     gc_max=args.gc_max,
                     max_homopolymer=args.max_homopolymer,
                 )
+
+            if args.fec == "triple_repeat":
+                final_encoded_dna_sequence = encode_triple_repeat(target_dna)
+            else:
+                final_encoded_dna_sequence = target_dna
 
         if checksum:
             fasta_header = f"{fasta_header} checksum={checksum}"

--- a/src/genecoder/constraint_fixer.py
+++ b/src/genecoder/constraint_fixer.py
@@ -1,4 +1,11 @@
-"""Utilities to modify DNA sequences to satisfy synthesis constraints."""
+"""Utilities to modify DNA sequences to satisfy synthesis constraints.
+
+This module exposes small helpers for adjusting GC balance and disrupting
+excessive homopolymers.  The high-level :func:`fix` convenience function ties
+these helpers together and is designed for use directly from the main encoding
+pipeline or CLI, allowing sequences to be automatically corrected before they
+are passed along for synthesis.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_gc_constraint_failures.py
+++ b/tests/test_gc_constraint_failures.py
@@ -7,6 +7,11 @@ from genecoder.gc_constrained_encoder import (
 )
 from genecoder.encoders import encode_base4_direct
 from genecoder.constraint_fixer import fix
+from genecoder.cli.encode import process_single_encode
+from genecoder.formats import from_fasta
+from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
+import argparse
+import os
 
 
 @pytest.mark.parametrize("which", ["gc", "homopolymer"])
@@ -48,3 +53,53 @@ def test_auto_fix_permits_decode(which) -> None:
             max_homopolymer=hp - 1,
         )
         decode_gc_balanced("0" + fixed_payload, expected_max_homopolymer=hp - 1)
+
+
+@pytest.mark.parametrize("which", ["gc", "homopolymer"])
+def test_cli_auto_fix_flag(tmp_path, which) -> None:
+    data = b"edge"
+    input_path = tmp_path / "in.bin"
+    output_path = tmp_path / "out.fasta"
+    input_path.write_bytes(data)
+
+    payload = encode_base4_direct(data)
+    gc = calculate_gc_content(payload)
+    hp = get_max_homopolymer_length(payload)
+
+    args = argparse.Namespace(
+        stream=False,
+        method="base4_direct",
+        fec=None,
+        chunk_size=0,
+        resume=False,
+        add_parity=False,
+        k_value=0,
+        parity_rule=PARITY_RULE_GC_EVEN_A_ODD_T,
+        alphabet="base4",
+        gc_min=gc + 0.1 if which == "gc" else 0.0,
+        gc_max=1.0,
+        max_homopolymer=hp if which == "gc" else hp - 1,
+        auto_fix=True,
+        fix_chisel=False,
+        encrypt=False,
+        key=None,
+        checksum=False,
+        mirror=False,
+        capsule=None,
+        file_type=None,
+        output_dir=None,
+        output_file=None,
+        auto_ext=False,
+        seed=None,
+    )
+
+    process_single_encode(str(input_path), str(output_path), args)
+    fasta = output_path.read_text(encoding="utf-8")
+    records = from_fasta(fasta)
+    dna_sequence = records[0][1]
+    os.remove(output_path)
+
+    if which == "gc":
+        decode_gc_balanced("0" + dna_sequence, expected_gc_min=gc + 0.1)
+    else:
+        decode_gc_balanced("0" + dna_sequence, expected_max_homopolymer=hp - 1)


### PR DESCRIPTION
## Summary
- expose constraint fixer for pipeline use
- add optional `--auto-fix` flag to CLI encode and apply fixes before DNA-level FEC
- test auto-fix behavior for GC and homopolymer constraint failures

## Testing
- `ruff check src/genecoder/constraint_fixer.py src/genecoder/cli/encode.py tests/test_gc_constraint_failures.py`
- `pytest tests/test_gc_constraint_failures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f32ffc3008326b1fc28dc1ad06b8b