### PR TITLE
Clarify FrameD removal and document FEC alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - **Breaking:** Simulator plugins must adopt the ``SequenceBatch`` API. Example
   packages now emit metadata for batch IDs, seeds and coverage, and declare a
   minimum dependency of ``genecoder>=0.2.0``.
+- Removed the deprecated FrameD wrapper and documented LDPC, Fountain and
+  RaptorQ extras as the supported advanced FEC alternatives.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ poetry install --with gui,web --no-interaction
 ```
 
 Additional plugins such as DNAformer can be installed via
-Poetry's ``--extras`` flag. FrameD remains available as a manual install due to
-its LGPL license:
+Poetry's ``--extras`` flag:
 
 ```bash
 poetry install --extras dnaformer --no-interaction
@@ -150,6 +149,11 @@ test suite:
 | `dnaformer`   | DNAformer AI codec                              |
 | `deepdna`     | DeepDNA FEC plugin                              |
 
+> **FrameD removal notice:** GeneCoder 0.2.0 and later no longer ship the
+> FrameD wrapper because the upstream library fell out of maintenance. The LDPC,
+> Fountain and RaptorQ extras cover the advanced FEC use cases previously
+> handled by FrameD.
+
 Install all groups required for development and testing with:
 
 ```bash
@@ -162,8 +166,9 @@ poetry install --with gui,web,dev \
 Installing all extras downloads many large packages such as Flet and
 framework backends. Expect the installation to consume around **2&nbsp;GB** of
 disk space and take roughly **10&nbsp;minutes** on a typical broadband
-connection. Install the third-party `FrameD` package separately if you need
-that codec's C++ acceleration.
+connection. FrameD support has been removed because the upstream LGPL bundle is
+no longer maintained; use the LDPC, Fountain or RaptorQ extras when you need
+advanced forward-error-correction.
 
 For running GeneCoder without any network access see the [offline usage guide](docs/offline_usage.md) and the [offline setup notes](docs/installation.md#offline-setup).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 
 * **CLI for encoding and decoding** using multiple methods.
 * **GC-Balanced encoding** with tunable constraints on [GC content](glossary.md#gc-content).
-* **[Forward Error Correction](glossary.md#forward-error-correction-fec)** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and optional third-party backends like FrameD (install manually due to LGPL licensing).
+* **[Forward Error Correction](glossary.md#forward-error-correction-fec)** options such as Triple-Repeat, Hamming(7,4), Reed-Solomon and optional extras for LDPC, Fountain or RaptorQ codes. FrameD integration has been removed because the upstream project is no longer maintained.
 * **Parity checks** for additional error detection.
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,10 +62,10 @@ These packages are quite large (Flet and the various FEC backends in
 particular). Installing all of them uses roughly **2&nbsp;GB** of disk space and
 takes about **10&nbsp;minutes** on a typical broadband connection.
 
-> **FrameD availability:** GeneCoder still ships a Python wrapper for FrameD but
-> no longer bundles the LGPL-licensed C++ dependency. Install the
-> [`FrameD` package](https://pypi.org/project/FrameD/) manually if you need this
-> backend and ensure it is on the Python path before importing GeneCoder.
+> **FrameD availability:** FrameD support has been retired and the wrapper is no
+> longer distributed. The upstream LGPL package is unmaintained on modern
+> platforms, so GeneCoder now recommends the LDPC, Fountain or RaptorQ extras
+> when advanced forward-error-correction is required.
 
 ## Editable install with pip
 
@@ -182,9 +182,10 @@ optional extras come with additional requirements:
 
 * **DeepDNA** &ndash; [MIT](https://opensource.org/license/mit/)
 
-FrameD remains available under the LGPL but must be installed separately as it
-is no longer distributed with GeneCoder. Other components are only needed when
-installing the corresponding extras.
+FrameD is no longer supported by GeneCoder because the upstream project is
+unmaintained. LDPC, Fountain and RaptorQ extras provide advanced
+forward-error-correction under permissive licenses. Other components are only
+needed when installing the corresponding extras.
 
 ## Custom Temporary Directory
 

--- a/docs/technology_stack.md
+++ b/docs/technology_stack.md
@@ -14,11 +14,12 @@ installed:
 
 - **LDPC** via `pyldpc` – experimental low-density parity-check codes.
 - **Fountain** via `pyfinite` – simple rateless encoding with parity chunks.
-- **FrameD** wrapper via `cffi` – requires the external LGPL `FrameD` package installed separately.
+- **RaptorQ** via `raptorq` – high-throughput fountain-style repair symbols.
 
-Install these with Poetry extras. The FrameD wrapper is provided for
-compatibility but the underlying library is no longer bundled; install it
-manually with `pip install FrameD` if needed.
+Install these with Poetry extras. The former FrameD integration has been
+removed because the upstream project is unmaintained on modern platforms; the
+LDPC, Fountain and RaptorQ extras cover the advanced FEC use cases previously
+served by FrameD.
 
 ## Web Components
 


### PR DESCRIPTION
## Summary
- update the README and user documentation to state that FrameD support has been removed and point readers to LDPC, Fountain, and RaptorQ extras
- add a changelog entry noting the FrameD removal and its suggested replacements

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f6371c67348326a7132ba55fa41c1c