### PR TITLE
Handle context indels from profile paths

### DIFF
--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -106,7 +106,7 @@ def _run_with_params(
         dna, subs, ins, dels, coverage = simulate(temp_name, dna)
         decoded = decode(codec, fec, dna, fec_info)
         Path(output_path).write_bytes(decoded)
-        metrics_any = gather_metrics(
+        metrics_dict: Dict[str, Any] = gather_metrics(
             dna,
             original_data,
             decoded,
@@ -119,7 +119,7 @@ def _run_with_params(
     finally:
         if temp_name != chan_name and temp_name in SIMULATOR_REGISTRY:
             del SIMULATOR_REGISTRY[temp_name]
-    return metrics_any
+    return metrics_dict
 
 
 def register_subcommand(

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -108,7 +108,7 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     for name, data in datasets.items():
         label = Path(name).stem
         min_gc, mean_gc, max_gc = _gc_stats(data.get("gc_distribution"))
-        if None not in (min_gc, mean_gc, max_gc):
+        if min_gc is not None and mean_gc is not None and max_gc is not None:
             gc_rows.extend(
                 [
                     {"Run": label, "Metric": "min", "Value": min_gc},

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -184,7 +184,7 @@ def _fetch_catalog(url: str, *, allow_network: bool) -> bytes:
             logger.error(msg)
             raise RuntimeError(msg)
         with urllib.request.urlopen(url, timeout=30) as response:
-            return response.read()
+            return cast(bytes, response.read())
     return _read_local(url)
 
 

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -462,7 +462,9 @@ class NanoporeChannel(BaseChannel):
                 ci = data["context_insertions"]
                 if not isinstance(ci, Mapping):
                     raise ValueError("context_insertions must be a mapping")
-                base = context_insertions or {}
+                base = {
+                    k: dict(v) for k, v in (context_insertions or {}).items()
+                }
                 for ctx, prof in ci.items():
                     if not isinstance(prof, Mapping):
                         raise ValueError(
@@ -474,7 +476,9 @@ class NanoporeChannel(BaseChannel):
                 cd = data["context_deletions"]
                 if not isinstance(cd, Mapping):
                     raise ValueError("context_deletions must be a mapping")
-                base = context_deletions or {}
+                base = {
+                    k: dict(v) for k, v in (context_deletions or {}).items()
+                }
                 for ctx, prof in cd.items():
                     if not isinstance(prof, Mapping):
                         raise ValueError(
@@ -488,12 +492,16 @@ class NanoporeChannel(BaseChannel):
                     data.get("context_indels"), "context_indels"
                 )
                 if ctx_ins:
-                    base = context_insertions or {}
+                    base = {
+                        k: dict(v) for k, v in (context_insertions or {}).items()
+                    }
                     for ctx, prof in ctx_ins.items():
                         base.setdefault(ctx, {}).update(prof)
                     context_insertions = base
                 if ctx_del:
-                    base = context_deletions or {}
+                    base = {
+                        k: dict(v) for k, v in (context_deletions or {}).items()
+                    }
                     for ctx, prof in ctx_del.items():
                         base.setdefault(ctx, {}).update(prof)
                     context_deletions = base

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -94,18 +94,33 @@ def _split_context_indels(
     single probability is provided for a run length, it is applied to both insertions
     and deletions by default. This helper validates the nested indel profiles and
     returns two dictionaries in the normalized format used internally by the
-    simulator.
+    simulator. Invalid context structures raise ``ValueError``.
     """
+
+    if profiles is None:
+        return {}, {}
+    if not isinstance(profiles, Mapping):
+        raise ValueError(f"{name} must be a mapping of contexts to profiles")
 
     ctx_ins: Dict[str, Dict[int, float]] = {}
     ctx_del: Dict[str, Dict[int, float]] = {}
-    for ctx, ctx_map in (profiles or {}).items():
+    for ctx, ctx_map in profiles.items():
         if not isinstance(ctx_map, Mapping):
-            continue
+            raise ValueError(f"{name}[{ctx}] must be a mapping")
         ctx_key = str(ctx).upper()
 
         if any(k in {"insertions", "insertion", "deletions", "deletion"} for k in ctx_map):
             # Traditional format with explicit insertion/deletion maps
+            extra = set(ctx_map) - {
+                "insertions",
+                "insertion",
+                "deletions",
+                "deletion",
+            }
+            if extra:
+                raise ValueError(
+                    f"{name}[{ctx}] has invalid keys: {', '.join(map(str, extra))}"
+                )
             ins_prof = ctx_map.get("insertions") or ctx_map.get("insertion")
             del_prof = ctx_map.get("deletions") or ctx_map.get("deletion")
             if ins_prof is not None:
@@ -123,8 +138,18 @@ def _split_context_indels(
             try:
                 rl = int(run_len)
             except (TypeError, ValueError):
-                continue
+                raise ValueError(f"{name}[{ctx}] run lengths must be integers") from None
             if isinstance(rates, Mapping):
+                extra = set(rates) - {
+                    "insertions",
+                    "insertion",
+                    "deletions",
+                    "deletion",
+                }
+                if extra:
+                    raise ValueError(
+                        f"{name}[{ctx}][{rl}] has invalid keys: {', '.join(map(str, extra))}"
+                    )
                 ins = rates.get("insertions") or rates.get("insertion")
                 dele = rates.get("deletions") or rates.get("deletion")
                 if ins is None and dele is None:
@@ -432,22 +457,46 @@ class NanoporeChannel(BaseChannel):
             coverage = float(data.get("coverage", coverage))
             quality_profile = data.get("quality_profile", quality_profile)
             context_errors = data.get("context_errors", context_errors)
-            context_insertions = data.get("context_insertions", context_insertions)
-            context_deletions = data.get("context_deletions", context_deletions)
+
+            if "context_insertions" in data:
+                ci = data["context_insertions"]
+                if not isinstance(ci, Mapping):
+                    raise ValueError("context_insertions must be a mapping")
+                base = context_insertions or {}
+                for ctx, prof in ci.items():
+                    if not isinstance(prof, Mapping):
+                        raise ValueError(
+                            f"context_insertions[{ctx}] must map run lengths to rates"
+                        )
+                    base.setdefault(str(ctx).upper(), {}).update(prof)
+                context_insertions = base
+            if "context_deletions" in data:
+                cd = data["context_deletions"]
+                if not isinstance(cd, Mapping):
+                    raise ValueError("context_deletions must be a mapping")
+                base = context_deletions or {}
+                for ctx, prof in cd.items():
+                    if not isinstance(prof, Mapping):
+                        raise ValueError(
+                            f"context_deletions[{ctx}] must map run lengths to rates"
+                        )
+                    base.setdefault(str(ctx).upper(), {}).update(prof)
+                context_deletions = base
+
             if "context_indels" in data:
                 ctx_ins, ctx_del = _split_context_indels(
                     data.get("context_indels"), "context_indels"
                 )
                 if ctx_ins:
-                    context_insertions = {
-                        **(context_insertions or {}),
-                        **ctx_ins,
-                    }
+                    base = context_insertions or {}
+                    for ctx, prof in ctx_ins.items():
+                        base.setdefault(ctx, {}).update(prof)
+                    context_insertions = base
                 if ctx_del:
-                    context_deletions = {
-                        **(context_deletions or {}),
-                        **ctx_del,
-                    }
+                    base = context_deletions or {}
+                    for ctx, prof in ctx_del.items():
+                        base.setdefault(ctx, {}).update(prof)
+                    context_deletions = base
             insertion_profile = data.get("insertion_profile", insertion_profile)
             deletion_profile = data.get("deletion_profile", deletion_profile)
         error_rate = _validate_rate("error_rate", error_rate)


### PR DESCRIPTION
## Summary
- support merging `context_indels` from YAML profile paths into context insertion/deletion maps
- validate context definitions and error on malformed mappings
- clean up type hints and helper functions so `mypy` and tests run without failures

## Testing
- `pre-commit run --files src/genecoder/simulators/nanopore.py src/genecoder/dashboard_streamlit.py src/genecoder/cli/pipeline.py src/genecoder/plugin_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb03f678d08326b4ac02022d5f486a