### PR TITLE
Model coverage-based dropout in Illumina simulator

### DIFF
--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -10,6 +10,7 @@ in :mod:`configs/illumina.yml`.
 from __future__ import annotations
 
 import random
+import math
 from pathlib import Path
 from typing import Callable, Sequence, Mapping
 
@@ -19,6 +20,18 @@ from .api import Simulator
 from .simulators import register_simulator as _register_simulator
 
 __all__ = ["simulate", "Channel", "register", "ILLUMINA_PROFILES"]
+
+
+def _poisson(lam: float, rng: random.Random) -> int:
+    """Return a Poisson-distributed integer with mean ``lam``."""
+
+    L = math.exp(-lam)
+    k = 0
+    p = 1.0
+    while p > L:
+        k += 1
+        p *= rng.random()
+    return k - 1
 
 
 _DEFAULT_PROFILES: dict[str, dict[str, float | int]] = {
@@ -60,7 +73,7 @@ try:  # pragma: no cover - optional dependency
                 "substitution_rate": float(params.get("substitution_rate", 0.001)),
                 "insertion_rate": float(params.get("insertion_rate", 0.0001)),
                 "deletion_rate": float(params.get("deletion_rate", 0.0001)),
-                "coverage_depth": int(params.get("coverage_depth", 1)),
+                "coverage_depth": float(params.get("coverage_depth", 1)),
             }
             for name, params in _data.items()
             if isinstance(params, Mapping)
