### PR TITLE
docs: add IlluminaInSilicoSeqChannel section

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -92,6 +92,38 @@ make
 sudo make install
 ```
 
+## IlluminaInSilicoSeqChannel
+
+`IlluminaInSilicoSeqChannel` wraps the optional
+[InSilicoSeq](https://github.com/HadrienG/InSilicoSeq) Illumina simulator. It
+invokes the `insilicoseq` CLI when present and falls back to the built-in
+Illumina model otherwise.
+
+### Command-line options
+
+```bash
+genecli decode --simulator illumina_insilicoseq --profile hiseq <other options>
+genecli decode --simulator illumina_insilicoseq --insilicoseq-options "--num_reads 1000" <other options>
+```
+
+Profiles such as `miseq` and `hiseq` map to the corresponding InSilicoSeq
+presets. Additional flags can be supplied with `--insilicoseq-options`.
+
+### Sample quality-profile file
+
+Illumina simulators accept per-base quality distributions via JSON or YAML. A
+sample configuration is provided in `configs/illumina_profile.yaml`:
+
+```yaml
+simulators:
+  - name: insilicoseq
+    read_length: 150
+pipeline:
+  illumina_profile: hiseq
+  illumina_depth: 1
+  illumina_quality_distribution: null
+```
+
 ## Command-line usage
 
 Apply substitutions and indels with chosen probabilities using the ``channel`` command:


### PR DESCRIPTION
## Summary
- document optional IlluminaInSilicoSeqChannel wrapper for InSilicoSeq
- show CLI usage and forwarding of additional flags
- include sample quality-profile YAML snippet

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68c0323906dc832682ac8f7b9bd48587