### PR TITLE
Add SequenceBatch support to core pipeline helpers

### DIFF
--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -23,8 +23,14 @@ from genecoder.plugin_manager import (
     init_plugins,
 )
 from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.formats import SequenceBatch
 
 logger = logging.getLogger(__name__)
+
+
+def _wrap_cli_sequence(sequence: str) -> SequenceBatch:
+    header = "batch_id=cli_pipeline oligo_index=1"
+    return SequenceBatch.build([(header, sequence)], batch_id="cli_pipeline")
 
 
 def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]]:
@@ -104,13 +110,16 @@ def _run_with_params(
         SIMULATOR_REGISTRY[temp_name] = ch
     try:
         original_data = Path(input_path).read_bytes()
-        dna, fec_info = encode(codec, fec, original_data)
-        dna, subs, ins, dels, coverage = simulate(temp_name, dna)
-        decoded = decode(codec, fec, dna, fec_info)
+        dna_batch, fec_info = encode(codec, fec, original_data)
+        simulated, subs, ins, dels, coverage = simulate(temp_name, dna_batch)
+        batch_result = (
+            simulated if isinstance(simulated, SequenceBatch) else _wrap_cli_sequence(simulated)
+        )
+        decoded = decode(codec, fec, batch_result, fec_info)
         Path(output_path).write_bytes(decoded)
         metrics: dict[str, Any] = gather_metrics(
 
-            dna,
+            batch_result,
             original_data,
             decoded,
             fec,

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
+import json
 from pathlib import Path
 from typing import Any, Mapping, Tuple, Dict, List, Sequence
 
@@ -10,6 +11,12 @@ from .utils import get_max_homopolymer_length
 
 from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from .simulators import SIMULATOR_REGISTRY
+from .formats import SequenceBatch
+from .simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+)
 
 __all__ = ["encode", "simulate", "decode", "metrics", "run_pipeline"]
 
@@ -90,10 +97,28 @@ def _homopolymer_runs(sequence: str) -> List[int]:
     return [counts.get(i, 0) for i in range(1, max_run + 1)]
 
 
+def _wrap_single_sequence(
+    sequence: str,
+    *,
+    batch_id: str = "sequence",
+    codec: str | None = None,
+) -> SequenceBatch:
+    """Return a :class:`SequenceBatch` for a legacy string ``sequence``."""
+
+    tokens = [f"batch_id={batch_id}", "oligo_index=1"]
+    if codec:
+        tokens.append(f"codec={codec}")
+    header = " ".join(tokens)
+    batch = SequenceBatch.build([(header, sequence)], batch_id=batch_id)
+    if codec:
+        batch.metadata.setdefault("codec", codec)
+    return batch
+
+
 def encode(
     codec: str, fec: str | None, data: bytes
-) -> Tuple[str, Mapping[str, Any] | None]:
-    """Return DNA sequence for ``data`` and optional FEC info."""
+) -> Tuple[SequenceBatch, Mapping[str, Any] | None]:
+    """Return encoded :class:`SequenceBatch` for ``data`` and optional FEC info."""
 
     if codec not in CODEC_REGISTRY:
         raise ValueError(f"Unknown codec: {codec}")
@@ -104,43 +129,111 @@ def encode(
     if fec:
         data, fec_info = FEC_REGISTRY[fec]["encode"](data)
 
-    dna = CODEC_REGISTRY[codec]["encode"](data)
-    return dna, fec_info
+    encoded = CODEC_REGISTRY[codec]["encode"](data)
+    if isinstance(encoded, SequenceBatch):
+        batch = encoded
+    elif isinstance(encoded, str):
+        batch = _wrap_single_sequence(encoded, batch_id=f"{codec}-batch", codec=codec)
+    else:
+        raise TypeError(
+            "Codec implementations must return a string or SequenceBatch"
+        )
+
+    if fec_info is not None:
+        info_dict = dict(fec_info)
+        info_dict.setdefault("batch_id", batch.batch_id)
+        info_dict.setdefault("batch_metadata", dict(batch.metadata))
+        fec_info = info_dict
+
+    return batch, fec_info
+
+
+def _parse_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _estimate_coverage(batch: SequenceBatch) -> int | None:
+    meta_value = batch.metadata.get("sim_average_coverage")
+    if meta_value is not None:
+        try:
+            return int(round(float(meta_value)))
+        except (TypeError, ValueError):
+            pass
+
+    coverages: list[int] = []
+    for oligo in batch.primary_oligos():
+        cov_val = oligo.metadata.get(RESULT_COVERAGE_KEY)
+        if cov_val is None:
+            continue
+        try:
+            coverages.append(int(cov_val))
+        except (TypeError, ValueError):
+            continue
+    if coverages:
+        return int(round(sum(coverages) / len(coverages)))
+    return None
 
 
 def simulate(
-    channel: str | None, dna: str
-) -> Tuple[str, int | None, int | None, int | None, int | None]:
+    channel: str | None, dna: SequenceBatch | str
+) -> Tuple[SequenceBatch | str, int | None, int | None, int | None, int | None]:
     """Return ``dna`` possibly mutated by ``channel`` and error counts."""
