### PR TITLE
Add default constraint checks for GC and homopolymers

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -22,8 +22,11 @@ from genecoder.manifest import generate_manifest
 from genecoder.encoders import (
     encode_base4_direct,
     encode_gc_balanced,
-    calculate_gc_content,
     encode_triple_repeat,
+)
+from genecoder.gc_constrained_encoder import (
+    calculate_gc_content,
+    check_default_constraints,
 )
 from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import encode_data_with_hamming
@@ -205,6 +208,11 @@ def process_single_encode(
     logger.info(
         f"\nProcessing encode for input: {input_file_path} -> output: {output_file_path}"
     )
+    suppress_warnings = (
+        getattr(args, "suppress_constraint_warnings", False)
+        or os.getenv("GENECODER_DISABLE_CONSTRAINT_WARNINGS", "").lower()
+        in {"1", "true"}
+    )
     try:
         if args.stream and args.method == "base4_direct" and args.fec is None:
             sanitized_name = os.path.basename(input_file_path.replace("\\", "/"))
@@ -266,6 +274,26 @@ def process_single_encode(
                 with open(output_file_path, "a", encoding="utf-8") as f_out:
                     f_out.write(to_fasta(rc_seq, rc_header, line_width=80))
                 parsed_records.append((rc_header, rc_seq))
+
+            final_gc, final_hp, _, _ = check_default_constraints(
+                dna_sequence, suppress_warnings
+            )
+            logger.info(f"Final GC content: {final_gc:.2%}")
+            logger.info(f"Final max homopolymer length: {final_hp}")
+            if not suppress_warnings:
+                if not (args.gc_min <= final_gc <= args.gc_max):
+                    logger.warning(
+                        "Final GC content %.2f%% outside requested range [%.2f%%, %.2f%%]",
+                        final_gc * 100,
+                        args.gc_min * 100,
+                        args.gc_max * 100,
+                    )
+                if final_hp > args.max_homopolymer:
+                    logger.warning(
+                        "Final max homopolymer length %d exceeds limit %d",
+                        final_hp,
+                        args.max_homopolymer,
+                    )
 
             return os.path.basename(input_file_path), dna_sequence
 
@@ -384,8 +412,14 @@ def process_single_encode(
             else 0.0
         )
 
-        final_gc = calculate_gc_content(final_encoded_dna_sequence)
-        final_hp = get_max_homopolymer_length(final_encoded_dna_sequence)
+        (
+            final_gc,
+            final_hp,
+            gc_default_bad,
+            hp_default_bad,
+        ) = check_default_constraints(
+            final_encoded_dna_sequence, suppress_warnings
+        )
 
         metrics = {
             "original_size": original_size_bytes,
@@ -394,6 +428,8 @@ def process_single_encode(
             "bits_per_nt": bits_per_nucleotide,
             "final_gc": final_gc,
             "final_max_homopolymer": final_hp,
+            "gc_exceeds_default": gc_default_bad,
+            "homopolymer_exceeds_default": hp_default_bad,
         }
 
         logger.info(f"\n--- Encoding Metrics for {input_file_path} ---")
@@ -414,19 +450,20 @@ def process_single_encode(
 
         logger.info(f"Final GC content: {final_gc:.2%}")
         logger.info(f"Final max homopolymer length: {final_hp}")
-        if not (args.gc_min <= final_gc <= args.gc_max):
-            logger.warning(
-                "Final GC content %.2f%% outside requested range [%.2f%%, %.2f%%]",
-                final_gc * 100,
-                args.gc_min * 100,
-                args.gc_max * 100,
-            )
-        if final_hp > args.max_homopolymer:
-            logger.warning(
-                "Final max homopolymer length %d exceeds limit %d",
-                final_hp,
-                args.max_homopolymer,
-            )
+        if not suppress_warnings:
+            if not (args.gc_min <= final_gc <= args.gc_max):
+                logger.warning(
+                    "Final GC content %.2f%% outside requested range [%.2f%%, %.2f%%]",
+                    final_gc * 100,
+                    args.gc_min * 100,
+                    args.gc_max * 100,
+                )
+            if final_hp > args.max_homopolymer:
+                logger.warning(
+                    "Final max homopolymer length %d exceeds limit %d",
+                    final_hp,
+                    args.max_homopolymer,
+                )
 
         if args.method == "gc_balanced":
             gc_balanced_payload_dna = (
@@ -609,6 +646,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--fix-chisel",
         action="store_true",
         help="Use DNA Chisel for constraint fixing when available.",
+    )
+    parser.add_argument(
+        "--suppress-constraint-warnings",
+        action="store_true",
+        help="Suppress warnings when results exceed default GC or homopolymer limits.",
     )
     parser.add_argument(
         "--seed",

--- a/src/genecoder/gc_constrained_encoder.py
+++ b/src/genecoder/gc_constrained_encoder.py
@@ -22,6 +22,56 @@ from .utils import check_homopolymer_length, get_max_homopolymer_length
 
 logger = logging.getLogger(__name__)
 
+# Recommended default constraints used by the CLI and other helpers.  These
+# values are exposed so callers can reference a single source of truth when
+# evaluating GC content and homopolymer runs.
+DEFAULT_GC_MIN = 0.45
+DEFAULT_GC_MAX = 0.55
+DEFAULT_MAX_HOMOPOLYMER = 3
+
+
+def check_default_constraints(
+    dna_sequence: str, suppress_warnings: bool = False
+) -> tuple[float, int, bool, bool]:
+    """Return GC/HP metrics and flags indicating violations of defaults.
+
+    Parameters
+    ----------
+    dna_sequence:
+        Sequence to analyse.
+    suppress_warnings:
+        When ``True`` no warnings are logged even if the defaults are
+        exceeded.  The caller is expected to consult the boolean flags in the
+        returned tuple.
+
+    Returns
+    -------
+    Tuple consisting of ``(gc_content, max_homopolymer, gc_violation,
+    homopolymer_violation)``.
+    """
+
+    gc_val = calculate_gc_content(dna_sequence)
+    hp_val = get_max_homopolymer_length(dna_sequence)
+    gc_bad = gc_val < DEFAULT_GC_MIN or gc_val > DEFAULT_GC_MAX
+    hp_bad = hp_val > DEFAULT_MAX_HOMOPOLYMER
+
+    if not suppress_warnings:
+        if gc_bad:
+            logger.warning(
+                "GC content %.2f%% outside recommended range [%.2f%%, %.2f%%]",
+                gc_val * 100,
+                DEFAULT_GC_MIN * 100,
+                DEFAULT_GC_MAX * 100,
+            )
+        if hp_bad:
+            logger.warning(
+                "Max homopolymer length %d exceeds recommended limit %d",
+                hp_val,
+                DEFAULT_MAX_HOMOPOLYMER,
+            )
+
+    return gc_val, hp_val, gc_bad, hp_bad
+
 def calculate_gc_content(dna_sequence: str) -> float:
     """Calculates the GC content of a DNA sequence.
 

--- a/tests/test_cli_encode.py
+++ b/tests/test_cli_encode.py
@@ -28,6 +28,7 @@ def _encode_args(stream: bool = False) -> argparse.Namespace:
         mirror=False,
         capsule=None,
         export_csv=None,
+        suppress_constraint_warnings=False,
     )
 
 

--- a/tests/test_cli_encode_warnings.py
+++ b/tests/test_cli_encode_warnings.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -38,3 +39,41 @@ def test_process_single_encode_homopolymer_warning(tmp_path: Path, caplog: pytes
     assert any("exceeds limit" in rec.message for rec in caplog.records)
     assert not any("outside requested range" in rec.message for rec in caplog.records)
     os.environ.pop("GENECODER_DISABLE_FIX", None)
+
+
+def test_default_constraint_warnings_and_manifest(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    input_file = tmp_path / "def.bin"
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_def.fasta"
+    os.environ["GENECODER_DISABLE_FIX"] = "1"
+    args = _encode_args()
+    args.gc_min = 0.0
+    args.gc_max = 1.0
+    args.max_homopolymer = 100
+    caplog.set_level(logging.WARNING)
+    process_single_encode(str(input_file), str(output_file), args)
+    os.environ.pop("GENECODER_DISABLE_FIX", None)
+    assert any("recommended" in rec.message for rec in caplog.records)
+    manifest_path = output_file.with_suffix(".manifest.json")
+    data = json.loads(manifest_path.read_text())
+    assert data["metrics"]["gc_exceeds_default"]
+    assert data["metrics"]["homopolymer_exceeds_default"]
+
+
+def test_suppress_default_constraint_warnings(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    input_file = tmp_path / "sup.bin"
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_sup.fasta"
+    os.environ["GENECODER_DISABLE_FIX"] = "1"
+    args = _encode_args()
+    args.gc_min = 0.0
+    args.gc_max = 1.0
+    args.max_homopolymer = 100
+    args.suppress_constraint_warnings = True
+    caplog.set_level(logging.WARNING)
+    process_single_encode(str(input_file), str(output_file), args)
+    os.environ.pop("GENECODER_DISABLE_FIX", None)
+    assert not any("recommended" in rec.message for rec in caplog.records)
+    manifest_path = output_file.with_suffix(".manifest.json")
+    data = json.loads(manifest_path.read_text())
+    assert data["metrics"]["gc_exceeds_default"]


### PR DESCRIPTION
## Summary
- enforce GC content and homopolymer checks after every encode
- warn and record when results exceed recommended defaults
- add optional suppression flag for constraint warnings

## Testing
- `pre-commit run ruff --files src/genecoder/gc_constrained_encoder.py src/genecoder/cli/encode.py tests/test_cli_encode.py tests/test_cli_encode_warnings.py`
- `pytest tests/test_cli_encode.py tests/test_cli_encode_warnings.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0cac1abb0832682a892fe1c9db3ba