### PR TITLE
feat: handle offline profile fetch

### DIFF
--- a/src/genecoder/data_service.py
+++ b/src/genecoder/data_service.py
@@ -8,6 +8,7 @@ __all__ = ["get_cache_dir", "fetch_profile", "is_cached"]
 
 DEFAULT_BASE_URL = "https://example.com/profiles"
 PROFILE_DIR_ENV = "GENECODER_PROFILE_DIR"
+OFFLINE_ENV = "GENECODER_OFFLINE"
 
 
 def get_cache_dir() -> Path:
@@ -48,6 +49,12 @@ def fetch_profile(
         if candidate.is_file():
             dest.write_bytes(candidate.read_bytes())
             return dest
+
+    if os.getenv(OFFLINE_ENV) not in (None, "", "0"):
+        raise RuntimeError(
+            f"Network access disabled via {OFFLINE_ENV}. "
+            f"Supply profiles via {PROFILE_DIR_ENV}."
+        )
 
     url = f"{base_url.rstrip('/')}/{profile}"
     try:

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -79,3 +79,18 @@ def test_fetch_profile_network_error(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(urllib.request, "urlopen", fake_open)
     with pytest.raises(RuntimeError, match="Failed to download"):
         fetch_profile("illumina_profile.json", cache_dir=cache)
+
+
+def test_fetch_profile_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def fake_open(url: str, *, timeout: int | None = None):
+        nonlocal called
+        called = True
+        raise AssertionError("network call")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    monkeypatch.setenv("GENECODER_OFFLINE", "1")
+    with pytest.raises(RuntimeError, match="GENECODER_PROFILE_DIR"):
+        fetch_profile("illumina_profile.json")
+    assert not called


### PR DESCRIPTION
## Summary
- honor `GENECODER_OFFLINE` flag to avoid network requests when fetching profiles
- raise helpful error directing users to provide local profiles via `GENECODER_PROFILE_DIR`
- test offline fetch behavior

## Testing
- `ruff check src/genecoder/data_service.py tests/test_data_service.py`
- `mypy src/genecoder/data_service.py`
- `pytest tests/test_data_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8480fc1388326b8bd0d89c3738b48