### PR TITLE
feat: expand dashboard metrics

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -525,7 +525,15 @@ genecli dashboard examples/pipeline_metrics.json
 This encodes and decodes `examples/pipeline_demo_input.txt`, stores metrics in
 `examples/pipeline_metrics.json` and opens the dashboard with the results.
 
-The interface plots GC content distribution, homopolymer run distributions, read-coverage distributions, and ECC success-rate bar charts. It also displays the overall decode success percentage derived from the metrics file. When substitution, insertion and deletion metrics are present, they are shown as separate rate charts. The dashboard additionally charts the total number of constraint violations when provided.
+The interface visualizes key metrics:
+
+* GC-content distribution
+* Homopolymer run distribution
+* Read-coverage distribution
+* ECC success-rate bar charts
+* Separate substitution, insertion and deletion rate charts when available
+* Overall decode-success percentage
+* Constraint-violation counts
 
 ![Homopolymer distribution screenshot](images/homopolymer_distribution.svg)
 

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -210,20 +210,24 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
             st.write("Install pandas and altair for multi-file homopolymer charts.")
 
     st.header("Error Rates")
+    subheader = getattr(st, "subheader", getattr(st, "header", lambda *a, **k: None))
     for label, key in [
         ("Substitution Rate", "substitutions"),
         ("Insertion Rate", "insertions"),
         ("Deletion Rate", "deletions"),
     ]:
-        rates: dict[str, float] = {}
+        rate_rows: list[dict[str, Any]] = []
         for name in selected:
             val = datasets[name].get(key)
             if isinstance(val, (int, float)):
-                rates[name] = float(val)
-        subheader = getattr(st, "subheader", getattr(st, "header", lambda *a, **k: None))
+                rate_rows.append({"Dataset": name, "Rate": float(val)})
         subheader(label)
-        if rates:
-            st.bar_chart(rates)
+        if rate_rows:
+            if pd and len({r["Dataset"] for r in rate_rows}) > 1:
+                df = pd.DataFrame(rate_rows).set_index("Dataset")
+                st.bar_chart(df)
+            else:
+                st.bar_chart({r["Dataset"]: r["Rate"] for r in rate_rows})
         else:
             st.write(f"No {label.lower()} data.")
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -91,6 +91,14 @@ def test_display_ecc_and_decode_metric(
     assert value == "85.00%"
 
 
+def test_calc_decode_success_fallback() -> None:
+    from genecoder import dashboard
+
+    data = {"ecc_success_rates": {"rs": 0.8, "bch": "x", "hamming": 1.0}}
+    # average of numeric rates 0.8 and 1.0 -> 0.9
+    assert dashboard._calc_decode_success(data) == pytest.approx(0.9)
+
+
 def test_homopolymer_distribution_chart(
     tmp_path: Path, dummy_streamlit: dict[str, list]
 ) -> None:

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -57,3 +57,29 @@ def test_dashboard_error_rates_rendered(
 
     assert charts
     assert charts[-3:] == [{"results": 2}, {"results": 0}, {"results": 0}]
+
+
+def test_dashboard_homopolymer_chart_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    metrics_file = Path(__file__).parent / "data" / "metrics.json"
+    results = tmp_path / "results.json"
+    results.write_text(metrics_file.read_text())
+
+    charts: list[object] = []
+
+    def capture_bar_chart(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        charts.append(data)
+
+    monkeypatch.setattr(streamlit, "bar_chart", capture_bar_chart)
+
+    from genecoder import dashboard as dash
+
+    # Force fallback chart rendering in case pandas/altair are installed
+    monkeypatch.setattr(dash, "pd", None)
+    monkeypatch.setattr(dash, "alt", None)
+
+    dash.main(str(results))
+
+    assert charts
+    assert [1, 2, 1, 0] in charts


### PR DESCRIPTION
## Summary
- handle homopolymer run distributions and individual error rate charts in dashboard
- document dashboard visualizations and screenshots
- test metric extraction and rendering for new visuals

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/dashboard.py docs/usage.md tests/test_dashboard.py tests/test_dashboard_streamlit.py`
- `pytest tests/test_dashboard.py tests/test_dashboard_streamlit.py tests/test_dashboard_render.py`


------
https://chatgpt.com/codex/tasks/task_e_689f330084e48326a7b6bee613fa9e1c