### PR TITLE
Rename error_rate property to substitution_prob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 - Refactored ``BaseSimulator`` for shared simulator settings.
 - Added ``BaseChannel`` with common error parameters for simulators.
 - Plugin registry now verifies package checksums before installation.
+- Renamed ``Channel.error_rate`` to ``Channel.substitution_prob``; ``error_rate`` remains
+  as a deprecated alias.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,8 @@
+# Migration Guide
+
+## Channel attribute rename
+
+The `Channel.error_rate` attribute has been renamed to `Channel.substitution_prob`.
+Accessing or setting `error_rate` still works but raises a `DeprecationWarning` and
+will be removed in a future release. Update any code that relies on `error_rate`
+to use `substitution_prob` instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Vision & Core Concept: vision.md
       - Implemented Features: features.md
       - Technology Stack: technology_stack.md
+  - Migration Guide: migration.md
   - Development:
       - Development Roadmap: development_roadmap.md
       - Development Vision: DEVELOPMENT_VISION.md

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -542,7 +542,7 @@ def run_channel(args: argparse.Namespace) -> None:
             if opts.del_rate is not None:
                 new_params["deletion_prob"] = opts.del_rate
         if name == "simple" and opts.sub_rate is not None:
-            new_params["error_rate"] = opts.sub_rate
+            new_params["substitution_prob"] = opts.sub_rate
         if name == "illumina_builtin":
             if opts.sub_rate is not None:
                 new_params["error_rate"] = opts.sub_rate

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -193,7 +193,7 @@ def _handle_command(args: argparse.Namespace) -> None:
             elif channel != "simple":
                 channel_params["substitution_rate"] = args.sub_rate
             else:
-                channel_params["error_rate"] = args.sub_rate
+                channel_params["substitution_prob"] = args.sub_rate
         if args.ins_rate is not None:
             if channel == "indel":
                 channel_params["insertion_prob"] = args.ins_rate

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import random
+import warnings
 from typing import Callable
 
 from .random_utils import make_rng
@@ -149,18 +150,36 @@ class Channel(Simulator):
                 deletion_prob = params["deletion_prob"]
         if error_rate is not None:
             substitution_prob = error_rate
-        self.substitution_prob = substitution_prob
+        self._substitution_prob = substitution_prob
         self.insertion_prob = insertion_prob
         self.deletion_prob = deletion_prob
+
+    @property
+    def substitution_prob(self) -> float:
+        return self._substitution_prob
+
+    @substitution_prob.setter
+    def substitution_prob(self, value: float) -> None:
+        self._substitution_prob = value
 
     # compatibility with older API expecting ``error_rate``
     @property
     def error_rate(self) -> float:
-        return self.substitution_prob
+        warnings.warn(
+            "Channel.error_rate is deprecated, use substitution_prob instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._substitution_prob
 
     @error_rate.setter
     def error_rate(self, value: float) -> None:
-        self.substitution_prob = value
+        warnings.warn(
+            "Channel.error_rate is deprecated, use substitution_prob instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._substitution_prob = value
 
     def simulate(self, sequence: str) -> str:
         return simulate_errors(

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -74,6 +74,13 @@ def simulate_reads(
                 f"Simulator '{simulator}' does not support profiles"
             )
 
+    if hasattr(channel, "substitution_prob"):
+        old_rate = getattr(channel, "substitution_prob")
+        setattr(channel, "substitution_prob", error_rate)
+        try:
+            return channel.simulate(sequence)
+        finally:
+            setattr(channel, "substitution_prob", old_rate)
     if hasattr(channel, "error_rate"):
         old_rate = getattr(channel, "error_rate")
         setattr(channel, "error_rate", error_rate)


### PR DESCRIPTION
## Summary
- Introduce `substitution_prob` property on the error simulation `Channel` and deprecate the old `error_rate` alias
- Update CLI and simulator helper to use `substitution_prob` for the simple channel
- Add migration guide and changelog entry for the property rename

## Testing
- `ruff check src/genecoder/error_simulation.py src/genecoder/simulators/__init__.py src/genecoder/cli/channel.py src/genecoder/cli/pipeline.py`
- `pytest tests/test_error_simulation.py tests/test_cli_channel.py::test_channel_cli_yaml tests/test_cli_channel.py::test_cli_indel_rates tests/test_cli_pipeline.py::test_cli_pipeline_indel_rates -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4dd5d4cc8326978fdb5358a0ef0c