### PR TITLE
Add DeSP pipeline preset and regression test

### DIFF
--- a/configs/desp_pipeline.yaml
+++ b/configs/desp_pipeline.yaml
@@ -1,0 +1,21 @@
+# configs/desp_pipeline.yaml
+# Pipeline preset using the external DeSP nanopore simulator. The default
+# error rate of 0.12 mirrors common R10.4 flow cell runs (~12% aggregate
+# substitutions+insertions+deletions). Adjust between 0.08 and 0.15 to match
+# other DeSP profiles.
+encode:
+  input_files:
+    - examples/pipeline_demo_input.txt
+  method: base4_direct
+  fec: reed_solomon
+simulate:
+  simulators:
+    - name: desp
+      error_rate: 0.12  # Typical R10.x DeSP runs land between 8–15% aggregate error.
+  pipeline:
+    parallel: false
+    workers: null
+    use_process_pool: false
+    use_mpi: false
+decode:
+  method: base4_direct

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -171,6 +171,49 @@ GENECODER_METRICS_PATH=examples/nanopore_metrics.json \
   genecli bundle run configs/fountain_nanopore_pipeline.yaml
 ```
 
+### DeSP Nanopore Simulation
+
+```yaml
+# configs/desp_pipeline.yaml
+# Pipeline preset using the external DeSP nanopore simulator. The default
+# error rate of 0.12 mirrors common R10.4 flow cell runs (~12% aggregate
+# substitutions+insertions+deletions). Adjust between 0.08 and 0.15 to match
+# other DeSP profiles.
+encode:
+  input_files:
+    - examples/pipeline_demo_input.txt
+  method: base4_direct
+  fec: reed_solomon
+simulate:
+  simulators:
+    - name: desp
+      error_rate: 0.12  # Typical R10.x DeSP runs land between 8–15% aggregate error.
+  pipeline:
+    parallel: false
+    workers: null
+    use_process_pool: false
+    use_mpi: false
+decode:
+  method: base4_direct
+```
+
+Install the [DeSP](https://github.com/atcg/deSP) binary and ensure it is on your
+`PATH` before running the preset. GeneCoder forwards the aggregated error rate
+to the adapter, so start with the included 12% setting for R10.4 data and tweak
+between 0.08 and 0.15 for other pore models.
+
+Run the preset while capturing metrics and writing artefacts to a temporary
+bundle cache:
+
+```bash
+GENECODER_METRICS_PATH=examples/desp_metrics.json \
+  genecli bundle run configs/desp_pipeline.yaml --cache-dir runs/desp
+```
+
+If the `desp` executable is missing the adapter falls back to the deterministic
+internal Nanopore error model, ensuring the preset still runs for documentation
+and CI scenarios.
+
 ### Multi-oligo Illumina Dropout Pipeline
 
 The `configs/channel_multi_oligo.yaml` file demonstrates the new dropout-aware channel pipeline. It mixes an Illumina simulator with a coverage distribution and enforces synthesis constraints for the streamed FASTA output.

--- a/tests/test_desp_pipeline.py
+++ b/tests/test_desp_pipeline.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from genecoder.api import Codec
+from genecoder.core import run_pipeline
+from genecoder.encoders import decode_base4_direct, encode_base4_direct
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+from genecoder.simulators import SIMULATOR_REGISTRY
+import genecoder.desp_adapter as desp_adapter
+from tests.test_cli import PROJECT_ROOT
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        return decode_base4_direct(encoded)[0]
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_desp_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Ensure the DeSP preset integrates with run_pipeline using a stub adapter."""
+
+    config_path = PROJECT_ROOT / "configs" / "desp_pipeline.yaml"
+    config = yaml.safe_load(config_path.read_text())
+    sim_cfg = config["simulate"]["simulators"][0]
+    assert sim_cfg["name"] == "desp"
+    error_rate = float(sim_cfg["error_rate"])
+
+    calls: list[tuple[str, float]] = []
+
+    def _fake_simulate_adapter(
+        command: str,
+        sequence: str,
+        rate: float,
+        rng,
+        extra_args=None,
+    ) -> str:
+        calls.append((command, rate))
+        translate = str.maketrans("ACGT", "CGTA")
+        return sequence.translate(translate)
+
+    monkeypatch.setattr(desp_adapter, "_simulate_adapter", _fake_simulate_adapter)
+    monkeypatch.setenv("GENECODER_SIM_SEED", "1")
+
+    init_plugins()
+    CODEC_REGISTRY["base4_direct"] = {
+        "encode": _Base4Codec().encode,
+        "decode": _Base4Codec().decode,
+    }
+    SIMULATOR_REGISTRY["desp"] = desp_adapter.DeSPChannel(error_rate=error_rate)
+
+    source_path = PROJECT_ROOT / "examples" / "pipeline_demo_input.txt"
+    input_path = tmp_path / "input.txt"
+    output_path = tmp_path / "output.bin"
+    input_path.write_bytes(source_path.read_bytes())
+
+    result, metrics = run_pipeline(
+        "base4_direct", "reed_solomon", "desp", str(input_path), str(output_path)
+    )
+
+    assert result == source_path.read_bytes()
+    assert output_path.read_bytes() == result
+    assert calls and calls[0] == ("desp", error_rate)
+    assert isinstance(metrics.get("substitutions"), int)
+    assert isinstance(metrics.get("insertions"), int)
+    assert isinstance(metrics.get("deletions"), int)


### PR DESCRIPTION
## Summary
- add a DeSP pipeline preset that selects the external simulator with recommended error rate guidance
- document how to run the preset via `genecli bundle run` and note the DeSP prerequisite
- add a regression test that stubs the DeSP adapter so the preset integrates with `run_pipeline`

## Testing
- pytest tests/test_desp_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68f8e01052788326afcd058e38c6df07