### PR TITLE
Add DNArSim context indel support and CLI profile flag

### DIFF
--- a/configs/dnarsim_rates.yaml
+++ b/configs/dnarsim_rates.yaml
@@ -10,14 +10,42 @@ r9:
   context_insertions:
     AA:
       2: 0.9
+    AAAA:
+      4: 0.5
+    TTTT:
+      4: 0.5
   context_deletions:
     TT:
       2: 0.9
+    AAAA:
+      4: 0.6
+    TTTT:
+      4: 0.6
 "r10.3":
   substitution_rate: 0.06
   insertion_rate: 0.02
   deletion_rate: 0.035
+  context_insertions:
+    AAAA:
+      4: 0.4
+    TTTT:
+      4: 0.4
+  context_deletions:
+    AAAA:
+      4: 0.5
+    TTTT:
+      4: 0.5
 "r10.4":
   substitution_rate: 0.045
   insertion_rate: 0.015
   deletion_rate: 0.025
+  context_insertions:
+    AAAA:
+      4: 0.35
+    TTTT:
+      4: 0.35
+  context_deletions:
+    AAAA:
+      4: 0.45
+    TTTT:
+      4: 0.45

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -21,7 +21,7 @@ from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
 from genecoder.parallel import parallel_map
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
-from genecoder.simulators.nanopore import NANOPORE_PROFILES
+from genecoder.simulators.nanopore import NANOPORE_PROFILES, DNARSIM_RATE_TABLES
 from genecoder.error_simulation import INDEL_PROFILES
 from genecoder.simulators.decay import DegradationChannel
 from .options import ChannelOptions, build_channel_options
@@ -297,6 +297,7 @@ def register_subcommand(
     run_parser.add_argument("config", type=str, help="Path to channel config")
     illumina_profiles = ", ".join(sorted(ILLUMINA_PROFILES))
     nanopore_profiles = ", ".join(sorted(NANOPORE_PROFILES))
+    dnarsim_profiles = ", ".join(sorted(DNARSIM_RATE_TABLES))
     profile_names = ", ".join(sorted(PROFILE_MAP))
     run_parser.add_argument(
         "--profile",
@@ -324,6 +325,12 @@ def register_subcommand(
         type=str,
         default=None,
         help="YAML file with Nanopore simulator parameters",
+    )
+    run_parser.add_argument(
+        "--dnarsim-profile",
+        type=str,
+        default=None,
+        help=f"Named DNArSim profile to use. Available profiles: {dnarsim_profiles}",
     )
     run_parser.add_argument(
         "--decay-rate",
@@ -418,6 +425,7 @@ def register_subcommand(
         target.add_argument("--nanopore-del-rate", type=float, default=None, help="Deletion rate for Nanopore reads")
         target.add_argument("--nanopore-profile", type=str, default=None, help="Named Nanopore profile to use")
         target.add_argument("--nanopore-profile-file", type=str, default=None, help="YAML file with Nanopore simulator parameters")
+        target.add_argument("--dnarsim-profile", type=str, default=None, help="Named DNArSim profile to use")
         target.add_argument("--indel-profile", type=str, default=None, help="Named indel profile to use")
         target.add_argument(
             "--decay-rate",
@@ -529,6 +537,8 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params["insertion_rate"] = opts.nanopore_ins_rate
             if opts.nanopore_del_rate is not None:
                 new_params["deletion_rate"] = opts.nanopore_del_rate
+            if name == "nanopore_dnarsim" and opts.dnarsim_profile:
+                new_params.setdefault("profile", opts.dnarsim_profile)
         if name == "indel":
             if opts.indel_profile is not None:
                 if opts.indel_profile not in INDEL_PROFILES:
@@ -586,6 +596,10 @@ def _handle_run(args: argparse.Namespace) -> None:
         cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
+    if args.dnarsim_profile is not None:
+        for name, params in simulators:
+            if name == "nanopore_dnarsim":
+                params.setdefault("profile", args.dnarsim_profile)
     if args.indel_profile is not None:
         if args.indel_profile not in INDEL_PROFILES:
             logger.error("Unknown indel profile: %s", args.indel_profile)

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -41,6 +41,7 @@ class ChannelOptions:
     profile: str | None = None
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    dnarsim_profile: str | None = None
     indel_profile: str | None = None
     nanopore_profile_file: str | None = None
     sub_rate: float | None = None
@@ -216,6 +217,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         profile=getattr(args, "profile", None),
         illumina_profile=args.illumina_profile,
         nanopore_profile=args.nanopore_profile,
+        dnarsim_profile=getattr(args, "dnarsim_profile", None),
         indel_profile=getattr(args, "indel_profile", None),
         nanopore_profile_file=args.nanopore_profile_file,
         sub_rate=args.sub_rate,

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from typing import Dict
+import os
 
 from ..api import Simulator
 from .pipeline import ChannelPipeline
+from ..random_utils import reset_rng
 
 SIMULATOR_REGISTRY: Dict[str, Simulator] = {}
 
@@ -70,9 +72,12 @@ def simulate_reads(
                 raise ValueError(f"Unknown Nanopore profile: {profile}")
             channel = channel.with_profile(prof)
         else:
-            raise ValueError(
-                f"Simulator '{simulator}' does not support profiles"
-            )
+                raise ValueError(
+                    f"Simulator '{simulator}' does not support profiles"
+                )
+
+    if os.getenv("GENECODER_SIM_SEED") is not None:
+        reset_rng()
 
     if hasattr(channel, "substitution_prob"):
         old_rate = getattr(channel, "substitution_prob")

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -166,6 +166,26 @@ try:  # pragma: no cover - optional dependency
             parsed["context_deletions"] = _validate_context_profiles(
                 tbl.get("context_deletions"), "context_deletions"
             )
+        if "context_indels" in tbl and isinstance(tbl["context_indels"], Mapping):
+            ctx_ins: Dict[str, Dict[int, float]] = {}
+            ctx_del: Dict[str, Dict[int, float]] = {}
+            for ctx, ctx_map in tbl["context_indels"].items():
+                if not isinstance(ctx_map, Mapping):
+                    continue
+                ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
+                del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
+                if ins_prof is not None:
+                    ctx_ins[str(ctx).upper()] = _validate_indel_profile(
+                        ins_prof, f"context_indels[{ctx}].insertions"
+                    )
+                if del_prof is not None:
+                    ctx_del[str(ctx).upper()] = _validate_indel_profile(
+                        del_prof, f"context_indels[{ctx}].deletions"
+                    )
+            if ctx_ins:
+                parsed.setdefault("context_insertions", {}).update(ctx_ins)
+            if ctx_del:
+                parsed.setdefault("context_deletions", {}).update(ctx_del)
         return parsed
 
     if isinstance(_rates_data, dict):


### PR DESCRIPTION
## Summary
- parse context-dependent indel probabilities in Nanopore profiles
- include common homopolymer contexts in dnarsim rate tables
- expose `--dnarsim-profile` CLI option and plumb through options
- reset simulator RNG when seeded to ensure reproducible runs

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0af18891c832683afd5617b4aa95d