### PR TITLE
Add multi-oligo integration tests and deterministic coverage fixture

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 addopts = -ra
-env =
-    SKIP_PACKAGING_TESTS=1
+markers =
+    slow: marks tests as slow-running integration suites

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+import json
 import os
 import sys
 import types
+from typing import Mapping, Sequence
+
+import pytest
 
 # Ensure the ``src`` directory is importable
 ROOT = os.path.dirname(os.path.dirname(__file__))
@@ -9,6 +13,8 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
+
+os.environ.setdefault("SKIP_PACKAGING_TESTS", "1")
 
 # Provide minimal cryptography exceptions only if the real dependency is missing
 try:  # pragma: no cover - exercised only when cryptography is absent
@@ -63,3 +69,70 @@ except Exception:  # pragma: no cover - import guard
     yaml_stub.safe_dump = _safe_dump
     yaml_stub.YAMLError = YAMLError
     sys.modules.setdefault("yaml", yaml_stub)
+
+
+@pytest.fixture
+def mock_coverage_distribution(monkeypatch: pytest.MonkeyPatch) -> dict[int, float]:
+    """Provide a deterministic coverage distribution for simulator tests."""
+
+    def _fake_loader(value: object) -> dict[int, float]:
+        if value in (None, "", {}, []):
+            return {4: 1.0}
+        if isinstance(value, Mapping):
+            result = {int(k): float(v) for k, v in value.items()}
+            return result or {4: 1.0}
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            result: dict[int, float] = {}
+            for item in value:
+                try:
+                    cov = int(item)
+                except (TypeError, ValueError):
+                    continue
+                result[cov] = result.get(cov, 0.0) + 1.0
+            return result or {4: 1.0}
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return {4: 1.0}
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                parsed_map: dict[int, float] = {}
+                for chunk in raw.split(","):
+                    chunk = chunk.strip()
+                    if not chunk:
+                        continue
+                    if ":" in chunk:
+                        key, weight = chunk.split(":", 1)
+                    else:
+                        key, weight = chunk, "1"
+                    try:
+                        cov = int(key.strip())
+                        wt = float(weight.strip())
+                    except ValueError:
+                        continue
+                    parsed_map[cov] = parsed_map.get(cov, 0.0) + wt
+                parsed = parsed_map
+            if isinstance(parsed, Mapping):
+                result = {int(k): float(v) for k, v in parsed.items()}
+                return result or {4: 1.0}
+            if isinstance(parsed, Sequence):
+                result: dict[int, float] = {}
+                for item in parsed:
+                    try:
+                        cov = int(item)
+                    except (TypeError, ValueError):
+                        continue
+                    result[cov] = result.get(cov, 0.0) + 1.0
+                return result or {4: 1.0}
+            return {4: 1.0}
+        try:
+            cov_value = int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return {4: 1.0}
+        return {cov_value: 1.0}
+
+    monkeypatch.setattr("genecoder.simulators.batch_utils.load_coverage_distribution", _fake_loader)
+    monkeypatch.setattr("genecoder.simulators.illumina.load_coverage_distribution", _fake_loader)
+    monkeypatch.setattr("genecoder.simulators.nanopore.load_coverage_distribution", _fake_loader)
+    return _fake_loader(None)

