### PR TITLE
Add offline tests for plugin manager and data service

### DIFF
--- a/tests/test_data_service_offline.py
+++ b/tests/test_data_service_offline.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import urllib.error
+import urllib.request
+
+import pytest
+
+from genecoder.data_service import fetch_profile
+
+
+def test_fetch_profile_offline_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetching profiles offline raises a helpful error."""
+
+    def fake_urlopen(url: str, *, timeout: int | None = None):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setenv("GENECODER_OFFLINE", "1")
+    monkeypatch.delenv("GENECODER_PROFILE_DIR", raising=False)
+
+    with pytest.raises(RuntimeError, match="GENECODER_PROFILE_DIR"):
+        fetch_profile("illumina_profile.json", cache_dir=tmp_path)

--- a/tests/test_plugin_manager_offline.py
+++ b/tests/test_plugin_manager_offline.py
@@ -1,0 +1,20 @@
+import urllib.error
+import urllib.request
+
+import pytest
+
+import genecoder.plugin_manager as plugins
+
+
+def test_registry_remote_rejected_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remote registries are blocked when offline is true."""
+
+    def fake_urlopen(url: str, *, timeout: int | None = None):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="GENECODER_ALLOW_NETWORK"):
+        plugins.install_registry_plugins(
+            "https://example.com/plugins.yaml", offline=True, allow_network=True
+        )


### PR DESCRIPTION
## Summary
- test plugin registry rejects remote access when offline
- ensure data service errors clearly when GENECODER_OFFLINE is set and profiles are missing

## Testing
- `ruff check tests/test_plugin_manager_offline.py tests/test_data_service_offline.py`
- `pytest tests/test_plugin_manager_offline.py tests/test_data_service_offline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8516c270c8326b1a0a3cd84674c74