### PR TITLE
Support multiple Chamaeleo codec methods

### DIFF
--- a/src/genecoder/chamaeleo_codec.py
+++ b/src/genecoder/chamaeleo_codec.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 """Codec wrapper exposing Chamaeleo via the plugin system."""
 
-from typing import Callable, TYPE_CHECKING, Any
+from importlib import import_module
+from functools import lru_cache
+from typing import Callable, Any, Mapping, Sequence
 from pathlib import Path
 import tempfile
 
-if TYPE_CHECKING:  # pragma: no cover - for typing
-    from Chamaeleo.methods import gc as gc_typing
-
 try:  # pragma: no cover - optional dependency
     from Chamaeleo.codec_factory import encode as _ce, decode as _cd
-    from Chamaeleo.methods import gc as gc_mod
     _HAS_CHAMAELEO = True
 except Exception:  # pragma: no cover - missing optional dependency
     _HAS_CHAMAELEO = False
-    gc_mod = None
 
 from .plugin_manager import register_codec as _register_codec
 from .api import Codec
@@ -30,49 +27,144 @@ def _require() -> None:  # pragma: no cover - helper
         )
 
 
-_method: "gc_typing.GC" | None
-if _HAS_CHAMAELEO:
-    _method = gc_mod.GC()
-else:  # pragma: no cover - optional dependency missing
-    _method = None
+_MethodPath = tuple[str, str]
 
 
-def encode_chamaeleo(data: bytes) -> str:
+_METHOD_CANDIDATES: Mapping[str, Sequence[_MethodPath]] = {
+    "chamaeleo_gc": (
+        ("Chamaeleo.methods.gc", "GC"),
+        ("Chamaeleo.methods.flowed", "YinYangCode"),
+    ),
+    "chamaeleo_fountain": (("Chamaeleo.methods.flowed", "DNAFountain"),),
+    "chamaeleo_goldman": (("Chamaeleo.methods.fixed", "Goldman"),),
+    "chamaeleo_church": (("Chamaeleo.methods.fixed", "Church"),),
+    "chamaeleo_grass": (("Chamaeleo.methods.fixed", "Grass"),),
+    "chamaeleo_blawat": (("Chamaeleo.methods.fixed", "Blawat"),),
+}
+
+
+_METHOD_INSTANCES: dict[str, object] = {}
+
+
+def _load_method_class(codec_name: str) -> type[Any]:
+    """Return the Chamaeleo method class for ``codec_name``."""
+
+    candidates = _METHOD_CANDIDATES.get(codec_name)
+    if not candidates:  # pragma: no cover - defensive guard
+        raise KeyError(f"Unknown Chamaeleo codec '{codec_name}'.")
+
     _require()
-    assert _method is not None
+
+    errors: list[Exception] = []
+    for module_name, class_name in candidates:
+        try:
+            module = import_module(module_name)
+            method_cls = getattr(module, class_name)
+        except Exception as exc:  # pragma: no cover - import fallback
+            errors.append(exc)
+            continue
+        else:
+            return method_cls
+
+    msg = f"Could not load a Chamaeleo method for codec '{codec_name}'."
+    if errors:
+        raise ImportError(msg) from errors[-1]
+    raise ImportError(msg)
+
+
+@lru_cache(maxsize=None)
+def _method_class(codec_name: str) -> type[Any]:
+    return _load_method_class(codec_name)
+
+
+def _get_method(codec_name: str) -> object:
+    method = _METHOD_INSTANCES.get(codec_name)
+    if method is None:
+        method_cls = _method_class(codec_name)
+        method = method_cls()
+        _METHOD_INSTANCES[codec_name] = method
+    return method
+
+
+def _encode_with_method(method: object, data: bytes) -> str:
     with tempfile.TemporaryDirectory() as td:
         in_file = Path(td) / "input.bin"
         out_file = Path(td) / "output.txt"
         in_file.write_bytes(data)
-        _ce(_method, str(in_file), str(out_file), need_index=False, segment_length=48)
+        _ce(method, str(in_file), str(out_file), need_index=False, segment_length=48)
         return out_file.read_text()
 
 
-def decode_chamaeleo(text: str) -> bytes:
-    _require()
-    assert _method is not None
+def _decode_with_method(method: object, text: str) -> bytes:
     with tempfile.TemporaryDirectory() as td:
         in_file = Path(td) / "input.txt"
         out_file = Path(td) / "output.bin"
         in_file.write_text(text)
-        _cd(_method, input_path=str(in_file), output_path=str(out_file), has_index=False)
+        _cd(method, input_path=str(in_file), output_path=str(out_file), has_index=False)
         data = out_file.read_bytes()
         return data.rstrip(b"\x00")
 
 
-class ChamaeleoCodec(Codec):
-    """Codec using the external Chamaeleo library."""
+class ChamaeleoMethodCodec(Codec):
+    """Codec using the external Chamaeleo library for a specific method."""
+
+    codec_name: str
+
+    def __init__(self) -> None:
+        self._method: object | None = None
+
+    def _ensure_method(self) -> object:
+        if self._method is None:
+            self._method = _get_method(self.codec_name)
+        return self._method
 
     def encode(self, data: bytes, /, **kwargs: Any) -> str:  # noqa: ANN401
-        return encode_chamaeleo(data)
+        _require()
+        method = self._ensure_method()
+        return _encode_with_method(method, data)
 
     def decode(self, encoded: str, /, **kwargs: Any) -> bytes:  # noqa: ANN401
