### PR TITLE
Adopt SequenceBatch in plugin templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - Plugin registry now verifies package checksums before installation.
 - Renamed ``Channel.error_rate`` to ``Channel.substitution_prob``; ``error_rate`` remains
   as a deprecated alias.
+- **Breaking:** Simulator plugins must adopt the ``SequenceBatch`` API. Example
+  packages now emit metadata for batch IDs, seeds and coverage, and declare a
+  minimum dependency of ``genecoder>=0.2.0``.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,27 @@ and mypy lint those files as well:
 pre-commit run --files plugins-examples/example_codec/example_codec/__init__.py
 ```
 
+### Migrating plugins to `SequenceBatch`
+
+Simulators must now accept and return ``genecoder.formats.SequenceBatch``
+instances. To update an existing string-based plugin:
+
+1. Convert any incoming ``str`` to a batch with
+   ``SequenceBatch.build(..., batch_seed=secrets.randbits(32))`` so oligo IDs and
+   seeds are populated automatically.
+2. Use ``genecoder.simulators.batch_utils.clone_batch`` to work on a copy of the
+   source batch and preserve metadata.
+3. Populate coverage, dropout and synthesis results via
+   ``genecoder.simulators.batch_utils.RESULT_*`` constants and finish with
+   ``finalize_batch_statistics`` to keep aggregate metadata in sync.
+4. Opt into the compatibility layer by calling
+   ``apply_legacy_simulator`` when you need to adapt an older ``str``-only
+   simulator. The helper takes care of all metadata bookkeeping.
+
+``mypy`` validates the plugin templates in ``plugins-examples/`` to ensure these
+hooks stay exercised. Run ``mypy --config-file mypy.ini`` locally after editing
+examples to confirm your plugin still satisfies the updated protocol.
+
 The hook also runs automatically on each commit if installed.
 
 CI runs `ruff check` and `mypy` on pull requests that modify code. Fix any

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,3 +6,17 @@ The `Channel.error_rate` attribute has been renamed to `Channel.substitution_pro
 Accessing or setting `error_rate` still works but raises a `DeprecationWarning` and
 will be removed in a future release. Update any code that relies on `error_rate`
 to use `substitution_prob` instead.
+
+## Simulator ``SequenceBatch`` adoption
+
+Simulators must return ``SequenceBatch`` objects from ``simulate``. When porting
+an older plugin:
+
+1. Wrap raw ``str`` inputs by calling ``SequenceBatch.build`` with a ``batch_id``
+   and ``batch_seed``. The helper fills in deterministic oligo identifiers.
+2. Clone the batch with ``genecoder.simulators.batch_utils.clone_batch`` before
+   mutating to avoid rewriting the caller's data in place.
+3. Record coverage and dropout metadata via ``RESULT_*`` constants and then
+   invoke ``finalize_batch_statistics`` to generate aggregate metrics.
+4. Reuse ``apply_legacy_simulator`` for simple passthrough simulators that do not
+   yet understand batches; it automatically produces ``SequenceBatch`` outputs.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,7 +5,9 @@ package can expose entry points under `genecoder.plugins`, `genecoder.fec`,
 `genecoder.simulators` or `genecoder.visualizers` that point to modules with a
 `register` function. The function receives a callback used to add the
 implementation to the appropriate registry. GeneCoder looks only at packages
-installed in your current Python environment when loading plugins.
+installed in your current Python environment when loading plugins. Plugins that
+use the batch-aware simulator API must declare `genecoder>=0.2.0` in their
+project metadata.
 
 ## Interface Expectations
 
