### PR TITLE
Add FEC backend selection to pipeline and tests

### DIFF
--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -2,11 +2,77 @@ from __future__ import annotations
 
 """Simple pipeline for processing sequences step by step."""
 
-from typing import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence, Tuple
 
+from .gc_constrained_encoder import calculate_gc_content
+from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
+from .simulators import SIMULATOR_REGISTRY
+from .utils import get_max_homopolymer_length
 from .parallel import parallel_map
 
-__all__ = ["SequencePipeline"]
+__all__ = ["SequencePipeline", "run_pipeline"]
+
+
+def _levenshtein_counts(original: str, mutated: str) -> Tuple[int, int, int]:
+    """Return substitution, insertion and deletion counts."""
+    try:
+        from Levenshtein import editops
+
+        ops = editops(original, mutated)
+
+        def get_tag(op: Any) -> str:  # noqa: D401,ANN401
+            return str(op[0])
+
+    except Exception:  # pragma: no cover - fallback
+        from rapidfuzz.distance import Levenshtein as RF
+
+        ops = RF.editops(original, mutated)
+
+        def get_tag(op: Any) -> str:  # noqa: D401,ANN401
+            return str(op.tag)
+
+    subs = ins = dels = 0
+    for op in ops:
+        tag = get_tag(op)
+        if tag == "replace":
+            subs += 1
+        elif tag == "insert":
+            ins += 1
+        elif tag == "delete":
+            dels += 1
+    return subs, ins, dels
+
+
+def _gc_distribution(sequence: str, window: int = 50) -> List[float]:
+    """Return GC content for non-overlapping windows in ``sequence``."""
+    values: List[float] = []
+    for i in range(0, len(sequence), window):
+        chunk = sequence[i : i + window]
+        if not chunk:
+            break
+        gc = sum(1 for base in chunk if base in "GCgc") / len(chunk)
+        values.append(gc)
+    return values
+
+
+def _homopolymer_runs(sequence: str) -> List[int]:
+    """Return counts of homopolymer runs by length for ``sequence``."""
+    if not sequence:
+        return []
+    counts: Dict[int, int] = {}
+    current = sequence[0]
+    run = 1
+    for base in sequence[1:]:
+        if base == current:
+            run += 1
+        else:
+            counts[run] = counts.get(run, 0) + 1
+            current = base
+            run = 1
+    counts[run] = counts.get(run, 0) + 1
+    max_run = max(counts)
+    return [counts.get(i, 0) for i in range(1, max_run + 1)]
 
 
 class SequencePipeline:
@@ -42,4 +108,90 @@ class SequencePipeline:
                 use_processes=use_processes,
             )
         return [self.run(s) for s in sequences]
+
+
+def run_pipeline(
+    codec: str,
+    fec_backend: str | None,
+    channel: str | None,
+    input_path: str,
+    output_path: str,
+) -> Tuple[bytes, Dict[str, Any], Mapping[str, Any] | None]:
+    """Process ``input_path`` through the selected codec, FEC and channel."""
+
+    init_plugins()
+
+    if codec not in CODEC_REGISTRY:
+        raise ValueError(f"Unknown codec: {codec}")
+    if fec_backend and fec_backend not in FEC_REGISTRY:
+        raise ValueError(f"Unknown FEC: {fec_backend}")
+    if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
+        raise ValueError(f"Unknown channel: {channel}")
+
+    original_data = Path(input_path).read_bytes()
+    data = original_data
+
+    fec_info: Mapping[str, Any] | None = None
+    if fec_backend:
+        data, fec_info = FEC_REGISTRY[fec_backend]["encode"](data)
+
+    dna = CODEC_REGISTRY[codec]["encode"](data)
+    orig_dna = dna
+    subs = ins = dels = None
+    coverage = None
+    if channel and channel != "none":
+        sim = SIMULATOR_REGISTRY[channel]
+        dna = sim.simulate(dna)
+        subs, ins, dels = _levenshtein_counts(orig_dna, dna)
+        cov_func = getattr(sim, "get_coverage", None)
+        if callable(cov_func):
+            try:
+                coverage = int(cov_func(orig_dna))
+            except Exception:
+                coverage = None
+
+    gc_content = calculate_gc_content(dna)
+    max_homopolymer = get_max_homopolymer_length(dna)
+    gc_dist = _gc_distribution(dna)
+    hp_runs = _homopolymer_runs(dna)
+    gc_variance = (
+        sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
+        if gc_dist
+        else 0.0
+    )
+
+    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
+    assert isinstance(decoded_any, (bytes, bytearray))
+    decoded = bytes(decoded_any)
+
+    if fec_backend:
+        assert fec_info is not None
+        decoded, _ = FEC_REGISTRY[fec_backend]["decode"](decoded, fec_info)
+
+    Path(output_path).write_bytes(decoded)
+    success = 1.0 if decoded == original_data else 0.0
+    constraint_violations = 0
+    try:
+        from .synthesis import validate_sequence
+
+        if not validate_sequence(dna):
+            constraint_violations = 1
+    except Exception:
+        constraint_violations = 0
+
+    metrics: Dict[str, Any] = {
+        "gc_distribution": gc_dist,
+        "gc_content": gc_content,
+        "gc_variance": gc_variance,
+        "max_homopolymer": max_homopolymer,
+        "homopolymer_runs": hp_runs,
+        "ecc_success_rates": {fec_backend: success} if fec_backend else {},
+        "decode_success_rate": success,
+        "coverage": coverage,
+        "constraint_violations": constraint_violations,
+    }
+    if subs is not None and ins is not None and dels is not None:
+        metrics.update({"substitutions": subs, "insertions": ins, "deletions": dels})
+
+    return decoded, metrics, fec_info
 

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from genecoder.core import run_pipeline
+from genecoder.pipeline import run_pipeline
 from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.channel_sim import Channel
