### PR TITLE
docs: add minimal visualizer plugin example

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -125,15 +125,33 @@ def register(register_simulator):
 
 ### Visualizer Example
 
+This minimal plugin prints the raw bytes it receives.
+
+`myviz.py`
+
 ```python
 from genecoder.api import Visualizer
 
 class MyViz(Visualizer):
     def visualize(self, data: bytes) -> None:
-        ...
+        print(f"visualized: {data!r}")
 
 def register(register_visualizer):
     register_visualizer("myviz", MyViz())
+```
+
+Declare the entry point in `pyproject.toml`:
+
+```toml
+[project.entry-points."genecoder.visualizers"]
+myviz = "myviz"
+```
+
+Run the visualizer:
+
+```bash
+$ genecli visualize myviz - <<<"hi"
+visualized: b'hi\n'
 ```
 
 See [`plugins-examples`](../plugins-examples/) for complete reference implementations.


### PR DESCRIPTION
## Summary
- document a minimal visualizer plugin and how to expose it via entry points
- illustrate demo output using the new visualizer

## Testing
- no tests run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c03d27cb148326bd11570db4e7f7c4