### PR TITLE
Support SequenceBatch-aware decode paths

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,17 +22,35 @@ and implement ``encode`` and ``decode`` methods:
 
 ```python
 from genecoder.api import Codec
+from genecoder.formats import SequenceBatch
+
 
 class MyCodec(Codec):
     def encode(self, data: bytes, /, **kwargs: object) -> str:
         ...
 
-    def decode(self, text: str, /, **kwargs: object) -> bytes:
+    def decode(
+        self,
+        encoded: SequenceBatch | str,
+        /,
+        *,
+        batch_metadata: dict[str, str] | None = None,
+        oligo_metadata: list[dict[str, str]] | None = None,
+        **kwargs: object,
+    ) -> bytes:
         ...
+
 
 def register(register_codec):
     register_codec("mycodec", MyCodec)
 ```
+
+Annotating the ``encoded`` parameter with :class:`~genecoder.formats.SequenceBatch`
+signals that the codec can operate on batches. When present GeneCoder passes the
+full :class:`SequenceBatch` object along with convenience keyword arguments
+containing ``batch_metadata`` and ``oligo_metadata`` dictionaries. Codecs that
+prefer not to use type annotations may instead set ``accepts_sequence_batch =
+True`` on the codec instance or class.
 
 ### Channels
 
@@ -144,13 +162,24 @@ visualizers. The general workflow is:
 
 ```python
 from genecoder.api import Codec
+from genecoder.formats import SequenceBatch
+
 
 class MyCodec(Codec):
     def encode(self, data: bytes, /, **kwargs: object) -> str:
         ...
 
-    def decode(self, text: str, /, **kwargs: object) -> bytes:
+    def decode(
+        self,
+        encoded: SequenceBatch | str,
+        /,
+        *,
+        batch_metadata: dict[str, str] | None = None,
+        oligo_metadata: list[dict[str, str]] | None = None,
+        **kwargs: object,
+    ) -> bytes:
         ...
+
 
 def register(register_codec):
     register_codec("mycodec", MyCodec)
@@ -242,13 +271,17 @@ adding your encode/decode logic the module may look like:
 ```python
 # mycodec/mycodec/plugin.py
 from genecoder.api import Codec
+from genecoder.formats import SequenceBatch
+
 
 class MyCodec(Codec):
     def encode(self, data: bytes) -> str:
         return data.decode().upper()
 
-    def decode(self, text: str) -> bytes:
+    def decode(self, encoded: SequenceBatch | str) -> bytes:
+        text = encoded.primary_sequence() if isinstance(encoded, SequenceBatch) else encoded
         return text.lower().encode()
+
 
 def register(register_plugin):
     register_plugin("mycodec", MyCodec())
@@ -273,13 +306,15 @@ genecli plugin list   # confirms the plugin is available
    # src/plugins/reverse_codec.py
    from typing import Callable
    from genecoder.api import Codec
+   from genecoder.formats import SequenceBatch
 
    class ReverseCodec(Codec):
        def encode(self, data: bytes, /, **kwargs: object) -> str:
            return data[::-1].decode("utf-8")
 
-       def decode(self, encoded: str, /, **kwargs: object) -> bytes:
-           return encoded[::-1].encode("utf-8")
+       def decode(self, encoded: SequenceBatch | str, /, **kwargs: object) -> bytes:
+           text = encoded.primary_sequence() if isinstance(encoded, SequenceBatch) else encoded
+           return text[::-1].encode("utf-8")
 
    def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
        register_codec("reverse", ReverseCodec)
