### PR TITLE
Document DeSP adapter and Nanopore fallback usage

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,6 +9,10 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **Batch processing** and streaming support for large files.
 * **Flet-based GUI** with analysis plots and asynchronous operations.
 * **Drag-and-drop file selection** on the Encode tab.
+* **Nanopore and Illumina simulators** with built-in fallbacks and optional
+  [DeSP integration](simulators.md#desp-adapter) for advanced profiles. Refer to
+  the [Nanopore fallback profiles](simulators.md#nanopore-fallback-profiles) for
+  details on presets and context files.
 * **CSV export for synthesis** with length and [homopolymer](glossary.md#homopolymer) validation. The analysis command warns when sequences violate these constraints.
 * **Mirror encoding** via `--mirror` to output forward and reverse-complement sequences.
 * **Fix my sequence** button adjusts GC balance and homopolymers on the fly.

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -15,6 +15,24 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 - **nanopore** — alias for `d2sim`. Customize rates with `--nanopore-sub-rate`,
   `--nanopore-ins-rate` and `--nanopore-del-rate`.
 
+### Nanopore fallback profiles
+
+GeneCoder ships Nanopore presets that mirror `d2sim` profiles so decoding
+pipelines continue to work even when the external binary is unavailable. The
+fallback draws its defaults from:
+
+- `configs/nanopore.yml` – substitution/indel/coverage values for profiles such
+  as `minion`, `promethion` and `r10`.
+- `configs/nanopore_context.yaml` – context-aware insertion/deletion tables used
+  when the external simulator cannot provide them.
+
+Both files are optional; if they are missing the embedded presets bundled with
+GeneCoder are used instead. Custom profiles or context overrides can be supplied
+with `--profile`, `--nanopore-profile`, `--nanopore-context` or the YAML
+configuration helpers. When the `d2sim` or `desp` executables are unavailable,
+the CLI falls back to these presets to mutate reads before continuing with the
+decode pipeline.
+
 Example YAML:
 
 ```yaml
@@ -41,9 +59,31 @@ your `PATH`:
 - **squigulator** — [Squigulator](https://github.com/hasindu2008/squigulator).
     Download a release or build from source so that the `squigulator` command is
     available.
+- **desp** — [DeSP](https://github.com/atcg/deSP) nanopore simulator. Install
+  the `desp` binary and ensure it is on your `PATH` to activate the adapter.
 
 GeneCoder automatically falls back to the internal error model when an external
 simulator is missing or fails.
+
+### DeSP adapter
+
+The optional DeSP integration is registered under both `desp` and
+`nanopore_desp`. Provide the binary via your `PATH` or a virtual environment and
+install any dependencies recommended by the
+[DeSP project](https://github.com/atcg/deSP). Once installed you can invoke it
+from the CLI or YAML pipelines:
+
+```bash
+genecli decode --simulator desp --desp-options "--model r10" <other options>
+genecli channel --simulator nanopore_desp --profile promethion <other options>
+```
+
+Use `--desp-options` or set `GENECODER_DESP_OPTIONS` to forward additional
+flags to the `desp` binary. Arguments are validated for safety before being
+passed through. If the executable exits with an error or is not present the
+channel automatically reverts to the built-in Nanopore fallback described
+above, so decode commands succeed with deterministic settings even without the
+external dependency.
 
 ### Installation tips
 
@@ -158,10 +198,12 @@ Provide extra flags to ``dnarsim`` or ``squigulator`` in the same way:
 ```bash
 genecli decode --simulator dnarsim --dnarsim-options "<opts>" <other options>
 genecli decode --simulator squigulator --squigulator-options "<opts>" <other options>
+genecli decode --simulator desp --desp-options "<opts>" <other options>
 ```
 
 Use `GENECODER_SIM_SEED=<seed>` to make runs reproducible.
-Set `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
-`GENECODER_SQUIGULATOR_OPTIONS` to forward extra flags to the respective
-simulator automatically. The same options can be specified on the command line
-with ``--d2sim-options``, ``--dnarsim-options`` and ``--squigulator-options``.
+Set `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS`,
+`GENECODER_SQUIGULATOR_OPTIONS` or `GENECODER_DESP_OPTIONS` to forward extra
+flags to the respective simulator automatically. The same options can be
+specified on the command line with ``--d2sim-options``, ``--dnarsim-options``,
+``--squigulator-options`` and ``--desp-options``.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -191,22 +191,29 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    Add `--checksum` to the encode and decode commands for automatic validation.
 13. **Decode using an external simulator**
 
-   The ``--simulator`` option accepts ``d2sim``, ``dnarsim`` or ``squigulator``.
-   Install the desired simulator separately and ensure the command is on your
-   ``PATH``:
+   The ``--simulator`` option accepts ``d2sim``, ``dnarsim``, ``squigulator`` or
+   ``desp``. Install the desired simulator separately and ensure the command is
+   on your ``PATH``:
 
    * ``d2sim`` — [D2Sim](https://github.com/kurimsw/d2sim). Follow the
      instructions in the repository to build the binary and place ``d2sim`` on
      your ``PATH``.
    * ``dnarsim`` — [DNArSim](https://github.com/Purdue-ScottLab/DNArSim)
    * ``squigulator`` — [Squigulator](https://github.com/hasindu2008/squigulator)
+   * ``desp`` — [DeSP](https://github.com/atcg/deSP). See the
+     [DeSP adapter](simulators.md#desp-adapter) notes for CLI flags and
+     environment variables.
 
    The ``d2sim`` adapter is bundled with GeneCoder and is registered
    automatically. Once the ``d2sim`` command is available you can invoke it with
-   ``--simulator d2sim``.
+   ``--simulator d2sim``. The DeSP adapter is loaded in the same way; pass
+   additional flags via ``--desp-options`` or by setting
+   ``GENECODER_DESP_OPTIONS``.
 
    When a command is missing GeneCoder automatically falls back to an internal
-   error model.
+   error model. For Nanopore presets this means the built-in profiles described
+   under [Nanopore fallback profiles](simulators.md#nanopore-fallback-profiles)
+   continue to be applied.
 
    The same simulators can be accessed programmatically via
    ``genecoder.simulators.simulate_reads``.
@@ -244,7 +251,9 @@ genecli decode corrupted.dna --output-dir decoded --auto-ext
    Named sequencing profiles are available:
 
    - **Illumina** – `miseq`, `hiseq`, `novaseq` (alias `nova`)
-   - **Nanopore** – `minion`, `promethion`, `r10`, `r9`, `r10.3`, `r10.4`
+   - **Nanopore** – `minion`, `promethion`, `r10`, `r9`, `r10.3`, `r10.4` (see
+     [Nanopore fallback profiles](simulators.md#nanopore-fallback-profiles) for
+     details on how these presets behave without external binaries)
 
    List available presets:
 


### PR DESCRIPTION
## Summary
- document built-in Nanopore fallback profiles and context files for internal simulation
- add a DeSP adapter section covering installation, CLI flags, and environment variables
- cross-link simulator documentation from usage and features guides

## Testing
- `mkdocs build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8dcf13c0c83268cc3dcb650d046ec