### PR TITLE
docs: expand plugin guides and examples

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -22,3 +22,5 @@
    - Continued collaboration with the research community to expand features.
 6. **Documentation Updates**
    - Inline comments in `encoders.py` and `flet_app.py` now point to sections of the Development Vision PDF (Sections III and IV) for added context.
+
+Refer to the [manifest format](manifest.md) for the current encoding metadata structure and the [plugin guide](plugins.md) for extension points that inform future roadmap items.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -16,3 +16,7 @@ The manifest has three top-level keys:
 `encoding_parameters` must at least contain a `method` field identifying the
 encoder used. Additional keys mirror the options supplied on the CLI or GUI.
 If required keys are missing an error will be raised when creating the manifest.
+
+See the [development roadmap](development_roadmap.md) for planned enhancements
+to the manifest format and the [plugin guide](plugins.md) for ways plugins can
+extend encoding parameters reflected in the manifest.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -172,41 +172,76 @@ class MyFEC(FEC):
 def register(register_fec):
     register_fec("myfec", MyFEC)
 ```
+## Simulator Plugins
 
-Simulator plugins follow the same pattern using the `genecoder.simulators`
-group with a `register_simulator` callback that receives an object implementing
-the :class:`genecoder.api.Simulator` interface.
+Simulator plugins model sequencing or transmission channels and register under
+`genecoder.simulators`.
 
-Visualizer plugins register under `genecoder.visualizers` with a
-`register_visualizer` callback. The class should implement the
-``genecoder.api.Visualizer`` interface. See
-[`plugins-examples/example_visualizer`](../plugins-examples/example_visualizer/)
-for a minimal implementation.
+1. Add an entry point in `pyproject.toml`:
 
-```toml
-[project.entry-points."genecoder.visualizers"]
-myvis = "my_package.my_vis"
-```
+   ```toml
+   [project.entry-points."genecoder.simulators"]
+   mysim = "my_package.my_sim"
+   ```
 
-```python
-from genecoder.api import Visualizer
+2. Implement a class with a `simulate()` method returning the mutated sequence.
 
-class MyVisualizer(Visualizer):
-    def visualize(self, sequence: str, /, **kwargs):
-        ...
+   ```python
+   from genecoder.api import Simulator
 
-def register(register_visualizer):
-    register_visualizer("myvis", MyVisualizer())
-```
+   class MyChannel(Simulator):
+       def simulate(self, sequence: str) -> str:
+           return sequence
+
+   def register(register_simulator):
+       register_simulator("mysim", MyChannel())
+   ```
+
+See [`plugins-examples/example_simulator`](../plugins-examples/example_simulator/)
+for a passthrough implementation.
+
+## Visualizer Plugins
+
+Visualizer plugins expose custom sequence renderers via
+`genecoder.visualizers`.
+
+1. Declare an entry point:
+
+   ```toml
+   [project.entry-points."genecoder.visualizers"]
+   myvis = "my_package.my_vis"
+   ```
+
+2. Provide a class implementing `visualize()` and register it:
+
+   ```python
+   from genecoder.api import Visualizer
+
+   class MyVisualizer(Visualizer):
+       def visualize(self, sequence: str, /, **kwargs):
+           ...
+
+   def register(register_visualizer):
+       register_visualizer("myvis", MyVisualizer())
+   ```
+
+See [`plugins-examples/example_visualizer`](../plugins-examples/example_visualizer/)
+for a minimal example.
 
 Registered codecs are available via `genecoder.CODEC_REGISTRY` after importing
 GeneCoder.
 
-## Plugin Security
+## Security Recommendations
 
-Installing a plugin runs code from a third-party package. Always verify
-downloads and use registries from trusted sources. GeneCoder can validate a
-wheel's digital signature with
+- Install plugins only from trusted sources.
+- Verify wheel checksums or signatures with
+  :func:`genecoder.plugin_security.verify_signature`.
+- Host registry files over HTTPS and keep them version controlled.
+- Set ``GENECODER_PLUGIN_PUBLIC_KEY`` so the installer can validate
+  signatures automatically.
+
+Installing a plugin runs code from a third-party package. GeneCoder can validate
+wheel signatures with
 :func:`genecoder.plugin_security.verify_signature`, which internally calls
 :func:`genecoder.security.compute_checksum` and raises ``InvalidSignature`` if
 verification fails. Set the ``GENECODER_PLUGIN_PUBLIC_KEY`` environment variable
@@ -441,4 +476,13 @@ curl -X POST http://localhost:8000/catalog/challenge \
 ```
 
 A React page in `web/helix-ui` displays the standings. After building the web assets open `helix-ui/scoreboard.html` (or `dist/scoreboard.html`) in a browser while the server is running to view the leaderboard.
+
+## Troubleshooting
+
+- **Plugin not discovered** – ensure the package is installed and
+  `load_plugins()` has been called.
+- **Entry point missing** – check `[project.entry-points]` in `pyproject.toml`
+  for typos.
+- **Signature verification failed** – confirm `GENECODER_PLUGIN_PUBLIC_KEY`
+  and registry checksums.
 

