### PR TITLE
Enable batch-aware simulators and manifest metadata

### DIFF
--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 """Public abstract interfaces for GeneCoder plugins."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .formats import SequenceBatch
 
 
 __all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
@@ -106,18 +109,18 @@ class Simulator(ABC):
     """
 
     @abstractmethod
-    def simulate(self, sequence: str) -> str:
+    def simulate(self, sequence: str | "SequenceBatch") -> str | "SequenceBatch":
         """Return a possibly corrupted version of ``sequence``.
 
         Parameters
         ----------
         sequence:
-            Input DNA sequence.
+            Input DNA sequence or :class:`~genecoder.formats.SequenceBatch`.
 
         Returns
         -------
-        str
-            Simulated read sequence.
+        str or :class:`~genecoder.formats.SequenceBatch`
+            Simulated read sequence(s).
         """
 
     def with_profile(self, profile: str) -> "Simulator":

--- a/src/genecoder/channel_config.py
+++ b/src/genecoder/channel_config.py
@@ -15,3 +15,6 @@ class ChannelConfig:
     use_mpi: bool = False
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    dropout_rate: float | None = None
+    coverage_distribution: dict[int, float] | None = None
+    synthesis_loss: float | None = None

--- a/src/genecoder/channels/base.py
+++ b/src/genecoder/channels/base.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..formats import SequenceBatch
 
 __all__ = ["BaseChannel"]
 
@@ -9,6 +12,6 @@ __all__ = ["BaseChannel"]
 class BaseChannel(Protocol):
     """Protocol for DNA read simulators."""
 
-    def simulate(self, sequence: str) -> str:
+    def simulate(self, sequence: str | "SequenceBatch") -> str | "SequenceBatch":
         """Return a possibly corrupted version of ``sequence``."""
         ...

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -8,23 +8,33 @@ import logging
 import os
 import random
 from pathlib import Path
-from typing import Sequence, Dict, Any
+from typing import Sequence, Dict, Any, Mapping
 from difflib import SequenceMatcher
 
 
-from genecoder.formats import from_fasta, to_fasta
+from genecoder.formats import SequenceBatch
 from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
 from genecoder.channel_config import ChannelConfig
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
-from genecoder.parallel import parallel_map
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES, DNARSIM_RATE_TABLES
 from genecoder.error_simulation import INDEL_PROFILES
 from genecoder.simulators.decay import DegradationChannel
-from .options import ChannelOptions, build_channel_options
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_LOG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+    RESULT_SYNTHESIS_FLAG_KEY,
+    bool_to_str,
+    clone_batch,
+    finalize_batch_statistics,
+    load_coverage_distribution,
+)
+from .options import ChannelOptions, build_channel_options, _parse_distribution
 from .shared import add_single_io_args
 
 logger = logging.getLogger(__name__)
