### PR TITLE
Resolve mypy errors blocking pre-commit

### DIFF
--- a/src/genecoder/app_helpers.py
+++ b/src/genecoder/app_helpers.py
@@ -72,7 +72,7 @@ def perform_encoding(data: bytes, options: EncodeOptions) -> EncodeResult:
     elif options.fec_method == "Reed-Solomon":
         if options.add_parity:
             info_msgs.append("Info: 'Add Parity' ignored when Reed-Solomon FEC selected.")
-        current_input, rs_nsym = encode_data_rs(data)
+        current_input, rs_nsym, _, _ = encode_data_rs(data)
 
     should_add_parity = options.add_parity and options.fec_method not in ("Hamming(7,4)", "Reed-Solomon")
 

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -274,14 +274,14 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
             continue
         subheader(f"{label} Histogram")
         if alt and pd and hasattr(st, "altair_chart"):
-            rows: list[dict[str, Any]] = []
+            hist_rows: list[dict[str, Any]] = []
             for name in selected:
                 hist = _calc_error_hist(datasets[name].get(key))
                 if hist:
                     for i, val in enumerate(hist):
-                        rows.append({"Errors": i, "Count": val, "Dataset": name})
-            if rows:
-                df = pd.DataFrame(rows)
+                        hist_rows.append({"Errors": i, "Count": val, "Dataset": name})
+            if hist_rows:
+                df = pd.DataFrame(hist_rows)
                 chart = (
                     alt.Chart(df)
                     .mark_bar(opacity=0.5)

--- a/src/genecoder/reed_solomon_codec.py
+++ b/src/genecoder/reed_solomon_codec.py
@@ -146,11 +146,13 @@ class ReedSolomonFEC(FEC):
         /,
         **kwargs: Any,
     ) -> Tuple[bytes, int]:  # noqa: ANN401
+        symbol_size_val = info.get("symbol_size")
+        primitive_val = info.get("primitive")
         return decode_data_rs(
             encoded,
             int(info["nsym"]),
-            symbol_size=int(info.get("symbol_size")) if info.get("symbol_size") is not None else None,
-            primitive=int(info.get("primitive")) if info.get("primitive") is not None else None,
+            symbol_size=int(symbol_size_val) if symbol_size_val is not None else None,
+            primitive=int(primitive_val) if primitive_val is not None else None,
         )
 
 

--- a/tests/test_encode_constraint_warnings.py
+++ b/tests/test_encode_constraint_warnings.py
@@ -1,0 +1,62 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from genecoder.cli.encode import process_single_encode
+from tests.test_cli_encode import _encode_args
+
+
+def test_encode_gc_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_file = tmp_path / "gc.bin"
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_gc.fasta"
+    monkeypatch.setenv("GENECODER_DISABLE_FIX", "1")
+    args = _encode_args()
+    args.gc_min = 0.4
+    args.gc_max = 0.6
+    args.max_homopolymer = 100
+    with caplog.at_level(logging.WARNING):
+        process_single_encode(str(input_file), str(output_file), args)
+    assert any("outside requested range" in rec.message for rec in caplog.records)
+    assert not any("exceeds limit" in rec.message for rec in caplog.records)
+
+
+def test_encode_homopolymer_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_file = tmp_path / "hp.bin"
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_hp.fasta"
+    monkeypatch.setenv("GENECODER_DISABLE_FIX", "1")
+    args = _encode_args()
+    args.gc_min = 0.0
+    args.gc_max = 1.0
+    args.max_homopolymer = 4
+    with caplog.at_level(logging.WARNING):
+        process_single_encode(str(input_file), str(output_file), args)
+    assert any("exceeds limit" in rec.message for rec in caplog.records)
+    assert not any("outside requested range" in rec.message for rec in caplog.records)
+
+
+def test_encode_default_warnings_manifest(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_file = tmp_path / "def.bin"
+    input_file.write_bytes(b"\x00" * 8)
+    output_file = tmp_path / "out_def.fasta"
+    monkeypatch.setenv("GENECODER_DISABLE_FIX", "1")
+    args = _encode_args()
+    args.gc_min = 0.0
+    args.gc_max = 1.0
+    args.max_homopolymer = 100
+    with caplog.at_level(logging.WARNING):
+        process_single_encode(str(input_file), str(output_file), args)
+    assert any("recommended" in rec.message for rec in caplog.records)
+    manifest_path = output_file.with_suffix(".manifest.json")
+    data = json.loads(manifest_path.read_text())
+    assert data["metrics"]["gc_exceeds_default"]
+    assert data["metrics"]["homopolymer_exceeds_default"]


### PR DESCRIPTION
## Summary
- fix ReedSolomon FEC decode to handle optional `symbol_size` and `primitive` cleanly
- avoid variable redefinition in dashboard error histogram construction
- unpack all return values from `encode_data_rs` to satisfy mypy

## Testing
- `PYTEST_ADDOPTS=tests/test_encode_constraint_warnings.py pre-commit run --files tests/test_encode_constraint_warnings.py src/genecoder/reed_solomon_codec.py src/genecoder/dashboard.py src/genecoder/app_helpers.py`
- `pytest tests/test_encode_constraint_warnings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4beb3808326ac054bd0507d98cd