### PR TITLE
Add d2sim adapter and cloud worker offline tests

### DIFF
--- a/tests/test_cloud_worker_offline.py
+++ b/tests/test_cloud_worker_offline.py
@@ -1,0 +1,101 @@
+import base64
+import tempfile
+import zipfile
+from pathlib import Path
+import sys
+import types
+from typing import Any, Callable
+
+import pytest
+
+# Provide a minimal FastAPI stub so the worker module can be imported without the
+# external dependency.
+try:  # pragma: no cover - real FastAPI is optional for tests
+    import fastapi  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - executed when fastapi missing
+    fastapi_stub = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str) -> None:
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self) -> None:
+            pass
+
+        def post(
+            self, *_args: object, **_kwargs: object
+        ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+                return func
+
+            return decorator
+
+    def Header(default: str | None = None) -> str | None:  # noqa: D401
+        return default
+
+    setattr(fastapi_stub, "FastAPI", FastAPI)
+    setattr(fastapi_stub, "HTTPException", HTTPException)
+    setattr(fastapi_stub, "Header", Header)
+    sys.modules["fastapi"] = fastapi_stub
+
+# Stub out the ``cryptography`` package used by plugin_security so the tests do
+# not require the external dependency.
+crypto_mod = types.ModuleType("cryptography")
+crypto_exc = types.ModuleType("cryptography.exceptions")
+
+class InvalidSignature(Exception):
+    pass
+
+setattr(crypto_exc, "InvalidSignature", InvalidSignature)
+setattr(crypto_mod, "exceptions", crypto_exc)
+sys.modules["cryptography"] = crypto_mod
+sys.modules["cryptography.exceptions"] = crypto_exc
+
+from genecoder.cloud import worker
+from genecoder import plugin_manager as plugins
+
+
+def _build_archive(bundle_path: Path) -> str:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive = Path(tmpdir) / "bundle.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.write(bundle_path, arcname=bundle_path.name)
+        return base64.b64encode(archive.read_bytes()).decode()
+
+
+def test_worker_offline_blocks_network(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    worker.API_TOKEN = "tok"
+
+    bundle_file = tmp_path / "b.yaml"
+    bundle_file.write_text("encode:\n  input_files: []\n")
+    archive_b64 = _build_archive(bundle_file)
+
+    def fake_urlopen(*args: object, **kwargs: object) -> None:  # pragma: no cover - should not run
+        raise AssertionError("network access attempted")
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        plugins.subprocess,
+        "check_call",
+        lambda *args: (_ for _ in ()).throw(AssertionError("pip install attempted")),
+    )
+    monkeypatch.setenv("GENECODER_OFFLINE", "1")
+
+    import genecoder
+
+    called = {"run": False}
+
+    def dummy(args: object) -> None:
+        called["run"] = True
+        genecoder.install_registry_plugins("https://example.com/plugins.yaml")
+
+    monkeypatch.setattr(worker.bundle_cli, "_handle_run", dummy)
+
+    response = worker.create_job(
+        {"type": "bundle", "payload": {"archive": archive_b64}},
+        authorization="Bearer tok",
+    )
+    assert response["status"] == "ok"
+    assert called["run"]

--- a/tests/test_d2sim_adapter.py
+++ b/tests/test_d2sim_adapter.py
@@ -1,0 +1,62 @@
+import random
+import sys
+import types
+
+import pytest
+
+# Stub out the ``cryptography`` package so tests don't require the external
+# dependency for import-time plugin security helpers.
+crypto_mod = types.ModuleType("cryptography")
+crypto_exc = types.ModuleType("cryptography.exceptions")
+
+class InvalidSignature(Exception):
+    pass
+
+setattr(crypto_exc, "InvalidSignature", InvalidSignature)
+setattr(crypto_mod, "exceptions", crypto_exc)
+sys.modules["cryptography"] = crypto_mod
+sys.modules["cryptography.exceptions"] = crypto_exc
+
+from genecoder import d2sim_adapter
+from genecoder import simulator_utils
+
+
+def test_simulate_d2sim_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """simulate_d2sim uses external command when available."""
+    monkeypatch.setattr(simulator_utils.shutil, "which", lambda cmd: "/usr/bin/d2sim")
+
+    called: dict[str, list[str] | str] = {}
+
+    def fake_run_external(cmd: list[str], sequence: str) -> str:
+        called["cmd"] = cmd
+        called["seq"] = sequence
+        return "SIMULATED"
+
+    monkeypatch.setattr(simulator_utils, "_run_external", fake_run_external)
+
+    result = d2sim_adapter.simulate_d2sim("ACGT", rng=random.Random(0))
+
+    assert result == "SIMULATED"
+    assert called["cmd"][0] == "d2sim"
+    assert called["seq"] == "ACGT"
+
+
+def test_simulate_d2sim_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """simulate_d2sim falls back when command missing."""
+    monkeypatch.setattr(simulator_utils.shutil, "which", lambda cmd: None)
+    called: dict[str, bool] = {"simulate_errors": False}
+
+    def fake_simulate_errors(seq: str, error_rate: float, rng: random.Random) -> str:
+        called["simulate_errors"] = True
+        return "FALLBACK"
+
+    def fake_run_external(*args: object, **kwargs: object) -> str:  # pragma: no cover - should not run
+        raise AssertionError("_run_external should not be called")
+
+    monkeypatch.setattr(simulator_utils, "simulate_errors", fake_simulate_errors)
+    monkeypatch.setattr(simulator_utils, "_run_external", fake_run_external)
+
+    result = d2sim_adapter.simulate_d2sim("ACGT", rng=random.Random(0))
+
+    assert result == "FALLBACK"
+    assert called["simulate_errors"]


### PR DESCRIPTION
## Summary
- add tests for d2sim adapter success and fallback behavior
- add cloud worker offline test to ensure network calls are blocked

## Testing
- `ruff check tests/test_cloud_worker_offline.py tests/test_d2sim_adapter.py`
- `mypy tests/test_d2sim_adapter.py tests/test_cloud_worker_offline.py`
- `pytest tests/test_d2sim_adapter.py tests/test_cloud_worker_offline.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac77cee96483269a2824f4d5f7d9d8