@@ -31,38 +31,31 @@ def _setup_simple_channel(rate: float) -> None:
     SIMULATOR_REGISTRY["simple"] = Channel(error_rate=rate)
 
 
-@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
-def test_pipeline_roundtrip_reed_solomon(tmp_path: Path) -> None:
+@pytest.mark.parametrize("fec_backend", ["reed_solomon", "fountain"])
+def test_pipeline_roundtrip(tmp_path: Path, fec_backend: str) -> None:
+    if fec_backend == "reed_solomon" and not _HAS_REEDSOLO:
+        pytest.skip("reedsolo not installed")
+    if fec_backend == "fountain":
+        pytest.importorskip("pyfinite")
+
     init_plugins()
     _register_base_codec()
     _setup_simple_channel(rate=0.1)
 
-    data = b"pipeline RS"
+    data = f"pipeline {fec_backend}".encode()
     inp = tmp_path / "data.bin"
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result, metrics = run_pipeline("base4", "reed_solomon", "simple", str(inp), str(outp))
+    result, metrics, info = run_pipeline("base4", fec_backend, "simple", str(inp), str(outp))
     assert result == data
     assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data
-
-
-def test_pipeline_roundtrip_fountain(tmp_path: Path) -> None:
-    pytest.importorskip("pyfinite")
-    init_plugins()
-    _register_base_codec()
-    _setup_simple_channel(rate=0.1)
-
-    data = b"pipeline fountain"
-    inp = tmp_path / "data.bin"
-    outp = tmp_path / "out.bin"
-    inp.write_bytes(data)
-
-    result, metrics = run_pipeline("base4", "fountain", "simple", str(inp), str(outp))
-    assert result == data
-    assert metrics["gc_content"] >= 0.0
-    assert outp.read_bytes() == data
+    assert info is not None
+    if fec_backend == "reed_solomon":
+        assert "nsym" in info
+    else:
+        assert "seed" in info
 
 
 @pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
@@ -78,7 +71,7 @@ def test_pipeline_roundtrip_rs_illumina(
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result, _ = run_pipeline(
+    result, _, _ = run_pipeline(
         "base4",
         "reed_solomon",
         "illumina",
@@ -102,7 +95,7 @@ def test_pipeline_roundtrip_fountain_nanopore(
     outp = tmp_path / "out.bin"
     inp.write_bytes(data)
 
-    result, _ = run_pipeline(
+    result, _, _ = run_pipeline(
         "base4",
         "fountain",
         "nanopore",


### PR DESCRIPTION
## Summary
- add `run_pipeline` helper that accepts a selectable FEC backend and returns FEC metadata
- propagate FEC metadata through the pipeline for decoding
- parameterize roundtrip tests to exercise both Reed–Solomon and Fountain modes

## Testing
- `ruff check src/genecoder/pipeline.py tests/test_pipeline_roundtrip.py`
- `pytest tests/test_pipeline_roundtrip.py`

------
https://chatgpt.com/codex/tasks/task_e_68af11be16ac8326977d4200b5d5a051