### PR TITLE
test: add nanopore context profile test

### DIFF
--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -106,7 +106,7 @@ def _run_with_params(
         dna, subs, ins, dels, coverage = simulate(temp_name, dna)
         decoded = decode(codec, fec, dna, fec_info)
         Path(output_path).write_bytes(decoded)
-        metrics_any = gather_metrics(
+        metrics: dict[str, Any] = gather_metrics(
             dna,
             original_data,
             decoded,
@@ -119,7 +119,7 @@ def _run_with_params(
     finally:
         if temp_name != chan_name and temp_name in SIMULATOR_REGISTRY:
             del SIMULATOR_REGISTRY[temp_name]
-    return metrics_any
+    return metrics
 
 
 def register_subcommand(

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -108,7 +108,7 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     for name, data in datasets.items():
         label = Path(name).stem
         min_gc, mean_gc, max_gc = _gc_stats(data.get("gc_distribution"))
-        if None not in (min_gc, mean_gc, max_gc):
+        if min_gc is not None and mean_gc is not None and max_gc is not None:
             gc_rows.extend(
                 [
                     {"Run": label, "Metric": "min", "Value": min_gc},

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -184,7 +184,7 @@ def _fetch_catalog(url: str, *, allow_network: bool) -> bytes:
             logger.error(msg)
             raise RuntimeError(msg)
         with urllib.request.urlopen(url, timeout=30) as response:
-            return response.read()
+            return cast(bytes, response.read())
     return _read_local(url)
 
 

--- a/tests/test_nanopore_context_profile.py
+++ b/tests/test_nanopore_context_profile.py
@@ -1,0 +1,37 @@
+import random
+from pathlib import Path
+
+from genecoder.simulators.nanopore import NanoporeChannel, _mutate_read
+
+
+def _simulate_many(channel: NanoporeChannel, sequence: str, runs: int = 1000) -> tuple[float, float]:
+    rng = random.Random(0)
+    ins = 0
+    dels = 0
+    for _ in range(runs):
+        mutated = _mutate_read(sequence, None, rng, channel)
+        if len(mutated) > len(sequence):
+            ins += 1
+        if len(mutated) < len(sequence):
+            dels += 1
+    return ins / runs, dels / runs
+
+
+def test_context_indel_rates(tmp_path: Path) -> None:
+    prof = tmp_path / "nanopore_context.yaml"
+    prof.write_text(
+        "substitution_rate: 0.0\n"
+        "insertion_rate: 0.0\n"
+        "deletion_rate: 0.0\n"
+        "context_indels:\n"
+        "  AA:\n"
+        "    5:\n"
+        "      insertions: 0.5\n"
+        "      deletions: 0.5\n"
+    )
+    channel = NanoporeChannel(profile_path=str(prof))
+
+    poly_ins, poly_del = _simulate_many(channel, "AAAAA")
+    control_ins, control_del = _simulate_many(channel, "ACGTACGT")
+    assert poly_ins > control_ins
+    assert poly_del > control_del


### PR DESCRIPTION
## Summary
- add coverage for NanoporeChannel context indel profiles
- avoid dependency on PyYAML by writing profile text directly in test
- fix mypy type issues in dashboard, pipeline, and plugin manager for clean pre-commit run

## Testing
- `SKIP=pytest pre-commit run --files tests/test_nanopore_context_profile.py src/genecoder/dashboard_streamlit.py src/genecoder/cli/pipeline.py src/genecoder/plugin_manager.py`
- `pytest tests/test_nanopore_context_profile.py`
- `pytest tests/test_plugin_manager.py tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb03f62ad883268fcc3a428d482119