### PR TITLE
Document enforced GC/homopolymer defaults and overrides

### DIFF
--- a/docs/gui_tutorial.md
+++ b/docs/gui_tutorial.md
@@ -33,7 +33,11 @@ input file.
 
 Use the buttons at the bottom of each tab to start the selected operation. The updated dashboard highlights per-oligo dropout flags, coverage heatmaps and recovery percentages so you can see how the multi-oligo pipeline behaves immediately after a run.
 
-After encoding completes, GC and homopolymer metrics are shown. If they fall outside recommended ranges, a **Fix Sequence** button allows automatic adjustment. Clicking it displays the fixed DNA snippet and updated metrics.
+After encoding completes, GC and homopolymer metrics are shown. The app uses the
+same enforced defaults as the CLI (45–55% GC and a three-base homopolymer cap).
+If a sequence violates those guardrails, a **Fix Sequence** button allows
+automatic adjustment. Clicking it displays the fixed DNA snippet and updated
+metrics.
 
 Example: encode any file, then click **Fix Sequence** when the suggestion text appears to view the corrected sequence.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,8 +111,12 @@ See [WORKFLOWS.md](../WORKFLOWS.md) for a step-by-step overview.
    ```bash
    genecli encode --input-files file1.txt notes.md image.png \
        --output-dir gc_encoded_batch/ --method gc_balanced \
-       --gc-min 0.40 --gc-max 0.60 --max-homopolymer 4
+       --gc-min 0.40 --gc-max 0.60 --max-homopolymer 5
    ```
+
+   The CLI enforces a 45–55% GC window and a maximum homopolymer length of 3 by
+   default. The flags above relax those limits for workloads that tolerate
+   higher variance.
 
 9. **Batch decode multiple FASTA files**
 
@@ -606,9 +610,9 @@ Example metrics snippet:
 ### Constraint Fix Suggestions
 
 Both the CLI `analyze` command and the GUI provide simple suggestions when a
-sequence falls outside the 40-60% GC range or exceeds the default homopolymer
-limit. After running `genecli analyze`, a log entry shows the GC content and
-maximum homopolymer length of an adjusted sequence. The GUI displays a
+sequence falls outside the enforced 45–55% GC window or exceeds the default
+three-base homopolymer limit. After running `genecli analyze`, a log entry shows
+the GC content and maximum homopolymer length of an adjusted sequence. The GUI displays a
 "Suggested fix" message beneath the encoding status when applicable.
 
 The **Visualizer** tab embeds a dedicated React/Three.js frontend. It renders the
@@ -643,3 +647,31 @@ GeneCoder is intended for educational simulations only. It should not be used
 to handle personal or medical DNA data. See the
 [README's Disclaimer](../README.md#disclaimer) for full details.
 
+#### Default GC/homopolymer guardrails
+
+`genecli encode`, the GUI, and constraint-fixing helpers all validate payloads
+against an enforced 45–55% GC range and a maximum homopolymer run of 3 bases.
+These checks run even if you do not pass constraint flags. When a sequence falls
+outside those guardrails, the CLI logs a warning and the GUI highlights the
+violation.
+
+Override the defaults by supplying constraint options explicitly:
+
+```bash
+genecli encode input.bin --method gc_balanced \
+    --gc-min 0.40 --gc-max 0.60 --max-homopolymer 5
+```
+
+YAML configurations and the pipeline runner accept the same keys:
+
+```yaml
+constraints:
+  gc_min: 0.40
+  gc_max: 0.60
+  max_homopolymer: 5
+```
+
+You can also provide the parameters when calling `genecli analyze`, `genecli
+bundle`, or the dashboard pipeline presets. If you simply want to silence the
+warnings while keeping the defaults, pass `--suppress-constraint-warnings` to
+`genecli encode`.

--- a/docs/web_api_tutorial.md
+++ b/docs/web_api_tutorial.md
@@ -98,13 +98,14 @@ POST /design/validate
 ```
 
 The response reports whether the sequence falls within the supplied GC
-and homopolymer limits.
+and homopolymer limits. When you omit the fields, the service applies the same
+defaults as the CLI: 45–55% GC content and a maximum homopolymer length of 3.
 
 To automatically adjust a sequence, call `/design/fix`:
 
 ```json
 POST /design/fix
-{ "sequence": "AAAAAA", "gc_min": 0.4, "gc_max": 0.6, "max_homopolymer": 3 }
+{ "sequence": "AAAAAA", "gc_min": 0.4, "gc_max": 0.6, "max_homopolymer": 5 }
 ```
 
 The fixed sequence and its metrics are returned in the JSON response.


### PR DESCRIPTION
## Summary
- clarify that GeneCoder enforces a 45–55% GC window and three-base homopolymer limit by default
- document how to override the constraint guardrails from the CLI, YAML configs, GUI, and web API
- refresh examples so they demonstrate relaxing the defaults when needed

## Testing
- PYTHONPATH=/workspace/GeneCoder mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68e3e006fb8c8326b8f81a79ee1d8b59