### PR TITLE
Document plugin interfaces and provide templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,10 @@ See the step-by-step
 [codec](docs/plugins.md#codec-plugin-walkthrough),
 [FEC](docs/plugins.md#fec-plugin-walkthrough) and
 [simulator](docs/plugins.md#simulator-plugin-walkthrough) examples in
-[docs/plugins.md](docs/plugins.md) for details on writing and registering
-new codecs, FEC back-ends or simulators. Plugins are automatically loaded when
+[docs/plugins.md](docs/plugins.md) for interface expectations and details on
+writing and registering new codecs, FEC back-ends or simulators. Minimal
+templates live in `plugins-examples/encoder_template` and
+`plugins-examples/channel_template`. Plugins are automatically loaded when
 using the CLI or GUI. When using GeneCoder as a library call
 ``genecoder.plugins.load_plugins()`` first to populate the registries.
 GeneCoder follows an offline-first design: without a registry URL only plugins

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,9 +7,60 @@ package can expose entry points under `genecoder.plugins`, `genecoder.fec`,
 implementation to the appropriate registry. GeneCoder looks only at packages
 installed in your current Python environment when loading plugins.
 
+## Interface Expectations
+
+Each plugin module must expose a ``register`` function that receives a callback
+for adding implementations to GeneCoder's registries. The plugin then invokes
+that callback with a unique name and the implementation class or instance.
+
+### Encoders
+
+Encoder plugins subclass :class:`genecoder.api.Codec` and implement
+``encode`` and ``decode`` methods:
+
+```python
+from genecoder.api import Codec
+
+class MyCodec(Codec):
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
+        ...
+
+    def decode(self, text: str, /, **kwargs: object) -> bytes:
+        ...
+
+def register(register_codec):
+    register_codec("mycodec", MyCodec)
+```
+
+### Channels
+
+Channel plugins subclass :class:`genecoder.api.Simulator` and implement a
+``simulate`` method:
+
+```python
+from genecoder.api import Simulator
+
+class MyChannel(Simulator):
+    def simulate(self, sequence: str) -> str:
+        ...
+
+def register(register_simulator):
+    register_simulator("mychannel", MyChannel())
+```
+
+### FEC and Visualizers
+
+Forward error correction back-ends implement :class:`genecoder.api.FEC` with
+``encode`` and ``decode`` methods. Visualizer plugins subclass
+:class:`genecoder.api.Visualizer` and provide a ``visualize`` method. Register
+them through ``genecoder.fec`` or ``genecoder.visualizers`` entry points.
+
 ## Quick Start
 
-Create a minimal codec plugin in four steps:
+Create a minimal codec plugin in four steps. Minimal templates for encoders and
+channels live in
+[`plugins-examples/encoder_template`](../plugins-examples/encoder_template/) and
+[`plugins-examples/channel_template`](../plugins-examples/channel_template/):
 
 1. **Project layout** – see
    [`plugins-examples/example_codec`](../plugins-examples/example_codec/) for a

--- a/plugins-examples/channel_template/README.md
+++ b/plugins-examples/channel_template/README.md
@@ -1,0 +1,11 @@
+# Channel Plugin Template
+
+Minimal skeleton for a custom channel plugin. Implement `simulate` in
+`channel_template/__init__.py` and adjust the entry point name in
+`pyproject.toml`.
+
+Install locally for experimentation:
+
+```bash
+pip install ./channel_template
+```

--- a/plugins-examples/channel_template/channel_template/__init__.py
+++ b/plugins-examples/channel_template/channel_template/__init__.py
@@ -1,0 +1,16 @@
+from typing import Callable
+
+from genecoder.api import Simulator
+
+
+class TemplateChannel(Simulator):  # type: ignore[misc]
+    """Skeleton channel plugin."""
+
+    def simulate(self, sequence: str) -> str:
+        """Return a possibly modified version of ``sequence``."""
+        raise NotImplementedError
+
+
+def register(register_simulator: Callable[[str, Simulator], None]) -> None:
+    """Register the channel simulator with GeneCoder."""
+    register_simulator("template", TemplateChannel())

--- a/plugins-examples/channel_template/pyproject.toml
+++ b/plugins-examples/channel_template/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-channel-template"
+version = "0.0.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.simulators"]
+template = "channel_template"

--- a/plugins-examples/encoder_template/README.md
+++ b/plugins-examples/encoder_template/README.md
@@ -1,0 +1,11 @@
+# Encoder Plugin Template
+
+Minimal skeleton for a custom encoder plugin. Implement `encode` and `decode`
+in `encoder_template/__init__.py` and adjust the entry point name in
+`pyproject.toml`.
+
+Install locally for experimentation:
+
+```bash
+pip install ./encoder_template
+```

--- a/plugins-examples/encoder_template/encoder_template/__init__.py
+++ b/plugins-examples/encoder_template/encoder_template/__init__.py
@@ -1,0 +1,20 @@
+from typing import Callable
+
+from genecoder.api import Codec
+
+
+class TemplateEncoder(Codec):  # type: ignore[misc]
+    """Skeleton encoder plugin."""
+
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
+        """Convert ``data`` into a DNA string."""
+        raise NotImplementedError
+
+    def decode(self, text: str, /, **kwargs: object) -> bytes:
+        """Reconstruct the original bytes from ``text``."""
+        raise NotImplementedError
+
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    """Register the encoder with GeneCoder."""
+    register_codec("template", TemplateEncoder)

--- a/plugins-examples/encoder_template/pyproject.toml
+++ b/plugins-examples/encoder_template/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-encoder-template"
+version = "0.0.0"
+dependencies = ["genecoder"]
+
+[project.entry-points."genecoder.plugins"]
+template = "encoder_template"


### PR DESCRIPTION
## Summary
- Document plugin interface expectations and registration contracts
- Add minimal encoder and channel plugin templates
- Link plugin documentation and templates from README

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac77cca46c8326a93abe54ead8e370