### PR TITLE
feat: load calibrated error profiles

### DIFF
--- a/configs/illumina.yml
+++ b/configs/illumina.yml
@@ -1,1 +1,20 @@
-error_rate: 0.05
+miseq:
+  substitution_rate: 0.001
+  insertion_rate: 0.0001
+  deletion_rate: 0.0001
+  coverage_depth: 1
+hiseq:
+  substitution_rate: 0.0005
+  insertion_rate: 0.00005
+  deletion_rate: 0.00005
+  coverage_depth: 1
+novaseq:
+  substitution_rate: 0.0003
+  insertion_rate: 0.00003
+  deletion_rate: 0.00003
+  coverage_depth: 1
+nova:
+  substitution_rate: 0.0003
+  insertion_rate: 0.00003
+  deletion_rate: 0.00003
+  coverage_depth: 1

--- a/configs/nanopore.yml
+++ b/configs/nanopore.yml
@@ -3,6 +3,7 @@ minion:
   substitution_rate: 0.02
   insertion_rate: 0.04
   deletion_rate: 0.06
+  coverage: 1
   insertion_profile:
     5: 0.08
   deletion_profile:
@@ -20,6 +21,7 @@ promethion:
   substitution_rate: 0.015
   insertion_rate: 0.02
   deletion_rate: 0.045
+  coverage: 1
   insertion_profile:
     5: 0.04
   deletion_profile:
@@ -33,10 +35,11 @@ promethion:
       1: 0.11
       2: 0.07
 r10:
-  error_rate: 0.05
+  error_rate: 0.06
   substitution_rate: 0.01
   insertion_rate: 0.02
   deletion_rate: 0.03
+  coverage: 1
   insertion_profile:
     5: 0.03
   deletion_profile:

--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -1,22 +1,74 @@
 """Built-in Illumina-like sequencing simulator.
 
-This module implements a very small Illumina error model dominated by
-base substitutions.  The overall error ``error_rate`` controls the
-probability of a substitution.  Insertion and deletion probabilities are
-scaled down to one hundredth of this value to approximate the relatively
-low indel rates of Illumina machines.
+This module implements a small Illumina error model dominated by base
+substitutions.  Earlier versions exposed a single ``error_rate`` parameter
+from which insertion and deletion probabilities were derived.  The model now
+accepts separate ``substitution_rate``, ``insertion_rate`` and
+``deletion_rate`` values which can also be loaded from named profiles defined
+in :mod:`configs/illumina.yml`.
 """
 from __future__ import annotations
 
 import random
-from typing import Callable, Sequence
+from pathlib import Path
+from typing import Callable, Sequence, Mapping
 
 from .error_simulation import NUCLEOTIDES, _random_substitution
 from .random_utils import make_rng
 from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
