### PR TITLE
feat: expose droplet count in fountain codec

### DIFF
--- a/src/genecoder/fountain_codec.py
+++ b/src/genecoder/fountain_codec.py
@@ -80,6 +80,7 @@ def encode_data_fountain(
     *,
     seed: int = 0,
     redundancy: float = 2.0,
+    droplet_count: int | None = None,
     c: float = 0.1,
     delta: float = 0.5,
 ) -> Tuple[bytes, Any]:
@@ -99,6 +100,10 @@ def encode_data_fountain(
         Base seed for droplet generation.
     redundancy:
         Number of droplets to emit relative to ``k`` (the number of chunks).
+        Ignored if ``droplet_count`` is provided.
+    droplet_count:
+        Explicit number of droplets to emit. If ``None`` the value is derived
+        from ``redundancy``.
     c:
         Scaling factor controlling the expected ripple size of the robust
         soliton distribution.
@@ -129,7 +134,11 @@ def encode_data_fountain(
         data[i : i + chunk_size].ljust(chunk_size, b"\x00")
         for i in range(0, len(data), chunk_size)
     ]
-    num_droplets = max(k, int(k * redundancy))
+    num_droplets = (
+        droplet_count
+        if droplet_count is not None
+        else max(k, int(k * redundancy))
+    )
     cdf = _robust_soliton_cdf(k, c=c, delta=delta)
     droplets: list[bytes] = []
     for i in range(num_droplets):
@@ -244,6 +253,7 @@ class FountainFEC(FEC):
         chunk_size: int = 4,
         seed: int = 0,
         redundancy: float = 2.0,
+        droplet_count: int | None = None,
         c: float = 0.1,
         delta: float = 0.5,
         **kwargs: Any,
@@ -253,6 +263,7 @@ class FountainFEC(FEC):
             chunk_size,
             seed=seed,
             redundancy=redundancy,
+            droplet_count=droplet_count,
             c=c,
             delta=delta,
         )

--- a/tests/test_fountain_codec.py
+++ b/tests/test_fountain_codec.py
@@ -3,6 +3,7 @@ import random
 import pytest
 
 pytest.importorskip("pyfinite")
+pytest.importorskip("reedsolo")
 
 from genecoder.fountain_codec import (
     _robust_soliton_cdf,
@@ -10,6 +11,7 @@ from genecoder.fountain_codec import (
     decode_data_fountain,
     encode_data_fountain,
 )
+from genecoder.reed_solomon_codec import encode_data_rs, decode_data_rs
 
 def test_fountain_roundtrip():
     data = b"Fountain test data"
@@ -38,6 +40,47 @@ def test_fountain_erasure_recovery():
     subset = b"".join(droplets[:keep])
     decoded, _ = decode_data_fountain(subset, info)
     assert decoded == data
+
+
+def test_fountain_roundtrip_explicit_droplets():
+    data = b"explicit droplet count"
+    encoded, info = encode_data_fountain(
+        data, chunk_size=3, droplet_count=20, seed=1
+    )
+    decoded, _ = decode_data_fountain(encoded, info)
+    assert decoded == data
+
+
+def test_fountain_droplet_loss_with_explicit_count():
+    data = b"loss scenario" * 4
+    encoded, info = encode_data_fountain(
+        data, chunk_size=4, droplet_count=40, seed=2
+    )
+    droplet_size = info["chunk_size"] + 4
+    droplets = [
+        encoded[i : i + droplet_size] for i in range(0, len(encoded), droplet_size)
+    ]
+    subset = b"".join(droplets[:-10])
+    decoded, _ = decode_data_fountain(subset, info)
+    assert decoded == data
+
+
+def test_fountain_with_reed_solomon_outer_code():
+    data = b"rs outer integration"
+    rs_encoded, nsym, sym_size, prim = encode_data_rs(data, nsym=4)
+    encoded, info = encode_data_fountain(
+        rs_encoded, chunk_size=5, droplet_count=30, seed=3
+    )
+    droplet_size = info["chunk_size"] + 4
+    droplets = [
+        encoded[i : i + droplet_size] for i in range(0, len(encoded), droplet_size)
+    ]
+    subset = b"".join(droplets[:-5])
+    fountain_decoded, _ = decode_data_fountain(subset, info)
+    rs_decoded, _ = decode_data_rs(
+        fountain_decoded, nsym, symbol_size=sym_size, primitive=prim
+    )
+    assert rs_decoded == data
 
 
 def test_fountain_degree_distribution_params():


### PR DESCRIPTION
## Summary
- allow configuring LT droplet count when encoding
- add tests for explicit droplet count, droplet loss and Reed-Solomon compatibility

## Testing
- `ruff check src/genecoder/fountain_codec.py tests/test_fountain_codec.py`
- `pytest tests/test_fountain_codec.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11bf101c8326bd0db1a1ec541bdb