### PR TITLE
Expose constraint fixer metrics

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -37,7 +37,7 @@ from genecoder.formats import to_fasta, from_fasta
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
-from genecoder.constraint_fixer import fix
+from genecoder.constraint_fixer import encode as constraint_fix_encode
 from .common import run_tasks
 from typing import Callable, cast
 
@@ -351,6 +351,7 @@ def process_single_encode(
             data_for_encoding, options, header_name
         )
 
+        auto_fix_metrics: dict[str, float] = {}
         if getattr(args, "auto_fix", True) and os.getenv("GENECODER_DISABLE_FIX") not in {"1", "true", "True"}:
             target_dna = raw_encoded_dna
             if getattr(args, "fix_chisel", False) and "dnachisel_fixer" in CODEC_REGISTRY:
@@ -362,13 +363,21 @@ def process_single_encode(
                     gc_max=args.gc_max,
                     max_homopolymer=args.max_homopolymer,
                 )
+                fix_metrics = {
+                    "gc_content": calculate_gc_content(target_dna),
+                    "max_homopolymer": get_max_homopolymer_length(target_dna),
+                }
             else:
-                target_dna = fix(
+                target_dna, fix_metrics = constraint_fix_encode(
                     target_dna,
                     gc_min=args.gc_min,
                     gc_max=args.gc_max,
                     max_homopolymer=args.max_homopolymer,
                 )
+            auto_fix_metrics = {
+                "fixed_gc": fix_metrics["gc_content"],
+                "fixed_max_homopolymer": fix_metrics["max_homopolymer"],
+            }
 
             if args.fec == "triple_repeat":
                 final_encoded_dna_sequence = encode_triple_repeat(target_dna)
@@ -457,6 +466,7 @@ def process_single_encode(
             "gc_exceeds_default": gc_default_bad,
             "homopolymer_exceeds_default": hp_default_bad,
         }
+        metrics.update(auto_fix_metrics)
 
         logger.info(f"\n--- Encoding Metrics for {input_file_path} ---")
         logger.info(f"Original file size: {original_size_bytes} bytes")

--- a/src/genecoder/constraint_fixer.py
+++ b/src/genecoder/constraint_fixer.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import random
 
+from .gc_constrained_encoder import calculate_gc_content
+from .utils import get_max_homopolymer_length
 from .random_utils import make_rng
 
 __all__ = [
@@ -18,6 +20,7 @@ __all__ = [
     "limit_homopolymers",
     "fix_sequence",
     "fix",
+    "encode",
 ]
 
 
@@ -142,3 +145,26 @@ def fix(
         max_homopolymer=max_homopolymer,
         rng=rng,
     )
+
+
+def encode(
+    sequence: str,
+    *,
+    gc_min: float,
+    gc_max: float,
+    max_homopolymer: int,
+    rng: random.Random | None = None,
+) -> tuple[str, dict[str, float]]:
+    """Return a fixed sequence along with GC and homopolymer metrics."""
+    fixed = fix_sequence(
+        sequence,
+        target_gc_min=gc_min,
+        target_gc_max=gc_max,
+        max_homopolymer=max_homopolymer,
+        rng=rng,
+    )
+    metrics = {
+        "gc_content": calculate_gc_content(fixed),
+        "max_homopolymer": get_max_homopolymer_length(fixed),
+    }
+    return fixed, metrics

--- a/tests/test_gc_constraint_failures.py
+++ b/tests/test_gc_constraint_failures.py
@@ -1,3 +1,7 @@
+import argparse
+import json
+import os
+
 import pytest
 
 from genecoder.gc_constrained_encoder import (
@@ -6,12 +10,10 @@ from genecoder.gc_constrained_encoder import (
     get_max_homopolymer_length,
 )
 from genecoder.encoders import encode_base4_direct
-from genecoder.constraint_fixer import fix
+from genecoder.constraint_fixer import encode
 from genecoder.cli.encode import process_single_encode
 from genecoder.formats import from_fasta
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-import argparse
-import os
 
 
 @pytest.mark.parametrize("which", ["gc", "homopolymer"])
@@ -38,20 +40,24 @@ def test_auto_fix_permits_decode(which) -> None:
     hp = get_max_homopolymer_length(payload)
 
     if which == "gc":
-        fixed_payload = fix(
+        fixed_payload, metrics = encode(
             payload,
             gc_min=gc + 0.1,
             gc_max=1.0,
             max_homopolymer=hp,
         )
+        assert metrics["gc_content"] == calculate_gc_content(fixed_payload)
+        assert metrics["max_homopolymer"] == get_max_homopolymer_length(fixed_payload)
         decode_gc_balanced("0" + fixed_payload, expected_gc_min=gc + 0.1)
     else:
-        fixed_payload = fix(
+        fixed_payload, metrics = encode(
             payload,
             gc_min=0.0,
             gc_max=1.0,
             max_homopolymer=hp - 1,
         )
+        assert metrics["gc_content"] == calculate_gc_content(fixed_payload)
+        assert metrics["max_homopolymer"] == get_max_homopolymer_length(fixed_payload)
         decode_gc_balanced("0" + fixed_payload, expected_max_homopolymer=hp - 1)
 
 
@@ -97,8 +103,14 @@ def test_cli_auto_fix_flag(tmp_path, which) -> None:
     fasta = output_path.read_text(encoding="utf-8")
     records = from_fasta(fasta)
     dna_sequence = records[0][1]
+    manifest_path = tmp_path / "out.manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    metrics = manifest["metrics"]
     os.remove(output_path)
+    os.remove(manifest_path)
 
+    assert "fixed_gc" in metrics
+    assert "fixed_max_homopolymer" in metrics
     if which == "gc":
         decode_gc_balanced("0" + dna_sequence, expected_gc_min=gc + 0.1)
     else:


### PR DESCRIPTION
## Summary
- compute GC% and max homopolymer length in `constraint_fixer.encode`
- surface constraint fixer metrics through CLI encode pipeline
- test for presence of metrics in auto-fix output
- refactor CLI auto-fix metric handling for consistency

## Testing
- `ruff check src/genecoder/cli/encode.py`
- `pytest tests/test_gc_constraint_failures.py`
- `pytest` *(fails: ImportError: cannot import name 'UnsupportedAlgorithm' from 'cryptography.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4cf2094832685d4c7b3fa3e5d00