### PR TITLE
Add error metrics to HTML manifest report

### DIFF
--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -26,6 +26,20 @@ def _calc_decode_success(data: dict[str, Any]) -> float | None:
     return None
 
 
+def _format_numeric(value: int | float) -> str:
+    """Return a user-friendly string for numeric values."""
+
+    if isinstance(value, bool):  # bool is a subclass of int, handle explicitly
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:.2f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
 def generate_html_report(manifest_path: str) -> str:
     """Return HTML summary for the manifest at ``manifest_path``."""
     with open(manifest_path, "r", encoding="utf-8") as fh:
@@ -54,6 +68,31 @@ def generate_html_report(manifest_path: str) -> str:
         html_lines.append(
             f"<p><strong>Max Homopolymer Length:</strong> {int(max_hp)}</p>"
         )
+
+    error_metrics: list[tuple[str, str]] = [
+        ("substitutions", "Substitutions"),
+        ("insertions", "Insertions"),
+        ("deletions", "Deletions"),
+    ]
+    error_lines: list[str] = []
+    for key, label in error_metrics:
+        value = metrics.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            error_lines.append(
+                f"<li><strong>{label}:</strong> {_format_numeric(value)}</li>"
+            )
+
+    coverage = metrics.get("coverage")
+    if isinstance(coverage, (int, float)) and not isinstance(coverage, bool):
+        error_lines.append(
+            f"<li><strong>Coverage:</strong> {_format_numeric(coverage)}</li>"
+        )
+
+    if error_lines:
+        html_lines.append("<h2>Error Metrics</h2>")
+        html_lines.append("<ul>")
+        html_lines.extend(error_lines)
+        html_lines.append("</ul>")
 
     ecc = metrics.get("ecc_success_rates")
     if isinstance(ecc, dict) and ecc:

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -14,6 +14,10 @@ def _make_manifest(path: Path) -> Path:
             "gc_variance": 0.01,
             "max_homopolymer": 4,
             "ecc_success_rates": {"rs": 0.9},
+            "substitutions": 7,
+            "insertions": 2,
+            "deletions": 3,
+            "coverage": 42,
         },
     }
     path.write_text(json.dumps(data))
@@ -27,6 +31,11 @@ def test_generate_html_report(tmp_path: Path) -> None:
     assert "GC Variance" in html
     assert "Max Homopolymer Length" in html
     assert "rs" in html
+    assert "<h2>Error Metrics</h2>" in html
+    assert "Substitutions:</strong> 7" in html
+    assert "Insertions:</strong> 2" in html
+    assert "Deletions:</strong> 3" in html
+    assert "Coverage:</strong> 42" in html
 
 
 def test_cli_html_report_stdout(tmp_path: Path) -> None:
@@ -36,3 +45,8 @@ def test_cli_html_report_stdout(tmp_path: Path) -> None:
     assert "GeneCoder Summary Report" in result.stdout
     assert "50.00%" in result.stdout
     assert "GC Variance" in result.stdout
+    assert "<h2>Error Metrics</h2>" in result.stdout
+    assert "Substitutions:</strong> 7" in result.stdout
+    assert "Insertions:</strong> 2" in result.stdout
+    assert "Deletions:</strong> 3" in result.stdout
+    assert "Coverage:</strong> 42" in result.stdout


### PR DESCRIPTION
## Summary
- render substitutions, insertions, deletions, and coverage values in the HTML manifest report when present
- add a small numeric formatter helper to keep the new metrics readable
- extend the HTML report tests and fixtures to assert the metrics surface in both direct and CLI usage

## Testing
- pytest tests/test_html_report.py

------
https://chatgpt.com/codex/tasks/task_e_68cd65506afc8326ae7a0a4fbc9f7618