@@ -35,14 +37,58 @@ def register(register_codec):
 ### Channels
 
 Channel plugins subclass [``genecoder.api.Simulator``](api_reference.md#genecoder.api.Simulator)
-and implement a ``simulate`` method:
+and implement a ``simulate`` method that accepts and returns
+``SequenceBatch`` instances. The helper demonstrates converting legacy string
+inputs into batches so per-oligo metadata is always available:
 
 ```python
+import secrets
+
 from genecoder.api import Simulator
+from genecoder.formats import SequenceBatch
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    clone_batch,
+    finalize_batch_statistics,
+)
+
 
 class MyChannel(Simulator):
-    def simulate(self, sequence: str) -> str:
-        ...
+    def simulate(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        batch = sequence if isinstance(sequence, SequenceBatch) else SequenceBatch.build(
+            [("mychannel", sequence)],
+            batch_id="mychannel",
+            batch_seed=secrets.randbits(32),
+        )
+
+        mutated = clone_batch(batch)
+        coverage_counts: list[int] = []
+        dropouts: list[bool] = []
+        synthesis_failures: list[bool] = []
+        mutation_totals: list[tuple[int, int, int]] = []
+
+        for source, oligo in zip(batch.oligos, mutated.oligos):
+            oligo.sequence = source.sequence
+            coverage_counts.append(1)
+            dropouts.append(False)
+            synthesis_failures.append(False)
+            mutation_totals.append((0, 0, 0))
+            oligo.metadata[RESULT_COVERAGE_KEY] = "1"
+
+        finalize_batch_statistics(
+            mutated,
+            coverage_counts,
+            dropouts,
+            synthesis_failures,
+            mutation_totals,
+        )
+
+        if mutated.seed is None:
+            mutated.seed = secrets.randbits(32)
+        mutated.metadata["sim_seed"] = str(mutated.seed)
+
+        return mutated
+
 
 def register(register_simulator):
     register_simulator("mychannel", MyChannel())
@@ -113,11 +159,22 @@ def register(register_codec):
 ### Channel Example
 
 ```python
+import secrets
+
 from genecoder.api import Simulator
+from genecoder.formats import SequenceBatch
+
 
 class MyChannel(Simulator):
-    def simulate(self, sequence: str) -> str:
-        ...
+    def simulate(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        if isinstance(sequence, SequenceBatch):
+            return sequence
+        return SequenceBatch.build(
+            [("mychannel", sequence)],
+            batch_id="mychannel",
+            batch_seed=secrets.randbits(32),
+        )
+
 
 def register(register_simulator):
     register_simulator("mychannel", MyChannel())
@@ -155,6 +212,20 @@ visualized: b'hi\n'
 ```
 
 See [`plugins-examples`](../plugins-examples/) for complete reference implementations.
+
+### Batch-aware Adapter Patterns
+
+- **Legacy simulators** – wrap older ``str``-only simulators with
+  ``genecoder.simulators.batch_utils.apply_legacy_simulator``. The helper
+  iterates each oligo, updates coverage statistics and returns a complete
+  ``SequenceBatch`` so the rest of the pipeline can remain batch-native.
+- **Metadata helpers** – use ``clone_batch`` to duplicate the incoming batch
+  before mutating oligos. After processing, call ``finalize_batch_statistics`` to
+  populate aggregate metrics such as coverage histograms and dropout rates.
+- **Validation hooks** – mypy treats the templates in ``plugins-examples`` as
+  first-class code. Running ``mypy --config-file mypy.ini`` will flag protocol
+  mismatches if ``simulate`` stops returning ``SequenceBatch`` objects or
+  required metadata keys are missing from the examples.
 
 ### Step-by-step Example
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,5 +5,5 @@ strict = true
 explicit_package_bases = true
 show_error_codes = true
 enable_error_code = ignore-without-code
-files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_visualizer/example_visualizer, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec
+files = src, plugins-examples/example_codec/example_codec, plugins-examples/example_fec/example_fec, plugins-examples/example_simulator/example_simulator, plugins-examples/example_visualizer/example_visualizer, plugins-examples/example_package_plugin/example_plugin, plugins-examples/advanced_fec/advanced_fec, plugins-examples/channel_template/channel_template, plugins-examples/encoder_template/encoder_template
 exclude = ^tests/

--- a/plugins-examples/README.md
+++ b/plugins-examples/README.md
@@ -2,12 +2,16 @@
 
 This directory contains minimal example plugins demonstrating how to integrate
 custom codecs, FEC implementations, visualizers and read simulators with GeneCoder.
+The simulator templates now showcase the ``genecoder.formats.SequenceBatch``
+API, including how to surface batch identifiers, seeds and coverage metrics
+through oligo metadata.
 
 Each subdirectory is an installable Python package using PEP 621 metadata:
 
 - `example_codec` – registers a codec named `example`.
 - `example_fec` – registers a FEC backend named `example`.
-- `example_simulator` – registers a simulator named `example`.
+- `example_simulator` – registers a simulator named `example` that returns a
+  full ``SequenceBatch`` with coverage statistics in the metadata.
 - `example_visualizer` – registers a visualizer named `example`.
 - `advanced_fec` – registers an LDPC FEC backend named `advanced_ldpc`.
 
@@ -16,3 +20,6 @@ Install any of the packages with `pip` to experiment locally, e.g.:
 ```bash
 pip install ./plugins-examples/example_codec
 ```
+
+All templates depend on `genecoder>=0.2.0` so batch-aware metadata helpers are
+available when you install them into a custom environment.

--- a/plugins-examples/advanced_fec/pyproject.toml
+++ b/plugins-examples/advanced_fec/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-advanced-fec"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.fec"]
 advanced_ldpc = "advanced_fec"

--- a/plugins-examples/channel_template/README.md
+++ b/plugins-examples/channel_template/README.md
@@ -1,8 +1,10 @@
 # Channel Plugin Template
 
-Minimal skeleton for a custom channel plugin. Implement `simulate` in
+Minimal skeleton for a custom channel plugin. Implement the
+``SequenceBatch``-aware ``simulate`` method in
 `channel_template/__init__.py` and adjust the entry point name in
-`pyproject.toml`.
+`pyproject.toml`. The template shows how to emit batch IDs, simulator
+seeds and per-oligo coverage values.
 
 Install locally for experimentation:
 

--- a/plugins-examples/channel_template/channel_template/__init__.py
+++ b/plugins-examples/channel_template/channel_template/__init__.py
@@ -1,16 +1,85 @@
+from __future__ import annotations
+
+import secrets
 from typing import Callable
 
 from genecoder.api import Simulator
+from genecoder.formats import SequenceBatch
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    clone_batch,
+    finalize_batch_statistics,
+)
 
 
 class TemplateChannel(Simulator):  # type: ignore[misc]
-    """Skeleton channel plugin."""
+    """Skeleton channel plugin showing ``SequenceBatch`` integration."""
 
-    def simulate(self, sequence: str) -> str:
-        """Return a possibly modified version of ``sequence``."""
-        raise NotImplementedError
+    def simulate(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        """Return a possibly modified version of ``sequence`` as a batch."""
+
+        batch = self._ensure_batch(sequence)
+        mutated = clone_batch(batch)
+
+        coverage_counts: list[int] = []
+        dropouts: list[bool] = []
+        synthesis_failures: list[bool] = []
+        mutation_totals: list[tuple[int, int, int]] = []
+
+        for original, oligo in zip(batch.oligos, mutated.oligos):
+            mutated_sequence = self._mutate_read(original.sequence)
+            coverage = self._coverage_for(original.sequence, mutated_sequence)
+
+            oligo.sequence = mutated_sequence
+            oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage)
+            coverage_counts.append(coverage)
+            dropouts.append(coverage == 0)
+            synthesis_failures.append(False)
+            mutation_totals.append((0, 0, 0))
+
+        finalize_batch_statistics(
+            mutated,
+            coverage_counts,
+            dropouts,
+            synthesis_failures,
+            mutation_totals,
+        )
+
+        if mutated.seed is None:
+            mutated.seed = secrets.randbits(32)
+        mutated.metadata.setdefault("simulator", "template")
+        mutated.metadata["sim_seed"] = str(mutated.seed)
+
+        return mutated
+
+    def _ensure_batch(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        if isinstance(sequence, SequenceBatch):
+            return sequence
+        batch_seed = secrets.randbits(32)
+        return SequenceBatch.build(
+            [("template", sequence)],
+            batch_id="template",
+            batch_seed=batch_seed,
+        )
+
+    def _mutate_read(self, sequence: str) -> str:
+        """Return a mutated copy of ``sequence``.
+
+        Override this hook with your channel behaviour.
+        """
+
+        return sequence
+
+    def _coverage_for(self, original: str, mutated: str) -> int:
+        """Return the coverage depth recorded for ``mutated``.
+
+        Override to report per-oligo coverage counts.
+        """
+
+        return 1
 
 
 def register(register_simulator: Callable[[str, Simulator], None]) -> None:
     """Register the channel simulator with GeneCoder."""
+
     register_simulator("template", TemplateChannel())

--- a/plugins-examples/channel_template/pyproject.toml
+++ b/plugins-examples/channel_template/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-channel-template"
 version = "0.0.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.simulators"]
 template = "channel_template"

--- a/plugins-examples/encoder_template/pyproject.toml
+++ b/plugins-examples/encoder_template/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-encoder-template"
 version = "0.0.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.plugins"]
 template = "encoder_template"

--- a/plugins-examples/example_codec/pyproject.toml
+++ b/plugins-examples/example_codec/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-example-codec"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.plugins"]
 example = "example_codec"

--- a/plugins-examples/example_fec/pyproject.toml
+++ b/plugins-examples/example_fec/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-example-fec"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.fec"]
 example = "example_fec"

--- a/plugins-examples/example_package_plugin/pyproject.toml
+++ b/plugins-examples/example_package_plugin/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-example-package-plugin"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.plugins"]
 package_example = "example_plugin"

--- a/plugins-examples/example_simulator/README.md
+++ b/plugins-examples/example_simulator/README.md
@@ -1,6 +1,8 @@
 # Example Simulator Plugin
 
-A passthrough simulator named `example`.
+A passthrough simulator named `example`. The implementation now operates on
+``SequenceBatch`` inputs and annotates each oligo with simulator coverage
+metadata.
 
 ## Step-by-step Usage
 
@@ -19,8 +21,9 @@ A passthrough simulator named `example`.
    print("example" in SIMULATOR_REGISTRY)
    ```
 
-3. Run the simulator through the pipeline CLI:
+3. Run the simulator through the pipeline CLI and inspect the emitted metadata:
 
    ```bash
    genecli pipeline input.bin output.bin --codec base4_direct --channel example
+   genecli bundle inspect output.bin --show-metadata | grep sim_
    ```

--- a/plugins-examples/example_simulator/example_simulator/__init__.py
+++ b/plugins-examples/example_simulator/example_simulator/__init__.py
@@ -1,13 +1,67 @@
+from __future__ import annotations
+
+import secrets
 from typing import Callable
 
 from genecoder.api import Simulator
+from genecoder.formats import SequenceBatch
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    clone_batch,
+    finalize_batch_statistics,
+)
 
 
 class PassthroughChannel(Simulator):  # type: ignore[misc]
-    """Simple channel that returns sequences unchanged."""
+    """Simple simulator demonstrating the :class:`SequenceBatch` API."""
 
-    def simulate(self, sequence: str) -> str:
-        return sequence
+    def simulate(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        batch = self._ensure_batch(sequence)
+        mutated = clone_batch(batch)
+
+        coverage_counts: list[int] = []
+        dropouts: list[bool] = []
+        synthesis_failures: list[bool] = []
+        mutation_totals: list[tuple[int, int, int]] = []
+
+        for original, oligo in zip(batch.oligos, mutated.oligos):
+            oligo.sequence = original.sequence
+            coverage = 1
+
+            coverage_counts.append(coverage)
+            dropouts.append(False)
+            synthesis_failures.append(False)
+            mutation_totals.append((0, 0, 0))
+
+            oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage)
+            oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = "false"
+
+        finalize_batch_statistics(
+            mutated,
+            coverage_counts,
+            dropouts,
+            synthesis_failures,
+            mutation_totals,
+        )
+
+        if mutated.seed is None:
+            mutated.seed = secrets.randbits(32)
+        mutated.metadata["simulator"] = "example"
+        mutated.metadata["sim_seed"] = str(mutated.seed)
+
+        return mutated
+
+    def _ensure_batch(self, sequence: str | SequenceBatch) -> SequenceBatch:
+        if isinstance(sequence, SequenceBatch):
+            return sequence
+
+        batch_seed = secrets.randbits(32)
+        return SequenceBatch.build(
+            [("example", sequence)],
+            batch_id="example",
+            batch_seed=batch_seed,
+        )
 
 
 def register(register_simulator: Callable[[str, Simulator], None]) -> None:

--- a/plugins-examples/example_simulator/pyproject.toml
+++ b/plugins-examples/example_simulator/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-example-simulator"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.simulators"]
 example = "example_simulator"

