### PR TITLE
Remove FrameD packaging extras and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ To run **all** tests, including those covering optional codecs and machine
 learning models, install every extras group:
 
 ```bash
-poetry install --with gui,web,dnaformer,deepdna,ldpc,fountain,raptorq,bch,framed --no-interaction
+poetry install --with gui,web,dnaformer,deepdna,ldpc,fountain,raptorq,bch --no-interaction
 ```
 
 You can also run `scripts/setup_test_env.sh` to install the same extras.

--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ GUI and web features are optional. Install their dependencies with:
 poetry install --with gui,web --no-interaction
 ```
 
-Additional plugins such as DNAformer or FrameD can be installed via
-Poetry's ``--extras`` flag:
+Additional plugins such as DNAformer can be installed via
+Poetry's ``--extras`` flag. FrameD remains available as a manual install due to
+its LGPL license:
 
 ```bash
-poetry install --extras dnaformer --extras framed --no-interaction
+poetry install --extras dnaformer --no-interaction
 ```
 
 GeneCoder now uses a single `poetry.lock` across Linux, macOS and Windows.
@@ -146,7 +147,6 @@ test suite:
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
 | `raptorq`     | RaptorQ FEC algorithms                          |
-| `framed`      | FrameD C++ backend                              |
 | `dnaformer`   | DNAformer AI codec                              |
 | `deepdna`     | DeepDNA FEC plugin                              |
 
@@ -155,14 +155,15 @@ Install all groups required for development and testing with:
 ```bash
 poetry install --with gui,web,dev \
   --extras ldpc --extras fountain --extras bch \
-  --extras raptorq --extras framed --extras dnaformer \
+  --extras raptorq --extras dnaformer \
   --extras deepdna --no-interaction
 ```
 
 Installing all extras downloads many large packages such as Flet and
 framework backends. Expect the installation to consume around **2&nbsp;GB** of
 disk space and take roughly **10&nbsp;minutes** on a typical broadband
-connection.
+connection. Install the third-party `FrameD` package separately if you need
+that codec's C++ acceleration.
 
 For running GeneCoder without any network access see the [offline usage guide](docs/offline_usage.md) and the [offline setup notes](docs/installation.md#offline-setup).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 
 * **CLI for encoding and decoding** using multiple methods.
 * **GC-Balanced encoding** with tunable constraints on [GC content](glossary.md#gc-content).
-* **[Forward Error Correction](glossary.md#forward-error-correction-fec)** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and the optional FrameD C++ backend.
+* **[Forward Error Correction](glossary.md#forward-error-correction-fec)** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and optional third-party backends like FrameD (install manually due to LGPL licensing).
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,6 @@ the optional groups and what they provide:
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
 | `raptorq`     | RaptorQ FEC algorithms                          |
-| `framed`      | FrameD C++ backend                              |
 | `dnaformer`   | DNAformer AI codec                              |
 | `deepdna`     | DeepDNA FEC plugin                              |
 
@@ -55,13 +54,18 @@ Install every group required for development and testing with:
 ```bash
 poetry install --with gui,web,dev \
   --extras ldpc --extras fountain --extras bch \
