### PR TITLE
Refactor core pipeline into modular helpers

### DIFF
--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -7,12 +7,12 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
 
-from genecoder.core import run_pipeline
+from genecoder.core import encode, simulate, decode, metrics as gather_metrics
 from genecoder.parallel import parallel_map
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
@@ -101,11 +101,25 @@ def _run_with_params(
         temp_name = f"_tmp_{chan_name}"
         SIMULATOR_REGISTRY[temp_name] = ch
     try:
-        _, metrics_any = run_pipeline(codec, fec, temp_name, input_path, output_path)
+        original_data = Path(input_path).read_bytes()
+        dna, fec_info = encode(codec, fec, original_data)
+        dna, subs, ins, dels, coverage = simulate(temp_name, dna)
+        decoded = decode(codec, fec, dna, fec_info)
+        Path(output_path).write_bytes(decoded)
+        metrics_any = gather_metrics(
+            dna,
+            original_data,
+            decoded,
+            fec,
+            subs,
+            ins,
+            dels,
+            coverage,
+        )
     finally:
         if temp_name != chan_name and temp_name in SIMULATOR_REGISTRY:
             del SIMULATOR_REGISTRY[temp_name]
-    return cast(Dict[str, Any], metrics_any)
+    return metrics_any
 
 
 def register_subcommand(
@@ -213,12 +227,9 @@ def _handle_command(args: argparse.Namespace) -> None:
         channel = "none"
 
     def _execute() -> Dict[str, Any]:
-        if channel_params:
-            return _run_with_params(
-                codec, fec, channel, channel_params, args.input, args.output
-            )
-        _, m = run_pipeline(codec, fec, channel, args.input, args.output)
-        return cast(Dict[str, Any], m)
+        return _run_with_params(
+            codec, fec, channel, channel_params, args.input, args.output
+        )
 
     if args.mpi_workers:
         metrics = parallel_map(

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -11,7 +11,7 @@ from .utils import get_max_homopolymer_length
 from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from .simulators import SIMULATOR_REGISTRY
 
-__all__ = ["run_pipeline"]
+__all__ = ["encode", "simulate", "decode", "metrics", "run_pipeline"]
 
 
 
@@ -81,6 +81,117 @@ def _homopolymer_runs(sequence: str) -> List[int]:
     return [counts.get(i, 0) for i in range(1, max_run + 1)]
 
 
+def encode(
+    codec: str, fec: str | None, data: bytes
+) -> Tuple[str, Mapping[str, Any] | None]:
+    """Return DNA sequence for ``data`` and optional FEC info."""
+
+    if codec not in CODEC_REGISTRY:
+        raise ValueError(f"Unknown codec: {codec}")
+    if fec and fec not in FEC_REGISTRY:
+        raise ValueError(f"Unknown FEC: {fec}")
+
+    fec_info: Mapping[str, Any] | None = None
+    if fec:
+        data, fec_info = FEC_REGISTRY[fec]["encode"](data)
+
+    dna = CODEC_REGISTRY[codec]["encode"](data)
+    return dna, fec_info
+
+
+def simulate(
+    channel: str | None, dna: str
+) -> Tuple[str, int | None, int | None, int | None, int | None]:
+    """Return ``dna`` possibly mutated by ``channel`` and error counts."""
+
+    if channel and channel != "none":
+        if channel not in SIMULATOR_REGISTRY:
+            raise ValueError(f"Unknown channel: {channel}")
+        sim = SIMULATOR_REGISTRY[channel]
+        mutated = sim.simulate(dna)
+        subs, ins, dels = _count_errors(dna, mutated)
+        cov_func = getattr(sim, "get_coverage", None)
+        coverage = None
+        if callable(cov_func):
+            try:
+                coverage = int(cov_func(dna))
+            except Exception:  # pragma: no cover - simulator failed
+                coverage = None
+        return mutated, subs, ins, dels, coverage
+    return dna, None, None, None, None
+
+
+def decode(
+    codec: str,
+    fec: str | None,
+    dna: str,
+    fec_info: Mapping[str, Any] | None,
+) -> bytes:
+    """Return decoded bytes from ``dna`` applying optional FEC."""
+
+    if codec not in CODEC_REGISTRY:
+        raise ValueError(f"Unknown codec: {codec}")
+    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
+    assert isinstance(decoded_any, (bytes, bytearray))
+    decoded = bytes(decoded_any)
+
+    if fec:
+        if fec not in FEC_REGISTRY:
+            raise ValueError(f"Unknown FEC: {fec}")
+        assert fec_info is not None
+        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
+
+    return decoded
+
+
+def metrics(
+    dna: str,
+    original_data: bytes,
+    decoded: bytes,
+    fec: str | None,
+    subs: int | None = None,
+    ins: int | None = None,
+    dels: int | None = None,
+    coverage: int | None = None,
+) -> Dict[str, Any]:
+    """Return quality metrics for ``dna`` and decode results."""
+
+    gc_content = calculate_gc_content(dna)
+    max_homopolymer = get_max_homopolymer_length(dna)
+    gc_dist = _gc_distribution(dna)
+    hp_runs = _homopolymer_runs(dna)
+    gc_variance = (
+        sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
+        if gc_dist
+        else 0.0
+    )
+
+    success = 1.0 if decoded == original_data else 0.0
+    constraint_violations = 0
+    try:
+        from .synthesis import validate_sequence
+
+        if not validate_sequence(dna):
+            constraint_violations = 1
+    except Exception:  # pragma: no cover - optional dependency
+        constraint_violations = 0
+
+    result: Dict[str, Any] = {
+        "gc_distribution": gc_dist,
+        "gc_content": gc_content,
+        "gc_variance": gc_variance,
+        "max_homopolymer": max_homopolymer,
+        "homopolymer_runs": hp_runs,
+        "ecc_success_rates": {fec: success} if fec else {},
+        "decode_success_rate": success,
+        "coverage": coverage,
+        "constraint_violations": constraint_violations,
+    }
+    if subs is not None and ins is not None and dels is not None:
+        result.update({"substitutions": subs, "insertions": ins, "deletions": dels})
+    return result
+
+
 def run_pipeline(
     codec: str,
     fec: str | None,
@@ -94,81 +205,20 @@ def run_pipeline(
     """
     init_plugins()
 
-    if codec not in CODEC_REGISTRY:
-        raise ValueError(f"Unknown codec: {codec}")
-    if fec and fec not in FEC_REGISTRY:
-        raise ValueError(f"Unknown FEC: {fec}")
-    if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
-        raise ValueError(f"Unknown channel: {channel}")
-
     original_data = Path(input_path).read_bytes()
-    data = original_data
-
-    fec_info: Mapping[str, Any] | None = None
-    if fec:
-        data, fec_info = FEC_REGISTRY[fec]["encode"](data)
-
-    dna = CODEC_REGISTRY[codec]["encode"](data)
-    orig_dna = dna
-    subs = ins = dels = None
-    coverage = None
-    if channel and channel != "none":
-        sim = SIMULATOR_REGISTRY[channel]
-        dna = sim.simulate(dna)
-        subs, ins, dels = _levenshtein_counts(orig_dna, dna)
-        cov_func = getattr(sim, "get_coverage", None)
-        if callable(cov_func):
-            try:
-                coverage = int(cov_func(orig_dna))
-            except Exception:
-                coverage = None
-
-    gc_content = calculate_gc_content(dna)
-    max_homopolymer = get_max_homopolymer_length(dna)
-    gc_dist = _gc_distribution(dna)
-    hp_runs = _homopolymer_runs(dna)
-    gc_variance = (
-        sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
-        if gc_dist
-        else 0.0
-    )
-
-    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
-    assert isinstance(decoded_any, (bytes, bytearray))
-    decoded = bytes(decoded_any)
-
-    if fec:
-        assert fec_info is not None
-        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
+    dna, fec_info = encode(codec, fec, original_data)
+    dna, subs, ins, dels, coverage = simulate(channel, dna)
+    decoded = decode(codec, fec, dna, fec_info)
 
     Path(output_path).write_bytes(decoded)
-    success = 1.0 if decoded == original_data else 0.0
-    constraint_violations = 0
-    try:
-        from .synthesis import validate_sequence
-
-        if not validate_sequence(dna):
-            constraint_violations = 1
-    except Exception:
-        constraint_violations = 0
-
-    metrics: Dict[str, Any] = {
-        "gc_distribution": gc_dist,
-        "gc_content": gc_content,
-        "gc_variance": gc_variance,
-        "max_homopolymer": max_homopolymer,
-        "homopolymer_runs": hp_runs,
-        "ecc_success_rates": {fec: success} if fec else {},
-        "decode_success_rate": success,
-        "coverage": coverage,
-        "constraint_violations": constraint_violations,
-    }
-    if subs is not None and ins is not None and dels is not None:
-        metrics.update(
-            {
-                "substitutions": subs,
-                "insertions": ins,
-                "deletions": dels,
-            }
-        )
-    return decoded, metrics
+    metrics_dict = metrics(
+        dna,
+        original_data,
+        decoded,
+        fec,
+        subs,
+        ins,
+        dels,
+        coverage,
+    )
+    return decoded, metrics_dict

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence, Tuple
 
-from .gc_constrained_encoder import calculate_gc_content
-from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
-from .simulators import SIMULATOR_REGISTRY
-from .utils import get_max_homopolymer_length
+from .plugin_manager import init_plugins
 from .parallel import parallel_map
+from .core import encode, simulate, decode, metrics as gather_metrics
 
 __all__ = ["SequencePipeline", "run_pipeline"]
 
@@ -121,77 +119,21 @@ def run_pipeline(
 
     init_plugins()
 
-    if codec not in CODEC_REGISTRY:
-        raise ValueError(f"Unknown codec: {codec}")
-    if fec_backend and fec_backend not in FEC_REGISTRY:
-        raise ValueError(f"Unknown FEC: {fec_backend}")
-    if channel and channel != "none" and channel not in SIMULATOR_REGISTRY:
-        raise ValueError(f"Unknown channel: {channel}")
-
     original_data = Path(input_path).read_bytes()
-    data = original_data
-
-    fec_info: Mapping[str, Any] | None = None
-    if fec_backend:
-        data, fec_info = FEC_REGISTRY[fec_backend]["encode"](data)
-
-    dna = CODEC_REGISTRY[codec]["encode"](data)
-    orig_dna = dna
-    subs = ins = dels = None
-    coverage = None
-    if channel and channel != "none":
-        sim = SIMULATOR_REGISTRY[channel]
-        dna = sim.simulate(dna)
-        subs, ins, dels = _levenshtein_counts(orig_dna, dna)
-        cov_func = getattr(sim, "get_coverage", None)
-        if callable(cov_func):
-            try:
-                coverage = int(cov_func(orig_dna))
-            except Exception:
-                coverage = None
-
-    gc_content = calculate_gc_content(dna)
-    max_homopolymer = get_max_homopolymer_length(dna)
-    gc_dist = _gc_distribution(dna)
-    hp_runs = _homopolymer_runs(dna)
-    gc_variance = (
-        sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
-        if gc_dist
-        else 0.0
-    )
-
-    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
-    assert isinstance(decoded_any, (bytes, bytearray))
-    decoded = bytes(decoded_any)
-
-    if fec_backend:
-        assert fec_info is not None
-        decoded, _ = FEC_REGISTRY[fec_backend]["decode"](decoded, fec_info)
+    dna, fec_info = encode(codec, fec_backend, original_data)
+    dna, subs, ins, dels, coverage = simulate(channel, dna)
+    decoded = decode(codec, fec_backend, dna, fec_info)
 
     Path(output_path).write_bytes(decoded)
-    success = 1.0 if decoded == original_data else 0.0
-    constraint_violations = 0
-    try:
-        from .synthesis import validate_sequence
-
-        if not validate_sequence(dna):
-            constraint_violations = 1
-    except Exception:
-        constraint_violations = 0
-
-    metrics: Dict[str, Any] = {
-        "gc_distribution": gc_dist,
-        "gc_content": gc_content,
-        "gc_variance": gc_variance,
-        "max_homopolymer": max_homopolymer,
-        "homopolymer_runs": hp_runs,
-        "ecc_success_rates": {fec_backend: success} if fec_backend else {},
-        "decode_success_rate": success,
-        "coverage": coverage,
-        "constraint_violations": constraint_violations,
-    }
-    if subs is not None and ins is not None and dels is not None:
-        metrics.update({"substitutions": subs, "insertions": ins, "deletions": dels})
-
-    return decoded, metrics, fec_info
+    metrics_dict = gather_metrics(
+        dna,
+        original_data,
+        decoded,
+        fec_backend,
+        subs,
+        ins,
+        dels,
+        coverage,
+    )
+    return decoded, metrics_dict, fec_info
 

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from genecoder.core import run_pipeline
+from genecoder.core import encode, simulate, decode, metrics as gather_metrics, run_pipeline
 from genecoder.api import Codec
 from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
@@ -38,3 +38,35 @@ def test_roundtrip_rs_simple(tmp_path: Path) -> None:
     assert result == data
     assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data
+
+
+def test_encode_helper() -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    dna, fec_info = encode("base4", None, b"hi")
+    assert isinstance(dna, str)
+    assert fec_info is None
+
+
+def test_simulate_helper() -> None:
+    dna, subs, ins, dels, coverage = simulate(None, "ACGT")
+    assert dna == "ACGT"
+    assert subs is ins is dels is None
+    assert coverage is None
+
+
+def test_decode_helper() -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    dna, fec_info = encode("base4", None, b"data")
+    assert decode("base4", None, dna, fec_info) == b"data"
+
+
+def test_metrics_helper() -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    data = b"metrics"
+    dna, _ = encode("base4", None, data)
+    m = gather_metrics(dna, data, data, None)
+    assert m["decode_success_rate"] == 1.0
+    assert "gc_content" in m


### PR DESCRIPTION
## Summary
- Split `run_pipeline` into new `encode`, `simulate`, `decode`, and `metrics` helpers
- Update pipeline and CLI modules to reuse the new helpers
- Add unit tests covering each helper

## Testing
- `ruff check src/genecoder/core.py src/genecoder/pipeline.py src/genecoder/cli/pipeline.py tests/test_core_pipeline.py`
- `pytest tests/test_core_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8516b4c78832684432ecb48b6e848