### PR TITLE
feat: expose reed solomon parameters

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,8 @@ poetry install --no-interaction
 * `--output-file` – output path for a single input file.
 * `--output-dir` – directory for batch operations.
 * `--fec` – optional [FEC](glossary.md#forward-error-correction-fec) method (`triple_repeat`, `hamming_7_4`, `reed_solomon`, `ldpc`, `fountain`).
+* `--rs-symbol-size` – symbol size for Reed-Solomon FEC (used with `--fec reed_solomon`).
+* `--rs-primitive` – primitive polynomial for Reed-Solomon FEC (used with `--fec reed_solomon`).
 * `--auto-ext` – save encoded files with a `.dna` suffix and decode back to the original extension.
 * `--seed` – seed random number generators for reproducible simulations.
 
@@ -88,14 +90,22 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --output-dir encoded_hamming/ --method base4_direct --fec hamming_7_4
    ```
 
-6. **Decode a Hamming(7,4) encoded file**
+6. **Encode with Reed–Solomon FEC**
+
+   ```bash
+   genecli encode --input-files path/to/data.bin \
+       --output-dir encoded_rs/ --method base4_direct --fec reed_solomon \
+       --rs-symbol-size 8 --rs-primitive 0x11d
+   ```
+
+7. **Decode a Hamming(7,4) encoded file**
 
    ```bash
    genecli decode --input-files encoded_hamming/important_data.txt.fasta \
        --output-file decoded_important_data.txt --method base4_direct
    ```
 
-7. **Batch encode multiple files using GC-Balanced**
+8. **Batch encode multiple files using GC-Balanced**
 
    ```bash
    genecli encode --input-files file1.txt notes.md image.png \
@@ -103,14 +113,14 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
        --gc-min 0.40 --gc-max 0.60 --max-homopolymer 4
    ```
 
-8. **Batch decode multiple FASTA files**
+9. **Batch decode multiple FASTA files**
 
    ```bash
    genecli decode --input-files gc_encoded_batch/*.fasta \
        --output-dir decoded_batch/ --method gc_balanced
    ```
 
-9. **Stream encode and decode a large file**
+10. **Stream encode and decode a large file**
 
    ```bash
    genecli encode --input-files big.bin --output-file big.fasta \
@@ -122,7 +132,7 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    Streaming operations are **resumable**. Pass `--resume state.json` to
    continue an interrupted encode or decode run.
 
-10. **Introduce channel errors before decoding**
+11. **Introduce channel errors before decoding**
 
 ```bash
 genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
@@ -157,7 +167,7 @@ genecli pipeline input.bin out2.bin --codec base4_direct --channel nanopore --pr
 cmp out1.bin out2.bin   # files match
 ```
 
-11. **Encode, corrupt and decode a file with automatic extensions**
+12. **Encode, corrupt and decode a file with automatic extensions**
 
 ```bash
 genecli encode --input-files hello.jpg --output-dir encoded \
@@ -174,7 +184,7 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    ```
 
    Add `--checksum` to the encode and decode commands for automatic validation.
-12. **Decode using an external simulator**
+13. **Decode using an external simulator**
 
    The ``--simulator`` option accepts ``d2sim``, ``dnarsim`` or ``squigulator``.
    Install the desired simulator separately and ensure the command is on your
@@ -201,7 +211,7 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
        --output-file decoded.bin --simulator squigulator
    ```
 
-13. **Combine simulators into a channel**
+14. **Combine simulators into a channel**
 
    Apply multiple simulators and enforce synthesis constraints:
 
@@ -313,7 +323,7 @@ genecli channel run config.yml
 genecli channel run config.yml
 ```
 
-14. **Add DNA decay to the channel pipeline**
+15. **Add DNA decay to the channel pipeline**
 
    Simulate long‑term storage by including a ``decay`` stage. ``half_life``
    controls how quickly bases are lost and ``variation`` adds random jitter to
@@ -332,7 +342,7 @@ genecli channel run config.yml
 genecli channel run decay_config.yml
 ```
 
-15. **AI-assisted decoding**
+16. **AI-assisted decoding**
 
    Install the optional `dnaformer` extras to enable a machine learning model
    that can recover sequences with high error rates:
@@ -351,7 +361,7 @@ genecli channel run decay_config.yml
        --method ai
    ```
 
-16. **Run the full pipeline from a YAML file**
+17. **Run the full pipeline from a YAML file**
 
    Create a configuration with the codec, FEC and channel settings:
 

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -87,7 +87,13 @@ def run_encoding_pipeline(
                 f"Warning for {input_file_name}: --add-parity is ignored when {options.fec} FEC is applied to binary data."
             )
         enc = FEC_REGISTRY[options.fec]
-        current_input, info = enc["encode"](data)
+        encode_kwargs = {}
+        if options.fec == "reed_solomon":
+            encode_kwargs = {
+                "symbol_size": options.rs_symbol_size,
+                "primitive": options.rs_primitive,
+            }
+        current_input, info = enc["encode"](data, **encode_kwargs)
         header_parts.append(f"fec={options.fec}")
         if info is not None:
             import base64
@@ -496,6 +502,24 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         default=None,
         choices=fec_choices,
         help="Forward Error Correction method to apply.",
+    )
+    parser.add_argument(
+        "--rs-symbol-size",
+        type=int,
+        default=None,
+        help=(
+            "Symbol size (c_exp) for Reed-Solomon FEC. Ignored unless --fec"
+            " reed_solomon."
+        ),
+    )
+    parser.add_argument(
+        "--rs-primitive",
+        type=lambda x: int(x, 0),
+        default=None,
+        help=(
+            "Primitive polynomial for Reed-Solomon FEC. Provide as integer or"
+            " 0x-prefixed hex. Ignored unless --fec reed_solomon."
+        ),
     )
     parser.add_argument(
         "--gc-min",

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -130,6 +130,8 @@ def build_encoding_options(args: argparse.Namespace) -> EncodingOptions:
         max_homopolymer=args.max_homopolymer,
         alphabet=getattr(args, "alphabet", "base4"),
         seed=getattr(args, "seed", None),
+        rs_symbol_size=getattr(args, "rs_symbol_size", None),
+        rs_primitive=getattr(args, "rs_primitive", None),
     )
 
 

--- a/src/genecoder/options.py
+++ b/src/genecoder/options.py
@@ -34,6 +34,8 @@ class EncodingOptions:
     max_homopolymer: int
     alphabet: str = "base4"
     seed: int | None = None
+    rs_symbol_size: int | None = None
+    rs_primitive: int | None = None
 
 
 @dataclass

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -41,7 +41,13 @@ def _require_reedsolo() -> None:  # pragma: no cover - helper
         )
 
 
-def encode_data_rs(data: bytes, nsym: int = 10) -> Tuple[bytes, int]:
+def encode_data_rs(
+    data: bytes,
+    nsym: int = 10,
+    *,
+    symbol_size: int | None = None,
+    primitive: int | None = None,
+) -> Tuple[bytes, int, int | None, int | None]:
     """Encode ``data`` with Reed--Solomon FEC.
 
     Parameters
@@ -50,20 +56,30 @@ def encode_data_rs(data: bytes, nsym: int = 10) -> Tuple[bytes, int]:
         Byte string to encode.
     nsym:
         Number of parity symbols to append. Defaults to ``10``.
+    symbol_size:
+        Optional symbol size (``c_exp``) in bits.
+    primitive:
+        Optional primitive polynomial value.
 
     Returns
     -------
     tuple
-        ``(encoded_bytes, nsym)`` where ``encoded_bytes`` is the encoded output
-        including parity symbols.
+        ``(encoded_bytes, nsym, symbol_size, primitive)`` where ``encoded_bytes``
+        is the encoded output including parity symbols.
     """
     _require_reedsolo()
-    rs = RSCodec(nsym)
+    rs = RSCodec(nsym, c_exp=symbol_size, prim=primitive)
     encoded = rs.encode(data)
-    return bytes(encoded), nsym
+    return bytes(encoded), nsym, symbol_size, primitive
 
 
-def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
+def decode_data_rs(
+    encoded: bytes,
+    nsym: int,
+    *,
+    symbol_size: int | None = None,
+    primitive: int | None = None,
+) -> Tuple[bytes, int]:
     """Decode Reed--Solomon encoded ``encoded`` bytes.
 
     Parameters
@@ -72,6 +88,10 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
         Encoded data including parity symbols.
     nsym:
         Number of parity symbols that were used during encoding.
+    symbol_size:
+        Optional symbol size (``c_exp``) in bits.
+    primitive:
+        Optional primitive polynomial value used during encoding.
 
     Returns
     -------
@@ -85,7 +105,7 @@ def decode_data_rs(encoded: bytes, nsym: int) -> Tuple[bytes, int]:
         If decoding fails due to too many errors.
     """
     _require_reedsolo()
-    rs = RSCodec(nsym)
+    rs = RSCodec(nsym, c_exp=symbol_size, prim=primitive)
     try:
         decoded, _full, err_pos = rs.decode(encoded)
     except ReedSolomonError as exc:  # pragma: no cover - error path
@@ -97,15 +117,41 @@ class ReedSolomonFEC(FEC):
     """Reed--Solomon FEC backend implementing :class:`BaseFEC`."""
 
     def encode(
-        self, data: bytes, /, *, nsym: int = 10, **kwargs: Any
+        self,
+        data: bytes,
+        /,
+        *,
+        nsym: int = 10,
+        symbol_size: int | None = None,
+        primitive: int | None = None,
+        **kwargs: Any,
     ) -> Tuple[bytes, Mapping[str, Any]]:  # noqa: ANN401
-        encoded, used_nsym = encode_data_rs(data, nsym)
-        return encoded, {"nsym": used_nsym}
+        encoded, used_nsym, used_symbol_size, used_primitive = encode_data_rs(
+            data,
+            nsym,
+            symbol_size=symbol_size,
+            primitive=primitive,
+        )
+        info: dict[str, Any] = {"nsym": used_nsym}
+        if used_symbol_size is not None:
+            info["symbol_size"] = used_symbol_size
+        if used_primitive is not None:
+            info["primitive"] = used_primitive
+        return encoded, info
 
     def decode(
-        self, encoded: bytes, info: Mapping[str, Any], /, **kwargs: Any
+        self,
+        encoded: bytes,
+        info: Mapping[str, Any],
+        /,
+        **kwargs: Any,
     ) -> Tuple[bytes, int]:  # noqa: ANN401
-        return decode_data_rs(encoded, int(info["nsym"]))
+        return decode_data_rs(
+            encoded,
+            int(info["nsym"]),
+            symbol_size=int(info.get("symbol_size")) if info.get("symbol_size") is not None else None,
+            primitive=int(info.get("primitive")) if info.get("primitive") is not None else None,
+        )
 
 
 from typing import Callable


### PR DESCRIPTION
## Summary
- allow custom symbol size and primitive for Reed-Solomon codec
- add CLI flags `--rs-symbol-size` and `--rs-primitive`
- document Reed-Solomon options and example usage

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0bd5ea314832693cba431371f0429