### PR TITLE
Document plugin interfaces and tighten enforcement

### DIFF
--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -19,7 +19,7 @@ class Codec(ABC):
     """
 
     @abstractmethod
-    def encode(self, data: bytes, /, **kwargs: Any) -> Any:
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:
         """Return an encoded representation of ``data``.
 
         Parameters
@@ -31,18 +31,18 @@ class Codec(ABC):
 
         Returns
         -------
-        Any
-            Encoded representation of the input bytes.
+        str
+            DNA sequence produced from the input bytes.
         """
 
     @abstractmethod
-    def decode(self, encoded: Any, /, **kwargs: Any) -> bytes:
+    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:
         """Decode ``encoded`` back into the original byte sequence.
 
         Parameters
         ----------
         encoded:
-            The encoded object returned by :meth:`encode`.
+            The sequence returned by :meth:`encode`.
         **kwargs:
             Optional codec specific parameters.
 
@@ -54,7 +54,11 @@ class Codec(ABC):
 
 
 class FEC(ABC):
-    """Abstract base class for forward error correction backends."""
+    """Abstract base class for forward error correction backends.
+
+    Implementations must provide matching :meth:`encode` and
+    :meth:`decode` methods as defined below.
+    """
 
     @abstractmethod
     def encode(self, data: bytes, /, **kwargs: Any) -> Tuple[bytes, Mapping[str, Any]]:
@@ -94,7 +98,12 @@ class FEC(ABC):
 
 
 class Simulator(ABC):
-    """Abstract base class for read simulators."""
+    """Abstract base class for read simulators.
+
+    At minimum implementations must define :meth:`simulate`.  The
+    :meth:`with_profile` helper is optional and may be overridden to
+    support external error profiles.
+    """
 
     @abstractmethod
     def simulate(self, sequence: str) -> str:
@@ -134,7 +143,10 @@ class Simulator(ABC):
 
 
 class Visualizer(ABC):
-    """Abstract base class for sequence visualizers."""
+    """Abstract base class for sequence visualizers.
+
+    Implementations must supply a :meth:`visualize` method.
+    """
 
     @abstractmethod
     def visualize(self, sequence: str, /, **kwargs: Any) -> Any:

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -122,28 +122,45 @@ def _coerce_plugin(
 
 
 def register_codec(name: str, codec: Codec | type[Codec]) -> None:
-    """Register a codec implementation under ``name``."""
+    """Register a codec implementation under ``name``.
+
+    If multiple plugins register the same ``name`` the last registration wins.
+    Plugins are discovered in the order built-in, entry-point and then local
+    modules, allowing user supplied plugins to override bundled ones.
+    """
 
     inst = cast(Any, _coerce_plugin(codec, Codec, ("encode", "decode"), "codec"))
     CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
 def register_fec(name: str, fec: FEC | type[FEC]) -> None:
-    """Register a FEC backend under ``name``."""
+    """Register a FEC backend under ``name``.
+
+    Later registrations override earlier ones; discovery follows the same
+    built-in, entry-point then local order as codecs.
+    """
 
     inst = cast(Any, _coerce_plugin(fec, FEC, ("encode", "decode"), "FEC"))
     FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
 
 
 def register_simulator(name: str, channel: Simulator | type[Simulator]) -> None:
-    """Register a read simulator under ``name``."""
+    """Register a read simulator under ``name``.
+
+    Later registrations with the same ``name`` replace earlier ones.  The
+    discovery order mirrors codecs and FEC backends.
+    """
 
     inst = cast(Any, _coerce_plugin(channel, Simulator, ("simulate",), "simulator"))
     _register_simulator(name, inst)
 
 
 def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
-    """Register a visualizer under ``name``."""
+    """Register a visualizer under ``name``.
+
+    As with other plugin types, later registrations win and discovery order is
+    built-in first followed by entry-point and local plugins.
+    """
 
     inst = cast(Any, _coerce_plugin(visualizer, Visualizer, ("visualize",), "visualizer"))
     VISUALIZER_REGISTRY[name] = inst.visualize

--- a/tests/test_plugin_interface_enforcement.py
+++ b/tests/test_plugin_interface_enforcement.py
@@ -31,5 +31,85 @@ def register(register_codec):
     plugins.FEC_REGISTRY.clear()
     plugins.SIMULATOR_REGISTRY.clear()
     plugins.VISUALIZER_REGISTRY.clear()
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="codec encode has incompatible signature"):
+        plugins.load_plugins()
+
+
+def test_fec_missing_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fec_mod = tmp_path / "bad_fec.py"
+    fec_mod.write_text(
+        """
+from genecoder.api import FEC
+
+class BadFEC(FEC):
+    def encode(self, data: bytes, /, **kwargs) -> tuple[bytes, dict[str, object]]:
+        return b"", {}
+    decode = None  # type: ignore[assignment]
+
+def register(register_fec):
+    register_fec("badfec", BadFEC)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="badfec", value="bad_fec", group="genecoder.fec")
+    monkeypatch.setattr(
+        plugins, "entry_points", lambda *, group=None: [ep] if group == "genecoder.fec" else []
+    )
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
+    with pytest.raises(TypeError, match="FEC missing required method decode"):
+        plugins.load_plugins()
+
+
+def test_simulator_missing_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    sim_mod = tmp_path / "bad_sim.py"
+    sim_mod.write_text(
+        """
+from genecoder.api import Simulator
+
+class BadSim(Simulator):
+    simulate = None  # type: ignore[assignment]
+
+def register(register_simulator):
+    register_simulator("badsim", BadSim)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="badsim", value="bad_sim", group="genecoder.simulators")
+    monkeypatch.setattr(
+        plugins, "entry_points", lambda *, group=None: [ep] if group == "genecoder.simulators" else []
+    )
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
+    with pytest.raises(TypeError, match="simulator missing required method simulate"):
+        plugins.load_plugins()
+
+
+def test_visualizer_missing_method(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    vis_mod = tmp_path / "bad_vis.py"
+    vis_mod.write_text(
+        """
+from genecoder.api import Visualizer
+
+class BadVis(Visualizer):
+    visualize = None  # type: ignore[assignment]
+
+def register(register_visualizer):
+    register_visualizer("badvis", BadVis)
+"""
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="badvis", value="bad_vis", group="genecoder.visualizers")
+    monkeypatch.setattr(
+        plugins, "entry_points", lambda *, group=None: [ep] if group == "genecoder.visualizers" else []
+    )
+    plugins.CODEC_REGISTRY.clear()
+    plugins.FEC_REGISTRY.clear()
+    plugins.SIMULATOR_REGISTRY.clear()
+    plugins.VISUALIZER_REGISTRY.clear()
+    with pytest.raises(TypeError, match="visualizer missing required method visualize"):
         plugins.load_plugins()


### PR DESCRIPTION
## Summary
- clarify codec, FEC, simulator and visualizer interfaces with return types
- document plugin registration order for all plugin types
- expand interface enforcement tests for misbehaving plugins

## Testing
- `ruff check src/genecoder/api.py src/genecoder/plugin_manager.py tests/test_plugin_interface_enforcement.py`
- `pytest tests/test_plugin_interface_enforcement.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0e12c2648326b495ec3beb368f19