### PR TITLE
feat: add offline flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,8 @@ genecli <command> --input-files <path1> [<path2> ...] \
     --method <method_name> [--fec <fec_method>] [options]
 ```
 
-Run `genecli --help` to see all available commands:
+Run `genecli --help` to see all available commands. Use `--offline` to disable
+network features and avoid loading cloud integrations:
 
 ```bash
 genecli --help

--- a/src/genecoder/cli/cli.py
+++ b/src/genecoder/cli/cli.py
@@ -6,6 +6,7 @@ from genecoder.random_utils import reset_rng
 
 from genecoder import __version__
 from genecoder.plugin_manager import init_plugins
+from genecoder.options import add_offline_flag, set_offline
 # simulators are imported lazily by subcommands that need them
 
 from typing import Any
@@ -110,6 +111,7 @@ def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", version=f"GeneCoder {__version__}")
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase output verbosity (can be used multiple times).")
     parser.add_argument("-q", "--quiet", action="count", default=0, help="Decrease output verbosity (can be used multiple times).")
+    add_offline_flag(parser)
     subparsers = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
 
     encode.register_subcommand(subparsers)
@@ -136,6 +138,7 @@ def main(argv: list[str] | None = None, prog: str | None = None) -> None:
     reset_rng()
     parser = build_parser(prog)
     args = parser.parse_args(argv)
+    set_offline(getattr(args, "offline", False))
 
     level = logging.INFO - (args.verbose * 10) + (args.quiet * 10)
     level = max(logging.DEBUG, min(logging.CRITICAL, level))

--- a/src/genecoder/cloud/worker.py
+++ b/src/genecoder/cloud/worker.py
@@ -12,6 +12,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Header
 
 from genecoder.cli import bundle as bundle_cli
+from genecoder.options import OFFLINE
 
 app = FastAPI()
 
@@ -21,6 +22,8 @@ API_TOKEN: str | None = None
 @app.post("/jobs")  # type: ignore[misc]
 def create_job(job: dict[str, Any], authorization: str | None = Header(None)) -> dict[str, str]:
     """Handle bundle job uploads from tests."""
+    if OFFLINE:
+        raise HTTPException(status_code=503, detail="Offline mode")
     if authorization != f"Bearer {API_TOKEN}":
         raise HTTPException(status_code=401, detail="Invalid token")
 

--- a/src/genecoder/options.py
+++ b/src/genecoder/options.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import argparse
+import os
 
 
 @dataclass
@@ -48,3 +50,29 @@ class DecodingOptions:
     parity_rule: str
     alphabet: str
     seed: int | None = None
+
+
+# Offline mode ------------------------------------------------------------
+
+OFFLINE: bool = bool(os.getenv("GENECODER_OFFLINE"))
+
+
+def add_offline_flag(parser: argparse.ArgumentParser) -> None:
+    """Register the ``--offline`` flag on a CLI parser."""
+
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Disable network features and cloud modules",
+    )
+
+
+def set_offline(offline: bool) -> None:
+    """Enable or disable offline mode globally."""
+
+    global OFFLINE
+    OFFLINE = offline
+    if offline:
+        os.environ["GENECODER_OFFLINE"] = "1"
+    else:
+        os.environ.pop("GENECODER_OFFLINE", None)


### PR DESCRIPTION
## Summary
- add global `--offline` flag to CLI
- disable cloud worker when running offline
- document offline usage

## Testing
- `ruff check src/genecoder/options.py src/genecoder/cli/cli.py src/genecoder/cloud/worker.py`
- `pytest tests/test_plugin_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac77cd73888326a7ca510119721c4a