### PR TITLE
Document multi-oligo pipeline and refreshed dashboard assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,23 @@ For deployment instructions including building the React dashboard see the
 
 ## End-to-End CLI Example
 
-Run encoding, simulation, and decoding with default settings:
+GeneCoder now treats each pipeline stage as a multi-oligo workflow. The encode step produces a `SequenceBatch` containing per-oligo metadata, the channel stage applies dropout-aware simulators, and the decode step reassembles the payload while tracking which strands survived. The diagram below illustrates the flow.
+
+![Multi-oligo pipeline](docs/images/multi_oligo_flow.svg)
 
 ```bash
-# Encode a sample file
-genecli encode --input-files tests/data/sample.txt --output-file encoded/message.fasta
+# Encode a sample file into streaming-sized oligos
+genecli encode --input-files tests/data/sample.txt \
+  --output-file encoded/multi_oligo_stream.fasta --stream --chunk-size 600000
 
-# Simulate sequencing noise using an existing config
-genecli channel run configs/channel_demo.yaml
+# Apply dropout-aware channel simulation with coverage mixing
+genecli channel run configs/channel_multi_oligo.yaml
 
-# Decode back to the original text
-genecli decode --input-files simulated.fasta --output-file decoded.txt
+# Decode the surviving oligos back to the original text
+genecli decode --input-files simulated_multi_oligo.fasta --output-file decoded.txt
 ```
 
-The `configs/channel_demo.yaml` configuration mixes basic synthesis constraints with an Illumina simulator.
+The `configs/channel_multi_oligo.yaml` configuration enables a `dropout_rate` and coverage distribution inside the channel pipeline so the metrics capture how many oligos are lost during sequencing.
 
 After running these commands GeneCoder leaves behind metrics artifacts that you can inspect immediately:
 
