### PR TITLE
feat: add error histograms to dashboard

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -563,6 +563,10 @@ The interface visualizes key metrics:
 * Overall decode-success percentage
 * Constraint-violation counts
 
+Use the **Error Types** multiselect in the sidebar to toggle which histograms
+are shown. Each bar chart illustrates how often reads contain a given number of
+substitutions, insertions or deletions.
+
 ![Homopolymer distribution screenshot](images/homopolymer_distribution.svg)
 
 ![Error rate charts screenshot](images/error_rates.svg)

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -41,6 +41,9 @@ _DEF_METRICS: dict[str, Any] = {
     "substitutions": None,
     "insertions": None,
     "deletions": None,
+    "substitutions_histogram": [],
+    "insertions_histogram": [],
+    "deletions_histogram": [],
     "coverage": None,
     "coverage_distribution": [],
     "constraint_violations": None,
@@ -141,6 +144,16 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     datasets: dict[str, dict[str, Any]] = {}
     for path in paths:
         data = {**_DEF_METRICS, **_load_metrics(path)}
+        for key in ("substitutions", "insertions", "deletions"):
+            val = data.get(key)
+            rate: float | None = None
+            hist: list[int] = []
+            if isinstance(val, (int, float)):
+                rate = float(val)
+            else:
+                hist = _calc_error_hist(val)
+            data[key] = rate
+            data[f"{key}_histogram"] = hist
         if data:
             datasets[Path(path).stem] = data
 
@@ -151,6 +164,16 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     uploaded = file_uploader("Add metrics files", type="json", accept_multiple_files=True)
     for up in uploaded or []:
         data = {**_DEF_METRICS, **_load_metrics(up)}
+        for key in ("substitutions", "insertions", "deletions"):
+            val = data.get(key)
+            rate: float | None = None
+            hist: list[int] = []
+            if isinstance(val, (int, float)):
+                rate = float(val)
+            else:
+                hist = _calc_error_hist(val)
+            data[key] = rate
+            data[f"{key}_histogram"] = hist
         datasets[Path(up.name).stem] = data
 
     st.title("GeneCoder Dashboard")
@@ -266,9 +289,9 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     select_err = getattr(sidebar, "multiselect", lambda *a, **k: err_labels)
     enabled_errs = select_err("Error Types", err_labels, default=err_labels)
     for label, key in [
-        ("Substitutions", "substitutions"),
-        ("Insertions", "insertions"),
-        ("Deletions", "deletions"),
+        ("Substitutions", "substitutions_histogram"),
+        ("Insertions", "insertions_histogram"),
+        ("Deletions", "deletions_histogram"),
     ]:
         if label not in enabled_errs:
             continue
@@ -276,8 +299,8 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         if alt and pd and hasattr(st, "altair_chart"):
             hist_rows: list[dict[str, Any]] = []
             for name in selected:
-                hist = _calc_error_hist(datasets[name].get(key))
-                if hist:
+                hist = datasets[name].get(key)
+                if isinstance(hist, list) and hist:
                     for i, val in enumerate(hist):
                         hist_rows.append({"Errors": i, "Count": val, "Dataset": name})
             if hist_rows:
@@ -292,8 +315,8 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
                 st.write(f"No {label.lower()} histogram data.")
         else:
             if len(selected) == 1:
-                hist = _calc_error_hist(datasets[selected[0]].get(key))
-                if hist:
+                hist = datasets[selected[0]].get(key)
+                if isinstance(hist, list) and hist:
                     st.bar_chart(hist)
                 else:
                     st.write(f"No {label.lower()} histogram data.")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -131,3 +131,21 @@ def test_display_coverage_and_constraint_metrics(
     charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
     assert [1, 3, 2] in charts
     assert {"Violations": 2} in charts
+
+
+def test_error_histograms_rendered(
+    tmp_path: Path, dummy_streamlit: dict[str, list]
+) -> None:
+    data = {
+        "substitutions": [0, 1, 1, 2],
+        "insertions": {"0": 2, "1": 1},
+    }
+    path = tmp_path / "metrics.json"
+    path.write_text(json.dumps(data))
+
+    mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
+    mod.main(str(path))
+
+    charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
+    assert [1, 2, 1] in charts
+    assert [2, 1] in charts


### PR DESCRIPTION
## Summary
- compute per-error histograms for substitutions, insertions, and deletions
- expose histograms in dashboard with toggleable charts
- document new histogram controls

## Testing
- `ruff check src/genecoder/dashboard.py tests/test_dashboard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d52502e08326bd291142cd237f78