--- a/plugins-examples/example_visualizer/pyproject.toml
+++ b/plugins-examples/example_visualizer/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [project]
 name = "genecoder-example-visualizer"
 version = "0.1.0"
-dependencies = ["genecoder"]
+dependencies = ["genecoder>=0.2.0"]
 
 [project.entry-points."genecoder.visualizers"]
 example = "example_visualizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ files = [
     "plugins-examples/example_visualizer/example_visualizer",
     "plugins-examples/example_package_plugin/example_plugin",
     "plugins-examples/advanced_fec/advanced_fec",
+    "plugins-examples/channel_template/channel_template",
+    "plugins-examples/encoder_template/encoder_template",
 ]
 exclude = "^tests/"
 


### PR DESCRIPTION
## Summary
- update simulator examples and templates to produce `SequenceBatch` output with coverage, seed, and metadata helpers
- document migration steps, adapter patterns, and new minimum `genecoder>=0.2.0` dependency for batch-aware plugins
- extend mypy configuration to lint plugin templates and bump example package requirements

## Testing
- `poetry run ruff check` *(fails: existing lint violations outside plugin examples)*
- `poetry run ruff check plugins-examples`
- `poetry run mypy --config-file mypy.ini plugins-examples/channel_template/channel_template/__init__.py`
- `poetry run mypy --config-file mypy.ini plugins-examples/example_simulator/example_simulator/__init__.py`
- `poetry run mypy --config-file mypy.ini plugins-examples/example_visualizer/example_visualizer/__init__.py`
- `poetry run mypy --config-file mypy.ini plugins-examples/example_package_plugin/example_plugin/__init__.py`
- `poetry run pytest -q` *(fails: numerous pre-existing CLI and dependency-related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2112181c83268d93071cf3cbb52f