### PR TITLE
feat: track gc and homopolymer metrics

### DIFF
--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -3,7 +3,7 @@ import os
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, IO, cast
+from typing import Any, IO, Sequence, cast
 
 try:  # pragma: no cover - optional dependency
     import portalocker
@@ -34,6 +34,8 @@ __all__ = [
     "increment",
     "get_metrics",
     "oligos_per_week",
+    "append_gc_distribution",
+    "append_homopolymer_runs",
 ]
 
 
@@ -98,21 +100,39 @@ class Metrics:
         """Metrics file path, respecting environment overrides."""
         return self._path or _get_metrics_path()
 
-    def increment(self, key: str) -> None:
+    def increment(self, key: str, counts: Sequence[float | int] | None = None) -> None:
         with self._lock:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             with portalocker.Lock(self.path, "a+", timeout=10, encoding="utf-8") as fh:
                 metrics = _load(self.path, fh)
-                current = metrics.get(key, 0)
-                if not isinstance(current, int):
-                    current = 0
-                metrics[key] = current + 1
+                if key == "gc_distribution":
+                    if counts is None:
+                        raise ValueError("counts required for gc_distribution")
+                    existing_obj: Any = metrics.get(key, [])
+                    existing = cast(list[float], existing_obj) if isinstance(existing_obj, list) else []
+                    existing.extend(float(c) for c in counts)
+                    metrics[key] = existing
+                elif key == "homopolymer_runs":
+                    if counts is None:
+                        raise ValueError("counts required for homopolymer_runs")
+                    existing_obj: Any = metrics.get(key, [])
+                    existing = cast(list[int], existing_obj) if isinstance(existing_obj, list) else []
+                    if len(existing) < len(counts):
+                        existing.extend([0] * (len(counts) - len(existing)))
+                    for i, c in enumerate(counts):
+                        existing[i] += int(c)
+                    metrics[key] = existing
+                else:
+                    current = metrics.get(key, 0)
+                    if not isinstance(current, int):
+                        current = 0
+                    metrics[key] = current + 1
 
-                if key == "oligos_simulated":
-                    ts_obj: Any = metrics.get("oligos_simulated_ts", [])
-                    ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
-                    ts_list.append(datetime.now(timezone.utc).isoformat())
-                    metrics["oligos_simulated_ts"] = ts_list
+                    if key == "oligos_simulated":
+                        ts_obj: Any = metrics.get("oligos_simulated_ts", [])
+                        ts_list = cast(list[str], ts_obj) if isinstance(ts_obj, list) else []
+                        ts_list.append(datetime.now(timezone.utc).isoformat())
+                        metrics["oligos_simulated_ts"] = ts_list
                 _save(self.path, metrics, fh)
 
     def get_metrics(self) -> dict[str, object]:
@@ -145,8 +165,16 @@ class Metrics:
 metrics = Metrics()
 
 
-def increment(key: str) -> None:
-    metrics.increment(key)
+def append_gc_distribution(values: Sequence[float]) -> None:
+    metrics.increment("gc_distribution", values)
+
+
+def append_homopolymer_runs(counts: Sequence[int]) -> None:
+    metrics.increment("homopolymer_runs", counts)
+
+
+def increment(key: str, counts: Sequence[float | int] | None = None) -> None:
+    metrics.increment(key, counts)
 
 
 def get_metrics() -> dict[str, object]:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,7 +7,11 @@ from tests.test_cli import run_cli_command
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
-from genecoder.metrics import Metrics
+from genecoder.metrics import (
+    Metrics,
+    append_gc_distribution,
+    append_homopolymer_runs,
+)
 
 
 def test_encode_increments_metrics(tmp_path: Path, monkeypatch) -> None:
@@ -162,3 +166,15 @@ def test_stats_cli_weekly_counts(tmp_path: Path, monkeypatch) -> None:
     weekly_line = [line for line in out if line.startswith("oligos_per_week:")][0]
     assert "2024-W01" in weekly_line
     assert "2024-W04" in weekly_line
+
+
+def test_metrics_accumulate_across_runs(tmp_path: Path, monkeypatch) -> None:
+    metrics_path = tmp_path / "acc.json"
+    monkeypatch.setenv("GENECODER_METRICS_PATH", str(metrics_path))
+    append_gc_distribution([0.1, 0.2])
+    append_gc_distribution([0.3])
+    append_homopolymer_runs([1, 2])
+    append_homopolymer_runs([2, 1, 1])
+    data = json.loads(metrics_path.read_text())
+    assert data["gc_distribution"] == [0.1, 0.2, 0.3]
+    assert data["homopolymer_runs"] == [3, 3, 1]


### PR DESCRIPTION
## Summary
- record `gc_distribution` values and cumulative `homopolymer_runs` counts when incrementing metrics
- provide helpers to append GC distribution and homopolymer metrics safely
- test that metrics accumulate data across multiple runs

## Testing
- `ruff check src/genecoder/metrics.py tests/test_metrics.py`
- `pytest tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4d015e483268ec383646db19dfc