### PR TITLE
Add plugin signature verification tests and unify error handling

### DIFF
--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import base64
 
+from cryptography.exceptions import InvalidSignature
+
 from .security import compute_checksum as _compute_checksum
 
 
@@ -47,10 +49,19 @@ def compute_checksum(
 def verify_signature(
     data: bytes, signature: bytes, public_key: bytes, *, padding_scheme: str = "pkcs1"
 ) -> None:
-    """Raise if *signature* does not verify *data* with *public_key*."""
-    _compute_checksum(
-        data,
-        signature=signature,
-        public_key=public_key,
-        padding_scheme=padding_scheme,
-    )
+    """Raise ``ValueError`` if *signature* fails to verify.
+
+    Parameters are forwarded to :func:`genecoder.security.compute_checksum`.
+    ``InvalidSignature`` from the underlying cryptography library is converted
+    into ``ValueError`` so callers can handle failures uniformly.
+    """
+
+    try:
+        _compute_checksum(
+            data,
+            signature=signature,
+            public_key=public_key,
+            padding_scheme=padding_scheme,
+        )
+    except InvalidSignature as exc:  # pragma: no cover - exercised in tests
+        raise ValueError("Invalid signature") from exc

--- a/tests/test_plugin_signature.py
+++ b/tests/test_plugin_signature.py
@@ -1,0 +1,59 @@
+import pytest
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from genecoder.plugin_security import verify_signature
+
+
+def _generate_keypair():
+    """Return a freshly generated RSA key pair."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_bytes = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return key, public_bytes
+
+
+def test_verify_signature_pkcs1_valid():
+    key, public_bytes = _generate_keypair()
+    data = b"signed data"
+    signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+
+    verify_signature(data, signature, public_bytes)
+
+
+def test_verify_signature_pkcs1_invalid_signature():
+    key, public_bytes = _generate_keypair()
+    data = b"signed data"
+    signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+    bad_signature = b"\x00" + signature[1:]
+
+    with pytest.raises(ValueError, match="Invalid signature"):
+        verify_signature(data, bad_signature, public_bytes)
+
+
+def test_verify_signature_pss_valid():
+    key, public_bytes = _generate_keypair()
+    data = b"signed data"
+    signature = key.sign(
+        data,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()),
+            salt_length=padding.PSS.MAX_LENGTH,
+        ),
+        hashes.SHA256(),
+    )
+
+    verify_signature(data, signature, public_bytes, padding_scheme="pss")
+
+
+def test_verify_signature_pss_mismatch():
+    key, public_bytes = _generate_keypair()
+    data = b"signed data"
+    signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+
+    with pytest.raises(ValueError, match="Invalid signature"):
+        verify_signature(data, signature, public_bytes, padding_scheme="pss")
+


### PR DESCRIPTION
## Summary
- convert `verify_signature` to raise `ValueError` on invalid signatures
- add tests exercising RSA PKCS#1 and PSS verification paths

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/plugin_security.py tests/test_plugin_signature.py`
- `pytest tests/test_plugin_signature.py`


------
https://chatgpt.com/codex/tasks/task_e_689f550eac2483269dcde6f6504fe0d9