@@ -93,6 +103,7 @@ def _load_config(
     if not isinstance(pipeline, dict):
         raise ValueError("'pipeline' must be a mapping")
 
+    coverage_config = pipeline.get("coverage_distribution")
     cfg = ChannelConfig(
         parallel=bool(pipeline.get("parallel", False)),
         workers=pipeline.get("workers"),
@@ -100,6 +111,13 @@ def _load_config(
         use_mpi=bool(pipeline.get("use_mpi", False)),
         illumina_profile=pipeline.get("illumina_profile"),
         nanopore_profile=pipeline.get("nanopore_profile"),
+        dropout_rate=(
+            float(pipeline["dropout_rate"]) if "dropout_rate" in pipeline else None
+        ),
+        coverage_distribution=load_coverage_distribution(coverage_config),
+        synthesis_loss=(
+            float(pipeline["synthesis_loss"]) if "synthesis_loss" in pipeline else None
+        ),
     )
 
     extra = {
@@ -140,13 +158,13 @@ def _load_profile_file(path: str) -> Dict[str, Any]:
 
 
 def _apply_simulators(
-    sequence: str,
+    batch: SequenceBatch,
     simulators: Sequence[
         BaseChannel | tuple[str, Dict[str, Any]]
     ],
     *,
     config: ChannelConfig,
-) -> str:
+) -> SequenceBatch:
     channels: list[BaseChannel] = []
     for item in simulators:
         if isinstance(item, BaseChannel):
@@ -167,8 +185,101 @@ def _apply_simulators(
         channels.append(channel)
         logger.info("Applied %s simulator", name)
     pipeline = ChannelPipeline(channels)
-    result: str = pipeline.simulate(sequence, config=config)
-    return result
+    result = pipeline.simulate(batch, config=config)
+    return result if isinstance(result, SequenceBatch) else _batch_from_string(result)
+
+
+def _batch_from_string(sequence: str) -> SequenceBatch:
+    batch = SequenceBatch.build([("cli", sequence)], batch_id="cli")
+    if batch.oligos:
+        oligo = batch.oligos[0]
+        oligo.metadata[RESULT_COVERAGE_KEY] = "1"
+        oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps([])
+        oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
+            {"substitutions": 0, "insertions": 0, "deletions": 0}
+        )
+        finalize_batch_statistics(batch, [1], [False], [False], [(0, 0, 0)])
+    return batch
+
+
+def _is_flag_true(metadata: Mapping[str, str], key: str) -> bool:
+    return metadata.get(key, "").strip().lower() in {"true", "1", "yes"}
+
+
+def _parse_float(value: str | None, default: float = 0.0) -> float:
+    try:
+        return float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_int(value: str | None, default: int = 0) -> int:
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        try:
+            return int(float(value)) if value is not None else default
+        except (TypeError, ValueError):
+            return default
+
+
+def _simulate_probabilities(
+    batch: SequenceBatch,
+    *,
+    sub_prob: float,
+    ins_prob: float,
+    del_prob: float,
+    seed: int | None,
+) -> SequenceBatch:
+    base_rng = random.Random(seed)
+    mutated = clone_batch(batch)
+    coverage_counts: list[int] = []
+    dropout_flags: list[bool] = []
+    synthesis_flags: list[bool] = []
+    consensus_totals: list[tuple[int, int, int]] = []
+
+    for idx, (original, oligo) in enumerate(zip(batch.oligos, mutated.oligos), start=1):
+        if seed is not None:
+            rng = random.Random(seed + idx)
+        else:
+            rng = random.Random(base_rng.random())
+        mutated_seq = introduce_errors(
+            original.sequence,
+            substitution_prob=sub_prob,
+            insertion_prob=ins_prob,
+            deletion_prob=del_prob,
+            rng=rng,
+        )
+        oligo.sequence = mutated_seq
+        subs, ins, dels = _count_errors(original.sequence, mutated_seq)
+        oligo.metadata[RESULT_COVERAGE_KEY] = "1"
+        oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps(
+            [
+                {
+                    "read": mutated_seq,
+                    "substitutions": subs,
+                    "insertions": ins,
+                    "deletions": dels,
+                }
+            ]
+        )
+        oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
+            {"substitutions": subs, "insertions": ins, "deletions": dels}
+        )
+        coverage_counts.append(1)
+        dropout_flags.append(False)
+        synthesis_flags.append(False)
+        consensus_totals.append((subs, ins, dels))
+
+    finalize_batch_statistics(
+        mutated, coverage_counts, dropout_flags, synthesis_flags, consensus_totals
+    )
+    metrics.increment("oligos_simulated")
+    return mutated
 
 
 def _count_errors(original: str, mutated: str) -> tuple[int, int, int]:
@@ -204,8 +315,14 @@ def process_channel(
     except FileNotFoundError:
         logger.error("Error: Input file %s not found.", input_file)
         raise SystemExit(1)
-    records = from_fasta(fasta_str)
-    if not records:
+
+    try:
+        batch = SequenceBatch.from_fasta(fasta_str)
+    except ValueError as exc:
+        logger.error("Failed to parse %s: %s", input_file, exc)
+        raise SystemExit(1)
+
+    if not batch.oligos:
         logger.error("No FASTA records found in %s", input_file)
         raise SystemExit(1)
 
@@ -213,59 +330,104 @@ def process_channel(
         synth = SynthesisConstraints(**constraints)
     except ValueError:
         synth = SynthesisConstraints()
-    headers = [h for h, _ in records]
-    sequences = [s for _, s in records]
 
-    def _process(item: tuple[int, str]) -> tuple[str, tuple[int, int, int]]:
-        idx, seq = item
-        original = seq
-        if simulators:
-            cfg = config or ChannelConfig()
-            seq = _apply_simulators(seq, simulators, config=cfg)
-        else:
-            rng = random.Random(seed + idx if seed is not None else None)
-            seq = introduce_errors(
-                seq,
-                substitution_prob=sub_prob,
-                insertion_prob=ins_prob,
-                deletion_prob=del_prob,
-                rng=rng,
-            )
-            metrics.increment("oligos_simulated")
-        if not validate_sequence(seq, synth):
-            raise ValueError("Sequence violates synthesis constraints")
-        logger.info("Sequence satisfies synthesis constraints")
-        return seq, _count_errors(original, seq)
-
-    if batch_workers and len(sequences) > 1:
-        processed = parallel_map(
-            _process,
-            list(enumerate(sequences)),
-            workers=batch_workers,
-        )
+    cfg = config or ChannelConfig()
+    if simulators:
+        processed_batch = _apply_simulators(batch, simulators, config=cfg)
     else:
-        processed = [_process(p) for p in enumerate(sequences)]
+        processed_batch = _simulate_probabilities(
+            batch,
+            sub_prob=sub_prob,
+            ins_prob=ins_prob,
+            del_prob=del_prob,
+            seed=seed,
+        )
 
-    processed_records: list[tuple[str, str]] = []
+    total_len = sum(len(ol.sequence) for ol in processed_batch.oligos)
     sub_total = ins_total = del_total = 0
-    for header, (seq, stats) in zip(headers, processed):
-        s, i, d = stats
-        sub_total += s
-        ins_total += i
-        del_total += d
-        processed_records.append((header, seq))
+    dropout_count = 0
+    synth_failures = 0
 
-    fasta_out = "".join(
-        to_fasta(seq, header, line_width=80) for header, seq in processed_records
-    )
+    for original, processed in zip(batch.oligos, processed_batch.oligos):
+        dropout = _is_flag_true(processed.metadata, RESULT_DROPOUT_FLAG_KEY)
+        synth_fail = _is_flag_true(processed.metadata, RESULT_SYNTHESIS_FLAG_KEY)
+        if dropout:
+            dropout_count += 1
+        if synth_fail:
+            synth_failures += 1
+        if dropout or synth_fail:
+            continue
+        if not validate_sequence(processed.sequence, synth):
+            raise ValueError("Sequence violates synthesis constraints")
+        totals_json = processed.metadata.get(RESULT_MUTATION_TOTALS_KEY)
+        totals = None
+        if totals_json:
+            try:
+                totals = json.loads(totals_json)
+            except json.JSONDecodeError:
+                totals = None
+        if totals:
+            sub_total += int(totals.get("substitutions", 0))
+            ins_total += int(totals.get("insertions", 0))
+            del_total += int(totals.get("deletions", 0))
+        else:
+            s, i, d = _count_errors(original.sequence, processed.sequence)
+            sub_total += s
+            ins_total += i
+            del_total += d
+        logger.info("Sequence satisfies synthesis constraints")
+
+    fasta_out = processed_batch.to_fasta(line_width=80)
     os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
     with open(output_file, "w", encoding="utf-8") as f_out:
         f_out.write(fasta_out)
 
-    total_len = sum(len(seq) for _, seq in processed_records)
+    coverage_hist = {}
+    coverage_raw = processed_batch.metadata.get("sim_coverage_histogram")
+    if coverage_raw:
+        try:
+            coverage_hist = json.loads(coverage_raw)
+        except json.JSONDecodeError:
+            coverage_hist = {}
+
+    mutation_totals_raw = processed_batch.metadata.get("sim_mutation_totals")
+    mutation_totals: dict[str, int] | None = None
+    if mutation_totals_raw:
+        try:
+            parsed = json.loads(mutation_totals_raw)
+            mutation_totals = {
+                "substitutions": int(parsed.get("substitutions", sub_total)),
+                "insertions": int(parsed.get("insertions", ins_total)),
+                "deletions": int(parsed.get("deletions", del_total)),
+            }
+        except (json.JSONDecodeError, TypeError, ValueError):
+            mutation_totals = None
+
+    dropout_total_meta = _parse_int(
+        processed_batch.metadata.get("sim_dropout_total"), dropout_count
+    )
+    dropout_fraction = _parse_float(
+        processed_batch.metadata.get("sim_dropout_fraction"),
+        dropout_count / max(1, len(processed_batch.oligos)),
+    )
+    synthesis_total_meta = _parse_int(
+        processed_batch.metadata.get("sim_synthesis_failures"), synth_failures
+    )
+    synthesis_fraction = _parse_float(
+        processed_batch.metadata.get("sim_synthesis_fraction"),
+        synth_failures / max(1, len(processed_batch.oligos)),
+    )
+
+    manifest_simulators: list[str] = []
+    for item in simulators:
+        if isinstance(item, tuple):
+            manifest_simulators.append(item[0])
+        else:
+            manifest_simulators.append(item.__class__.__name__)
+
     manifest = {
         "file": os.path.basename(Path(input_file).as_posix()),
-        "simulators": [name for name, _ in simulators],
+        "simulators": manifest_simulators,
         "probabilities": {
             "sub_prob": sub_prob,
             "ins_prob": ins_prob,
@@ -278,7 +440,23 @@ def process_channel(
             "insertions": ins_total,
             "deletions": del_total,
         },
+        "coverage": {
+            "average": _parse_float(processed_batch.metadata.get("sim_average_coverage")),
+            "histogram": coverage_hist,
+            "total_reads": _parse_int(processed_batch.metadata.get("sim_total_reads")),
+        },
+        "dropout": {
+            "count": dropout_total_meta,
+            "fraction": dropout_fraction,
+        },
+        "synthesis": {
+            "count": synthesis_total_meta,
+            "fraction": synthesis_fraction,
+        },
     }
+    if mutation_totals is not None:
+        manifest["mutation_totals"] = mutation_totals
+
     manifest_path = os.path.splitext(output_file)[0] + ".manifest.json"
     with open(manifest_path, "w", encoding="utf-8") as m_out:
         json.dump(manifest, m_out, indent=2)
@@ -340,6 +518,24 @@ def register_subcommand(
         type=float,
         default=None,
         help="Probability of strand loss and damage",
+    )
+    run_parser.add_argument(
+        "--dropout-rate",
+        type=float,
+        default=None,
+        help="Probability that an oligo drops out before sequencing",
+    )
+    run_parser.add_argument(
+        "--coverage-distribution",
+        type=str,
+        default=None,
+        help="Coverage distribution mapping or JSON/YAML file",
+    )
+    run_parser.add_argument(
+        "--synthesis-loss",
+        type=float,
+        default=None,
+        help="Probability of synthesis failure per oligo",
     )
     run_parser.set_defaults(func=_handle_run)
 
@@ -436,6 +632,24 @@ def register_subcommand(
             default=None,
             help="Probability of strand loss and damage",
         )
+        target.add_argument(
+            "--dropout-rate",
+            type=float,
+            default=None,
+            help="Probability that an oligo drops out before sequencing",
+        )
+        target.add_argument(
+            "--coverage-distribution",
+            type=str,
+            default=None,
+            help="Coverage distribution mapping or JSON/YAML file",
+        )
+        target.add_argument(
+            "--synthesis-loss",
+            type=float,
+            default=None,
+            help="Probability of synthesis failure per oligo",
+        )
         target.add_argument("--seed", type=int, default=None, help="Random seed for deterministic output")
         target.add_argument("--min-length", type=int, default=25, help="Minimum synthesis length")
         target.add_argument("--max-length", type=int, default=300, help="Maximum synthesis length")
@@ -478,6 +692,11 @@ def run_channel(args: argparse.Namespace) -> None:
         use_mpi=False,
         illumina_profile=opts.illumina_profile,
         nanopore_profile=opts.nanopore_profile,
+        dropout_rate=opts.dropout_rate,
+        coverage_distribution=(
+            dict(opts.coverage_distribution) if opts.coverage_distribution else None
+        ),
+        synthesis_loss=opts.synthesis_loss,
     )
     simulators = opts.simulator_specs
     if opts.profile:
@@ -599,6 +818,12 @@ def _handle_run(args: argparse.Namespace) -> None:
         cfg.illumina_profile = args.illumina_profile
     if args.nanopore_profile is not None:
         cfg.nanopore_profile = args.nanopore_profile
+    if args.dropout_rate is not None:
+        cfg.dropout_rate = args.dropout_rate
+    if args.synthesis_loss is not None:
+        cfg.synthesis_loss = args.synthesis_loss
+    if args.coverage_distribution is not None:
+        cfg.coverage_distribution = _parse_distribution(args.coverage_distribution)
     if args.dnarsim_profile is not None:
         for name, params in simulators:
             if name == "nanopore_dnarsim":

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -48,6 +48,9 @@ class ChannelOptions:
     ins_rate: float | None = None
     del_rate: float | None = None
     decay_rate: float | None = None
+    dropout_rate: float | None = None
+    coverage_distribution: Dict[int, float] | None = None
+    synthesis_loss: float | None = None
 
 
 def _parse_quality(value: str | None) -> Sequence[float] | None:
@@ -89,6 +92,69 @@ def _parse_context(value: str | None) -> Dict[str, float] | None:
     if not isinstance(data, dict):
         raise ValueError("context must be a mapping")
     return {str(k).upper(): float(v) for k, v in data.items()}
+
+
+def _parse_distribution(value: str | None) -> Dict[int, float] | None:
+    if value is None:
+        return None
+    from pathlib import Path
+    path = Path(value)
+    data: object
+    if path.is_file():
+        import json
+        import yaml
+
+        text = path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            data = yaml.safe_load(text)
+    else:
+        data = value
+
+    if isinstance(data, dict):
+        result: Dict[int, float] = {}
+        for key, weight in data.items():
+            try:
+                cov = int(key)
+                wt = float(weight)
+            except (TypeError, ValueError):
+                continue
+            if wt < 0:
+                continue
+            result[cov] = result.get(cov, 0.0) + wt
+        return result or None
+
+    if isinstance(data, Sequence) and not isinstance(data, str):
+        result: Dict[int, float] = {}
+        for item in data:
+            try:
+                cov = int(item)
+            except (TypeError, ValueError):
+                continue
+            result[cov] = result.get(cov, 0.0) + 1.0
+        return result or None
+
+    if isinstance(data, str):
+        result: Dict[int, float] = {}
+        for chunk in data.split(","):
+            if not chunk:
+                continue
+            if ":" in chunk:
+                key, weight = chunk.split(":", 1)
+            else:
+                key, weight = chunk, "1"
+            try:
+                cov = int(key.strip())
+                wt = float(weight.strip())
+            except ValueError:
+                continue
+            if wt < 0:
+                continue
+            result[cov] = result.get(cov, 0.0) + wt
+        return result or None
+
+    raise ValueError("coverage distribution must be a mapping or sequence")
 
 
 def _validate_simulator_prob_args(
@@ -161,6 +227,12 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
     }
 
     sim_specs: list[tuple[str, dict[str, object]]] | None = None
+    dropout_rate = getattr(args, "dropout_rate", None)
+    synthesis_loss = getattr(args, "synthesis_loss", None)
+    coverage_distribution = _parse_distribution(
+        getattr(args, "coverage_distribution", None)
+    )
+
     if args.config:
         cfg_sim, cfg_con, cfg_pipeline, extra = _load_config(args.config)
         if cfg_sim:
@@ -176,6 +248,12 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
             args.processes = args.threads
         if getattr(args, "decay_rate", None) is None:
             args.decay_rate = extra.get("decay_rate")
+        if dropout_rate is None and cfg_pipeline.dropout_rate is not None:
+            dropout_rate = cfg_pipeline.dropout_rate
+        if synthesis_loss is None and cfg_pipeline.synthesis_loss is not None:
+            synthesis_loss = cfg_pipeline.synthesis_loss
+        if coverage_distribution is None and cfg_pipeline.coverage_distribution:
+            coverage_distribution = dict(cfg_pipeline.coverage_distribution)
 
     _validate_simulator_prob_args(
         simulators, args.sub_prob, args.ins_prob, args.del_prob, getattr(args, "profile", None)
@@ -190,6 +268,8 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("Cannot specify both --threads and --processes")
     if args.batch_workers is not None and args.batch_workers <= 0:
         raise ValueError("batch_workers must be greater than 0")
+    if coverage_distribution is not None:
+        coverage_distribution = dict(coverage_distribution)
     return ChannelOptions(
         simulators=simulators,
         constraints=constraints,
@@ -226,4 +306,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         ins_rate=args.ins_rate,
         del_rate=args.del_rate,
         decay_rate=getattr(args, "decay_rate", None),
+        dropout_rate=dropout_rate,
+        coverage_distribution=coverage_distribution,
+        synthesis_loss=synthesis_loss,
     )

--- a/src/genecoder/simulators/__init__.py
+++ b/src/genecoder/simulators/__init__.py
@@ -1,18 +1,61 @@
 """Sequencing simulator implementations and registry."""
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Type
 import os
 
 from ..api import Simulator
-from .pipeline import ChannelPipeline
+from ..formats import SequenceBatch
 from ..random_utils import reset_rng
+from .batch_utils import apply_legacy_simulator
+from .pipeline import ChannelPipeline
 
 SIMULATOR_REGISTRY: Dict[str, Simulator] = {}
+
+_ADAPTER_CACHE: Dict[Type[Simulator], Type[Simulator]] = {}
+
+
+def _get_batch_adapter(base_cls: Type[Simulator]) -> Type[Simulator]:
+    if getattr(base_cls, "supports_batches", False):
+        return base_cls
+    adapter = _ADAPTER_CACHE.get(base_cls)
+    if adapter is not None:
+        return adapter
+
+    class BatchAdapter(base_cls):  # type: ignore[misc]
+        """Auto-generated adapter adding SequenceBatch support."""
+
+        supports_batches = True
+
+        def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:  # type: ignore[override]
+            if isinstance(sequence, SequenceBatch):
+                return apply_legacy_simulator(
+                    sequence,
+                    super(BatchAdapter, self).simulate,  # type: ignore[misc]
+                )
+            return super(BatchAdapter, self).simulate(sequence)  # type: ignore[misc]
+
+        def with_profile(self, profile: str):  # type: ignore[override]
+            result = super(BatchAdapter, self).with_profile(profile)
+            if isinstance(result, base_cls) and not getattr(
+                result.__class__, "supports_batches", False
+            ):
+                result.__class__ = _get_batch_adapter(result.__class__)
+            return result
+
+    BatchAdapter.__name__ = f"{base_cls.__name__}BatchAdapter"
+    BatchAdapter.__qualname__ = BatchAdapter.__name__
+    BatchAdapter.__module__ = base_cls.__module__
+    _ADAPTER_CACHE[base_cls] = BatchAdapter
+    return BatchAdapter
 
 
 def register_simulator(name: str, channel: Simulator) -> None:
     """Register ``channel`` under ``name``."""
+
+    adapter_cls = _get_batch_adapter(channel.__class__)
+    if adapter_cls is not channel.__class__:
+        channel.__class__ = adapter_cls  # type: ignore[misc]
     SIMULATOR_REGISTRY[name] = channel
 
 from .base import BaseChannel, BaseSimulator

--- a/src/genecoder/simulators/base.py
+++ b/src/genecoder/simulators/base.py
@@ -1,11 +1,14 @@
 """Common base classes for sequencing simulators."""
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Sequence, TYPE_CHECKING
 from dataclasses import dataclass
 from abc import abstractmethod
 
 from ..api import Simulator
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..formats import SequenceBatch
 
 
 __all__ = ["BaseChannel", "BaseSimulator"]
@@ -25,7 +28,7 @@ class BaseChannel(Simulator):
         return int(self.coverage)
 
     @abstractmethod
-    def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
+    def simulate(self, sequence: str | "SequenceBatch") -> str | "SequenceBatch":  # pragma: no cover - abstract
         """Return a possibly corrupted version of ``sequence``."""
         raise NotImplementedError
 
@@ -57,6 +60,6 @@ class BaseSimulator(BaseChannel):
         return profile + (tail,) * (length - len(profile))
 
     @abstractmethod
-    def simulate(self, sequence: str) -> str:  # pragma: no cover - abstract
+    def simulate(self, sequence: str | "SequenceBatch") -> str | "SequenceBatch":  # pragma: no cover - abstract
         """Return a possibly corrupted version of ``sequence``."""
         raise NotImplementedError

--- a/src/genecoder/simulators/batch_utils.py
+++ b/src/genecoder/simulators/batch_utils.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+"""Helpers for batch-aware sequencing simulators."""
+
+import json
+from collections import Counter
+from dataclasses import replace
+from difflib import SequenceMatcher
+from typing import Any, Callable, Mapping, Sequence
+
+from ..formats import SequenceBatch
+
+CONFIG_DROPOUT_KEY = "sim_dropout_rate"
+CONFIG_SYNTHESIS_KEY = "sim_synthesis_loss"
+CONFIG_COVERAGE_KEY = "sim_coverage_distribution"
+
+RESULT_COVERAGE_KEY = "sim_coverage"
+RESULT_DROPOUT_FLAG_KEY = "sim_dropout"
+RESULT_SYNTHESIS_FLAG_KEY = "sim_synthesis_failed"
+RESULT_MUTATION_LOG_KEY = "sim_mutation_log"
+RESULT_MUTATION_TOTALS_KEY = "sim_mutation_counts"
+RESULT_CONSENSUS_TOTALS_KEY = "sim_consensus_counts"
+
+__all__ = [
+    "clone_batch",
+    "finalize_batch_statistics",
+    "mutation_counts",
+    "apply_legacy_simulator",
+    "bool_to_str",
+    "load_coverage_distribution",
+    "CONFIG_DROPOUT_KEY",
+    "CONFIG_SYNTHESIS_KEY",
+    "CONFIG_COVERAGE_KEY",
+    "RESULT_COVERAGE_KEY",
+    "RESULT_DROPOUT_FLAG_KEY",
+    "RESULT_SYNTHESIS_FLAG_KEY",
+    "RESULT_MUTATION_LOG_KEY",
+    "RESULT_MUTATION_TOTALS_KEY",
+    "RESULT_CONSENSUS_TOTALS_KEY",
+    "metadata_float",
+]
+
+
+def clone_batch(batch: SequenceBatch) -> SequenceBatch:
+    """Return a deep-ish copy of ``batch`` with independent metadata."""
+
+    return SequenceBatch(
+        batch_id=batch.batch_id,
+        metadata=dict(batch.metadata),
+        seed=batch.seed,
+        oligos=[replace(oligo, metadata=dict(oligo.metadata)) for oligo in batch.oligos],
+        legacy=batch.legacy,
+    )
+
+
+def mutation_counts(original: str, mutated: str) -> tuple[int, int, int]:
+    """Return substitution, insertion and deletion counts between two strings."""
+
+    subs = ins = dels = 0
+    matcher = SequenceMatcher(None, original, mutated)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "replace":
+            subs += max(i2 - i1, j2 - j1)
+        elif tag == "delete":
+            dels += i2 - i1
+        elif tag == "insert":
+            ins += j2 - j1
+    return subs, ins, dels
+
+
+def bool_to_str(value: bool) -> str:
+    """Return ``"true"`` or ``"false"`` for ``value``."""
+
+    return "true" if value else "false"
+
+
+def load_coverage_distribution(
+    value: object,
+) -> dict[int, float] | None:
+    """Parse ``value`` into a coverage distribution mapping."""
+
+    if value in (None, ""):
+        return None
+
+    data: object
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = {}
+            for chunk in raw.split(","):
+                if not chunk:
+                    continue
+                if ":" in chunk:
+                    key, weight = chunk.split(":", 1)
+                else:
+                    key, weight = chunk, "1"
+                try:
+                    cov = int(key.strip())
+                    wt = float(weight.strip())
+                except ValueError:
+                    continue
+                data[cov] = data.get(cov, 0.0) + wt
+    else:
+        data = value
+
+    if isinstance(data, Mapping):
+        result: dict[int, float] = {}
+        for key, weight in data.items():
+            try:
+                cov = int(key)
+                wt = float(weight)
+            except (TypeError, ValueError):
+                continue
+            if wt < 0:
+                continue
+            result[cov] = result.get(cov, 0.0) + wt
+        return result or None
+
+    if isinstance(data, Sequence):
+        result: dict[int, float] = {}
+        for item in data:
+            try:
+                cov = int(item)
+            except (TypeError, ValueError):
+                continue
+            result[cov] = result.get(cov, 0.0) + 1.0
+        return result or None
+
+    return None
+
+
+def metadata_float(
+    metadata: Mapping[str, Any], key: str, default: float = 0.0
+) -> float:
+    """Return ``key`` parsed from ``metadata`` as ``float``."""
+
+    value = metadata.get(key, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def finalize_batch_statistics(
+    batch: SequenceBatch,
+    coverage: Sequence[int],
+    dropouts: Sequence[bool],
+    synthesis_failures: Sequence[bool],
+    per_oligo_counts: Sequence[tuple[int, int, int]],
+) -> None:
+    """Augment ``batch`` metadata with aggregate statistics."""
+
+    total = len(coverage) or 1
+    histogram = Counter(int(c) for c in coverage)
+    batch.metadata["sim_coverage_histogram"] = json.dumps(
+        {str(k): histogram[k] for k in sorted(histogram)}
+    )
+    batch.metadata["sim_total_reads"] = str(sum(int(c) for c in coverage))
+    batch.metadata["sim_average_coverage"] = (
+        f"{(sum(float(c) for c in coverage) / total):.6f}"
+    )
+    dropout_total = sum(1 for flag in dropouts if flag)
+    batch.metadata["sim_dropout_total"] = str(dropout_total)
+    batch.metadata["sim_dropout_fraction"] = f"{(dropout_total / total):.6f}"
+    synth_total = sum(1 for flag in synthesis_failures if flag)
+    batch.metadata["sim_synthesis_failures"] = str(synth_total)
+    batch.metadata["sim_synthesis_fraction"] = f"{(synth_total / total):.6f}"
+    batch.metadata["sim_mutation_totals"] = json.dumps(
+        {
+            "substitutions": sum(item[0] for item in per_oligo_counts),
+            "insertions": sum(item[1] for item in per_oligo_counts),
+            "deletions": sum(item[2] for item in per_oligo_counts),
+        }
+    )
+
+
+def apply_legacy_simulator(
+    batch: SequenceBatch, simulate_fn: Callable[[str], str]
+) -> SequenceBatch:
+    """Return ``batch`` processed by a legacy string-based simulator."""
+
+    mutated = clone_batch(batch)
+
+    coverage_counts: list[int] = []
+    dropout_flags: list[bool] = []
+    synthesis_flags: list[bool] = []
+    consensus_totals: list[tuple[int, int, int]] = []
+
+    for original, oligo in zip(batch.oligos, mutated.oligos):
+        result = simulate_fn(original.sequence)
+        if not isinstance(result, str):
+            raise TypeError(
+                "legacy simulator must return a string when given a string input"
+            )
+
+        dropped = result == ""
+        coverage = 0 if dropped else 1
+        oligo.sequence = result
+
+        if dropped:
+            mutation_log: list[dict[str, int | str]] = []
+            mutation_totals = {"substitutions": 0, "insertions": 0, "deletions": 0}
+            consensus_counts = (0, 0, 0)
+        else:
+            sub, ins, dele = mutation_counts(original.sequence, result)
+            mutation_log = [
+                {
+                    "read": result,
+                    "substitutions": sub,
+                    "insertions": ins,
+                    "deletions": dele,
+                }
+            ]
+            mutation_totals = {
+                "substitutions": sub,
+                "insertions": ins,
+                "deletions": dele,
+            }
+            consensus_counts = (sub, ins, dele)
+
+        oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage)
+        oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(dropped)
+        oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps(mutation_log)
+        oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(mutation_totals)
+        oligo.metadata[RESULT_CONSENSUS_TOTALS_KEY] = json.dumps(
+            {
+                "substitutions": consensus_counts[0],
+                "insertions": consensus_counts[1],
+                "deletions": consensus_counts[2],
+            }
+        )
+
+        coverage_counts.append(coverage)
+        dropout_flags.append(dropped)
+        synthesis_flags.append(False)
+        consensus_totals.append(consensus_counts)
+
+    finalize_batch_statistics(
+        mutated, coverage_counts, dropout_flags, synthesis_flags, consensus_totals
+    )
+    return mutated

--- a/src/genecoder/simulators/illumina.py
+++ b/src/genecoder/simulators/illumina.py
@@ -26,12 +26,30 @@ except Exception:  # pragma: no cover - fallback when numba missing
         return wrapper
 
 from .base import BaseSimulator
+from .batch_utils import (
+    CONFIG_COVERAGE_KEY,
+    CONFIG_DROPOUT_KEY,
+    CONFIG_SYNTHESIS_KEY,
+    RESULT_CONSENSUS_TOTALS_KEY,
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_LOG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+    RESULT_SYNTHESIS_FLAG_KEY,
+    bool_to_str,
+    clone_batch,
+    finalize_batch_statistics,
+    load_coverage_distribution,
+    metadata_float,
+    mutation_counts,
+)
 
 from ..random_utils import make_rng
 from ..api import Simulator
 from ..error_simulation import _random_substitution, NUCLEOTIDES
 from ..d2sim_adapter import simulate_d2sim
 from ..simulator_utils import _run_external, _parse_env_options
+from ..formats import SequenceBatch
 from . import register_simulator as _register_simulator
 
 __all__ = [
@@ -82,7 +100,6 @@ def _parse_quality_profile(value: str) -> Sequence[float]:
             raise ValueError("quality profile must be a list")
         return [float(x) for x in data]
     return [float(x) for x in value.split(",") if x]
-
 
 @dataclass
 class IlluminaProfile:
@@ -221,6 +238,8 @@ def _mutate_read_jit(
 
 class IlluminaChannel(BaseSimulator):
     """Channel modeling basic Illumina read errors."""
+
+    supports_batches = True
 
     def __init__(
         self,
@@ -363,7 +382,12 @@ class IlluminaChannel(BaseSimulator):
                 result.append(max(counts, key=lambda k: counts[k]))
         return "".join(result)
 
-    def simulate(self, sequence: str) -> str:
+    def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:
+        if isinstance(sequence, SequenceBatch):
+            return self._simulate_batch(sequence)
+        return self._simulate_string(sequence)
+
+    def _simulate_string(self, sequence: str) -> str:
         rng = make_rng()
         read_length = self.get_read_length(sequence)
         read = sequence[:read_length]
@@ -373,6 +397,115 @@ class IlluminaChannel(BaseSimulator):
         if coverage == 1:
             return reads[0]
         return self._consensus(reads)
+
+    def _simulate_batch(self, batch: SequenceBatch) -> SequenceBatch:
+        rng = make_rng()
+        mutated = clone_batch(batch)
+        dropout_rate = metadata_float(mutated.metadata, CONFIG_DROPOUT_KEY, 0.0)
+        synthesis_loss = metadata_float(mutated.metadata, CONFIG_SYNTHESIS_KEY, 0.0)
+        coverage_dist = load_coverage_distribution(
+            mutated.metadata.get(CONFIG_COVERAGE_KEY)
+        )
+
+        coverage_counts: list[int] = []
+        dropout_flags: list[bool] = []
+        synthesis_flags: list[bool] = []
+        consensus_totals: list[tuple[int, int, int]] = []
+
+        for original, oligo in zip(batch.oligos, mutated.oligos):
+            seed = (
+                oligo.seed
+                if oligo.seed is not None
+                else int(rng.random() * (2**32 - 1))
+            )
+            oligo_rng = random.Random(seed)
+
+            dropped = False
+            synth_failed = False
+            coverage = 0
+            read_logs: list[dict[str, int | str]] = []
+            per_read_totals = [0, 0, 0]
+            read_length = self.get_read_length(original.sequence)
+            read = original.sequence[:read_length]
+            quality = self.get_quality_profile(original.sequence, read_length)
+
+            if oligo_rng.random() < synthesis_loss:
+                synth_failed = True
+            elif oligo_rng.random() < dropout_rate:
+                dropped = True
+
+            if not dropped and not synth_failed:
+                if coverage_dist:
+                    total_weight = sum(coverage_dist.values())
+                    threshold = oligo_rng.random() * total_weight if total_weight > 0 else 0.0
+                    cumulative = 0.0
+                    coverage_choice = 0
+                    for cov, weight in sorted(coverage_dist.items()):
+                        cumulative += weight
+                        coverage_choice = int(cov)
+                        if threshold <= cumulative:
+                            break
+                    coverage = max(0, coverage_choice)
+                else:
+                    coverage = max(1, _poisson(self.coverage, oligo_rng))
+                if coverage <= 0:
+                    dropped = True
+
+            reads: list[str] = []
+            if not dropped and not synth_failed:
+                for _ in range(coverage):
+                    mutated_read = self._mutate_read(read, quality, oligo_rng)
+                    reads.append(mutated_read)
+                    sub, ins, dele = mutation_counts(read, mutated_read)
+                    per_read_totals[0] += sub
+                    per_read_totals[1] += ins
+                    per_read_totals[2] += dele
+                    read_logs.append(
+                        {
+                            "read": mutated_read,
+                            "substitutions": sub,
+                            "insertions": ins,
+                            "deletions": dele,
+                        }
+                    )
+
+            consensus_counts = (0, 0, 0)
+            if reads:
+                consensus = reads[0] if len(reads) == 1 else self._consensus(reads)
+                oligo.sequence = consensus
+                consensus_counts = mutation_counts(read[: len(consensus)], consensus)
+            else:
+                oligo.sequence = ""
+                coverage = 0
+
+            oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage)
+            oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(dropped)
+            oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(synth_failed)
+            oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps(read_logs)
+            oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
+                {
+                    "substitutions": per_read_totals[0],
+                    "insertions": per_read_totals[1],
+                    "deletions": per_read_totals[2],
+                }
+            )
+            oligo.metadata[RESULT_CONSENSUS_TOTALS_KEY] = json.dumps(
+                {
+                    "substitutions": consensus_counts[0],
+                    "insertions": consensus_counts[1],
+                    "deletions": consensus_counts[2],
+                }
+            )
+
+            coverage_counts.append(int(coverage))
+            dropout_flags.append(dropped)
+            synthesis_flags.append(synth_failed)
+            consensus_totals.append(consensus_counts)
+
+        finalize_batch_statistics(
+            mutated, coverage_counts, dropout_flags, synthesis_flags, consensus_totals
+        )
+        return mutated
 
     def with_profile(self, profile: str) -> "IlluminaChannel":
         """Return a new channel configured to use ``profile``.

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Callable, Sequence, Dict, Iterable, Mapping, cast
 from copy import deepcopy
 from types import ModuleType
+import json
 import random
 import shutil
 import subprocess
@@ -30,6 +31,24 @@ from ..desp_adapter import simulate_desp
 from ..simulator_utils import _run_external, _parse_env_options
 from ..api import Simulator
 from .base import BaseChannel
+from .batch_utils import (
+    CONFIG_COVERAGE_KEY,
+    CONFIG_DROPOUT_KEY,
+    CONFIG_SYNTHESIS_KEY,
+    RESULT_CONSENSUS_TOTALS_KEY,
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_LOG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+    RESULT_SYNTHESIS_FLAG_KEY,
+    bool_to_str,
+    clone_batch,
+    finalize_batch_statistics,
+    load_coverage_distribution,
+    metadata_float,
+    mutation_counts,
+)
+from ..formats import SequenceBatch
 from ..error_simulation import (
     _random_substitution,
     NUCLEOTIDES,
@@ -545,6 +564,8 @@ def _mutate_read_jit(
 class NanoporeChannel(BaseChannel):
     """Channel that delegates to :mod:`d2sim` if installed."""
 
+    supports_batches = True
+
     def __init__(
         self,
         error_rate: float = 0.05,
@@ -706,22 +727,141 @@ class NanoporeChannel(BaseChannel):
         self.insertion_profile = insertion_profile
         self.deletion_profile = deletion_profile
 
-    def simulate(self, sequence: str) -> str:
+    def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:
+        if isinstance(sequence, SequenceBatch):
+            return self._simulate_batch(sequence)
+        return self._simulate_string(sequence)
+
+    def _simulate_string(self, sequence: str) -> str:
         rng = make_rng()
-        quality = self.quality_profile
         coverage = max(1, self.get_coverage(sequence))
         reads = [
-            _mutate_read(
-                simulate_d2sim(sequence, error_rate=self.error_rate, rng=rng),
-                quality,
-                rng,
-                self,
+            self._mutate_observed_read(
+                sequence, self._simulate_base_read(sequence, rng), rng
             )
             for _ in range(coverage)
         ]
         if coverage == 1:
             return reads[0]
         return _consensus(reads)
+
+    def _simulate_base_read(self, sequence: str, rng: random.Random) -> str:
+        return simulate_d2sim(sequence, error_rate=self.error_rate, rng=rng)
+
+    def _mutate_observed_read(
+        self, original: str, base_read: str, rng: random.Random
+    ) -> str:
+        quality = self.quality_profile
+        return _mutate_read(base_read, quality, rng, self)
+
+    def _simulate_batch(self, batch: SequenceBatch) -> SequenceBatch:
+        rng = make_rng()
+        mutated = clone_batch(batch)
+        dropout_rate = metadata_float(mutated.metadata, CONFIG_DROPOUT_KEY, 0.0)
+        synthesis_loss = metadata_float(mutated.metadata, CONFIG_SYNTHESIS_KEY, 0.0)
+        coverage_dist = load_coverage_distribution(
+            mutated.metadata.get(CONFIG_COVERAGE_KEY)
+        )
+
+        coverage_counts: list[int] = []
+        dropout_flags: list[bool] = []
+        synthesis_flags: list[bool] = []
+        consensus_totals: list[tuple[int, int, int]] = []
+
+        for original, oligo in zip(batch.oligos, mutated.oligos):
+            seed = (
+                oligo.seed
+                if oligo.seed is not None
+                else int(rng.random() * (2**32 - 1))
+            )
+            oligo_rng = random.Random(seed)
+
+            dropped = False
+            synth_failed = False
+            coverage = 0
+            read_logs: list[dict[str, int | str]] = []
+            per_read_totals = [0, 0, 0]
+
+            if oligo_rng.random() < synthesis_loss:
+                synth_failed = True
+            elif oligo_rng.random() < dropout_rate:
+                dropped = True
+
+            if not dropped and not synth_failed:
+                if coverage_dist:
+                    total_weight = sum(coverage_dist.values())
+                    threshold = oligo_rng.random() * total_weight if total_weight > 0 else 0.0
+                    cumulative = 0.0
+                    coverage_choice = 0
+                    for cov, weight in sorted(coverage_dist.items()):
+                        cumulative += weight
+                        coverage_choice = int(cov)
+                        if threshold <= cumulative:
+                            break
+                    coverage = max(0, coverage_choice)
+                else:
+                    coverage = max(1, int(self.get_coverage(original.sequence)))
+                if coverage <= 0:
+                    dropped = True
+
+            reads: list[str] = []
+            if not dropped and not synth_failed:
+                for _ in range(coverage):
+                    base_read = self._simulate_base_read(original.sequence, oligo_rng)
+                    mutated_read = self._mutate_observed_read(
+                        original.sequence, base_read, oligo_rng
+                    )
+                    reads.append(mutated_read)
+                    sub, ins, dele = mutation_counts(original.sequence, mutated_read)
+                    per_read_totals[0] += sub
+                    per_read_totals[1] += ins
+                    per_read_totals[2] += dele
+                    read_logs.append(
+                        {
+                            "read": mutated_read,
+                            "substitutions": sub,
+                            "insertions": ins,
+                            "deletions": dele,
+                        }
+                    )
+
+            consensus_counts = (0, 0, 0)
+            if reads:
+                consensus = reads[0] if len(reads) == 1 else _consensus(reads)
+                oligo.sequence = consensus
+                consensus_counts = mutation_counts(original.sequence, consensus)
+            else:
+                oligo.sequence = ""
+                coverage = 0
+
+            oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage)
+            oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(dropped)
+            oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(synth_failed)
+            oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps(read_logs)
+            oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
+                {
+                    "substitutions": per_read_totals[0],
+                    "insertions": per_read_totals[1],
+                    "deletions": per_read_totals[2],
+                }
+            )
+            oligo.metadata[RESULT_CONSENSUS_TOTALS_KEY] = json.dumps(
+                {
+                    "substitutions": consensus_counts[0],
+                    "insertions": consensus_counts[1],
+                    "deletions": consensus_counts[2],
+                }
+            )
+
+            coverage_counts.append(int(coverage))
+            dropout_flags.append(dropped)
+            synthesis_flags.append(synth_failed)
+            consensus_totals.append(consensus_counts)
+
+        finalize_batch_statistics(
+            mutated, coverage_counts, dropout_flags, synthesis_flags, consensus_totals
+        )
+        return mutated
 
     def with_profile(self, profile: str) -> "NanoporeChannel":
         """Return a new channel configured to use ``profile``.
@@ -745,22 +885,8 @@ class NanoporeChannel(BaseChannel):
 class NanoporeDeSPChannel(NanoporeChannel):
     """Channel wrapper using the external ``desp`` simulator."""
 
-    def simulate(self, sequence: str) -> str:
-        rng = make_rng()
-        quality = self.quality_profile
-        coverage = max(1, self.get_coverage(sequence))
-        reads = [
-            _mutate_read(
-                simulate_desp(sequence, error_rate=self.error_rate, rng=rng),
-                quality,
-                rng,
-                self,
-            )
-            for _ in range(coverage)
-        ]
-        if coverage == 1:
-            return reads[0]
-        return _consensus(reads)
+    def _simulate_base_read(self, sequence: str, rng: random.Random) -> str:
+        return simulate_desp(sequence, error_rate=self.error_rate, rng=rng)
 
 
 class NanoporeDNArSimChannel(NanoporeChannel):
@@ -796,6 +922,7 @@ class NanoporeDNArSimChannel(NanoporeChannel):
         self._profile_rates: dict[str, float] = (
             DNARSIM_RATE_TABLES.get(profile, {}) if profile else {}
         )
+        self._current_rates: tuple[float, float, float] | None = None
 
     def _simulate_cli(self, sequence: str) -> str:
         cmd = "dnarsim"
@@ -834,49 +961,54 @@ class NanoporeDNArSimChannel(NanoporeChannel):
 
         return cast(str, _simulate_fallback_jit(sequence, error_rate, rng))
 
+    def _simulate_base_read(self, sequence: str, rng: random.Random) -> str:
+        try:
+            base = self._simulate_cli(sequence)
+            self._current_rates = (
+                self.substitution_rate,
+                self.insertion_rate,
+                self.deletion_rate,
+            )
+            return base
+        except Exception:
+            base = self._simulate_fallback(sequence, self.error_rate, rng)
+            rates = self._profile_rates
+            self._current_rates = (
+                rates.get("substitution_rate", self.substitution_rate),
+                rates.get("insertion_rate", self.insertion_rate),
+                rates.get("deletion_rate", self.deletion_rate),
+            )
+            return base
 
-    def simulate(self, sequence: str) -> str:
+    def _mutate_observed_read(
+        self, original: str, base_read: str, rng: random.Random
+    ) -> str:
         from typing import cast
 
-        rng = make_rng()
+        sub, ins, dele = self._current_rates or (
+            self.substitution_rate,
+            self.insertion_rate,
+            self.deletion_rate,
+        )
         quality = self.quality_profile
-        coverage = max(1, self.get_coverage(sequence))
-
-        reads = []
-        for _ in range(coverage):
-            try:
-                base = self._simulate_cli(sequence)
-                sub = self.substitution_rate
-                ins = self.insertion_rate
-                dele = self.deletion_rate
-            except Exception:
-                base = self._simulate_fallback(sequence, self.error_rate, rng)
-                rates = self._profile_rates
-                sub = rates.get("substitution_rate", self.substitution_rate)
-                ins = rates.get("insertion_rate", self.insertion_rate)
-                dele = rates.get("deletion_rate", self.deletion_rate)
-            reads.append(
-                cast(
-                    str,
-                    _mutate_read_jit(
-                        base,
-                        quality,
-                        rng,
-                        sub,
-                        ins,
-                        dele,
-                        self.context_errors,
-                        self.insertion_profile,
-                        self.deletion_profile,
-                        self.context_insertions,
-                        self.context_deletions,
-                    ),
-                )
-            )
-
-        if coverage == 1:
-            return reads[0]
-        return _consensus(reads)
+        mutated = cast(
+            str,
+            _mutate_read_jit(
+                base_read,
+                quality,
+                rng,
+                sub,
+                ins,
+                dele,
+                self.context_errors,
+                self.insertion_profile,
+                self.deletion_profile,
+                self.context_insertions,
+                self.context_deletions,
+            ),
+        )
+        self._current_rates = None
+        return mutated
 
 
 def _mutate_read(

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -1,22 +1,74 @@
 from __future__ import annotations
 
-from typing import Iterable, List
 import concurrent.futures
+import json
 import os
+from typing import Iterable, List
 
 
-def _run_channel(sequence: str, channel: BaseChannel) -> str:
-    return channel.simulate(sequence)
+def _run_channel(batch: "SequenceBatch", channel: BaseChannel) -> "SequenceBatch":
+    result = channel.simulate(batch)
+    if isinstance(result, SequenceBatch):
+        return result
+    return _batch_from_string(result)
 
 from ..channels.base import BaseChannel
 from ..metrics import metrics
 from ..channel_config import ChannelConfig
+from ..formats import SequenceBatch
+from .batch_utils import (
+    CONFIG_COVERAGE_KEY,
+    CONFIG_DROPOUT_KEY,
+    CONFIG_SYNTHESIS_KEY,
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_LOG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+    RESULT_SYNTHESIS_FLAG_KEY,
+    bool_to_str,
+    clone_batch,
+    finalize_batch_statistics,
+)
 
 __all__ = ["ChannelPipeline"]
 
 
+def _batch_from_string(sequence: str) -> SequenceBatch:
+    batch = SequenceBatch.build([("pipeline", sequence)], batch_id="pipeline")
+    if batch.oligos:
+        oligo = batch.oligos[0]
+        oligo.metadata[RESULT_COVERAGE_KEY] = "1"
+        oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_SYNTHESIS_FLAG_KEY] = bool_to_str(False)
+        oligo.metadata[RESULT_MUTATION_LOG_KEY] = json.dumps([])
+        oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
+            {"substitutions": 0, "insertions": 0, "deletions": 0}
+        )
+        finalize_batch_statistics(batch, [1], [False], [False], [(0, 0, 0)])
+    return batch
+
+
+def _prepare_batch(
+    batch: SequenceBatch, config: ChannelConfig | None
+) -> SequenceBatch:
+    if config is None:
+        return batch
+    prepared = clone_batch(batch)
+    if config.dropout_rate is not None:
+        prepared.metadata[CONFIG_DROPOUT_KEY] = str(float(config.dropout_rate))
+    if config.synthesis_loss is not None:
+        prepared.metadata[CONFIG_SYNTHESIS_KEY] = str(float(config.synthesis_loss))
+    if config.coverage_distribution:
+        prepared.metadata[CONFIG_COVERAGE_KEY] = json.dumps(
+            {int(k): float(v) for k, v in config.coverage_distribution.items()}
+        )
+    return prepared
+
+
 class ChannelPipeline(BaseChannel):
     """Apply a sequence of channels to a DNA sequence."""
+
+    supports_batches = True
 
     def __init__(self, channels: Iterable[BaseChannel] | None = None) -> None:
         self.channels: List[BaseChannel] = list(channels or [])
@@ -27,14 +79,18 @@ class ChannelPipeline(BaseChannel):
 
     def simulate(
         self,
-        sequence: str,
+        sequence: str | SequenceBatch,
         *,
         config: ChannelConfig | None = None,
-    ) -> str:
+    ) -> str | SequenceBatch:
         """Return ``sequence`` processed by each channel."""
 
         if config is None:
             config = ChannelConfig()
+
+        is_batch = isinstance(sequence, SequenceBatch)
+        batch = sequence if is_batch else _batch_from_string(sequence)
+        batch = _prepare_batch(batch, config)
 
         parallel = config.parallel or config.use_mpi
         workers = config.workers
@@ -65,9 +121,10 @@ class ChannelPipeline(BaseChannel):
 
         if not parallel or len(channels) <= 1:
             for channel in channels:
-                sequence = channel.simulate(sequence)
+                result = channel.simulate(batch)
+                batch = result if isinstance(result, SequenceBatch) else _batch_from_string(result)
             metrics.increment("oligos_simulated")
-            return sequence
+            return batch if is_batch else (batch.oligos[0].sequence if batch.oligos else "")
 
         if workers is None:
             workers = min(len(channels), os.cpu_count() or 1)
@@ -86,10 +143,10 @@ class ChannelPipeline(BaseChannel):
             )
 
         with executor_cls(max_workers=workers) as executor:
-            done_future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            done_future: concurrent.futures.Future[SequenceBatch] = concurrent.futures.Future()
 
-            def _dispatch(idx: int, seq: str) -> None:
-                fut = executor.submit(_run_channel, seq, channels[idx])
+            def _dispatch(idx: int, current: SequenceBatch) -> None:
+                fut = executor.submit(_run_channel, current, channels[idx])
                 if hasattr(fut, "add_done_callback"):
                     if idx + 1 < len(channels):
                         fut.add_done_callback(
@@ -104,8 +161,8 @@ class ChannelPipeline(BaseChannel):
                     else:
                         done_future.set_result(res)
 
-            _dispatch(0, sequence)
-            sequence = done_future.result()
+            _dispatch(0, batch)
+            batch = done_future.result()
 
         metrics.increment("oligos_simulated")
-        return sequence
+        return batch if is_batch else (batch.oligos[0].sequence if batch.oligos else "")

--- a/tests/test_channel_batch.py
+++ b/tests/test_channel_batch.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from genecoder.channel_config import ChannelConfig
+from genecoder.cli.channel import process_channel
+from genecoder.error_simulation import Channel as LegacyChannel
+from genecoder.formats import SequenceBatch
+from genecoder.simulators import (
+    SIMULATOR_REGISTRY,
+    ChannelPipeline,
+    register_simulator,
+)
+from genecoder.simulators.batch_utils import (
+    CONFIG_COVERAGE_KEY,
+    CONFIG_DROPOUT_KEY,
+    CONFIG_SYNTHESIS_KEY,
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_LOG_KEY,
+    RESULT_SYNTHESIS_FLAG_KEY,
+)
+from genecoder.simulators.illumina import IlluminaChannel
+
+
+def _build_batch() -> SequenceBatch:
+    return SequenceBatch.build(
+        [
+            ("oligo-1", "ACGTACGT"),
+            ("oligo-2", "TGCATGCA"),
+        ],
+        batch_id="test-batch",
+    )
+
+
+def test_illumina_batch_dropout_statistics() -> None:
+    batch = _build_batch()
+    batch.metadata[CONFIG_DROPOUT_KEY] = "1.0"
+
+    channel = IlluminaChannel()
+    result = channel.simulate(batch)
+
+    assert all(ol.sequence == "" for ol in result.oligos)
+    assert all(ol.metadata[RESULT_DROPOUT_FLAG_KEY] == "true" for ol in result.oligos)
+
+    histogram = json.loads(result.metadata["sim_coverage_histogram"])
+    assert histogram == {"0": len(batch.oligos)}
+    assert result.metadata["sim_dropout_total"] == str(len(batch.oligos))
+    assert result.metadata["sim_dropout_fraction"] == "1.000000"
+
+
+def test_illumina_batch_coverage_histogram() -> None:
+    batch = _build_batch()
+    batch.metadata[CONFIG_COVERAGE_KEY] = json.dumps({3: 1.0})
+
+    channel = IlluminaChannel()
+    result = channel.simulate(batch)
+
+    for oligo in result.oligos:
+        assert oligo.metadata[RESULT_COVERAGE_KEY] == "3"
+        reads = json.loads(oligo.metadata[RESULT_MUTATION_LOG_KEY])
+        assert len(reads) == 3
+
+    histogram = json.loads(result.metadata["sim_coverage_histogram"])
+    assert histogram == {"3": len(batch.oligos)}
+    assert result.metadata["sim_total_reads"] == str(3 * len(batch.oligos))
+
+
+def test_pipeline_records_synthesis_failures() -> None:
+    batch = _build_batch()
+    batch.metadata[CONFIG_SYNTHESIS_KEY] = "1.0"
+
+    pipeline = ChannelPipeline([IlluminaChannel()])
+    config = ChannelConfig(synthesis_loss=1.0)
+    result = pipeline.simulate(batch, config=config)
+
+    assert all(ol.metadata[RESULT_SYNTHESIS_FLAG_KEY] == "true" for ol in result.oligos)
+    assert result.metadata["sim_synthesis_failures"] == str(len(batch.oligos))
+    assert result.metadata["sim_synthesis_fraction"] == "1.000000"
+
+
+def test_process_channel_enforces_constraints(tmp_path: Path) -> None:
+    fasta = tmp_path / "input.fasta"
+    fasta.write_text(">ol1\nACGTACGT\n>ol2\nTGCATGCA\n", encoding="utf-8")
+    output = tmp_path / "output.fasta"
+
+    with pytest.raises(ValueError):
+        process_channel(
+            str(fasta),
+            str(output),
+            [],
+            {"min_length": 1, "max_length": 3, "max_homopolymer": 10},
+            sub_prob=0.0,
+            ins_prob=0.0,
+            del_prob=0.0,
+            config=ChannelConfig(),
+        )
+
+
+def test_legacy_simulator_adapter_adds_metadata() -> None:
+    batch = _build_batch()
+    name = "legacy_batch_adapter_test"
+    register_simulator(name, LegacyChannel())
+    try:
+        entry = SIMULATOR_REGISTRY[name]
+        channel = type(entry)(
+            substitution_prob=0.0, insertion_prob=0.0, deletion_prob=0.0
+        )
+        result = channel.simulate(batch)
+
+        for oligo in result.oligos:
+            assert oligo.metadata[RESULT_COVERAGE_KEY] == "1"
+            assert oligo.metadata[RESULT_DROPOUT_FLAG_KEY] == "false"
+            logs = json.loads(oligo.metadata[RESULT_MUTATION_LOG_KEY])
+            assert logs == [
+                {
+                    "read": oligo.sequence,
+                    "substitutions": 0,
+                    "insertions": 0,
+                    "deletions": 0,
+                }
+            ]
+    finally:
+        SIMULATOR_REGISTRY.pop(name, None)


### PR DESCRIPTION
## Summary
- add batch utilities for cloning sequence batches, computing aggregate statistics, and adapting legacy simulators to populate coverage/dropout metadata
- teach Illumina/Nanopore channels and the channel pipeline to operate on SequenceBatch inputs with detailed per-oligo mutation logs while wrapping legacy simulators via the registry
- extend channel CLI/config handling to surface dropout, coverage, and synthesis controls in manifests and add regression tests exercising multi-oligo batch behaviour

## Testing
- `poetry run ruff check src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/simulators src/genecoder/channel_config.py tests/test_channel_batch.py`
- `pytest tests/test_channel_batch.py`
- `pytest tests/test_simulator_registry.py tests/test_channel_run.py tests/test_core_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68d29ffa28dc8326981aae663fdbf390