-  --extras raptorq --extras framed --extras dnaformer \
+  --extras raptorq --extras dnaformer \
   --extras deepdna --no-interaction
 ```
 
 These packages are quite large (Flet and the various FEC backends in
 particular). Installing all of them uses roughly **2&nbsp;GB** of disk space and
 takes about **10&nbsp;minutes** on a typical broadband connection.
+
+> **FrameD availability:** GeneCoder still ships a Python wrapper for FrameD but
+> no longer bundles the LGPL-licensed C++ dependency. Install the
+> [`FrameD` package](https://pypi.org/project/FrameD/) manually if you need this
+> backend and ensure it is on the Python path before importing GeneCoder.
 
 ## Editable install with pip
 
@@ -171,30 +175,16 @@ poetry install --extras deepdna --no-interaction
 
 The codec registers itself automatically when imported.
 
-## FrameD FEC Backend
-
-The optional FrameD plugin wraps optimized C++ kernels using CFFI to provide additional
-[FEC](glossary.md#forward-error-correction-fec) methods.
-Install it using the ``framed`` extras:
-
-```bash
-poetry install --extras framed --no-interaction
-```
-
-
-
-The `framed` FEC method becomes available automatically after
-installation.
-
 ## Licenses for Optional Extras
 
 GeneCoder itself and all core functionality use permissive licenses. Some
 optional extras come with additional requirements:
 
-* **FrameD** &ndash; [LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.html)
 * **DeepDNA** &ndash; [MIT](https://opensource.org/license/mit/)
 
-These components are only needed when installing the corresponding extras.
+FrameD remains available under the LGPL but must be installed separately as it
+is no longer distributed with GeneCoder. Other components are only needed when
+installing the corresponding extras.
 
 ## Custom Temporary Directory
 

--- a/docs/technology_stack.md
+++ b/docs/technology_stack.md
@@ -14,9 +14,11 @@ installed:
 
 - **LDPC** via `pyldpc` – experimental low-density parity-check codes.
 - **Fountain** via `pyfinite` – simple rateless encoding with parity chunks.
-- **FrameD** via `cffi` – wrappers around optimized C++ kernels.
+- **FrameD** wrapper via `cffi` – requires the external LGPL `FrameD` package installed separately.
 
-Install these with Poetry extras, for example `poetry install --extras framed`.
+Install these with Poetry extras. The FrameD wrapper is provided for
+compatibility but the underlying library is no longer bundled; install it
+manually with `pip install FrameD` if needed.
 
 ## Web Components
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3487,11 +3487,10 @@ chamaeleo = ["chamaeleo"]
 deepdna = []
 dnaformer = []
 fountain = ["pyfinite"]
-framed = []
 ldpc = ["numpy", "pyldpc"]
 raptorq = ["numpy", "raptorq"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "26a29af98c38dcef5c446817ca2b1c0e4f9509c3a9821c2744d8558be0fa762b"
+content-hash = "83865dec35f227b77f85123e70ea64f5d61a0bf65c785704985f984ccb2a0e2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ pyldpc = ">=0.7.6,<0.7.7"
 pyfinite = ">=1.9,<2.0"
 bchlib = ">=2.1,<3.0"
 raptorq = ">=2.0,<3.0"
-FrameD = "*"
 numba = "*"
 playwright = "*"
 
@@ -100,7 +99,6 @@ ldpc = "genecoder.ldpc_codec"
 fountain = "genecoder.fountain_codec"
 bch = "genecoder.bch_codec"
 raptorq = "genecoder.raptorq_codec"
-framed = "genecoder.fec.framed"
 dnaformer = "genecoder.dnaformer_codec"
 deepdna = "genecoder.deepdna_codec"
 
@@ -115,7 +113,6 @@ illumina = "genecoder.simulators.illumina"
 
 [tool.poetry.extras]
 dnaformer = ["dnaformer", "torch"]
-framed = ["FrameD"]
 ldpc = ["pyldpc", "numpy"]
 fountain = ["pyfinite"]
 raptorq = ["raptorq", "numpy"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,15 @@ import json
 import os
 import sys
 import types
+from pathlib import Path
 from typing import Mapping, Sequence
 
 import pytest
 
 # Ensure the ``src`` directory is importable
-ROOT = os.path.dirname(os.path.dirname(__file__))
-SRC = os.path.join(ROOT, "src")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ROOT = str(PROJECT_ROOT)
+SRC = str(PROJECT_ROOT / "src")
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 if SRC not in sys.path:


### PR DESCRIPTION
## Summary
- remove the FrameD development dependency, extra, and plugin entry from the packaging metadata and refresh the lock file metadata
- update installation, features, technology stack, README, and contributor docs to explain that FrameD must be installed manually due to its LGPL license
- expose the `PROJECT_ROOT` constant from the shared pytest configuration so tests that import it can resolve the project directory

## Testing
- `pytest -q` *(fails: numerous pre-existing assertion and type errors across the CLI, bundle, pipeline, and plugin test suites)*
- `ruff check` *(fails: pre-existing lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e91a4adda48326bcf9fed8ac8cd61b