### PR TITLE
docs: expand plugin examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ See [CITATION.cff](CITATION.cff) for citation information.
 
 GeneCoder can be extended through plugins discovered via the
 `genecoder.plugins`, `genecoder.fec` and `genecoder.simulators` entry points.
+Sample implementations include
+[`src/plugins/reverse_codec.py`](src/plugins/reverse_codec.py) and
+[`src/plugins/helix_visualizer.py`](src/plugins/helix_visualizer.py).
 See the step-by-step
 [codec](docs/plugins.md#codec-plugin-walkthrough),
 [FEC](docs/plugins.md#fec-plugin-walkthrough) and

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -100,6 +100,7 @@ genecli plugin list   # confirms the plugin is available
    a `ReverseCodec` class and registers it with the plugin system:
 
    ```python
+   # src/plugins/reverse_codec.py
    from typing import Callable
    from genecoder.api import Codec
 
@@ -230,6 +231,26 @@ function shown above.
 Simulator plugins model sequencing or transmission channels and use the same
 registration pattern as
 [`src/plugins/helix_visualizer.py`](../src/plugins/helix_visualizer.py).
+
+```python
+# src/plugins/helix_visualizer.py
+from typing import Callable
+from genecoder.api import Visualizer
+from genecoder.app_helpers import EncodeResult, DecodeResult
+from genecoder.helix_view import show_helix_ui
+
+
+class HelixVisualizer(Visualizer):  # type: ignore[misc]
+    def visualize(self, result: EncodeResult | DecodeResult, /, **kwargs: object) -> None:
+        if isinstance(result, EncodeResult):
+            show_helix_ui(result.encoded_dna, **kwargs)
+        else:
+            raise TypeError("HelixVisualizer supports EncodeResult only")
+
+
+def register(register_visualizer: Callable[[str, type[Visualizer]], None]) -> None:
+    register_visualizer("helix", HelixVisualizer)
+```
 
 1. Add an entry point in `pyproject.toml`:
 


### PR DESCRIPTION
## Summary
- document codec, FEC, and simulator plugin development with templates
- link README to built-in plugin examples

## Testing
- ⚠️ no tests run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68a491ae46e8832691b17249de6174c7