### PR TITLE
Add tests for encode constraint warnings manifest

### DIFF
--- a/tests/test_encode_constraint_warnings.py
+++ b/tests/test_encode_constraint_warnings.py
@@ -23,6 +23,9 @@ def test_encode_gc_warning(
         process_single_encode(str(input_file), str(output_file), args)
     assert any("outside requested range" in rec.message for rec in caplog.records)
     assert not any("exceeds limit" in rec.message for rec in caplog.records)
+    manifest_path = output_file.with_suffix(".manifest.json")
+    data = json.loads(manifest_path.read_text())
+    assert data["metrics"]["gc_exceeds_default"]
 
 
 def test_encode_homopolymer_warning(
@@ -40,6 +43,9 @@ def test_encode_homopolymer_warning(
         process_single_encode(str(input_file), str(output_file), args)
     assert any("exceeds limit" in rec.message for rec in caplog.records)
     assert not any("outside requested range" in rec.message for rec in caplog.records)
+    manifest_path = output_file.with_suffix(".manifest.json")
+    data = json.loads(manifest_path.read_text())
+    assert data["metrics"]["homopolymer_exceeds_default"]
 
 
 def test_encode_default_warnings_manifest(


### PR DESCRIPTION
## Summary
- verify encoding logs GC and homopolymer constraint warnings
- assert manifest flags when limits are exceeded

## Testing
- `ruff check tests/test_encode_constraint_warnings.py`
- `pytest tests/test_encode_constraint_warnings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72013b6b883269e05b06a286b3297