+
+    is_batch = isinstance(dna, SequenceBatch)
+    original_batch = dna if is_batch else _wrap_single_sequence(str(dna), batch_id="channel")
 
     if channel and channel != "none":
         if channel not in SIMULATOR_REGISTRY:
             raise ValueError(f"Unknown channel: {channel}")
         sim = SIMULATOR_REGISTRY[channel]
-        mutated = sim.simulate(dna)
-        subs, ins, dels = _count_errors(dna, mutated)
-        cov_func = getattr(sim, "get_coverage", None)
-        coverage = None
-        if callable(cov_func):
-            try:
-                coverage = int(cov_func(dna))
-            except Exception:  # pragma: no cover - simulator failed
-                coverage = None
-        return mutated, subs, ins, dels, coverage
-    return dna, None, None, None, None
+        result = sim.simulate(original_batch)
+        mutated_batch = (
+            result
+            if isinstance(result, SequenceBatch)
+            else _wrap_single_sequence(str(result), batch_id=original_batch.batch_id)
+        )
+
+        original_sequence = original_batch.primary_sequence()
+        mutated_sequence = mutated_batch.primary_sequence()
+        subs, ins, dels = _count_errors(original_sequence, mutated_sequence)
+
+        coverage = _estimate_coverage(mutated_batch)
+        if coverage is None:
+            cov_func = getattr(sim, "get_coverage", None)
+            if callable(cov_func):
+                try:
+                    coverage = int(cov_func(original_sequence))
+                except Exception:  # pragma: no cover - simulator failed
+                    coverage = None
+
+        return (
+            mutated_batch if is_batch else mutated_sequence,
+            subs,
+            ins,
+            dels,
+            coverage,
+        )
+
+    return (dna if is_batch else str(dna)), None, None, None, None
 
 
 def decode(
     codec: str,
     fec: str | None,
-    dna: str,
+    dna: SequenceBatch | str,
     fec_info: Mapping[str, Any] | None,
 ) -> bytes:
     """Return decoded bytes from ``dna`` applying optional FEC."""
 
     if codec not in CODEC_REGISTRY:
         raise ValueError(f"Unknown codec: {codec}")
-    decoded_any = CODEC_REGISTRY[codec]["decode"](dna)
+
+    batch = dna if isinstance(dna, SequenceBatch) else _wrap_single_sequence(str(dna))
+    decoded_any = CODEC_REGISTRY[codec]["decode"](batch.primary_sequence())
     assert isinstance(decoded_any, (bytes, bytearray))
     decoded = bytes(decoded_any)
 
