### PR TITLE
docs: add offline usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ framework backends. Expect the installation to consume around **2&nbsp;GB** of
 disk space and take roughly **10&nbsp;minutes** on a typical broadband
 connection.
 
-For running GeneCoder without any network access see
-[the offline setup notes](docs/installation.md#offline-setup).
+For running GeneCoder without any network access see the [offline usage guide](docs/offline_usage.md) and the [offline setup notes](docs/installation.md#offline-setup).
 
 
 Desktop packages are available on the [releases page](https://github.com/d0tTino/GeneCoder/releases).
@@ -226,7 +225,7 @@ templates live in `plugins-examples/encoder_template` and
 using the CLI or GUI. When using GeneCoder as a library call
 ``genecoder.plugins.load_plugins()`` first to populate the registries.
 GeneCoder follows an offline-first design: without a registry URL only plugins
-already installed in the environment are loaded.
+already installed in the environment are loaded. See the [offline usage guide](docs/offline_usage.md) for environment flags and registry opt-in details.
 
 Remote plugin sources can be configured via the environment variables
 ``GENECODER_PLUGIN_REGISTRY_URL`` and ``GENECODER_PLUGIN_CATALOG_URL``. Set

--- a/docs/offline_usage.md
+++ b/docs/offline_usage.md
@@ -1,0 +1,32 @@
+# Offline Usage
+
+GeneCoder avoids network access by default and supports fully air‑gapped deployments.
+This guide shows how to configure offline mode, provide local profiles and
+manage the optional plugin registry.
+
+## Environment Flags
+
+Most CLI commands accept `--offline` to disable all network operations.
+The same behaviour can be enabled globally by setting `GENECODER_OFFLINE=1`.
+
+## Profile Paths
+
+Sequencing simulators may download profile files the first time they run.
+Set `GENECODER_PROFILE_DIR` to a directory containing pre‑downloaded profiles
+so runs succeed without contacting the network. Cached data normally lives
+under `~/.genecoder/data`; override this location with `GENECODER_DATA_DIR`.
+
+## Plugin Registry Opt‑In
+
+GeneCoder only loads plugins already installed in the environment. To install
+additional packages from a registry provide `GENECODER_PLUGIN_REGISTRY_URL`
+and opt in explicitly:
+
+```bash
+genecli plugin install-registry --allow-registry [--offline]
+```
+
+`--allow-registry` confirms you trust the registry source. When the registry and
+wheels are available locally add `--offline` to prevent any network access. Set
+`GENECODER_PLUGIN_CATALOG_URL` to point plugin management commands at a JSON or
+YAML catalog, or leave both variables empty to disable remote lookups entirely.


### PR DESCRIPTION
## Summary
- document offline usage including CLI flags, environment variables, profile directories, and plugin registry opt-in
- link offline usage guide from README Quick Start and Plugins sections

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68b85c12c3ac8326a708c816c4f8d4bd