### PR TITLE
Add context-specific indel profiles for DNArSim Nanopore simulator

### DIFF
--- a/configs/dnarsim_rates.yaml
+++ b/configs/dnarsim_rates.yaml
@@ -14,12 +14,20 @@ r9:
       4: 0.5
     TTTT:
       4: 0.5
+    CCCC:
+      4: 0.5
+    GGGG:
+      4: 0.5
   context_deletions:
     TT:
       2: 0.9
     AAAA:
       4: 0.6
     TTTT:
+      4: 0.6
+    CCCC:
+      4: 0.6
+    GGGG:
       4: 0.6
 "r10.3":
   substitution_rate: 0.06
@@ -30,10 +38,18 @@ r9:
       4: 0.4
     TTTT:
       4: 0.4
+    CCCC:
+      4: 0.4
+    GGGG:
+      4: 0.4
   context_deletions:
     AAAA:
       4: 0.5
     TTTT:
+      4: 0.5
+    CCCC:
+      4: 0.5
+    GGGG:
       4: 0.5
 "r10.4":
   substitution_rate: 0.045
@@ -44,8 +60,16 @@ r9:
       4: 0.35
     TTTT:
       4: 0.35
+    CCCC:
+      4: 0.35
+    GGGG:
+      4: 0.35
   context_deletions:
     AAAA:
       4: 0.45
     TTTT:
+      4: 0.45
+    CCCC:
+      4: 0.45
+    GGGG:
       4: 0.45

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -37,6 +37,9 @@ PROFILE_MAP: dict[str, tuple[str, str]] = {
     "nova": ("illumina", "nova"),
     "minion": ("nanopore", "minion"),
     "promethion": ("nanopore", "promethion"),
+    "r9": ("nanopore_dnarsim", "r9"),
+    "r10.3": ("nanopore_dnarsim", "r10.3"),
+    "r10.4": ("nanopore_dnarsim", "r10.4"),
 }
 
 
@@ -639,7 +642,7 @@ def _handle_run(args: argparse.Namespace) -> None:
 
 
 def list_profiles() -> None:
-    """Print available Illumina and Nanopore profiles."""
+    """Print available Illumina, Nanopore and DNArSim profiles."""
 
     print("Illumina profiles:")
     for name in sorted(ILLUMINA_PROFILES):
@@ -648,6 +651,11 @@ def list_profiles() -> None:
     print("Nanopore profiles:")
     for name in sorted(NANOPORE_PROFILES):
         print(f"  {name}")
+
+    if DNARSIM_RATE_TABLES:
+        print("DNArSim profiles:")
+        for name in sorted(DNARSIM_RATE_TABLES):
+            print(f"  {name}")
 
 
 def _handle_list_profiles(_: argparse.Namespace) -> None:

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -82,6 +82,35 @@ def _validate_context_profiles(
         validated[str(ctx).upper()] = _validate_indel_profile(prof, f"{name}[{ctx}]")
     return validated
 
+
+def _split_context_indels(
+    profiles: Mapping[str, Mapping[str, Mapping[int, float]]] | None,
+    name: str,
+) -> tuple[Dict[str, Dict[int, float]], Dict[str, Dict[int, float]]]:
+    """Return separate insertion and deletion context maps.
+
+    ``profiles`` maps contexts to ``{"insertions": {...}, "deletions": {...}}``. This
+    helper validates the nested indel profiles and returns two dictionaries in the
+    same normalized format used internally by the simulator.
+    """
+
+    ctx_ins: Dict[str, Dict[int, float]] = {}
+    ctx_del: Dict[str, Dict[int, float]] = {}
+    for ctx, ctx_map in (profiles or {}).items():
+        if not isinstance(ctx_map, Mapping):
+            continue
+        ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
+        del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
+        if ins_prof is not None:
+            ctx_ins[str(ctx).upper()] = _validate_indel_profile(
+                ins_prof, f"{name}[{ctx}].insertions"
+            )
+        if del_prof is not None:
+            ctx_del[str(ctx).upper()] = _validate_indel_profile(
+                del_prof, f"{name}[{ctx}].deletions"
+            )
+    return ctx_ins, ctx_del
+
 # ---------------------------------------------------------------------------
 # Preset parameter profiles for :class:`NanoporeChannel` loaded from YAML.
 _DEFAULT_NANOPORE_PROFILES: dict[
@@ -125,6 +154,12 @@ try:  # pragma: no cover - optional dependency
             elif key in {"context_insertions", "context_deletions"}:
                 prof = value if isinstance(value, Mapping) else None
                 parsed[key] = _validate_context_profiles(prof, key)
+            elif key == "context_indels" and isinstance(value, Mapping):
+                ctx_ins, ctx_del = _split_context_indels(value, "context_indels")
+                if ctx_ins:
+                    parsed.setdefault("context_insertions", {}).update(ctx_ins)
+                if ctx_del:
+                    parsed.setdefault("context_deletions", {}).update(ctx_del)
             else:
                 parsed[key] = value
         return parsed
@@ -167,21 +202,9 @@ try:  # pragma: no cover - optional dependency
                 tbl.get("context_deletions"), "context_deletions"
             )
         if "context_indels" in tbl and isinstance(tbl["context_indels"], Mapping):
-            ctx_ins: Dict[str, Dict[int, float]] = {}
-            ctx_del: Dict[str, Dict[int, float]] = {}
-            for ctx, ctx_map in tbl["context_indels"].items():
-                if not isinstance(ctx_map, Mapping):
-                    continue
-                ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
-                del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
-                if ins_prof is not None:
-                    ctx_ins[str(ctx).upper()] = _validate_indel_profile(
-                        ins_prof, f"context_indels[{ctx}].insertions"
-                    )
-                if del_prof is not None:
-                    ctx_del[str(ctx).upper()] = _validate_indel_profile(
-                        del_prof, f"context_indels[{ctx}].deletions"
-                    )
+            ctx_ins, ctx_del = _split_context_indels(
+                tbl["context_indels"], "context_indels"
+            )
             if ctx_ins:
                 parsed.setdefault("context_insertions", {}).update(ctx_ins)
             if ctx_del:
@@ -370,6 +393,20 @@ class NanoporeChannel(BaseChannel):
             context_errors = data.get("context_errors", context_errors)
             context_insertions = data.get("context_insertions", context_insertions)
             context_deletions = data.get("context_deletions", context_deletions)
+            if "context_indels" in data:
+                ctx_ins, ctx_del = _split_context_indels(
+                    data.get("context_indels"), "context_indels"
+                )
+                if ctx_ins:
+                    context_insertions = {
+                        **(context_insertions or {}),
+                        **ctx_ins,
+                    }
+                if ctx_del:
+                    context_deletions = {
+                        **(context_deletions or {}),
+                        **ctx_del,
+                    }
             insertion_profile = data.get("insertion_profile", insertion_profile)
             deletion_profile = data.get("deletion_profile", deletion_profile)
         error_rate = _validate_rate("error_rate", error_rate)


### PR DESCRIPTION
## Summary
- parse context-dependent indel probabilities in Nanopore simulator
- include common homopolymer contexts in DNArSim rate tables
- allow CLI selection of DNArSim profiles and list them

## Testing
- `ruff check src/genecoder/simulators/nanopore.py src/genecoder/cli/channel.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a491ad01688326bc91852351b25b22