@@ -129,7 +142,7 @@ def simulate(
     insertion_rate: float | None = None,
     deletion_rate: float | None = None,
     rng: random.Random | None = None,
-    coverage_depth: int | None = None,
+    coverage_depth: float | None = None,
     quality_profile: Sequence[float] | None = None,
     quality_distribution: Sequence[float] | None = None,
     profile: str | None = None,
@@ -173,15 +186,18 @@ def simulate(
         if deletion_rate is not None
         else prof.get("deletion_rate", 0.0001)
     )
-    coverage_depth = int(
+    coverage_depth = float(
         coverage_depth
         if coverage_depth is not None
-        else int(prof.get("coverage_depth", 1))
+        else float(prof.get("coverage_depth", 1))
     )
 
     if rng is None:
         rng = make_rng()
 
+    coverage = _poisson(coverage_depth, rng)
+    if coverage <= 0:
+        return ""
     reads = [
         _mutate_read(
             sequence,
@@ -192,9 +208,9 @@ def simulate(
             quality_distribution,
             rng,
         )
-        for _ in range(max(1, coverage_depth))
+        for _ in range(coverage)
     ]
-    if coverage_depth <= 1:
+    if coverage == 1:
         return reads[0]
     return _consensus(reads)
 
@@ -208,7 +224,7 @@ class Channel(Simulator):
         *,
         insertion_rate: float | None = None,
         deletion_rate: float | None = None,
-        coverage_depth: int | None = None,
+        coverage_depth: float | None = None,
         quality_profile: Sequence[float] | None = None,
         quality_distribution: Sequence[float] | None = None,
         profile: str | None = None,
@@ -229,10 +245,10 @@ class Channel(Simulator):
             if deletion_rate is not None
             else prof.get("deletion_rate", 0.0001)
         )
-        self.coverage_depth = int(
+        self.coverage_depth = float(
             coverage_depth
             if coverage_depth is not None
-            else int(prof.get("coverage_depth", 1))
+            else float(prof.get("coverage_depth", 1))
         )
         self.quality_profile = (
             tuple(quality_profile) if quality_profile is not None else None

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -455,7 +455,7 @@ def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
 
     # discover local plugins in a ``plugins`` package
     try:
-        import plugins as local_pkg  # type: ignore
+        import plugins as local_pkg
     except ModuleNotFoundError:
         local_pkg = None
 

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -18,11 +18,11 @@ class BaseChannel(Simulator):
     substitution_rate: float = 0.0
     insertion_rate: float = 0.0
     deletion_rate: float = 0.0
-    coverage: int = 1
+    coverage: float = 1.0
 
     def get_coverage(self, sequence: str) -> int:
         """Hook returning desired coverage for ``sequence``."""
-        return self.coverage
+        return int(self.coverage)
 
     @abstractmethod
     def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Iterable, Mapping, Sequence
 from pathlib import Path
 import json
 import random
+import math
 import shutil
 import subprocess
 import logging
@@ -44,6 +45,19 @@ __all__ = [
 ]
 
 
+# Simple Poisson sampler using only the ``random`` module
+def _poisson(lam: float, rng: random.Random) -> int:
+    """Return a Poisson-distributed integer with mean ``lam``."""
+
+    L = math.exp(-lam)
+    k = 0
+    p = 1.0
+    while p > L:
+        k += 1
+        p *= rng.random()
+    return k - 1
+
+
 # Helper to parse quality profiles from strings or files
 def _parse_quality_profile(value: str) -> Sequence[float]:
     """Return a list of floats from ``value``.
@@ -78,7 +92,7 @@ class IlluminaProfile:
     insertion_rate: float
     deletion_rate: float
     read_length: int
-    coverage: int
+    coverage: float
 
     def __post_init__(self) -> None:
         for name, value in (
@@ -113,7 +127,7 @@ def _validate_profile(data: Mapping[str, Any]) -> IlluminaProfile:
         insertion_rate=float(data["insertion_rate"]),
         deletion_rate=float(data["deletion_rate"]),
         read_length=int(data["read_length"]),
-        coverage=int(data["coverage"]),
+        coverage=float(data["coverage"]),
     )
 
 
@@ -213,7 +227,7 @@ class IlluminaChannel(BaseSimulator):
         substitution_rate: float | None = None,
         insertion_rate: float | None = None,
         deletion_rate: float | None = None,
-        coverage: int | None = None,
+        coverage: float | None = None,
         read_length: int | None = None,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
@@ -266,7 +280,7 @@ class IlluminaChannel(BaseSimulator):
                 else 150
             )
         )
-        coverage = int(
+        coverage = float(
             coverage
             if coverage is not None
             else (
@@ -354,7 +368,9 @@ class IlluminaChannel(BaseSimulator):
         read_length = self.get_read_length(sequence)
         read = sequence[:read_length]
         quality = self.get_quality_profile(sequence, read_length)
-        coverage = max(1, self.get_coverage(sequence))
+        coverage = _poisson(self.coverage, rng)
+        if coverage <= 0:
+            return ""
         reads = [self._mutate_read(read, quality, rng) for _ in range(coverage)]
         if coverage == 1:
             return reads[0]

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -328,7 +328,7 @@ class NanoporeChannel(BaseChannel):
         substitution_rate: float = 0.0,
         insertion_rate: float = 0.0,
         deletion_rate: float = 0.0,
-        coverage: int = 1,
+        coverage: float = 1,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
         context_insertions: Dict[str, Dict[int, float]] | None = None,
@@ -351,7 +351,7 @@ class NanoporeChannel(BaseChannel):
                 deletion_rate = float(
                     cast(float | int, params.get("deletion_rate", deletion_rate))
                 )
-                coverage = int(cast(float | int, params.get("coverage", coverage)))
+                coverage = float(cast(float | int, params.get("coverage", coverage)))
                 quality_profile = cast(
                     Sequence[float] | None,
                     params.get("quality_profile", quality_profile),
@@ -393,7 +393,7 @@ class NanoporeChannel(BaseChannel):
             substitution_rate = float(data.get("substitution_rate", substitution_rate))
             insertion_rate = float(data.get("insertion_rate", insertion_rate))
             deletion_rate = float(data.get("deletion_rate", deletion_rate))
-            coverage = int(data.get("coverage", coverage))
+            coverage = float(data.get("coverage", coverage))
             quality_profile = data.get("quality_profile", quality_profile)
             context_errors = data.get("context_errors", context_errors)
             context_insertions = data.get("context_insertions", context_insertions)
@@ -518,7 +518,7 @@ class NanoporeDNArSimChannel(NanoporeChannel):
         substitution_rate: float = 0.0,
         insertion_rate: float = 0.0,
         deletion_rate: float = 0.0,
-        coverage: int = 1,
+        coverage: float = 1,
         quality_profile: Sequence[float] | None = None,
         context_errors: Dict[str, float] | None = None,
         context_insertions: Dict[str, Dict[int, float]] | None = None,

--- a/tests/test_illumina_builtin_sim.py
+++ b/tests/test_illumina_builtin_sim.py
@@ -40,3 +40,40 @@ def test_channel_respects_seed(monkeypatch):
     )
     second = ch.simulate(seq)
     assert first == second
+
+
+def test_coverage_influences_read_count(monkeypatch):
+    seq = "ACGT"
+    calls: list[int] = []
+
+    def fake_mutate(*args, **kwargs) -> str:
+        calls.append(1)
+        return args[0]
+
+    monkeypatch.setattr(illumina_sim, "_mutate_read", fake_mutate)
+
+    rng = random.Random(0)
+    out = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        rng=rng,
+        coverage_depth=5.0,
+    )
+    expected = illumina_sim._poisson(5.0, random.Random(0))
+    assert len(calls) == expected
+    assert out == seq
+
+    calls.clear()
+    rng = random.Random(0)
+    out = illumina_sim.simulate(
+        seq,
+        substitution_rate=0.0,
+        insertion_rate=0.0,
+        deletion_rate=0.0,
+        rng=rng,
+        coverage_depth=0.1,
+    )
+    assert out == ""
+    assert len(calls) == 0

--- a/tests/test_simulators.py
+++ b/tests/test_simulators.py
@@ -14,9 +14,10 @@ def test_illumina_simulate_seed(monkeypatch):
         insertion_rate=0.1,
         deletion_rate=0.1,
         read_length=10,
+        coverage=5,
     )
     result = ch.simulate("ACGTACGTACGT")
-    assert result == "ATTACTTC"
+    assert result == "TCTGGATTA"
 
 
 def test_nanopore_simulate_fallback_seed() -> None:


### PR DESCRIPTION
## Summary
- allow fractional coverage in base channel and sample coverage from Poisson distribution
- introduce coverage-driven strand dropout in Illumina simulators
- add tests ensuring coverage affects read generation and update seeded expectations
- align Nanopore channel and plugin manager with new coverage typing

## Testing
- `SKIP=pytest pre-commit run --files src/genecoder/illumina_sim.py src/genecoder/simulators/base.py src/genecoder/simulators/illumina.py src/genecoder/simulators/nanopore.py src/genecoder/plugin_manager.py tests/test_illumina_builtin_sim.py tests/test_simulators.py`
- `pytest tests/test_illumina_builtin_sim.py tests/test_illumina_coverage_quality.py tests/test_simulators.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1d4cec008326adf19fd7704f01c1