### PR TITLE
Handle run-length dependent nanopore context indels

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -455,7 +455,7 @@ def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
 
     # discover local plugins in a ``plugins`` package
     try:
-        import plugins as local_pkg  # type: ignore
+        import plugins as local_pkg
     except ModuleNotFoundError:
         local_pkg = None
 

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -84,14 +84,17 @@ def _validate_context_profiles(
 
 
 def _split_context_indels(
-    profiles: Mapping[str, Mapping[str, Mapping[int, float]]] | None,
+    profiles: Mapping[str, Mapping[Any, Any]] | None,
     name: str,
 ) -> tuple[Dict[str, Dict[int, float]], Dict[str, Dict[int, float]]]:
     """Return separate insertion and deletion context maps.
 
-    ``profiles`` maps contexts to ``{"insertions": {...}, "deletions": {...}}``. This
-    helper validates the nested indel profiles and returns two dictionaries in the
-    same normalized format used internally by the simulator.
+    ``profiles`` can map contexts either to ``{"insertions": {...}, "deletions": {...}}``
+    or to run-length specific mappings such as ``{5: {"insertions": 0.1}}``. When only a
+    single probability is provided for a run length, it is applied to both insertions
+    and deletions by default. This helper validates the nested indel profiles and
+    returns two dictionaries in the normalized format used internally by the
+    simulator.
     """
 
     ctx_ins: Dict[str, Dict[int, float]] = {}
@@ -99,16 +102,49 @@ def _split_context_indels(
     for ctx, ctx_map in (profiles or {}).items():
         if not isinstance(ctx_map, Mapping):
             continue
-        ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
-        del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
-        if ins_prof is not None:
-            ctx_ins[str(ctx).upper()] = _validate_indel_profile(
-                ins_prof, f"{name}[{ctx}].insertions"
-            )
-        if del_prof is not None:
-            ctx_del[str(ctx).upper()] = _validate_indel_profile(
-                del_prof, f"{name}[{ctx}].deletions"
-            )
+        ctx_key = str(ctx).upper()
+
+        if any(k in {"insertions", "insertion", "deletions", "deletion"} for k in ctx_map):
+            # Traditional format with explicit insertion/deletion maps
+            ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
+            del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
+            if ins_prof is not None:
+                ctx_ins[ctx_key] = _validate_indel_profile(
+                    ins_prof, f"{name}[{ctx}].insertions"
+                )
+            if del_prof is not None:
+                ctx_del[ctx_key] = _validate_indel_profile(
+                    del_prof, f"{name}[{ctx}].deletions"
+                )
+            continue
+
+        # Run-length first format: {context: {run_len: {"insertions": x, ...}}}
+        for run_len, rates in ctx_map.items():
+            try:
+                rl = int(run_len)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(rates, Mapping):
+                ins = rates.get("insertions") or rates.get("insertion")
+                dele = rates.get("deletions") or rates.get("deletion")
+                if ins is None and dele is None:
+                    raise ValueError(
+                        f"{name}[{ctx}][{rl}] must specify insertions or deletions"
+                    )
+                if ins is not None:
+                    val = _validate_rate(
+                        f"{name}[{ctx}][{rl}].insertions", ins
+                    )
+                    ctx_ins.setdefault(ctx_key, {})[rl] = val
+                if dele is not None:
+                    val = _validate_rate(
+                        f"{name}[{ctx}][{rl}].deletions", dele
+                    )
+                    ctx_del.setdefault(ctx_key, {})[rl] = val
+            else:
+                val = _validate_rate(f"{name}[{ctx}][{rl}]", rates)
+                ctx_ins.setdefault(ctx_key, {})[rl] = val
+                ctx_del.setdefault(ctx_key, {})[rl] = val
     return ctx_ins, ctx_del
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nanopore_homopolymer.py
+++ b/tests/test_nanopore_homopolymer.py
@@ -1,6 +1,10 @@
 import random
 
-from genecoder.simulators.nanopore import NanoporeChannel, _mutate_read
+from genecoder.simulators.nanopore import (
+    NanoporeChannel,
+    _mutate_read,
+    _split_context_indels,
+)
 
 
 def _simulate_many(channel: NanoporeChannel, sequence: str, runs: int = 1000) -> tuple[float, float]:
@@ -36,4 +40,21 @@ def test_deletion_profile_distribution() -> None:
     )
     _, del_rate = _simulate_many(channel, "AAAAA")
     assert 0.4 < del_rate < 0.6
+
+
+def test_long_homopolymer_has_higher_error_rate() -> None:
+    ctx_ins, ctx_del = _split_context_indels(
+        {"AA": {1: 0.05, 5: 0.8}}, "context_indels"
+    )
+    channel = NanoporeChannel(
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        context_insertions=ctx_ins,
+        context_deletions=ctx_del,
+    )
+    short_ins, short_del = _simulate_many(channel, "AA")
+    long_ins, long_del = _simulate_many(channel, "AAAAA")
+    assert long_ins > short_ins
+    assert long_del > short_del
 


### PR DESCRIPTION
## Summary
- support run-length specific `context_indels` that default to both insertion and deletion rates
- parse run-length dependent indel profiles from YAML
- test higher indel rates in long homopolymer contexts
- remove unused type ignore in plugin manager to satisfy linters

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/plugin_manager.py src/genecoder/simulators/nanopore.py tests/test_nanopore_homopolymer.py`
- `mypy --config-file pyproject.toml src/genecoder/simulators/nanopore.py tests/test_nanopore_homopolymer.py src/genecoder/plugin_manager.py`
- `pytest tests/test_nanopore_homopolymer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1d4d91f0832695a8e113aa141410