@@ -148,13 +241,15 @@ def decode(
         if fec not in FEC_REGISTRY:
             raise ValueError(f"Unknown FEC: {fec}")
         assert fec_info is not None
-        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, fec_info)
+        combined_info: dict[str, Any] = {"batch_id": batch.batch_id, **batch.metadata}
+        combined_info.update(fec_info)
+        decoded, _ = FEC_REGISTRY[fec]["decode"](decoded, combined_info)
 
     return decoded
 
 
 def metrics(
-    dna: str,
+    dna: SequenceBatch | str,
     original_data: bytes,
     decoded: bytes,
     fec: str | None,
@@ -169,10 +264,74 @@ def metrics(
 ) -> Dict[str, Any]:
     """Return quality metrics for ``dna`` and decode results."""
 
-    gc_content = calculate_gc_content(dna)
-    max_homopolymer = get_max_homopolymer_length(dna)
-    gc_dist = _gc_distribution(dna)
-    hp_runs = _homopolymer_runs(dna)
+    batch = dna if isinstance(dna, SequenceBatch) else None
+    if batch is not None:
+        base_sequence = batch.primary_sequence() or batch.combined_sequence()
+        primary_oligos = batch.primary_oligos() or batch.oligos
+        sequences = [ol.sequence for ol in primary_oligos] or [base_sequence]
+
+        per_oligo_dropout: list[bool] = []
+        per_oligo_coverage: list[int | None] = []
+        per_oligo_mutations: list[dict[str, int]] = []
+        for ol in primary_oligos:
+            dropout_flag = _parse_bool(ol.metadata.get(RESULT_DROPOUT_FLAG_KEY, False))
+            per_oligo_dropout.append(dropout_flag)
+
+            coverage_val = ol.metadata.get(RESULT_COVERAGE_KEY)
+            coverage_int: int | None
+            try:
+                coverage_int = int(coverage_val) if coverage_val is not None else None
+            except (TypeError, ValueError):
+                coverage_int = None
+            per_oligo_coverage.append(coverage_int)
+
+            mutations_val = ol.metadata.get(RESULT_MUTATION_TOTALS_KEY)
+            mutation_counts: dict[str, int] = {}
+            if mutations_val is not None:
+                parsed: dict[str, Any] | None
+                if isinstance(mutations_val, str):
+                    try:
+                        parsed = json.loads(mutations_val)
+                    except json.JSONDecodeError:
+                        parsed = None
+                elif isinstance(mutations_val, Mapping):
+                    parsed = dict(mutations_val)
+                else:
+                    parsed = None
+                if parsed:
+                    for key in ("substitutions", "insertions", "deletions"):
+                        try:
+                            mutation_counts[key] = int(parsed.get(key, 0))
+                        except (TypeError, ValueError):
+                            mutation_counts[key] = 0
+            per_oligo_mutations.append(mutation_counts)
+
+        dropout_list = per_oligo_dropout or [False] * len(sequences)
+        per_oligo_coverage = (
+            per_oligo_coverage
+            if any(value is not None for value in per_oligo_coverage)
+            else [None] * len(sequences)
+        )
+        per_oligo_mutations = (
+            per_oligo_mutations
+            if any(mutation_counts for mutation_counts in per_oligo_mutations)
+            else [{} for _ in sequences]
+        )
+
+        coverage = coverage if coverage is not None else _estimate_coverage(batch)
+    else:
+        base_sequence = str(dna)
+        sequences = list(oligos or [base_sequence])
+        dropout_list = list(dropout_flags) if dropout_flags is not None else [False] * len(sequences)
+        if len(dropout_list) < len(sequences):
+            dropout_list.extend([False] * (len(sequences) - len(dropout_list)))
+        per_oligo_coverage = [None] * len(sequences)
+        per_oligo_mutations = [{} for _ in sequences]
+
+    gc_content = calculate_gc_content(base_sequence)
+    max_homopolymer = get_max_homopolymer_length(base_sequence)
+    gc_dist = _gc_distribution(base_sequence)
+    hp_runs = _homopolymer_runs(base_sequence)
     gc_variance = (
         sum((val - gc_content) ** 2 for val in gc_dist) / len(gc_dist)
         if gc_dist
@@ -184,19 +343,10 @@ def metrics(
     try:
         from .synthesis import validate_sequence
 
-        if not validate_sequence(dna):
+        if not validate_sequence(base_sequence):
             constraint_violations = 1
     except Exception:  # pragma: no cover - optional dependency
         constraint_violations = 0
-
-    sequences: list[str] = list(oligos or [dna])
-    dropout_list: list[bool] = (
-        list(dropout_flags)
-        if dropout_flags is not None
-        else [False] * len(sequences)
-    )
-    if len(dropout_list) < len(sequences):
-        dropout_list.extend([False] * (len(sequences) - len(dropout_list)))
 
     per_oligo_gc = [calculate_gc_content(seq) for seq in sequences]
     per_oligo_hp = [get_max_homopolymer_length(seq) for seq in sequences]
@@ -230,6 +380,8 @@ def metrics(
             "gc_percentages": per_oligo_gc,
             "max_homopolymers": per_oligo_hp,
             "dropout_flags": [bool(flag) for flag in dropout_list[: len(sequences)]],
+            "coverage": per_oligo_coverage,
+            "mutation_counts": per_oligo_mutations,
             "ecc_success": ecc_map or ({fec: [success]} if fec else {}),
         },
     }
@@ -252,13 +404,14 @@ def run_pipeline(
     init_plugins()
 
     original_data = Path(input_path).read_bytes()
-    dna, fec_info = encode(codec, fec, original_data)
-    dna, subs, ins, dels, coverage = simulate(channel, dna)
-    decoded = decode(codec, fec, dna, fec_info)
+    dna_batch, fec_info = encode(codec, fec, original_data)
+    simulated, subs, ins, dels, coverage = simulate(channel, dna_batch)
+    batch_result = simulated if isinstance(simulated, SequenceBatch) else _wrap_single_sequence(simulated)
+    decoded = decode(codec, fec, batch_result, fec_info)
 
     Path(output_path).write_bytes(decoded)
     metrics_dict = metrics(
-        dna,
+        batch_result,
         original_data,
         decoded,
         fec,

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence, Tuple
 from .plugin_manager import init_plugins
 from .parallel import parallel_map
 from .core import encode, simulate, decode, metrics as gather_metrics
+from .formats import SequenceBatch
 
 __all__ = ["SequencePipeline", "run_pipeline"]
 
@@ -73,6 +74,11 @@ def _homopolymer_runs(sequence: str) -> List[int]:
     return [counts.get(i, 0) for i in range(1, max_run + 1)]
 
 
+def _wrap_pipeline_sequence(sequence: str) -> SequenceBatch:
+    header = "batch_id=pipeline oligo_index=1"
+    return SequenceBatch.build([(header, sequence)], batch_id="pipeline")
+
+
 class SequencePipeline:
     """Process sequences through a series of transformation steps."""
 
@@ -120,16 +126,19 @@ def run_pipeline(
     init_plugins()
 
     original_data = Path(input_path).read_bytes()
-    dna, fec_info = encode(codec, fec_backend, original_data)
+    dna_batch, fec_info = encode(codec, fec_backend, original_data)
     selected_channel = channel
     if fec_backend == "fountain" and channel in {"simple", "nanopore"}:
         selected_channel = None
-    dna, subs, ins, dels, coverage = simulate(selected_channel, dna)
-    decoded = decode(codec, fec_backend, dna, fec_info)
+    simulated, subs, ins, dels, coverage = simulate(selected_channel, dna_batch)
+    batch_result = (
+        simulated if isinstance(simulated, SequenceBatch) else _wrap_pipeline_sequence(simulated)
+    )
+    decoded = decode(codec, fec_backend, batch_result, fec_info)
 
     Path(output_path).write_bytes(decoded)
     metrics_dict = gather_metrics(
-        dna,
+        batch_result,
         original_data,
         decoded,
         fec_backend,

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from genecoder.core import encode, simulate, decode, metrics as gather_metrics, run_pipeline
+from genecoder.formats import SequenceBatch
 from genecoder.api import Codec
 from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
@@ -43,8 +44,10 @@ def test_roundtrip_rs_simple(tmp_path: Path) -> None:
 def test_encode_helper() -> None:
     init_plugins()
     CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    expected = _Base4Codec().encode(b"hi")
     dna, fec_info = encode("base4", None, b"hi")
-    assert isinstance(dna, str)
+    assert isinstance(dna, SequenceBatch)
+    assert dna.primary_sequence() == expected
     assert fec_info is None
 
 
@@ -70,3 +73,5 @@ def test_metrics_helper() -> None:
     m = gather_metrics(dna, data, data, None)
     assert m["decode_success_rate"] == 1.0
     assert "gc_content" in m
+    assert m["oligo_metrics"]["dropout_flags"] == [False]
+    assert m["oligo_metrics"]["coverage"] == [None]

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -49,10 +49,15 @@ def test_pipeline_roundtrip(tmp_path: Path, fec_backend: str) -> None:
     assert metrics["gc_content"] >= 0.0
     assert outp.read_bytes() == data
     assert info is not None
+    assert "batch_metadata" in info
     if fec_backend == "reed_solomon":
         assert "nsym" in info
+        assert info["batch_metadata"]["batch_id"].startswith("base4")
     else:
         assert "seed" in info
+        assert "chunk_size" in info
+        assert info["batch_metadata"]["batch_id"].startswith("base4")
+    assert len(metrics["oligo_metrics"]["dropout_flags"]) >= 1
 
 
 @pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")


### PR DESCRIPTION
## Summary
- Update the core encode/simulate/decode/metrics helpers to operate on `SequenceBatch` objects and surface simulator metadata
- Propagate the batch-aware flow through the pipeline module and CLI pipeline entrypoint
- Refresh core pipeline tests to validate `SequenceBatch` handling and dropout metrics

## Testing
- `pytest tests/test_core_pipeline.py tests/test_pipeline_roundtrip.py tests/test_rs_illumina_pipeline.py tests/test_fountain_nanopore_pipeline.py tests/test_manifest.py`
- `ruff check src/genecoder/core.py src/genecoder/pipeline.py src/genecoder/cli/pipeline.py tests/test_core_pipeline.py tests/test_pipeline_roundtrip.py`


------
https://chatgpt.com/codex/tasks/task_e_68de8bbf73bc8326a2089a1cb520e8bb