### PR TITLE
feat: introduce sequence batches for FASTA workflows

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -13,6 +13,7 @@ from typing import Any, Mapping, cast
 
 from . import cli as cli_module
 from genecoder.metrics import metrics
+from genecoder.formats import SequenceBatch
 
 
 @dataclass
@@ -132,6 +133,7 @@ def _create_archive(
     config_hash: str,
     author: str | None = None,
     description: str | None = None,
+    batch_metadata: Mapping[str, object] | None = None,
 ) -> None:
     """Create a gzipped tar archive of ``run_dir`` with a summary manifest."""
     summary = {
@@ -139,6 +141,8 @@ def _create_archive(
         "timestamp": run_dir.name,
         "files": [str(p.relative_to(run_dir)) for p in run_dir.rglob("*") if p.is_file()],
     }
+    if batch_metadata:
+        summary["sequence_batches"] = batch_metadata
     if author is not None:
         summary["author"] = author
     if description is not None:
@@ -187,6 +191,7 @@ def _handle_run(args: argparse.Namespace) -> None:
                     config_hash,
                     args.author,
                     args.description,
+                    batch_metadata=None,
                 )
         return
 
@@ -206,6 +211,41 @@ def _handle_run(args: argparse.Namespace) -> None:
     _run_cli(enc_args)
 
     input_files = [encoded_dir / (Path(p).name + ".fasta") for p in enc_cfg.get("input_files", [])]
+    batch_summary: dict[str, object] = {}
+    for fasta_path in input_files:
+        if not fasta_path.exists():
+            continue
+        try:
+            batch = SequenceBatch.from_fasta(fasta_path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            logger.warning("Could not parse FASTA batch for %s: %s", fasta_path, exc)
+            continue
+        payload = {
+            "batch_id": batch.batch_id,
+            "seed": batch.seed,
+            "metadata": batch.metadata,
+            "oligos": [
+                {
+                    "id": ol.oligo_id,
+                    "index": ol.index,
+                    "seed": ol.seed,
+                    "metadata": ol.metadata,
+                }
+                for ol in batch.oligos
+            ],
+        }
+        metadata_path = fasta_path.with_suffix(fasta_path.suffix + ".batch.json")
+        with open(metadata_path, "w", encoding="utf-8") as meta_f:
+            json.dump(payload, meta_f, indent=2)
+        try:
+            rel = fasta_path.relative_to(run_dir)
+        except ValueError:
+            rel = fasta_path
+        batch_summary[str(rel)] = payload
+
+    if batch_summary:
+        with open(run_dir / "sequence_batches.json", "w", encoding="utf-8") as fh:
+            json.dump(batch_summary, fh, indent=2)
 
     sim_cfg = config.get("simulate")
     if sim_cfg is not None and not isinstance(sim_cfg, dict):
@@ -238,6 +278,7 @@ def _handle_run(args: argparse.Namespace) -> None:
             config_hash,
             args.author,
             args.description,
+            batch_summary,
         )
 
     metrics.increment("bundle_runs")

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -16,7 +16,7 @@ from genecoder.plugin_manager import FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
-from genecoder.formats import from_fasta
+from genecoder.formats import SequenceBatch
 from genecoder.utils import get_alphabet_maps
 from ..options import DecodingOptions
 from .common import run_tasks