@@ -50,7 +53,7 @@ For full pipeline runs the CLI also emits reusable metrics outputs:
 - Launch `genecli dashboard decoded.txt.json` to explore the metrics interactively, or build the React dashboard (`npm install` then
   `npm run build` inside `web/helix-ui`) and open `web/helix-ui/dist/dashboard.html` as outlined in the
   [dashboard quickstart](docs/gui_tutorial.md#launching-the-streamlit-dashboard) and
-  [deployment guide](docs/deployment.md).
+  [deployment guide](docs/deployment.md). When iterating on the documentation, run `mkdocs serve` from the repository root to preview the new pages and diagrams locally.
 
 ## Introductory notebooks
 

--- a/configs/channel_multi_oligo.yaml
+++ b/configs/channel_multi_oligo.yaml
@@ -1,0 +1,23 @@
+# Dropout-aware channel pipeline for multi-oligo batches.
+input: encoded/multi_oligo_stream.fasta
+output: simulated_multi_oligo.fasta
+
+synthesis:
+  min_length: 80
+  max_length: 220
+  max_homopolymer: 5
+
+simulators:
+  - name: illumina
+    profile: miseq
+    coverage: 18
+    read_length: 150
+
+pipeline:
+  dropout_rate: 0.12
+  coverage_distribution:
+    12: 0.25
+    16: 0.5
+    24: 0.25
+  parallel: true
+  workers: 4

--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -29,9 +29,9 @@ Visualizer.
 Drag files onto the Encode tab or use the **Browse File** button to select an
 input file.
 
-![GUI screenshot](https://flet.dev/docs/images/screenshot.png)
+![Dashboard overview](images/dashboard_enhanced.svg)
 
-Use the buttons at the bottom of each tab to start the selected operation.
+Use the buttons at the bottom of each tab to start the selected operation. The updated dashboard highlights per-oligo dropout flags, coverage heatmaps and recovery percentages so you can see how the multi-oligo pipeline behaves immediately after a run.
 
 After encoding completes, GC and homopolymer metrics are shown. If they fall outside recommended ranges, a **Fix Sequence** button allows automatic adjustment. Clicking it displays the fixed DNA snippet and updated metrics.
 

--- a/docs/images/dashboard_enhanced.svg
+++ b/docs/images/dashboard_enhanced.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 420" role="img" aria-labelledby="dashTitle dashDesc">
+  <title id="dashTitle">Enhanced GeneCoder dashboard</title>
+  <desc id="dashDesc">Mock dashboard layout showing dropout ribbon, coverage heatmap and oligo table.</desc>
+  <defs>
+    <style>
+      text { font-family: "Inter", "Segoe UI", sans-serif; fill: #1f2a3a; }
+      .title { font-size: 22px; font-weight: 700; }
+      .subtitle { font-size: 16px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; }
+      .small { font-size: 14px; }
+    </style>
+    <linearGradient id="card" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#eff6ff" />
+      <stop offset="100%" stop-color="#e0f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="720" height="420" rx="24" fill="#f8fafc" />
+  <rect x="24" y="24" width="672" height="372" rx="20" fill="#ffffff" stroke="#d0d7e3" stroke-width="2" />
+  <text x="60" y="72" class="title">Run 42 · Multi-oligo bundle</text>
+  <text x="60" y="96" class="small" fill="#475569">Dropout-aware Illumina simulation with Fountain FEC</text>
+  <rect x="60" y="116" width="280" height="120" rx="16" fill="url(#card)" />
+  <text x="80" y="148" class="subtitle" fill="#0f172a">dropout trend</text>
+  <polyline points="80,204 110,180 140,188 170,160 200,152 230,166 260,140 300,132" fill="none" stroke="#f97316" stroke-width="5" stroke-linecap="round" />
+  <circle cx="80" cy="204" r="6" fill="#f97316" />
+  <circle cx="170" cy="160" r="6" fill="#f97316" />
+  <circle cx="260" cy="140" r="6" fill="#f97316" />
+  <text x="80" y="222" class="small" fill="#f97316">Peak dropout 12%</text>
+  <rect x="360" y="116" width="288" height="120" rx="16" fill="url(#card)" />
+  <text x="380" y="148" class="subtitle" fill="#0f172a">coverage heatmap</text>
+  <g transform="translate(380 156)">
+    <rect x="0" y="0" width="240" height="80" fill="#e2e8f0" rx="12" />
+    <rect x="8" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.3" rx="8" />
+    <rect x="60" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.6" rx="8" />
+    <rect x="112" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.85" rx="8" />
+    <rect x="164" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.45" rx="8" />
+  </g>
+  <text x="380" y="222" class="small" fill="#0284c7">Mean coverage 18×</text>
+  <rect x="60" y="260" width="588" height="120" rx="16" fill="#0f172a" opacity="0.85" />
+  <text x="80" y="296" class="subtitle" fill="#e2e8f0">oligo inspector</text>
+  <text x="80" y="320" class="small" fill="#cbd5f5">#0216 · GC 48% · homopolymer 3 · dropout ✓</text>
+  <text x="80" y="344" class="small" fill="#cbd5f5">#0217 · GC 51% · homopolymer 4 · dropout ✗</text>
+  <text x="80" y="368" class="small" fill="#cbd5f5">#0218 · GC 49% · homopolymer 2 · dropout ✗</text>
+  <text x="420" y="320" class="small" fill="#34d399">Recovered payload 99.4%</text>
+</svg>

--- a/docs/images/multi_oligo_flow.svg
+++ b/docs/images/multi_oligo_flow.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 240" role="img" aria-labelledby="title desc">
+  <title id="title">Multi-oligo pipeline flow</title>
+  <desc id="desc">Encode to oligo batches, simulate channel dropout, and decode reconstructed payloads.</desc>
+  <defs>
+    <linearGradient id="oligoGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#2b9ad8" />
+      <stop offset="100%" stop-color="#8ad7f6" />
+    </linearGradient>
+    <linearGradient id="channelGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f7b733" />
+      <stop offset="100%" stop-color="#fc4a1a" />
+    </linearGradient>
+    <linearGradient id="decodeGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#5ec16e" />
+      <stop offset="100%" stop-color="#a6e89c" />
+    </linearGradient>
+    <style>
+      text { font-family: "Fira Sans", "Segoe UI", sans-serif; fill: #1f2933; }
+      .label { font-size: 20px; font-weight: 600; }
+      .body { font-size: 16px; }
+    </style>
+  </defs>
+  <rect x="32" y="48" width="160" height="144" rx="16" fill="url(#oligoGradient)" opacity="0.9" />
+  <rect x="240" y="48" width="160" height="144" rx="16" fill="url(#channelGradient)" opacity="0.9" />
+  <rect x="448" y="48" width="160" height="144" rx="16" fill="url(#decodeGradient)" opacity="0.9" />
+  <text x="112" y="88" text-anchor="middle" class="label">Encode</text>
+  <text x="112" y="120" text-anchor="middle" class="body">chunk → oligos</text>
+  <text x="112" y="146" text-anchor="middle" class="body">SequenceBatch + manifest</text>
+  <text x="320" y="88" text-anchor="middle" class="label">Channel</text>
+  <text x="320" y="120" text-anchor="middle" class="body">coverage mix</text>
+  <text x="320" y="146" text-anchor="middle" class="body">dropout_rate &amp; synthesis checks</text>
+  <text x="528" y="88" text-anchor="middle" class="label">Decode</text>
+  <text x="528" y="120" text-anchor="middle" class="body">reassemble payload</text>
+  <text x="528" y="146" text-anchor="middle" class="body">metrics + dashboard</text>
+  <g fill="none" stroke="#1f2933" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M200 120h32" />
+    <path d="M408 120h32" />
+    <polygon points="416,120 400,132 400,108" fill="#1f2933" />
+    <polygon points="624,120 608,132 608,108" fill="#1f2933" />
+  </g>
+  <g>
+    <circle cx="320" cy="182" r="22" fill="#fff" stroke="#fc4a1a" stroke-width="4" />
+    <text x="320" y="190" text-anchor="middle" class="body" fill="#fc4a1a">10% drop</text>
+    <circle cx="112" cy="182" r="22" fill="#fff" stroke="#2b9ad8" stroke-width="4" />
+    <text x="112" y="190" text-anchor="middle" class="body" fill="#2b9ad8">96 nt</text>
+    <circle cx="528" cy="182" r="22" fill="#fff" stroke="#5ec16e" stroke-width="4" />
+    <text x="528" y="190" text-anchor="middle" class="body" fill="#2f855a">99.2%</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ GeneCoder has been enhanced with new encoding strategies, error correction, batc
 
 For more details, explore the sections below.
 
-* [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo.
+* [Vertical Slice Guide](vertical_slice.md) – Quick setup and interface demo featuring the multi-oligo pipeline.
 * [n8n Overview](n8n_overview.md) – Automate workflows with n8n.
 * [Simulators](simulators.md) – Available read simulators and how to install external tools.
 * [Performance Benchmarks](performance.md) – Encoding/decoding throughput numbers.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,3 +6,14 @@ The `Channel.error_rate` attribute has been renamed to `Channel.substitution_pro
 Accessing or setting `error_rate` still works but raises a `DeprecationWarning` and
 will be removed in a future release. Update any code that relies on `error_rate`
 to use `substitution_prob` instead.
+
+## Migrating to the multi-oligo pipeline
+
+GeneCoder 0.18 promotes the multi-oligo encode → channel → decode flow. Earlier releases operated on single FASTA records, so existing automation may need small adjustments:
+
+- **Encoding** – the new streaming mode (`--stream` with `--chunk-size`) writes a `SequenceBatch` containing many oligos plus a manifest. Leave streaming disabled to retain the previous single-record output. The CLI still honours legacy options such as `--auto-ext` and `--capsule`.
+- **Channel simulation** – `genecli channel run` now expects the streamed FASTA with batch metadata. Legacy single-record files continue to work because `SequenceBatch.from_fasta` wraps them automatically, marking the batch as `legacy`. To keep scripts quiet, pass `--suppress-constraint-warnings` (or set `GENECODER_DISABLE_CONSTRAINT_WARNINGS=1`) just like before. The YAML loader also keeps the historical `constraints` key as an alias for `synthesis` so older configs do not need to change.
+- **Dropout controls** – the pipeline uses the new compatibility flags `--dropout-rate`, `--coverage-distribution` and `--synthesis-loss` on `genecli channel` (and the matching YAML fields) to emulate the single-sequence error rate tunables. Supply the same values you used previously to reproduce older simulations, then tighten them gradually to explore multi-oligo loss scenarios.
+- **Decoding** – `genecli decode` accepts both legacy FASTA and new multi-oligo batches. No flags are required, but you can continue to rely on familiar arguments such as `--output-dir` and `--file-type` to mirror older automation.
+
+Finally, rebuild the documentation (`mkdocs serve`) to confirm your guides and READMEs reference the updated flow before shipping your migration notes.

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -6,19 +6,21 @@ metrics in the dashboard.
 
 ## Basic CLI Flow
 
+The multi-oligo pipeline splits the encoded payload into manageable oligos, simulates dropout-heavy sequencing, and stitches the surviving strands back together. The commands below mirror the workflow presented in the repository README.
+
 ```bash
-# Encode a sample file with Reed-Solomon FEC
+# Encode the payload into multiple oligos using streaming mode
 genecli encode --input-files examples/pipeline_demo_input.txt \
-  --output-file encoded.fasta --fec reed_solomon
+  --output-file encoded/multi_oligo_stream.fasta --stream --chunk-size 400000
 
-# Run a channel simulation using a configuration file
-genecli channel run configs/channel_demo.yaml
+# Run the dropout-aware channel pipeline
+genecli channel run configs/channel_multi_oligo.yaml
 
-# Decode the simulated reads back to the original data
-genecli decode --input-files simulated.fasta --output-file decoded.txt
+# Decode the surviving oligos into the original payload
+genecli decode --input-files simulated_multi_oligo.fasta --output-file decoded_multi.txt
 
-# Launch the Streamlit dashboard to inspect metrics
-genecli dashboard examples/illumina_metrics.json
+# Launch the dashboard to inspect dropout, coverage and ECC metrics
+genecli dashboard decoded_multi.txt.json
 ```
 
 ## RaptorQ and Fountain via `genecli pipeline`
@@ -96,6 +98,7 @@ simulate:
     - nanopore
   pipeline:
     nanopore_profile: r10
+    dropout_rate: 0.15
 decode:
   method: base4_direct
 ```
@@ -105,6 +108,44 @@ Execute with metrics enabled:
 ```bash
 GENECODER_METRICS_PATH=examples/nanopore_metrics.json \
   genecli bundle run configs/fountain_nanopore_pipeline.yaml
+```
+
+### Multi-oligo Illumina Dropout Pipeline
+
+The `configs/channel_multi_oligo.yaml` file demonstrates the new dropout-aware channel pipeline. It mixes an Illumina simulator with a coverage distribution and enforces synthesis constraints for the streamed FASTA output.
+
+```yaml
+# configs/channel_multi_oligo.yaml
+input: encoded/multi_oligo_stream.fasta
+output: simulated_multi_oligo.fasta
+
+synthesis:
+  min_length: 80
+  max_length: 220
+  max_homopolymer: 5
+
+simulators:
+  - name: illumina
+    profile: miseq
+    coverage: 18
+    read_length: 150
+
+pipeline:
+  dropout_rate: 0.12
+  coverage_distribution:
+    12: 0.25
+    16: 0.50
+    24: 0.25
+  parallel: true
+  workers: 4
+```
+
+Run the configuration and inspect the emitted `simulated_multi_oligo.fasta.manifest.json` to see per-oligo dropout flags:
+
+```bash
+genecli channel run configs/channel_multi_oligo.yaml
+genecli html-report --manifest simulated_multi_oligo.fasta.manifest.json \
+  --output-file reports/multi_oligo_channel.html
 ```
 
 ## Metrics and Troubleshooting

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -379,23 +379,47 @@ genecli channel run decay_config.yml
        --method ai
    ```
 
-17. **Run the full pipeline from a YAML file**
+17. **Run the multi-oligo encode → channel → decode flow**
 
-   Create a configuration with the codec, FEC and channel settings:
+   Multi-oligo runs use streaming encode output, a dropout-aware channel configuration, and a standard decode step. Start by encoding the payload into a `SequenceBatch` with per-oligo metadata:
 
-   ```yaml
-   codec: base4_direct
-   fec: reed_solomon
-   channel:
-     name: simple
-     substitution_rate: 0.01
+   ```bash
+   genecli encode --input-files examples/pipeline_demo_input.txt \
+       --output-file encoded/multi_oligo_stream.fasta --stream --chunk-size 500000
    ```
 
-   Then execute:
+   Define the channel stage with `dropout_rate` and `coverage_distribution` so coverage variation is tracked in the manifest. The sample lives at `configs/channel_multi_oligo.yaml`:
 
-  ```bash
-  genecli pipeline input.bin output.bin --config pipeline.yml
-  ```
+   ```yaml
+   input: encoded/multi_oligo_stream.fasta
+   output: simulated_multi_oligo.fasta
+   synthesis:
+     min_length: 80
+     max_length: 220
+     max_homopolymer: 5
+   simulators:
+     - name: illumina
+       profile: miseq
+       coverage: 18
+       read_length: 150
+   pipeline:
+     dropout_rate: 0.12
+     coverage_distribution:
+       12: 0.25
+       16: 0.50
+       24: 0.25
+     parallel: true
+     workers: 4
+   ```
+
+   Run the channel and decode the surviving strands:
+
+   ```bash
+   genecli channel run configs/channel_multi_oligo.yaml
+   genecli decode --input-files simulated_multi_oligo.fasta --output-file decoded_multi.txt
+   ```
+
+   The resulting `decoded_multi.txt.json` manifest lists dropout counts, coverage histograms, and oligo-level GC and homopolymer metrics. Open it with `genecli dashboard` or a browser pointed at the rebuilt React dashboard. Preview the updated documentation and diagrams locally with `mkdocs serve`.
 
 ### MPI Channel Pipeline
 

--- a/web/helix-ui/README.md
+++ b/web/helix-ui/README.md
@@ -2,6 +2,10 @@
 
 This directory contains the React-based interfaces used by the GeneCoder web server.
 
+![Enhanced dashboard](src/assets/dashboard_enhanced.svg)
+
+The redesigned dashboard surfaces multi-oligo dropout, coverage heatmaps and oligo inspectors to match the new pipeline flow.
+
 ## Building
 
 Install Node dependencies and run the build script:
@@ -13,6 +17,6 @@ npm run build
 
 The compiled assets will be placed in the `dist` folder. During development you can run `npm run dev` to launch a hot-reload server.
 
-## Scoreboard
+## Dashboard & Scoreboard
 
-The React scoreboard page lives in `scoreboard.html` and relies on the `/catalog/challenge` API. After running `npm run build` open `dist/scoreboard.html` directly or visit `/helix-ui/scoreboard.html` while the backend server is running to view and submit challenge scores.
+The React dashboard (`dashboard.html`) and scoreboard (`scoreboard.html`) share the same build. After running `npm run build` open `dist/dashboard.html` to explore the enhanced charts or `dist/scoreboard.html` to submit challenge scores. When previewing alongside the Python documentation, run `mkdocs serve` in another terminal so content changes are reflected in both places.

--- a/web/helix-ui/src/assets/dashboard_enhanced.svg
+++ b/web/helix-ui/src/assets/dashboard_enhanced.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 420" role="img" aria-labelledby="dashTitle dashDesc">
+  <title id="dashTitle">Enhanced GeneCoder dashboard</title>
+  <desc id="dashDesc">Mock dashboard layout showing dropout ribbon, coverage heatmap and oligo table.</desc>
+  <defs>
+    <style>
+      text { font-family: "Inter", "Segoe UI", sans-serif; fill: #1f2a3a; }
+      .title { font-size: 22px; font-weight: 700; }
+      .subtitle { font-size: 16px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; }
+      .small { font-size: 14px; }
+    </style>
+    <linearGradient id="card" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#eff6ff" />
+      <stop offset="100%" stop-color="#e0f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="720" height="420" rx="24" fill="#f8fafc" />
+  <rect x="24" y="24" width="672" height="372" rx="20" fill="#ffffff" stroke="#d0d7e3" stroke-width="2" />
+  <text x="60" y="72" class="title">Run 42 · Multi-oligo bundle</text>
+  <text x="60" y="96" class="small" fill="#475569">Dropout-aware Illumina simulation with Fountain FEC</text>
+  <rect x="60" y="116" width="280" height="120" rx="16" fill="url(#card)" />
+  <text x="80" y="148" class="subtitle" fill="#0f172a">dropout trend</text>
+  <polyline points="80,204 110,180 140,188 170,160 200,152 230,166 260,140 300,132" fill="none" stroke="#f97316" stroke-width="5" stroke-linecap="round" />
+  <circle cx="80" cy="204" r="6" fill="#f97316" />
+  <circle cx="170" cy="160" r="6" fill="#f97316" />
+  <circle cx="260" cy="140" r="6" fill="#f97316" />
+  <text x="80" y="222" class="small" fill="#f97316">Peak dropout 12%</text>
+  <rect x="360" y="116" width="288" height="120" rx="16" fill="url(#card)" />
+  <text x="380" y="148" class="subtitle" fill="#0f172a">coverage heatmap</text>
+  <g transform="translate(380 156)">
+    <rect x="0" y="0" width="240" height="80" fill="#e2e8f0" rx="12" />
+    <rect x="8" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.3" rx="8" />
+    <rect x="60" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.6" rx="8" />
+    <rect x="112" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.85" rx="8" />
+    <rect x="164" y="8" width="48" height="64" fill="#0ea5e9" opacity="0.45" rx="8" />
+  </g>
+  <text x="380" y="222" class="small" fill="#0284c7">Mean coverage 18×</text>
+  <rect x="60" y="260" width="588" height="120" rx="16" fill="#0f172a" opacity="0.85" />
+  <text x="80" y="296" class="subtitle" fill="#e2e8f0">oligo inspector</text>
+  <text x="80" y="320" class="small" fill="#cbd5f5">#0216 · GC 48% · homopolymer 3 · dropout ✓</text>
+  <text x="80" y="344" class="small" fill="#cbd5f5">#0217 · GC 51% · homopolymer 4 · dropout ✗</text>
+  <text x="80" y="368" class="small" fill="#cbd5f5">#0218 · GC 49% · homopolymer 2 · dropout ✗</text>
+  <text x="420" y="320" class="small" fill="#34d399">Recovered payload 99.4%</text>
+</svg>


### PR DESCRIPTION
## Summary
- describe the multi-oligo encode → channel → decode workflow in the README and usage guides, including dropout-aware YAML snippets
- add a reusable `configs/channel_multi_oligo.yaml` sample and new diagrams that highlight the pipeline and updated dashboard visuals
- refresh GUI and Helix UI documentation with the enhanced dashboard artwork and migration guidance for legacy single-sequence users

## Testing
- `poetry run mkdocs build` *(fails: mkdocs command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2111ad408326804dcf52e63b604f