-        return decode_chamaeleo(encoded)
+        _require()
+        method = self._ensure_method()
+        return _decode_with_method(method, encoded)
+
+
+def _codec_class_name(codec_name: str) -> str:
+    return "".join(part.title() for part in codec_name.split("_"))
+
+
+_CODECS: dict[str, type[ChamaeleoMethodCodec]] = {}
+for name in _METHOD_CANDIDATES:
+    class_name = _codec_class_name(name)
+    _CODECS[name] = type(
+        class_name,
+        (ChamaeleoMethodCodec,),
+        {"codec_name": name, "__module__": __name__},
+    )
+
+
+_DEFAULT_CODEC_NAME = "chamaeleo_gc"
+_DEFAULT_CODEC = _CODECS[_DEFAULT_CODEC_NAME]()
+
+SUPPORTED_CHAMAELEO_CODECS: tuple[str, ...] = tuple(_CODECS.keys())
+
+
+def encode_chamaeleo(data: bytes) -> str:
+    """Encode ``data`` using the default Chamaeleo method (GC)."""
+
+    return _DEFAULT_CODEC.encode(data)
+
+
+def decode_chamaeleo(text: str) -> bytes:
+    """Decode ``text`` using the default Chamaeleo method (GC)."""
+
+    return _DEFAULT_CODEC.decode(text)
 
 
 def register(
     registrar: Callable[[str, type[Codec]], None] = _register_codec,
 ) -> None:
-    """Register the Chamaeleo codec."""
+    """Register the available Chamaeleo codecs."""
 
-    registrar("chamaeleo_gc", ChamaeleoCodec)
+    for name, codec in _CODECS.items():
+        registrar(name, codec)

--- a/tests/test_chamaeleo_codec_roundtrip.py
+++ b/tests/test_chamaeleo_codec_roundtrip.py
@@ -4,39 +4,55 @@ from pathlib import Path
 
 import pytest
 
-from genecoder.chamaeleo_codec import decode_chamaeleo, encode_chamaeleo
+import genecoder.chamaeleo_codec as cc
 
 
-def test_chamaeleo_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure encode_chamaeleo followed by decode_chamaeleo is lossless."""
+def _fake_encode(
+    _method: object,
+    input_path: str,
+    output_path: str,
+    *,
+    need_index: bool = False,
+    segment_length: int = 48,
+) -> None:  # noqa: ARG001
+    data = Path(input_path).read_bytes()
+    Path(output_path).write_text(data.hex())
 
-    def fake_ce(
-        _method: object,
-        input_path: str,
-        output_path: str,
-        *,
-        need_index: bool = False,
-        segment_length: int = 48,
-    ) -> None:  # noqa: ARG001
-        data = Path(input_path).read_bytes()
-        Path(output_path).write_text(data.hex())
 
-    def fake_cd(
-        _method: object,
-        *,
-        input_path: str,
-        output_path: str,
-        has_index: bool = False,
-    ) -> None:  # noqa: ARG001
-        text = Path(input_path).read_text()
-        Path(output_path).write_bytes(bytes.fromhex(text))
+def _fake_decode(
+    _method: object,
+    *,
+    input_path: str,
+    output_path: str,
+    has_index: bool = False,
+) -> None:  # noqa: ARG001
+    text = Path(input_path).read_text()
+    Path(output_path).write_bytes(bytes.fromhex(text))
 
-    monkeypatch.setattr("genecoder.chamaeleo_codec._ce", fake_ce, raising=False)
-    monkeypatch.setattr("genecoder.chamaeleo_codec._cd", fake_cd, raising=False)
-    monkeypatch.setattr("genecoder.chamaeleo_codec._HAS_CHAMAELEO", True)
-    monkeypatch.setattr("genecoder.chamaeleo_codec._method", object())
+
+@pytest.mark.parametrize("codec_name", cc.SUPPORTED_CHAMAELEO_CODECS)
+def test_chamaeleo_roundtrip(codec_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each Chamaeleo codec round-trips successfully."""
+
+    monkeypatch.setattr(cc, "_ce", _fake_encode, raising=False)
+    monkeypatch.setattr(cc, "_cd", _fake_decode, raising=False)
+    monkeypatch.setattr(cc, "_HAS_CHAMAELEO", True)
+    monkeypatch.setattr(cc, "_METHOD_INSTANCES", {})
+    cc._method_class.cache_clear()
+
+    codec_cls = cc._CODECS[codec_name]
+    codec = codec_cls()
+    method_token = object()
+    cc._METHOD_INSTANCES[codec_name] = method_token
 
     data = b"roundtrip test"
-    encoded = encode_chamaeleo(data)
-    decoded = decode_chamaeleo(encoded)
+    encoded = codec.encode(data)
+    decoded = codec.decode(encoded)
     assert decoded == data
+
+    if codec_name == "chamaeleo_gc":
+        monkeypatch.setattr(cc, "_DEFAULT_CODEC", cc._CODECS["chamaeleo_gc"]())
+        cc._METHOD_INSTANCES["chamaeleo_gc"] = method_token
+        encoded_default = cc.encode_chamaeleo(data)
+        decoded_default = cc.decode_chamaeleo(encoded_default)
+        assert decoded_default == data


### PR DESCRIPTION
## Summary
- add dynamic method resolution for Chamaeleo codecs and register each method-specific variant
- expose the supported Chamaeleo codec list and reuse encode/decode helpers per method
- expand the Chamaeleo round-trip test to cover every registered method using mocked helpers

## Testing
- pytest tests/test_chamaeleo_codec_roundtrip.py
- ruff check src/genecoder/chamaeleo_codec.py tests/test_chamaeleo_codec_roundtrip.py

------
https://chatgpt.com/codex/tasks/task_e_68f8dcf06b5c832689a64cf2a6472a72