--- a/plugins-examples/advanced_fec/README.md
+++ b/plugins-examples/advanced_fec/README.md
@@ -5,23 +5,28 @@ forward error correction plugin for GeneCoder. It reuses the
 built-in LDPC helpers from the `genecoder.ldpc_codec` module and
 exposes them under the entry point `advanced_ldpc`.
 
-## Installation
+## Step-by-step Usage
 
-Install the package from the repository root:
+1. Install the package from the repository root:
 
-```bash
-pip install ./plugins-examples/advanced_fec
-```
+   ```bash
+   pip install ./plugins-examples/advanced_fec
+   ```
 
-The LDPC implementation relies on optional dependencies. Install
-GeneCoder with the `ldpc` extra to enable them:
+2. Install GeneCoder with LDPC extras so the helper libraries are available:
 
-```bash
-pip install 'genecoder[ldpc]'
-```
+   ```bash
+   pip install 'genecoder[ldpc]'
+   ```
 
-## Usage
+3. Import GeneCoder to load the plugin and confirm registration:
 
-After installation simply import GeneCoder (or invoke the CLI) to
-load the plugin automatically. The new FEC backend will appear in
-`genecoder.plugins.FEC_REGISTRY` under the name `advanced_ldpc`.
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import FEC_REGISTRY
+   print("advanced_ldpc" in FEC_REGISTRY)
+   ```
+
+The package registers an `advanced_ldpc` backend within
+`genecoder.plugins.FEC_REGISTRY`.

--- a/plugins-examples/example_codec/README.md
+++ b/plugins-examples/example_codec/README.md
@@ -1,0 +1,26 @@
+# Example Codec Plugin
+
+This package registers a minimal codec named `example`.
+
+## Step-by-step Usage
+
+1. Install the package:
+
+   ```bash
+   pip install ./plugins-examples/example_codec
+   ```
+
+2. Load plugins and verify the codec is available:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import CODEC_REGISTRY
+   print("example" in CODEC_REGISTRY)
+   ```
+
+3. Encode a file via the CLI using the plugin:
+
+   ```bash
+   genecli encode --method example --input-files data.txt --output-file out.fasta
+   ```

--- a/plugins-examples/example_fec/README.md
+++ b/plugins-examples/example_fec/README.md
@@ -1,0 +1,26 @@
+# Example FEC Plugin
+
+A minimal forward error correction plugin named `example`.
+
+## Step-by-step Usage
+
+1. Install the package:
+
+   ```bash
+   pip install ./plugins-examples/example_fec
+   ```
+
+2. Load plugins and verify registration:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import FEC_REGISTRY
+   print("example" in FEC_REGISTRY)
+   ```
+
+3. Use the FEC module during encoding:
+
+   ```bash
+   genecli encode --method base4_direct --fec example --input-files data.txt --output-file out.fasta
+   ```

--- a/plugins-examples/example_package_plugin/README.md
+++ b/plugins-examples/example_package_plugin/README.md
@@ -2,3 +2,26 @@
 
 This sample package registers a simple codec using the generic
 `genecoder.plugins` entry point group.
+
+## Step-by-step Usage
+
+1. Install the package from the repository root:
+
+   ```bash
+   pip install ./plugins-examples/example_package_plugin
+   ```
+
+2. Load plugins and confirm registration:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import CODEC_REGISTRY
+   print("package_example" in CODEC_REGISTRY)
+   ```
+
+3. Encode data with the new codec via the CLI:
+
+   ```bash
+   genecli encode --method package_example --input-files data.txt --output-file out.fasta
+   ```

--- a/plugins-examples/example_simulator/README.md
+++ b/plugins-examples/example_simulator/README.md
@@ -1,0 +1,26 @@
+# Example Simulator Plugin
+
+A passthrough simulator named `example`.
+
+## Step-by-step Usage
+
+1. Install the package:
+
+   ```bash
+   pip install ./plugins-examples/example_simulator
+   ```
+
+2. Load plugins and verify the simulator registered:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder.simulators import SIMULATOR_REGISTRY
+   print("example" in SIMULATOR_REGISTRY)
+   ```
+
+3. Run the simulator through the pipeline CLI:
+
+   ```bash
+   genecli pipeline input.bin output.bin --codec base4_direct --channel example
+   ```

--- a/plugins-examples/example_visualizer/README.md
+++ b/plugins-examples/example_visualizer/README.md
@@ -1,0 +1,26 @@
+# Example Visualizer Plugin
+
+A trivial visualizer named `example`.
+
+## Step-by-step Usage
+
+1. Install the package:
+
+   ```bash
+   pip install ./plugins-examples/example_visualizer
+   ```
+
+2. Load plugins and ensure the visualizer is registered:
+
+   ```python
+   from genecoder.plugins import load_plugins
+   load_plugins()
+   from genecoder import VISUALIZER_REGISTRY
+   print("example" in VISUALIZER_REGISTRY)
+   ```
+
+3. Invoke the visualizer from Python:
+
+   ```python
+   VISUALIZER_REGISTRY["example"]("ACGT")
+   ```


### PR DESCRIPTION
## Summary
- document simulator and visualizer plugin patterns
- add security recommendations and troubleshooting tips
- provide step-by-step examples for plugin packages and cross-link docs

## Testing
- ⚠️ no tests were run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_689f37082dac832699c1f7f3f1b85ba0