-__all__ = ["simulate", "Channel", "register"]
+__all__ = ["simulate", "Channel", "register", "ILLUMINA_PROFILES"]
+
+
+_DEFAULT_PROFILES: dict[str, dict[str, float | int]] = {
+    "hiseq": {
+        "substitution_rate": 0.0005,
+        "insertion_rate": 0.00005,
+        "deletion_rate": 0.00005,
+        "coverage_depth": 1,
+    },
+    "miseq": {
+        "substitution_rate": 0.001,
+        "insertion_rate": 0.0001,
+        "deletion_rate": 0.0001,
+        "coverage_depth": 1,
+    },
+    "novaseq": {
+        "substitution_rate": 0.0003,
+        "insertion_rate": 0.00003,
+        "deletion_rate": 0.00003,
+        "coverage_depth": 1,
+    },
+    "nova": {
+        "substitution_rate": 0.0003,
+        "insertion_rate": 0.00003,
+        "deletion_rate": 0.00003,
+        "coverage_depth": 1,
+    },
+}
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+
+    _cfg_dir = Path(__file__).resolve().parents[2] / "configs"
+    with open(_cfg_dir / "illumina.yml", "r", encoding="utf-8") as _fh:
+        _data = yaml.safe_load(_fh) or {}
+    if isinstance(_data, Mapping):
+        ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
+            str(name): {
+                "substitution_rate": float(params.get("substitution_rate", 0.001)),
+                "insertion_rate": float(params.get("insertion_rate", 0.0001)),
+                "deletion_rate": float(params.get("deletion_rate", 0.0001)),
+                "coverage_depth": int(params.get("coverage_depth", 1)),
+            }
+            for name, params in _data.items()
+            if isinstance(params, Mapping)
+        }
+    else:  # pragma: no cover - unexpected structure
+        ILLUMINA_PROFILES = _DEFAULT_PROFILES
+except Exception:  # pragma: no cover - fall back to defaults
+    ILLUMINA_PROFILES = _DEFAULT_PROFILES
 
 
 def _mutate_read(
@@ -72,11 +124,15 @@ def _consensus(reads: Sequence[str]) -> str:
 
 def simulate(
     sequence: str,
-    error_rate: float = 0.001,
+    substitution_rate: float | None = None,
+    *,
+    insertion_rate: float | None = None,
+    deletion_rate: float | None = None,
     rng: random.Random | None = None,
-    coverage_depth: int = 1,
+    coverage_depth: int | None = None,
     quality_profile: Sequence[float] | None = None,
     quality_distribution: Sequence[float] | None = None,
+    profile: str | None = None,
 ) -> str:
     """Return ``sequence`` mutated with Illumina-style errors.
 
@@ -84,9 +140,9 @@ def simulate(
     ----------
     sequence:
         Input DNA sequence.
-    error_rate:
-        Probability of substituting each nucleotide.  Insertion and
-        deletion probabilities are ``error_rate / 100``.
+    substitution_rate, insertion_rate, deletion_rate:
+        Per-base error probabilities.  Missing values are filled from the
+        named ``profile`` when provided, otherwise from the builtin defaults.
     rng:
         Optional :class:`random.Random` instance for deterministic behaviour.
     coverage_depth:
@@ -97,19 +153,41 @@ def simulate(
     quality_distribution:
         Optional list describing a distribution of substitution probabilities
         to sample for each base when ``quality_profile`` is not provided.
+    profile:
+        Optional profile name defined in :data:`ILLUMINA_PROFILES`.
     """
 
-    insertion_prob = error_rate / 100.0
-    deletion_prob = error_rate / 100.0
+    prof = ILLUMINA_PROFILES.get(profile or "hiseq", {})
+    substitution_rate = float(
+        substitution_rate
+        if substitution_rate is not None
+        else prof.get("substitution_rate", 0.001)
+    )
+    insertion_rate = float(
+        insertion_rate
+        if insertion_rate is not None
+        else prof.get("insertion_rate", 0.0001)
+    )
+    deletion_rate = float(
+        deletion_rate
+        if deletion_rate is not None
+        else prof.get("deletion_rate", 0.0001)
+    )
+    coverage_depth = int(
+        coverage_depth
+        if coverage_depth is not None
+        else int(prof.get("coverage_depth", 1))
+    )
+
     if rng is None:
         rng = make_rng()
 
     reads = [
         _mutate_read(
             sequence,
-            error_rate,
-            insertion_prob,
-            deletion_prob,
+            substitution_rate,
+            insertion_rate,
+            deletion_rate,
             quality_profile,
             quality_distribution,
             rng,
@@ -126,13 +204,36 @@ class Channel(Simulator):
 
     def __init__(
         self,
-        error_rate: float = 0.001,
-        coverage_depth: int = 1,
+        substitution_rate: float | None = None,
+        *,
+        insertion_rate: float | None = None,
+        deletion_rate: float | None = None,
+        coverage_depth: int | None = None,
         quality_profile: Sequence[float] | None = None,
         quality_distribution: Sequence[float] | None = None,
+        profile: str | None = None,
     ) -> None:
-        self.error_rate = error_rate
-        self.coverage_depth = coverage_depth
+        prof = ILLUMINA_PROFILES.get(profile or "hiseq", {})
+        self.substitution_rate = float(
+            substitution_rate
+            if substitution_rate is not None
+            else prof.get("substitution_rate", 0.001)
+        )
+        self.insertion_rate = float(
+            insertion_rate
+            if insertion_rate is not None
+            else prof.get("insertion_rate", 0.0001)
+        )
+        self.deletion_rate = float(
+            deletion_rate
+            if deletion_rate is not None
+            else prof.get("deletion_rate", 0.0001)
+        )
+        self.coverage_depth = int(
+            coverage_depth
+            if coverage_depth is not None
+            else int(prof.get("coverage_depth", 1))
+        )
         self.quality_profile = (
             tuple(quality_profile) if quality_profile is not None else None
         )
@@ -143,8 +244,10 @@ class Channel(Simulator):
     def simulate(self, sequence: str) -> str:  # pragma: no cover - thin wrapper
         return simulate(
             sequence,
-            self.error_rate,
-            make_rng(),
+            substitution_rate=self.substitution_rate,
+            insertion_rate=self.insertion_rate,
+            deletion_rate=self.deletion_rate,
+            rng=make_rng(),
             coverage_depth=self.coverage_depth,
             quality_profile=self.quality_profile,
             quality_distribution=self.quality_distribution,

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -162,6 +162,11 @@ try:  # pragma: no cover - optional dependency
                     parsed.setdefault("context_deletions", {}).update(ctx_del)
             else:
                 parsed[key] = value
+        if "error_rate" not in parsed:
+            sub = float(parsed.get("substitution_rate", 0.0))
+            ins = float(parsed.get("insertion_rate", 0.0))
+            dele = float(parsed.get("deletion_rate", 0.0))
+            parsed["error_rate"] = sub + ins + dele
         return parsed
 
     if isinstance(_data, dict):

--- a/tests/test_illumina_builtin_sim.py
+++ b/tests/test_illumina_builtin_sim.py
@@ -7,9 +7,21 @@ from genecoder.random_utils import reset_rng
 def test_simulate_deterministic_with_rng():
     seq = "ACGTACGT"
     rng = random.Random(0)
-    first = illumina_sim.simulate(seq, error_rate=0.1, rng=rng)
+    first = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.1,
+        insertion_rate=0.001,
+        deletion_rate=0.001,
+        rng=rng,
+    )
     rng = random.Random(0)
-    second = illumina_sim.simulate(seq, error_rate=0.1, rng=rng)
+    second = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.1,
+        insertion_rate=0.001,
+        deletion_rate=0.001,
+        rng=rng,
+    )
     assert first == second
 
 
@@ -17,10 +29,14 @@ def test_channel_respects_seed(monkeypatch):
     seq = "ACGTACGT"
     monkeypatch.setenv("GENECODER_SIM_SEED", "7")
     reset_rng()
-    ch = illumina_sim.Channel(error_rate=0.1)
+    ch = illumina_sim.Channel(
+        substitution_rate=0.1, insertion_rate=0.001, deletion_rate=0.001
+    )
     first = ch.simulate(seq)
     monkeypatch.setenv("GENECODER_SIM_SEED", "7")
     reset_rng()
-    ch = illumina_sim.Channel(error_rate=0.1)
+    ch = illumina_sim.Channel(
+        substitution_rate=0.1, insertion_rate=0.001, deletion_rate=0.001
+    )
     second = ch.simulate(seq)
     assert first == second

--- a/tests/test_illumina_coverage_quality.py
+++ b/tests/test_illumina_coverage_quality.py
@@ -12,9 +12,23 @@ def _hamming(a: str, b: str) -> int:
 def test_coverage_reduces_errors() -> None:
     seq = "A" * 50
     rng1 = random.Random(0)
-    out1 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng1, coverage_depth=1)
+    out1 = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.1,
+        insertion_rate=0.001,
+        deletion_rate=0.001,
+        rng=rng1,
+        coverage_depth=1,
+    )
     rng2 = random.Random(0)