@@ -317,11 +352,11 @@ implementations of each entry point group.
 
 Channel plugins are adapters around
 [``genecoder.api.Simulator``](api_reference.md#genecoder.api.Simulator). The
-base class requires a ``simulate(sequence: str) -> str`` method that returns the
-mutated DNA sequence for the downstream pipeline. Implementations may override
-``with_profile(profile: str)`` to support external error profiles; the default
-implementation raises ``NotImplementedError`` so simulators that expose profile
-selection must supply their own version.
+base class requires a ``simulate(sequence: str | SequenceBatch) -> SequenceBatch``
+method that returns the mutated DNA sequence(s) for the downstream pipeline.
+Implementations may override ``with_profile(profile: str)`` to support external
+error profiles; the default implementation raises ``NotImplementedError`` so
+simulators that expose profile selection must supply their own version.
 
 Simulators are discovered from the ``genecoder.simulators`` entry-point group
 and should use a short, descriptive slug for the entry-point key. The slug is

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -39,13 +39,16 @@ class Codec(ABC):
         """
 
     @abstractmethod
-    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:
+    def decode(self, encoded: "SequenceBatch" | str, /, **kwargs: Any) -> bytes:
         """Decode ``encoded`` back into the original byte sequence.
 
         Parameters
         ----------
         encoded:
-            The sequence returned by :meth:`encode`.
+            The sequence returned by :meth:`encode`. Implementations that
+            advertise support for batch-aware decoding receive a
+            :class:`~genecoder.formats.SequenceBatch`. Legacy codecs continue to
+            be passed a plain string containing the primary sequence.
         **kwargs:
             Optional codec specific parameters.
 

--- a/src/genecoder/cli/decode.py
+++ b/src/genecoder/cli/decode.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import os
 import re
+from dataclasses import replace
 from pathlib import Path
 
 
@@ -59,18 +60,27 @@ def _get_header_filename(file_path: str) -> str | None:
     return None
 
 def run_decoding_pipeline(
-    sequence: str, header: str, options: DecodingOptions, input_file_name: str
+    sequence: str | SequenceBatch,
+    header: str | None,
+    options: DecodingOptions,
+    input_file_name: str,
 ) -> bytes:
-    dna_for_primary = sequence
+    batch: SequenceBatch | None = sequence if isinstance(sequence, SequenceBatch) else None
+    if batch is not None:
+        dna_for_primary = batch.primary_sequence() or batch.combined_sequence()
+        header_value = header or batch.first_header()
+    else:
+        dna_for_primary = sequence
+        header_value = header or ""
     _, decode_map = get_alphabet_maps(options.alphabet)
-    if "fec=triple_repeat" in header:
+    if "fec=triple_repeat" in header_value:
         logger.info(f"Triple-Repeat FEC detected in header for {input_file_name}.")
-        if len(sequence) % 3 != 0:
+        if len(dna_for_primary) % 3 != 0:
             logger.warning(
-                f"Warning for {input_file_name}: Sequence length {len(sequence)} is not multiple of 3 for Triple-Repeat FEC. Attempting decode."
+                f"Warning for {input_file_name}: Sequence length {len(dna_for_primary)} is not multiple of 3 for Triple-Repeat FEC. Attempting decode."
             )
         try:
-            dna_for_primary, corrected_tr, uncorr_tr = decode_triple_repeat(sequence)
+            dna_for_primary, corrected_tr, uncorr_tr = decode_triple_repeat(dna_for_primary)
             logger.info(
                 f"Triple-Repeat FEC decoding for {input_file_name}: {corrected_tr} corrected, {uncorr_tr} uncorrectable errors in triplets."
             )
@@ -83,7 +93,7 @@ def run_decoding_pipeline(
     fec_names = [f"fec={name}" for name in FEC_REGISTRY]
     should_check_parity = (
         options.check_parity
-        and not any(tag in header for tag in fec_names)
+        and not any(tag in header_value for tag in fec_names)
     )
 
     if options.method == "base4_direct":
@@ -105,9 +115,9 @@ def run_decoding_pipeline(
             logger.warning(
                 f"Warning for {input_file_name}: --check-parity is not applicable to 'gc_balanced' method's DNA layer."
             )
-        gc_min_match = re.search(r"gc_min=([\d.]+)", header)
-        gc_max_match = re.search(r"gc_max=([\d.]+)", header)
-        max_hp_match = re.search(r"max_homopolymer=(\d+)", header)
+        gc_min_match = re.search(r"gc_min=([\d.]+)", header_value)
+        gc_max_match = re.search(r"gc_max=([\d.]+)", header_value)
+        max_hp_match = re.search(r"max_homopolymer=(\d+)", header_value)
         gc_min = float(gc_min_match.group(1)) if gc_min_match else None
         gc_max = float(gc_max_match.group(1)) if gc_max_match else None
         max_hp = int(max_hp_match.group(1)) if max_hp_match else None
@@ -133,19 +143,19 @@ def run_decoding_pipeline(
         )
 
     final_data: bytes = binary_data
-    if "fec=hamming_7_4" in header:
+    if "fec=hamming_7_4" in header_value:
         logger.info(f"Hamming(7,4) FEC detected in header for {input_file_name}.")
-        fec_padding_bits_match = re.search(r"fec_padding_bits=(\d+)", header)
+        fec_padding_bits_match = re.search(r"fec_padding_bits=(\d+)", header_value)
         if not fec_padding_bits_match:
             raise ValueError("'fec_padding_bits' missing in header for Hamming(7,4) FEC.")
         fec_padding_bits = int(fec_padding_bits_match.group(1))
         final_data, _ = decode_data_with_hamming(binary_data, fec_padding_bits)
     else:
-        fec_match = re.search(r"fec=([\w_]+)", header)
+        fec_match = re.search(r"fec=([\w_]+)", header_value)
         if fec_match:
             fec_name = fec_match.group(1)
             if fec_name in FEC_REGISTRY:
-                info_match = re.search(r"fec_info=([^ ]+)", header)
+                info_match = re.search(r"fec_info=([^ ]+)", header_value)
                 info = None
                 if info_match:
                     import base64
@@ -210,8 +220,17 @@ def process_single_decode(
                 input_file_path,
             )
 
-        header = primary_oligos[0].header
-        sequence_from_fasta = "".join(ol.sequence for ol in primary_oligos)
+        primary_batch = SequenceBatch(
+            batch_id=batch.batch_id,
+            metadata=dict(batch.metadata),
+            seed=batch.seed,
+            oligos=[replace(ol) for ol in primary_oligos],
+            legacy=batch.legacy,
+        )
+
+        header = primary_batch.oligos[0].header if primary_batch.oligos else ""
+        sequence_from_fasta = "".join(ol.sequence for ol in primary_batch.oligos)
+        oligo_lengths = [len(ol.sequence) for ol in primary_batch.oligos]
         if getattr(args, "seed", None) is None and batch.seed is not None:
             args.seed = batch.seed
 
@@ -252,10 +271,23 @@ def process_single_decode(
                     "Applied %s simulator before decoding.", args.simulator
                 )
 
+        if primary_batch.oligos:
+            if len(primary_batch.oligos) == 1:
+                primary_batch.oligos[0].sequence = sequence_from_fasta
+            else:
+                offset = 0
+                for ol, length in zip(primary_batch.oligos, oligo_lengths):
+                    ol.sequence = sequence_from_fasta[offset : offset + length]
+                    offset += length
+                if offset < len(sequence_from_fasta):
+                    primary_batch.oligos[-1].sequence += sequence_from_fasta[offset:]
 
         options = build_decoding_options(args)
         final_decoded_data = run_decoding_pipeline(
-            sequence_from_fasta, header, options, os.path.basename(input_file_path)
+            primary_batch if primary_batch.oligos else sequence_from_fasta,
+            header,
+            options,
+            os.path.basename(input_file_path),
         )
 
         _key_bytes = None

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
+import inspect
 import json
 from pathlib import Path
 from typing import Any, Mapping, Tuple, Dict, List, Sequence
+from typing import get_args, get_origin
 
 from .gc_constrained_encoder import calculate_gc_content
 from .utils import get_max_homopolymer_length
@@ -19,6 +21,49 @@ from .simulators.batch_utils import (
 )
 
 __all__ = ["encode", "simulate", "decode", "metrics", "run_pipeline"]
+
+
+def _annotation_supports_sequence_batch(annotation: object) -> bool:
+    """Return ``True`` if ``annotation`` references :class:`SequenceBatch`."""
+
+    if annotation is inspect._empty:
+        return False
+    if isinstance(annotation, str):
+        return "SequenceBatch" in annotation
+    origin = get_origin(annotation)
+    if origin is not None:
+        return any(_annotation_supports_sequence_batch(arg) for arg in get_args(annotation))
+    try:
+        return bool(annotation is SequenceBatch or issubclass(annotation, SequenceBatch))
+    except TypeError:
+        return False
+
+
+def _has_batch_flag(candidate: object) -> bool:
+    """Return ``True`` if ``candidate`` advertises batch support."""
+
+    return bool(
+        getattr(candidate, "__genecoder_accepts_batch__", False)
+        or getattr(candidate, "accepts_sequence_batch", False)
+        or getattr(candidate, "supports_sequence_batch", False)
+    )
+
+
+def _codec_accepts_sequence_batch(decode_fn: Any) -> bool:
+    """Return ``True`` when ``decode_fn`` opts into ``SequenceBatch`` inputs."""
+
+    for candidate in (decode_fn, getattr(decode_fn, "__self__", None), getattr(decode_fn, "__func__", None)):
+        if candidate is not None and _has_batch_flag(candidate):
+            return True
+    try:
+        signature = inspect.signature(decode_fn)
+    except (TypeError, ValueError):
+        return False
+    params = list(signature.parameters.values())
+    if not params:
+        return False
+    first_param = params[0]
+    return _annotation_supports_sequence_batch(first_param.annotation)
 
 
 
@@ -233,7 +278,16 @@ def decode(
         raise ValueError(f"Unknown codec: {codec}")
 
     batch = dna if isinstance(dna, SequenceBatch) else _wrap_single_sequence(str(dna))
-    decoded_any = CODEC_REGISTRY[codec]["decode"](batch.primary_sequence())
+    decode_fn = CODEC_REGISTRY[codec]["decode"]
+    primary_sequence = batch.primary_sequence()
+    if _codec_accepts_sequence_batch(decode_fn):
+        decoded_any = decode_fn(
+            batch,
+            batch_metadata=dict(batch.metadata),
+            oligo_metadata=[dict(ol.metadata) for ol in batch.oligos],
+        )
+    else:
+        decoded_any = decode_fn(primary_sequence)
     assert isinstance(decoded_any, (bytes, bytearray))
     decoded = bytes(decoded_any)
 

--- a/src/genecoder/streaming.py
+++ b/src/genecoder/streaming.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from typing import (
-    Callable,
-    Iterable,
-    Iterator,
-    Tuple,
-    Union,
-)
+import inspect
+from typing import Any, Callable, Iterable, Iterator, Tuple, Union
+from typing import get_args, get_origin
 import os
 import json
 import hashlib
@@ -20,8 +16,45 @@ from .utils import get_alphabet_maps
 from .formats import SequenceBatch
 
 
-EncodeFunc = Callable[[bytes], str]
-DecodeFunc = Callable[[str], bytes]
+DNAChunk = Union[str, SequenceBatch]
+EncodeFunc = Callable[[bytes], DNAChunk]
+DecodeFunc = Callable[[DNAChunk], bytes]
+
+
+def _annotation_supports_sequence_batch(annotation: object) -> bool:
+    if annotation is inspect._empty:
+        return False
+    if isinstance(annotation, str):
+        return "SequenceBatch" in annotation
+    origin = get_origin(annotation)
+    if origin is not None:
+        return any(_annotation_supports_sequence_batch(arg) for arg in get_args(annotation))
+    try:
+        return bool(annotation is SequenceBatch or issubclass(annotation, SequenceBatch))
+    except TypeError:
+        return False
+
+
+def _has_batch_flag(candidate: object) -> bool:
+    return bool(
+        getattr(candidate, "__genecoder_accepts_batch__", False)
+        or getattr(candidate, "accepts_sequence_batch", False)
+        or getattr(candidate, "supports_sequence_batch", False)
+    )
+
+
+def _decode_accepts_sequence_batch(decode_fn: Callable[..., Any]) -> bool:
+    for candidate in (decode_fn, getattr(decode_fn, "__self__", None), getattr(decode_fn, "__func__", None)):
+        if candidate is not None and _has_batch_flag(candidate):
+            return True
+    try:
+        signature = inspect.signature(decode_fn)
+    except (TypeError, ValueError):
+        return False
+    params = list(signature.parameters.values())
+    if not params:
+        return False
+    return _annotation_supports_sequence_batch(params[0].annotation)
 
 
 def stream_encode(
@@ -41,7 +74,7 @@ def stream_encode(
 
 
 def stream_decode(
-    dna_iter: Iterable[Union[str, Tuple[str, object]]],
+    dna_iter: Iterable[Union[DNAChunk, Tuple[DNAChunk, object]]],
     decode_fn: DecodeFunc,
     *,
     fec_decode: Callable[[bytes, object], tuple[bytes, int]] | None = None,
@@ -53,7 +86,15 @@ def stream_decode(
             dna, info = item
         else:
             dna, info = item, None
-        chunk = decode_fn(dna)
+        if isinstance(dna, SequenceBatch) and _decode_accepts_sequence_batch(decode_fn):
+            metadata_kwargs = {
+                "batch_metadata": dict(dna.metadata),
+                "oligo_metadata": [dict(ol.metadata) for ol in dna.oligos],
+            }
+            chunk = decode_fn(dna, **metadata_kwargs)
+        else:
+            dna_string = dna.primary_sequence() if isinstance(dna, SequenceBatch) else dna
+            chunk = decode_fn(dna_string)  # type: ignore[arg-type]
         if fec_decode:
             chunk, _ = fec_decode(chunk, info)
         yield idx, chunk

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from typing import Any, Mapping, Sequence
+
 from genecoder.core import encode, simulate, decode, metrics as gather_metrics, run_pipeline
 from genecoder.formats import SequenceBatch
 from genecoder.api import Codec
@@ -20,6 +22,40 @@ class _Base4Codec(Codec):
     def decode(self, encoded: str) -> bytes:  # type: ignore[override]
         from genecoder.encoders import decode_base4_direct
         return decode_base4_direct(encoded)[0]
+
+
+class _BatchAwareCodec(Codec):
+    def __init__(self) -> None:
+        self.last_batch: SequenceBatch | None = None
+        self.last_batch_metadata: Mapping[str, str] | None = None
+        self.last_oligo_metadata: list[Mapping[str, str]] | None = None
+
+    def encode(self, data: bytes, /, **kwargs: Any) -> SequenceBatch:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+
+        dna = encode_base4_direct(data)
+        half = max(1, len(dna) // 2)
+        records = [
+            ("batch_id=batchy oligo_index=1", dna[:half]),
+            ("batch_id=batchy oligo_index=2", dna[half:]),
+        ]
+        return SequenceBatch.build(records, batch_id="batchy", batch_seed=11)
+
+    def decode(
+        self,
+        encoded: SequenceBatch,
+        /,
+        *,
+        batch_metadata: Mapping[str, str] | None = None,
+        oligo_metadata: Sequence[Mapping[str, str]] | None = None,
+        **_kwargs: Any,
+    ) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+
+        self.last_batch = encoded
+        self.last_batch_metadata = dict(batch_metadata or {})
+        self.last_oligo_metadata = [dict(m) for m in (oligo_metadata or [])]
+        return decode_base4_direct(encoded.primary_sequence())[0]
 
 
 def test_roundtrip_rs_simple(tmp_path: Path) -> None:
@@ -63,6 +99,22 @@ def test_decode_helper() -> None:
     CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
     dna, fec_info = encode("base4", None, b"data")
     assert decode("base4", None, dna, fec_info) == b"data"
+
+
+def test_decode_helper_sequence_batch_metadata() -> None:
+    init_plugins()
+    codec = _BatchAwareCodec()
+    CODEC_REGISTRY["batchy"] = {"encode": codec.encode, "decode": codec.decode}
+
+    payload = b"batch aware payload"
+    dna, fec_info = encode("batchy", None, payload)
+    assert isinstance(dna, SequenceBatch)
+
+    result = decode("batchy", None, dna, fec_info)
+    assert result == payload
+    assert codec.last_batch is dna
+    assert codec.last_batch_metadata == dict(dna.metadata)
+    assert codec.last_oligo_metadata == [dict(ol.metadata) for ol in dna.oligos]
 
 
 def test_metrics_helper() -> None:


### PR DESCRIPTION
## Summary
- allow codecs to advertise SequenceBatch-aware decode methods and supply batch metadata during pipeline decoding
- thread SequenceBatch objects through CLI and streaming helpers so multi-oligo payloads keep per-oligo headers
- add regression coverage and documentation describing the new decoder contract for plugin authors

## Testing
- poetry run pytest tests/test_core_pipeline.py tests/test_cli_decode.py

------
https://chatgpt.com/codex/tasks/task_e_68ee6a1790148326a4170000bdb1cc21