@@ -194,18 +194,26 @@ def process_single_decode(
         with open(input_file_path, "r", encoding="utf-8") as f_in:
             file_content_str = f_in.read()
 
-        parsed_records = from_fasta(file_content_str)
-        if not parsed_records:
+        batch = SequenceBatch.from_fasta(file_content_str)
+        if not batch.oligos:
             logger.info(
                 f"Error for {input_file_path}: No valid FASTA records found."
             )
             return
-        if len(parsed_records) > 1:
+        primary_oligos = batch.primary_oligos()
+        if not primary_oligos:
+            primary_oligos = batch.oligos
+        if len(primary_oligos) < len(batch.oligos):
             logger.info(
-                f"Warning for {input_file_path}: Multiple FASTA records found. Processing the first one only."
+                "Skipping %d secondary oligo(s) during decode for %s.",
+                len(batch.oligos) - len(primary_oligos),
+                input_file_path,
             )
 
-        header, sequence_from_fasta = parsed_records[0]
+        header = primary_oligos[0].header
+        sequence_from_fasta = "".join(ol.sequence for ol in primary_oligos)
+        if getattr(args, "seed", None) is None and batch.seed is not None:
+            args.seed = batch.seed
 
         header_method_match = re.search(r"method=([\w_]+)", header)
         if header_method_match:

--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -34,7 +34,7 @@ from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import encode_data_with_hamming
 from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
-from genecoder.formats import to_fasta, from_fasta
+from genecoder.formats import SequenceBatch
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
@@ -236,6 +236,7 @@ def process_single_encode(
                 k_value=args.k_value,
                 parity_rule=args.parity_rule,
                 alphabet=args.alphabet,
+                batch_seed=getattr(args, "seed", None),
             )
 
             original_size_bytes = os.path.getsize(input_file_path)
@@ -268,15 +269,26 @@ def process_single_encode(
             with open(output_file_path, "r", encoding="utf-8") as f_out:
                 fasta_content = f_out.read()
 
-            parsed_records = from_fasta(fasta_content)
-            dna_sequence = parsed_records[0][1] if parsed_records else ""
+            batch = SequenceBatch.from_fasta(fasta_content)
+            dna_sequence = batch.primary_sequence()
 
             if getattr(args, "mirror", False) and dna_sequence:
                 rc_seq = reverse_complement(dna_sequence)
-                rc_header = f"{header} mirror=rc"
-                with open(output_file_path, "a", encoding="utf-8") as f_out:
-                    f_out.write(to_fasta(rc_seq, rc_header, line_width=80))
-                parsed_records.append((rc_header, rc_seq))
+                base_header = batch.first_header() or header
+                mirror_header = f"{base_header} mirror=rc"
+                existing_records = [
+                    (record.header, record.sequence) for record in batch.records()
+                ]
+                existing_records.append((mirror_header, rc_seq))
+                rebuilt_batch = SequenceBatch.build(
+                    existing_records,
+                    batch_id=batch.batch_id or Path(sanitized_name).stem,
+                    batch_seed=batch.seed,
+                )
+                with open(output_file_path, "w", encoding="utf-8") as f_out:
+                    f_out.write(rebuilt_batch.to_fasta(line_width=80))
+                batch = rebuilt_batch
+                dna_sequence = batch.primary_sequence()
 
             final_gc = calculate_gc_content(dna_sequence)
             final_hp = get_max_homopolymer_length(dna_sequence)
@@ -388,22 +400,31 @@ def process_single_encode(
         if checksum:
             fasta_header = f"{fasta_header} checksum={checksum}"
 
-        fasta_output = to_fasta(final_encoded_dna_sequence, fasta_header, line_width=80)
+        records: list[tuple[str, str]] = [(fasta_header, final_encoded_dna_sequence)]
         if getattr(args, "mirror", False):
             rc_seq = reverse_complement(final_encoded_dna_sequence)
-            rc_header = f"{fasta_header} mirror=rc"
-            fasta_output += to_fasta(rc_seq, rc_header, line_width=80)
+            records.append((f"{fasta_header} mirror=rc", rc_seq))
+
+        batch_id = Path(header_name).stem.replace(" ", "_") or "batch"
+        batch = SequenceBatch.build(
+            records,
+            batch_id=batch_id,
+            batch_seed=getattr(args, "seed", None),
+        )
 
         os.makedirs(os.path.dirname(output_file_path) or ".", exist_ok=True)
         with open(output_file_path, "w", encoding="utf-8") as f_out:
-            f_out.write(fasta_output)
+            f_out.write(batch.to_fasta(line_width=80))
+
+        primary_sequence = batch.primary_sequence()
+        primary_header = batch.first_header() or fasta_header
 
         if getattr(args, "mirror", False):
             try:
                 from genecoder.helix_view import show_helix_ui
 
-                rc_seq = reverse_complement(final_encoded_dna_sequence)
-                show_helix_ui(final_encoded_dna_sequence, strand2_sequence=rc_seq)
+                rc_seq = reverse_complement(primary_sequence)
+                show_helix_ui(primary_sequence, strand2_sequence=rc_seq)
             except Exception as exc:  # pragma: no cover - optional GUI
                 logger.warning("Could not launch helix viewer: %s", exc)
 
@@ -416,15 +437,15 @@ def process_single_encode(
                 "fec": args.fec,
             }
             write_capsule(
-                final_encoded_dna_sequence,
-                fasta_header,
+                primary_sequence,
+                primary_header,
                 metadata,
                 args.capsule,
             )
             logger.info(f"Capsule written to {args.capsule}")
 
         original_size_bytes = len(plaintext_data)
-        final_encoded_length_nucleotides = len(final_encoded_dna_sequence)
+        final_encoded_length_nucleotides = len(primary_sequence)
         dna_equivalent_bytes = final_encoded_length_nucleotides * 0.25
 
         compression_ratio = (
@@ -438,8 +459,8 @@ def process_single_encode(
             else 0.0
         )
 
-        final_gc = calculate_gc_content(final_encoded_dna_sequence)
-        final_hp = get_max_homopolymer_length(final_encoded_dna_sequence)
+        final_gc = calculate_gc_content(primary_sequence)
+        final_hp = get_max_homopolymer_length(primary_sequence)
         gc_default_bad = final_gc < DEFAULT_GC_MIN or final_gc > DEFAULT_GC_MAX
         hp_default_bad = final_hp > DEFAULT_MAX_HOMOPOLYMER
         if not suppress_warnings:
@@ -524,7 +545,7 @@ def process_single_encode(
         with open(manifest_path, "w", encoding="utf-8") as mf:
             json.dump(manifest, mf, indent=2)
 
-        return os.path.basename(input_file_path), final_encoded_dna_sequence
+        return os.path.basename(input_file_path), primary_sequence
 
     except FileNotFoundError:
         logger.error(f"Error for {input_file_path}: Input file not found.")

--- a/src/genecoder/formats.py
+++ b/src/genecoder/formats.py
@@ -1,17 +1,312 @@
-"""Provides functions for formatting data into and parsing data from FASTA format.
+"""Helpers for working with FASTA records and :class:`SequenceBatch` objects."""
 
-FASTA is a text-based format for representing nucleotide sequences or peptide
-sequences, where nucleotides or amino acids are represented using single-letter
-codes. A sequence in FASTA format consists of a single-line description (header),
-followed by lines of sequence data.
-"""
-from typing import List, Tuple, Sequence  # For type hints
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, List, Mapping, MutableMapping, Sequence, Tuple
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 # The set of valid characters for FASTA sequence lines.
 # Valid characters are the uppercase ASCII letters ``A``-``Z``, the digits
 # ``0``-``9``, the gap characters ``-`` and ``*``, and the slash ``/``.
 # Lowercase characters are considered invalid and will trigger a ``ValueError``.
 FASTA_ALLOWED_CHARS: set[str] = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-*/")
+
+
+@dataclass(slots=True)
+class FastaRecord:
+    """Represents a single FASTA record."""
+
+    header: str
+    sequence: str
+
+    def as_tuple(self) -> tuple[str, str]:
+        """Return ``(header, sequence)`` for compatibility with legacy helpers."""
+
+        return self.header, self.sequence
+
+
+@dataclass(slots=True)
+class SequenceOligo:
+    """A single oligo entry within a :class:`SequenceBatch`."""
+
+    sequence: str
+    header: str
+    index: int
+    oligo_id: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    seed: int | None = None
+
+    def to_record(self) -> FastaRecord:
+        """Return the oligo as a :class:`FastaRecord`."""
+
+        return FastaRecord(header=self.header, sequence=self.sequence)
+
+
+@dataclass
+class SequenceBatch:
+    """A batch of related oligos accompanied by shared metadata."""
+
+    batch_id: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    seed: int | None = None
+    oligos: list[SequenceOligo] = field(default_factory=list)
+    legacy: bool = False
+
+    def __post_init__(self) -> None:
+        self.oligos.sort(key=lambda ol: ol.index)
+
+    def add_oligo(self, oligo: SequenceOligo) -> None:
+        """Append ``oligo`` and keep records ordered."""
+
+        self.oligos.append(oligo)
+        self.oligos.sort(key=lambda item: item.index)
+
+    @property
+    def total_length(self) -> int:
+        """Return the total number of nucleotides across all oligos."""
+
+        return sum(len(ol.sequence) for ol in self.oligos)
+
+    def records(self) -> list[FastaRecord]:
+        """Return the batch as a list of :class:`FastaRecord` objects."""
+
+        return [ol.to_record() for ol in self.oligos]
+
+    def to_fasta(self, line_width: int = 60) -> str:
+        """Serialise the batch into FASTA text."""
+
+        return format_fasta_records(self.records(), line_width=line_width)
+
+    def combined_sequence(self) -> str:
+        """Concatenate the sequences for all oligos in order."""
+
+        return "".join(ol.sequence for ol in self.oligos)
+
+    def primary_oligos(self) -> list[SequenceOligo]:
+        """Return oligos that are not marked as mirrors."""
+
+        return [
+            ol for ol in self.oligos if ol.metadata.get("mirror", "").lower() != "rc"
+        ]
+
+    def primary_sequence(self) -> str:
+        """Concatenate only the primary oligo sequences."""
+
+        return "".join(ol.sequence for ol in self.primary_oligos())
+
+    def first_header(self) -> str:
+        """Return the header for the first primary oligo, if present."""
+
+        primaries = self.primary_oligos()
+        return primaries[0].header if primaries else (self.oligos[0].header if self.oligos else "")
+
+    @classmethod
+    def build(
+        cls,
+        records: Sequence[FastaRecord | tuple[str, str]],
+        *,
+        batch_id: str | None = None,
+        batch_seed: int | None = None,
+        max_oligo_length: int | None = None,
+    ) -> "SequenceBatch":
+        """Construct a batch from ``records``.
+
+        The ``records`` iterable may contain :class:`FastaRecord` instances or
+        ``(header, sequence)`` tuples. Each record can optionally be split into
+        multiple oligos by providing ``max_oligo_length``. Metadata is preserved
+        and augmented with ``batch_id``, ``batch_size`` and per-oligo identifiers.
+        """
+
+        items = [r if isinstance(r, FastaRecord) else FastaRecord(*r) for r in records]
+        if not items:
+            raise ValueError("records cannot be empty")
+
+        base_meta = _metadata_from_header(items[0].header)
+        derived_id = _sanitize_header_value(
+            batch_id or base_meta.get("batch_id") or base_meta.get("input_file") or "batch"
+        )
+        batch = cls(batch_id=derived_id, metadata=dict(base_meta), seed=batch_seed)
+
+        index = 0
+        for record in items:
+            rec_meta = _metadata_from_header(record.header)
+            sequences = list(_split_sequence(record.sequence, max_oligo_length))
+            if not sequences:
+                sequences = [""]
+            for chunk in sequences:
+                index += 1
+                metadata = dict(rec_meta)
+                metadata["batch_id"] = derived_id
+                metadata["oligo_index"] = str(index)
+                metadata.setdefault("oligo_id", f"{derived_id}-{index:04d}")
+                if batch_seed is not None:
+                    metadata["batch_seed"] = str(batch_seed)
+                    metadata.setdefault("oligo_seed", str(batch_seed + index - 1))
+                header = _update_header_tokens(record.header, metadata)
+                oligo_seed = metadata.get("oligo_seed")
+                try:
+                    oligo_seed_int = int(oligo_seed) if oligo_seed is not None else None
+                except ValueError:
+                    oligo_seed_int = None
+                batch.add_oligo(
+                    SequenceOligo(
+                        sequence=chunk,
+                        header=header,
+                        index=index,
+                        oligo_id=metadata["oligo_id"],
+                        metadata=metadata,
+                        seed=oligo_seed_int,
+                    )
+                )
+
+        total = len(batch.oligos)
+        batch.metadata["batch_id"] = derived_id
+        batch.metadata["batch_size"] = str(total)
+        if batch_seed is not None:
+            batch.metadata["batch_seed"] = str(batch_seed)
+
+        for oligo in batch.oligos:
+            oligo.metadata["batch_size"] = str(total)
+            oligo.header = _update_header_tokens(
+                oligo.header,
+                {"batch_size": str(total), "batch_id": derived_id}
+                | ({"batch_seed": str(batch_seed)} if batch_seed is not None else {}),
+            )
+
+        return batch
+
+    @classmethod
+    def from_fasta(cls, fasta_content: str) -> "SequenceBatch":
+        """Parse ``fasta_content`` into a :class:`SequenceBatch`.
+
+        Legacy single-record FASTA files (without batch metadata) are wrapped into
+        a batch with a deprecation warning.
+        """
+
+        records = parse_fasta_records(fasta_content)
+        if not records:
+            return cls(batch_id="", metadata={}, seed=None, oligos=[], legacy=False)
+
+        first_meta = _metadata_from_header(records[0].header)
+        has_batch = "batch_id" in first_meta and (
+            "oligo_index" in first_meta or "oligo_id" in first_meta
+        )
+
+        if len(records) == 1 and not has_batch:
+            logger.warning(
+                "Legacy FASTA without SequenceBatch metadata detected; treating as a single-oligo batch."
+            )
+            batch_id = _sanitize_header_value(
+                first_meta.get("input_file") or first_meta.get("name") or "legacy"
+            )
+            batch = cls.build(records, batch_id=batch_id)
+            batch.legacy = True
+            return batch
+
+        batch_id = _sanitize_header_value(first_meta.get("batch_id") or "batch")
+        batch_seed = first_meta.get("batch_seed")
+        try:
+            seed_int = int(batch_seed) if batch_seed is not None else None
+        except ValueError:
+            seed_int = None
+
+        oligos: list[SequenceOligo] = []
+        for idx, record in enumerate(records, start=1):
+            meta = _metadata_from_header(record.header)
+            index_str = meta.get("oligo_index") or meta.get("oligo_id")
+            try:
+                index = int(index_str) if index_str is not None else idx
+            except ValueError:
+                index = idx
+            oligo_seed = meta.get("oligo_seed")
+            try:
+                seed_val = int(oligo_seed) if oligo_seed is not None else None
+            except ValueError:
+                seed_val = None
+            oligo_id = meta.get("oligo_id") or f"{batch_id}-{index:04d}"
+            oligos.append(
+                SequenceOligo(
+                    sequence=record.sequence,
+                    header=record.header,
+                    index=index,
+                    oligo_id=oligo_id,
+                    metadata=meta,
+                    seed=seed_val,
+                )
+            )
+
+        batch_meta = dict(first_meta)
+        batch_meta["batch_id"] = batch_id
+        batch_meta.setdefault("batch_size", str(len(oligos)))
+        if seed_int is not None:
+            batch_meta["batch_seed"] = str(seed_int)
+
+        return cls(
+            batch_id=batch_id,
+            metadata=batch_meta,
+            seed=seed_int,
+            oligos=sorted(oligos, key=lambda ol: ol.index),
+            legacy=False,
+        )
+
+
+def _split_sequence(sequence: str, max_length: int | None) -> Iterator[str]:
+    """Yield ``sequence`` chunks of at most ``max_length`` nucleotides."""
+
+    if max_length is None or max_length <= 0:
+        yield sequence
+        return
+    for start in range(0, len(sequence), max_length):
+        yield sequence[start : start + max_length]
+
+
+def _sanitize_header_value(value: object) -> str:
+    """Return ``value`` as a header-safe string without whitespace."""
+
+    text = str(value).strip()
+    if not text:
+        return "0"
+    for bad in "\r\n\t>":
+        text = text.replace(bad, "_")
+    return "_".join(part for part in text.split()) or "0"
+
+
+def _tokenize_header(header: str) -> tuple[list[str], MutableMapping[str, int]]:
+    tokens = header.strip().split()
+    positions: MutableMapping[str, int] = {}
+    for idx, token in enumerate(tokens):
+        if "=" in token:
+            key, _ = token.split("=", 1)
+            positions[key] = idx
+    return tokens, positions
+
+
+def _update_header_tokens(header: str, updates: Mapping[str, object]) -> str:
+    tokens, positions = _tokenize_header(header)
+    for key, value in updates.items():
+        if value is None:
+            continue
+        sanitized = _sanitize_header_value(value)
+        token = f"{key}={sanitized}"
+        if key in positions:
+            tokens[positions[key]] = token
+        else:
+            positions[key] = len(tokens)
+            tokens.append(token)
+    return " ".join(tokens)
+
+
+def _metadata_from_header(header: str) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for token in header.strip().split():
+        if "=" in token:
+            key, value = token.split("=", 1)
+            metadata[key] = value
+    return metadata
 
 def to_fasta(dna_sequence: str, header: str, line_width: int = 60) -> str:
     """Formats a DNA sequence into a FASTA formatted string.
@@ -57,41 +352,23 @@ def to_fasta(dna_sequence: str, header: str, line_width: int = 60) -> str:
     return fasta_string
 
 
-def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
-    """Parses content in FASTA format and extracts sequence records.
+def format_fasta_records(records: Sequence[FastaRecord], line_width: int = 60) -> str:
+    """Return FASTA text for ``records``."""
 
-    A FASTA record consists of a header line starting with ">" followed by
-    one or more lines of sequence data. This function can parse multiple
-    FASTA records from a single string input. Lines not part of a valid
-    record structure (e.g., text before the first header) are ignored.
+    return "".join(
+        to_fasta(record.sequence, record.header, line_width=line_width)
+        for record in records
+    )
 
-    Sequence lines are processed by first stripping leading/trailing whitespace,
-    then removing all internal whitespace before concatenation. For example,
-    a line "  AT GC  " becomes "ATGC".
 
-    Args:
-        fasta_content (str): A string containing the entire FASTA formatted data.
+def parse_fasta_records(fasta_content: str) -> List[FastaRecord]:
+    """Parse ``fasta_content`` and return :class:`FastaRecord` objects.
 
-    Returns:
-        List[Tuple[str, str]]: A list of tuples, where each tuple contains 
-        `(header, sequence)`.
-        - `header` (str): The header string (content after the initial ">", 
-          stripped of leading/trailing whitespace).
-        - `sequence` (str): The concatenated sequence data, with all internal
-          whitespace removed from each original sequence line.
-        Returns an empty list if no valid FASTA records (lines starting with ">")
-        are found.
-    
-    Example:
-        >>> fasta_data = ">seq1 description1\\nAT GC\\nCGTA\\n>seq2\\nTT TT\\nAAAA"
-        >>> from_fasta(fasta_data)
-        [('seq1 description1', 'ATGCCGTA'), ('seq2', 'TTTTAAAA')]
-
-    Raises:
-        ValueError: If any sequence line contains lowercase letters or
-            characters not present in :data:`FASTA_ALLOWED_CHARS`.
+    This function mirrors :func:`from_fasta` but preserves the headers exactly as
+    they appear in the file.
     """
-    records: List[Tuple[str, str]] = []
+
+    records: List[FastaRecord] = []
     current_header: str | None = None
     current_sequence_parts: List[str] = []
 
@@ -99,19 +376,15 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
 
     for line_number, line_text in enumerate(lines, start=1):
         stripped_line = line_text.strip()
-        if not stripped_line: # Skip empty or whitespace-only lines
+        if not stripped_line:
             continue
 
         if stripped_line.startswith(">"):
-            # If a previous record was being processed, finalize and save it.
             if current_header is not None:
-                records.append((current_header, "".join(current_sequence_parts)))
-            
-            current_header = stripped_line[1:].strip() # Store header without ">"
-            current_sequence_parts = [] # Reset for the new sequence
+                records.append(FastaRecord(current_header, "".join(current_sequence_parts)))
+            current_header = stripped_line[1:].strip()
+            current_sequence_parts = []
         elif current_header is not None:
-            # This is a sequence line for the current active header.
-            # Remove all whitespace (leading, trailing, and internal) from the sequence line.
             processed_sequence_line = "".join(stripped_line.split())
             if (
                 any(ch.islower() for ch in processed_sequence_line)
@@ -119,15 +392,17 @@ def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
             ):
                 raise ValueError(f"Invalid characters on line {line_number}.")
             current_sequence_parts.append(processed_sequence_line)
-        # else: If line_text does not start with ">" and no current_header is active,
-        #       it's considered content outside a valid FASTA record (e.g., text
-        #       before the first header) and is ignored.
 
-    # After the loop, save the last processed record, if any.
     if current_header is not None:
-        records.append((current_header, "".join(current_sequence_parts)))
+        records.append(FastaRecord(current_header, "".join(current_sequence_parts)))
 
     return records
+
+
+def from_fasta(fasta_content: str) -> List[Tuple[str, str]]:
+    """Parse ``fasta_content`` and return ``(header, sequence)`` tuples."""
+
+    return [record.as_tuple() for record in parse_fasta_records(fasta_content)]
 
 
 def to_fastq(

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -12,10 +12,12 @@ from typing import (
 import os
 import json
 import hashlib
+from pathlib import Path
 
 from .encoders import encode_base4_direct, decode_base4_direct
 from .error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from .utils import get_alphabet_maps
+from .formats import SequenceBatch
 
 
 EncodeFunc = Callable[[bytes], str]
@@ -69,6 +71,7 @@ def stream_encode_file(
     k_value: int = 7,
     parity_rule: str = PARITY_RULE_GC_EVEN_A_ODD_T,
     alphabet: str = "base4",
+    batch_seed: int | None = None,
 ) -> int:
     """Encode ``input_path`` to ``output_path`` streaming chunks.
 
@@ -84,6 +87,7 @@ def stream_encode_file(
     manifest_file = None
     processed_chunks = 0
     manifest_lines: list[dict[str, int | str]] = []
+    verified_chunks: list[str] = []
     encode_map, _ = get_alphabet_maps(alphabet)
     if manifest_path:
         mode = "a" if resume else "w"
@@ -109,6 +113,7 @@ def stream_encode_file(
                             stream=True,
                         )
                         dna_chunk = next(iter(dna_iter))
+                        verified_chunks.append(dna_chunk)
                         expected = hashlib.sha256(dna_chunk.encode()).hexdigest()
                         entry = manifest_lines[idx]
                         if (
@@ -122,6 +127,20 @@ def stream_encode_file(
 
     start_offset = processed_chunks * chunk_size
 
+    existing_sequence = "".join(verified_chunks)
+    if resume and os.path.exists(output_path):
+        try:
+            existing_batch = SequenceBatch.from_fasta(
+                Path(output_path).read_text(encoding="utf-8")
+            )
+            parsed_sequence = existing_batch.primary_sequence()
+            if parsed_sequence:
+                existing_sequence = parsed_sequence
+            if batch_seed is None:
+                batch_seed = existing_batch.seed
+        except (OSError, ValueError):
+            existing_sequence = "".join(verified_chunks)
+
     def data_iter() -> Iterator[bytes]:
         with open(input_path, "rb") as f_in:
             if start_offset:
@@ -132,35 +151,37 @@ def stream_encode_file(
                     break
                 yield chunk
 
-    total_len = 0
-    line_width = 80
-    buffer = ""
-    mode = "a" if resume and os.path.exists(output_path) else "w"
-    with open(output_path, mode, encoding="utf-8") as f_out:
-        if mode == "w":
-            f_out.write(f">{header}\n")
-        offset = processed_chunks * chunk_size
-        for dna_chunk in encode_base4_direct(
-            data_iter(),
-            add_parity=add_parity,
-            k_value=k_value,
-            parity_rule=parity_rule,
-            encode_map=encode_map,
-            stream=True,
-        ):
-            if manifest_file:
-                chunk_hash = hashlib.sha256(dna_chunk.encode()).hexdigest()
-                manifest_file.write(json.dumps({"offset": offset, "hash": chunk_hash}) + "\n")
-                offset += chunk_size
-            total_len += len(dna_chunk)
-            buffer += dna_chunk
-            while len(buffer) >= line_width:
-                f_out.write(buffer[:line_width] + "\n")
-                buffer = buffer[line_width:]
-        if buffer:
-            f_out.write(buffer + "\n")
+    sequence_parts: list[str] = []
+    if existing_sequence:
+        sequence_parts.append(existing_sequence)
+    total_len = len(existing_sequence)
+    offset = processed_chunks * chunk_size
+    for dna_chunk in encode_base4_direct(
+        data_iter(),
+        add_parity=add_parity,
+        k_value=k_value,
+        parity_rule=parity_rule,
+        encode_map=encode_map,
+        stream=True,
+    ):
         if manifest_file:
-            manifest_file.close()
+            chunk_hash = hashlib.sha256(dna_chunk.encode()).hexdigest()
+            manifest_file.write(json.dumps({"offset": offset, "hash": chunk_hash}) + "\n")
+            offset += chunk_size
+        total_len += len(dna_chunk)
+        sequence_parts.append(dna_chunk)
+    if manifest_file:
+        manifest_file.close()
+
+    full_sequence = "".join(sequence_parts)
+
+    batch = SequenceBatch.build(
+        [(header, full_sequence)],
+        batch_seed=batch_seed,
+    )
+    with open(output_path, "w", encoding="utf-8") as f_out:
+        f_out.write(batch.to_fasta(line_width=80))
+
     return total_len
 
 

--- a/tests/test_cli_decode.py
+++ b/tests/test_cli_decode.py
@@ -9,7 +9,7 @@ from tests.test_cli import run_cli_command
 from genecoder.cli.options import build_encoding_options, build_decoding_options
 from genecoder.cli import run_encoding_pipeline, run_decoding_pipeline
 from genecoder.encoders import encode_base4_direct
-from genecoder.formats import to_fasta
+from genecoder.formats import SequenceBatch, to_fasta
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder import plugins
 
@@ -88,6 +88,62 @@ def test_cli_decode_duplicate_output_names(tmp_path: Path) -> None:
     out2 = tmp_path / "dup_1.bin"
     assert out1.read_bytes() == b"one"
     assert out2.read_bytes() == b"two"
+
+
+def test_cli_decode_sequence_batch_round_trip(tmp_path: Path) -> None:
+    input_file = tmp_path / "payload.bin"
+    input_file.write_bytes(b"hello world")
+    encoded_dir = tmp_path / "encoded"
+    encoded_dir.mkdir()
+
+    enc_res = run_cli_command(
+        [
+            "encode",
+            "--input-files",
+            str(input_file),
+            "--output-dir",
+            str(encoded_dir),
+            "--method",
+            "base4_direct",
+            "--seed",
+            "7",
+        ]
+    )
+    assert enc_res.returncode == 0, enc_res.stderr
+    fasta_path = encoded_dir / "payload.bin.fasta"
+    batch = SequenceBatch.from_fasta(fasta_path.read_text())
+
+    sequence = batch.primary_sequence()
+    split = len(sequence) // 2 or len(sequence)
+    records = [
+        (batch.first_header(), sequence[:split]),
+        (batch.first_header(), sequence[split:]),
+    ]
+    split_batch = SequenceBatch.build(
+        records,
+        batch_id=batch.batch_id,
+        batch_seed=batch.seed,
+    )
+    split_path = tmp_path / "payload_split.fasta"
+    split_path.write_text(split_batch.to_fasta(line_width=80))
+
+    decoded_dir = tmp_path / "decoded"
+    decoded_dir.mkdir()
+    dec_res = run_cli_command(
+        [
+            "decode",
+            "--input-files",
+            str(split_path),
+            "--output-dir",
+            str(decoded_dir),
+            "--method",
+            "base4_direct",
+        ]
+    )
+    assert dec_res.returncode == 0, dec_res.stderr
+    outputs = list(decoded_dir.glob("*"))
+    assert len(outputs) == 1
+    assert outputs[0].read_bytes() == input_file.read_bytes()
 
 
 @pytest.mark.parametrize("sim_name", ["d2sim", "dnarsim", "squigulator", "desp"])

--- a/tests/test_cli_encode.py
+++ b/tests/test_cli_encode.py
@@ -12,7 +12,7 @@ import pytest
 
 from genecoder.cli.encode import process_single_encode
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
-from genecoder.formats import from_fasta
+from genecoder.formats import SequenceBatch, from_fasta
 from genecoder.reed_solomon_codec import _HAS_REEDSOLO
 
 
@@ -113,6 +113,28 @@ def test_process_single_encode_windows_path(tmp_path: Path) -> None:
     header = records[0][0]
     assert "input_file=file.txt" in header
     assert "\\" not in header
+
+
+def test_process_single_encode_sequence_batch_metadata(tmp_path: Path) -> None:
+    input_file = tmp_path / "meta.bin"
+    input_file.write_text("batch")
+    output_file = tmp_path / "meta_out.fasta"
+    args = _encode_args()
+    args.seed = 123
+    process_single_encode(str(input_file), str(output_file), args)
+
+    batch = SequenceBatch.from_fasta(output_file.read_text())
+    assert batch.batch_id == "meta"
+    assert batch.seed == 123
+    assert batch.metadata.get("method") == "base4_direct"
+    assert batch.metadata.get("input_file") == "meta.bin"
+    assert len(batch.oligos) == 1
+    oligo = batch.oligos[0]
+    assert oligo.metadata.get("batch_size") == "1"
+    assert oligo.metadata.get("oligo_index") == "1"
+    assert oligo.seed == 123
+    assert "batch_id=" in oligo.header
+    assert batch.primary_sequence() == from_fasta(output_file.read_text())[0][1]
 
 
 def test_process_single_encode_windows_path_stream(tmp_path: Path) -> None:

--- a/tests/test_streaming_additional.py
+++ b/tests/test_streaming_additional.py
@@ -12,7 +12,8 @@ def test_stream_encode_line_width(tmp_path):
     header = "method=base4_direct input_file=in.bin"
     total_len = stream_encode_file(str(input_file), str(output_file), header=header, chunk_size=50)
     lines = output_file.read_text().splitlines()
-    assert lines[0] == f">{header}"
+    assert lines[0].startswith(f">{header}")
+    assert "batch_id=" in lines[0]
     dna = "".join(lines[1:])
     assert len(dna) == total_len
     for line in lines[1:]:


### PR DESCRIPTION
## Summary
- add SequenceBatch helpers to formats module with FASTA parsing utilities
- update encode/decode CLI, bundler, and streaming helpers to emit SequenceBatch metadata
- extend CLI and streaming tests to cover batch handling and metadata propagation

## Testing
- pytest tests/test_cli_encode.py tests/test_cli_decode.py tests/test_streaming.py tests/test_streaming_additional.py tests/test_streaming_fec.py tests/test_streaming_directories.py tests/test_streaming_files.py tests/test_streaming_png.py tests/test_streaming_resume.py

------
https://chatgpt.com/codex/tasks/task_e_68d1492d28ac83268c7bffd75b49e5a1