-    out5 = illumina_sim.simulate(seq, error_rate=0.1, rng=rng2, coverage_depth=5)
+    out5 = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.1,
+        insertion_rate=0.001,
+        deletion_rate=0.001,
+        rng=rng2,
+        coverage_depth=5,
+    )
     assert _hamming(seq, out5) <= _hamming(seq, out1)
 
 
@@ -23,7 +37,9 @@ def test_quality_distribution_controls_errors() -> None:
     rng1 = random.Random(0)
     out_none = illumina_sim.simulate(
         seq,
-        error_rate=0.0,
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
         rng=rng1,
         coverage_depth=1,
         quality_distribution=[0.0],
@@ -31,7 +47,9 @@ def test_quality_distribution_controls_errors() -> None:
     rng2 = random.Random(0)
     out_all = illumina_sim.simulate(
         seq,
-        error_rate=0.0,
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
         rng=rng2,
         coverage_depth=1,
         quality_distribution=[1.0],


### PR DESCRIPTION
## Summary
- load Illumina error profiles from `configs/illumina.yml`
- derive Nanopore error rates from substitution/insertion/deletion stats and correct r10 profile
- switch built-in Illumina simulator to profile-based substitution, insertion, and deletion rates

## Testing
- `ruff check src/genecoder/illumina_sim.py src/genecoder/simulators/nanopore.py tests/test_illumina_builtin_sim.py tests/test_illumina_coverage_quality.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac77ce5d7483268cbba4b1b86fdcac