### PR TITLE
Document Chamaeleo codec extras across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ handle personal or medical DNA data.
 - Flet-based GUI with analysis plots and an enhanced 3D helix viewer.
 - Base5 and base6 alphabet options for alternative nucleotide letters. These
   modes remap the standard ACGT symbols but **do not increase capacity**.
+- Chamaeleo-backed codecs (GC, Fountain, Goldman, Church, Grass, Blawat) available
+  via an optional extra for reproducing published DNA storage schemes.
 - External read simulators can be invoked with ``--simulator``.
   Extra parameters may be supplied via ``--d2sim-options``,
   ``--dnarsim-options`` or ``--squigulator-options``. The same values can be
@@ -128,6 +130,13 @@ Poetry's ``--extras`` flag:
 poetry install --extras dnaformer --no-interaction
 ```
 
+Install the Chamaeleo-backed codecs to try the historical schemes referenced in
+the documentation:
+
+```bash
+poetry install --extras chamaeleo --no-interaction
+```
+
 GeneCoder now uses a single `poetry.lock` across Linux, macOS and Windows.
 Previous OS-specific lock files have been removed and the unified lock file
 should be used on all platforms.
@@ -146,6 +155,7 @@ test suite:
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
 | `raptorq`     | RaptorQ FEC algorithms                          |
+| `chamaeleo`   | Chamaeleo-backed codecs (GC, Fountain, Goldman, Church, Grass, Blawat) |
 | `dnaformer`   | DNAformer AI codec                              |
 | `deepdna`     | DeepDNA FEC plugin                              |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,6 +32,12 @@ poetry install --with gui,web,dnaformer --no-interaction
 The `gui` group installs Flet, Matplotlib and `flet-webview` while the `web`
 group pulls in FastAPI, Uvicorn (with the `standard` extras) and HTTPX.
 
+Install the Chamaeleo-backed codecs for the classic DNA storage schemes with:
+
+```bash
+poetry install --extras chamaeleo --no-interaction
+```
+
 ## Extras Required for the Full Test Suite
 
 Install all extras needed to exercise the complete test suite. This table lists
@@ -46,6 +52,7 @@ the optional groups and what they provide:
 | `fountain`    | Fountain code support                           |
 | `bch`         | BCH error-correcting codes                      |
 | `raptorq`     | RaptorQ FEC algorithms                          |
+| `chamaeleo`   | Chamaeleo-backed codecs (GC, Fountain, Goldman, Church, Grass, Blawat) |
 | `dnaformer`   | DNAformer AI codec                              |
 | `deepdna`     | DeepDNA FEC plugin                              |
 

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -64,6 +64,45 @@ genecli --version
 poetry run pytest -q
 ```
 
+## Chamaeleo Codec Extras
+
+GeneCoder bundles optional adapters for the
+[Chamaeleo](https://github.com/Biocomputing-Research-Group/Chamaeleo)
+library. Install the extra dependencies before using any of the
+`chamaeleo_*` codecs:
+
+```bash
+poetry install --extras chamaeleo --no-interaction
+```
+
+The following identifiers mirror the classic schemes exposed by
+Chamaeleo:
+
+- `chamaeleo_gc` – GC-balanced mapping with a Yin–Yang fallback.
+- `chamaeleo_fountain` – DNA Fountain implementation for robust random access.
+- `chamaeleo_goldman` – Encodes data following the Goldman et al. 2013 method.
+- `chamaeleo_church` – Implements the Church et al. 2012 encoding.
+- `chamaeleo_grass` – Grass et al. constrained code aimed at archival density.
+- `chamaeleo_blawat` – Blawat et al. fountain-style constrained encoder.
+
+### Sample CLI usage
+
+Run an encode/decode cycle with the GC-balanced preset:
+
+```bash
+genecli encode --input-files input.bin --output-file output_gc.fasta --method chamaeleo_gc
+genecli decode --input-files output_gc.fasta --output-file recovered.bin --method chamaeleo_gc
+```
+
+Switch to another method by replacing `chamaeleo_gc` with any of the other
+identifiers listed above. Pair the codecs with FEC and simulators just like the
+built-in methods:
+
+```bash
+genecli encode --input-files demo.bin --output-file demo_chamaeleo.fasta \
+    --method chamaeleo_fountain --fec reed_solomon --channel illumina
+```
+
 ## Bundle Workflow
 
 An example configuration file at `configs/vertical_slice_demo.yaml` demonstrates
@@ -72,6 +111,15 @@ using a simulator and Hamming FEC. The `pipeline` section selects the built-in
 
 ```bash
 genecli bundle run configs/vertical_slice_demo.yaml --cache-dir runs
+```
+
+To experiment with the Chamaeleo codecs inside any bundle, change the
+`method:` entries in the YAML preset to one of the new identifiers. For example,
+to GC-balance a payload with Chamaeleo swap the encode stage to:
+
+```yaml
+encode:
+  method: chamaeleo_gc  # or chamaeleo_fountain, chamaeleo_goldman, etc.
 ```
 
 For a pipeline run that records usage statistics see
@@ -125,7 +173,7 @@ genecli channel run configs/decay_demo.yaml
 Run a single encode step with error correction and channel simulation:
 
 ```bash
-genecli encode input.bin output.fasta --codec chamaeleo_gc --fec reed_solomon --channel illumina
+genecli encode input.bin output.fasta --method chamaeleo_gc --fec reed_solomon --channel illumina
 ```
 
 This creates `output.fasta.manifest.json` containing encoding metrics.


### PR DESCRIPTION
## Summary
- expand the vertical slice walkthrough with Chamaeleo codec identifiers, installation instructions, CLI examples, and YAML preset guidance
- highlight the optional chamaeleo extra and codecs in the README feature list and extras table
- mention the chamaeleo extra in the installation guide alongside the optional dependency tables

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f8e0110d908326b5649eb1bdd37e2c