### PR TITLE
Add checksum verification to plugin signature helper

### DIFF
--- a/src/genecoder/plugin_security.py
+++ b/src/genecoder/plugin_security.py
@@ -47,17 +47,26 @@ def compute_checksum(
 
 
 def verify_signature(
-    data: bytes, signature: bytes, public_key: bytes, *, padding_scheme: str = "pkcs1"
-) -> None:
-    """Raise ``ValueError`` if *signature* fails to verify.
+    data: bytes,
+    signature: bytes,
+    public_key: bytes,
+    *,
+    padding_scheme: str = "pkcs1",
+    expected_checksum: str | None = None,
+) -> str:
+    """Return the SHA256 digest for ``data`` after signature validation.
 
     Parameters are forwarded to :func:`genecoder.security.compute_checksum`.
     ``InvalidSignature`` from the underlying cryptography library is converted
-    into ``ValueError`` so callers can handle failures uniformly.
+    into ``ValueError`` so callers can handle failures uniformly. When
+    ``expected_checksum`` is provided the value is normalised via
+    :func:`decode_checksum` and compared against the computed digest. A mismatch
+    raises ``ValueError`` with a clear error message. Callers can persist the
+    returned digest in registry metadata for subsequent verification.
     """
 
     try:
-        _compute_checksum(
+        digest = _compute_checksum(
             data,
             signature=signature,
             public_key=public_key,
@@ -65,3 +74,13 @@ def verify_signature(
         )
     except InvalidSignature as exc:  # pragma: no cover - exercised in tests
         raise ValueError("Invalid signature") from exc
+
+    if expected_checksum is not None:
+        try:
+            expected = decode_checksum(expected_checksum)
+        except ValueError as exc:  # pragma: no cover - invalid checksum encoding
+            raise ValueError("Invalid checksum") from exc
+        if digest != expected:
+            raise ValueError("Checksum mismatch")
+
+    return digest

--- a/tests/test_plugin_signature.py
+++ b/tests/test_plugin_signature.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 
 pytest.importorskip("cryptography.hazmat.primitives.asymmetric")
@@ -21,7 +23,8 @@ def test_verify_signature_pkcs1_valid():
     data = b"signed data"
     signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
 
-    verify_signature(data, signature, public_bytes)
+    digest = verify_signature(data, signature, public_bytes)
+    assert digest == hashlib.sha256(data).hexdigest()
 
 
 def test_verify_signature_pkcs1_invalid_signature():
@@ -46,7 +49,8 @@ def test_verify_signature_pss_valid():
         hashes.SHA256(),
     )
 
-    verify_signature(data, signature, public_bytes, padding_scheme="pss")
+    digest = verify_signature(data, signature, public_bytes, padding_scheme="pss")
+    assert digest == hashlib.sha256(data).hexdigest()
 
 
 def test_verify_signature_pss_mismatch():
@@ -56,4 +60,19 @@ def test_verify_signature_pss_mismatch():
 
     with pytest.raises(ValueError, match="Invalid signature"):
         verify_signature(data, signature, public_bytes, padding_scheme="pss")
+
+
+def test_verify_signature_checksum_mismatch():
+    key, public_bytes = _generate_keypair()
+    data = b"signed data"
+    signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+    bad_checksum = "0" * 64
+
+    with pytest.raises(ValueError, match="Checksum mismatch"):
+        verify_signature(
+            data,
+            signature,
+            public_bytes,
+            expected_checksum=bad_checksum,
+        )
 


### PR DESCRIPTION
## Summary
- extend plugin signature verification to return the computed SHA-256 digest and optionally validate an expected checksum
- update the plugin signature tests to assert the digest and cover checksum mismatch handling

## Testing
- pytest tests/test_plugin_signature.py

------
https://chatgpt.com/codex/tasks/task_e_68c990999b608326a68ab269a190da24