--- a/tests/test_pipeline_multi_oligo.py
+++ b/tests/test_pipeline_multi_oligo.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import random
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from genecoder.encoders import decode_base4_direct, encode_base4_direct
+from genecoder.formats import SequenceBatch
+from genecoder.reed_solomon_codec import ReedSolomonFEC, _HAS_REEDSOLO
+from genecoder.fountain_codec import (
+    FountainFEC,
+    droplet_batch_to_bytes,
+    encode_data_fountain,
+)
+from genecoder.cli.channel import process_channel
+from genecoder.channel_config import ChannelConfig
+from genecoder.simulators.illumina import IlluminaChannel
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_reed_solomon_multi_oligo_correction(
+    mock_coverage_distribution, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutate Reed--Solomon encoded oligos and ensure decoding succeeds."""
+
+    monkeypatch.setenv("GENECODER_SIM_SEED", "314159")
+
+    data = b"multi-oligo reed solomon integration"
+    fec = ReedSolomonFEC()
+    encoded_bytes, info = fec.encode(data, nsym=32)
+
+    rng = random.Random(1234)
+    mutated_bytes = bytearray(encoded_bytes)
+    error_positions = rng.sample(range(len(mutated_bytes)), k=min(4, len(mutated_bytes)))
+    for pos in error_positions:
+        mutated_bytes[pos] ^= 0x01
+
+    dna_payload = encode_base4_direct(bytes(mutated_bytes))
+    batch = SequenceBatch.build(
+        [("integration", dna_payload)], batch_id="rs", max_oligo_length=96
+    )
+    assert len(batch.oligos) > 1
+
+    recovered_dna = "".join(ol.sequence for ol in batch.oligos)
+    roundtrip_bytes = decode_base4_direct(recovered_dna)[0]
+    decoded, corrections = fec.decode(roundtrip_bytes, info)
+
+    assert decoded == data
+    assert corrections >= len(error_positions)
+
+
+@pytest.mark.slow
+def test_fountain_multi_oligo_dropout_recovery(
+    mock_coverage_distribution, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drop and perturb Fountain droplets while maintaining successful decode."""
+
+    monkeypatch.setenv("GENECODER_SIM_SEED", "271828")
+
+    data = b"multi-oligo fountain integration payload" * 2
+    batch, info = encode_data_fountain(
+        data,
+        chunk_size=6,
+        seed=7,
+        redundancy=2.2,
+    )
+    assert len(batch.oligos) > int(info["k"])
+
+    rng = random.Random(4321)
+    total = len(batch.oligos)
+    required = int(info["k"])
+    max_drop = max(0, total - required)
+    drop_count = min(max(1, total // 5), max_drop)
+    drop_indices = set(rng.sample(range(total), drop_count)) if drop_count else set()
+
+    survivors = [
+        replace(oligo, metadata=dict(oligo.metadata))
+        for idx, oligo in enumerate(batch.oligos)
+        if idx not in drop_indices
+    ]
+
+    mutated_batch = SequenceBatch(
+        batch_id=batch.batch_id,
+        metadata=dict(batch.metadata),
+        seed=batch.seed,
+        oligos=survivors,
+    )
+
+    assert len(mutated_batch.oligos) >= required
+    assert len(mutated_batch.oligos) <= len(batch.oligos)
+
+    mutated_info = dict(info)
+    mutated_info["droplet_count"] = len(mutated_batch.oligos)
+    encoded_stream = droplet_batch_to_bytes(mutated_batch)
+    decoded, _ = FountainFEC().decode(encoded_stream, mutated_info)
+
+    assert decoded == data
+    assert drop_indices
+
+
+@pytest.mark.slow
+def test_channel_synthesis_constraint_violation(
+    mock_coverage_distribution, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure channel processing rejects oligos violating synthesis constraints."""
+
+    monkeypatch.setenv("GENECODER_SIM_SEED", "424242")
+
+    fasta_path = tmp_path / "input.fasta"
+    fasta_path.write_text(
+        ">oligo1\n" + "A" * 48 + "\n>oligo2\n" + "CG" * 12 + "\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "output.fasta"
+
+    constraints = {"min_length": 20, "max_length": 80, "max_homopolymer": 3, "gc_min": 0.25, "gc_max": 0.75}
+
+    with pytest.raises(ValueError, match="violates synthesis constraints"):
+        process_channel(
+            str(fasta_path),
+            str(output_path),
+            [IlluminaChannel(substitution_rate=0.0, insertion_rate=0.0, deletion_rate=0.0)],
+            constraints,
+            sub_prob=0.0,
+            ins_prob=0.0,
+            del_prob=0.0,
+            config=ChannelConfig(coverage_distribution={4: 1.0}),
+        )


### PR DESCRIPTION
## Summary
- add slow-marked multi-oligo integration tests covering Reed–Solomon mutation recovery, Fountain dropout handling, and synthesis constraint enforcement
- introduce a reusable fixture that mocks Illumina and Nanopore coverage distributions for deterministic simulations
- register a pytest "slow" marker so the heavier suites can be selected explicitly

## Testing
- ruff check tests/test_pipeline_multi_oligo.py tests/conftest.py
- pytest tests/test_pipeline_multi_oligo.py

------
https://chatgpt.com/codex/tasks/task_e_68dd125308d88326bedf3b3d92c1a359