### PR TITLE
Handle per-oligo constraint violation reporting

### DIFF
--- a/src/genecoder/bundle_metrics.py
+++ b/src/genecoder/bundle_metrics.py
@@ -2,6 +2,28 @@ import json
 from pathlib import Path
 from typing import Any, Iterable
 
+
+def _extract_violation_count(value: object) -> int:
+    """Return an integer count from ``constraint_violations`` values."""
+
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, dict):
+        count_val = value.get("count")
+        if isinstance(count_val, (int, float)):
+            return int(count_val)
+        violations = value.get("violations")
+        if isinstance(violations, list):
+            return len(violations)
+        total = value.get("total") or value.get("violation_count")
+        if isinstance(total, (int, float)):
+            return int(total)
+    if isinstance(value, list):
+        return len(value)
+    return 0
+
 __all__ = ["parse_manifests", "aggregate_metrics"]
 
 
@@ -57,8 +79,7 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
             if isinstance(cov, int):
                 total_cov += cov
             viol = metrics.get("constraint_violations")
-            if isinstance(viol, int):
-                total_viol += viol
+            total_viol += _extract_violation_count(viol)
     avg_bpn = sum(bpn_values) / len(bpn_values) if bpn_values else 0.0
     return {
         "files": total_files,

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Tuple, Dict, List, Sequence
 from typing import get_args, get_origin
@@ -49,7 +50,7 @@ def _has_batch_flag(candidate: object) -> bool:
     )
 
 
-def _codec_accepts_sequence_batch(decode_fn: Any) -> bool:
+def _codec_accepts_sequence_batch(decode_fn: object) -> bool:
     """Return ``True`` when ``decode_fn`` opts into ``SequenceBatch`` inputs."""
 
     for candidate in (decode_fn, getattr(decode_fn, "__self__", None), getattr(decode_fn, "__func__", None)):
@@ -393,14 +394,89 @@ def metrics(
     )
 
     success = 1.0 if decoded == original_data else 0.0
-    constraint_violations = 0
+    constraint_violations: Dict[str, Any]
     try:
-        from .synthesis import validate_sequence
+        from .synthesis import SynthesisConstraints, validate_sequence
 
-        if not validate_sequence(base_sequence):
-            constraint_violations = 1
+        constraints = SynthesisConstraints()
+        violation_records: list[dict[str, Any]] = []
+        type_counts: Counter[str] = Counter()
+
+        target_oligos: list[tuple[int, str, dict[str, Any]]] = []
+        if batch is not None:
+            for idx, oligo in enumerate(primary_oligos, start=1):
+                sequence_id = (
+                    oligo.metadata.get("oligo_id")
+                    or oligo.metadata.get("sequence_id")
+                    or oligo.oligo_id
+                    or oligo.metadata.get("oligo_index")
+                    or f"oligo-{idx}"
+                )
+                info: dict[str, Any] = {
+                    "sequence_id": str(sequence_id),
+                    "oligo_index": oligo.metadata.get("oligo_index") or str(idx),
+                }
+                oligo_id_val = oligo.metadata.get("oligo_id") or oligo.oligo_id
+                if oligo_id_val is not None:
+                    info["oligo_id"] = str(oligo_id_val)
+                target_oligos.append((idx, oligo.sequence, info))
+        else:
+            for idx, sequence in enumerate(sequences, start=1):
+                info = {"sequence_id": f"sequence-{idx}", "oligo_index": str(idx)}
+                target_oligos.append((idx, sequence, info))
+
+        for idx, sequence, info in target_oligos:
+            try:
+                is_valid = validate_sequence(sequence, constraints)
+            except Exception:
+                continue
+            if is_valid:
+                continue
+
+            reasons: list[str] = []
+            length = len(sequence)
+            if length < constraints.min_length:
+                reasons.append("length_short")
+            elif length > constraints.max_length:
+                reasons.append("length_long")
+
+            homopolymer = get_max_homopolymer_length(sequence)
+            if homopolymer > constraints.max_homopolymer:
+                reasons.append("homopolymer")
+
+            gc_fraction = calculate_gc_content(sequence) if sequence else 0.0
+            if gc_fraction < constraints.gc_min:
+                reasons.append("gc_low")
+            elif gc_fraction > constraints.gc_max:
+                reasons.append("gc_high")
+
+            if not reasons:
+                reasons.append("unknown")
+
+            for name in reasons:
+                type_counts[name] += 1
+
+            record: dict[str, Any] = {
+                "sequence_id": info.get("sequence_id", f"oligo-{idx}"),
+                "index": idx,
+                "length": length,
+                "type": reasons[0],
+            }
+            if len(reasons) > 1:
+                record["types"] = reasons
+            if info.get("oligo_id"):
+                record["oligo_id"] = info["oligo_id"]
+            if info.get("oligo_index") is not None:
+                record["oligo_index"] = info["oligo_index"]
+            violation_records.append(record)
+
+        constraint_violations = {
+            "count": len(violation_records),
+            "violations": violation_records,
+            "type_counts": dict(type_counts),
+        }
     except Exception:  # pragma: no cover - optional dependency
-        constraint_violations = 0
+        constraint_violations = {"count": 0, "violations": [], "type_counts": {}}
 
     per_oligo_gc = [calculate_gc_content(seq) for seq in sequences]
     per_oligo_hp = [get_max_homopolymer_length(seq) for seq in sequences]

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -239,6 +239,7 @@ def _parse_constraint_violations(value: object) -> dict[str, Any]:
 
     sequences: list[str] = []
     type_counts: Counter[str] = Counter()
+    explicit_type_counts: dict[str, int] | None = None
     explicit_count: int | None = None
 
     def add_sequence(seq: object) -> None:
@@ -265,7 +266,7 @@ def _parse_constraint_violations(value: object) -> dict[str, Any]:
         type_counts[label] += amount
 
     def parse_collection(collection: object) -> None:
-        nonlocal explicit_count
+        nonlocal explicit_count, explicit_type_counts
         if isinstance(collection, dict):
             for key, val in collection.items():
                 if key in {"count", "total", "violation_count"}:
@@ -285,15 +286,18 @@ def _parse_constraint_violations(value: object) -> dict[str, Any]:
                     continue
                 if isinstance(val, dict):
                     if key in {"type_counts", "counts", "violations_by_type"}:
+                        parsed_counts: dict[str, int] = {}
                         for sub_key, sub_val in val.items():
                             if isinstance(sub_val, (int, float)):
-                                add_type(sub_key, int(sub_val))
+                                parsed_counts[str(sub_key)] = int(sub_val)
                             elif isinstance(sub_val, list):
-                                add_type(sub_key, len(sub_val))
+                                parsed_counts[str(sub_key)] = len(sub_val)
                                 for item in sub_val:
                                     parse_item(item)
                             else:
-                                add_type(sub_key)
+                                parsed_counts[str(sub_key)] = parsed_counts.get(str(sub_key), 0) + 1
+                        if parsed_counts:
+                            explicit_type_counts = parsed_counts
                         continue
                     parse_collection(val)
                     continue
@@ -360,7 +364,8 @@ def _parse_constraint_violations(value: object) -> dict[str, Any]:
         except Exception:
             pass
 
-    total_types = sum(type_counts.values())
+    final_type_counts = explicit_type_counts or dict(type_counts)
+    total_types = sum(final_type_counts.values())
     count = explicit_count if explicit_count is not None else 0
     if count == 0:
         if sequences:
@@ -371,7 +376,7 @@ def _parse_constraint_violations(value: object) -> dict[str, Any]:
     return {
         "count": count,
         "sequence_ids": sequences,
-        "type_counts": dict(type_counts),
+        "type_counts": final_type_counts,
     }
 
 
@@ -705,6 +710,8 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         count = 0
         sequences: list[str] = []
         type_counts: dict[str, int] = {}
+        detail_records: list[dict[str, Any]] = []
+        details_source: object | None = None
         if isinstance(summary, dict):
             try:
                 count = int(summary.get("count", 0))
@@ -725,16 +732,52 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
                         except Exception:
                             continue
                 type_counts = {k: v for k, v in cleaned.items() if v}
+            details_source = summary.get("violations")
         original_value = data.get("constraint_violations")
+        if details_source is None and isinstance(original_value, dict):
+            details_source = original_value.get("violations")
+        if isinstance(details_source, list):
+            for entry in details_source:
+                if not isinstance(entry, dict):
+                    continue
+                record: dict[str, Any] = {}
+                if entry.get("sequence_id"):
+                    record["Sequence ID"] = str(entry["sequence_id"])
+                if entry.get("oligo_id"):
+                    record["Oligo ID"] = str(entry["oligo_id"])
+                if entry.get("index") is not None:
+                    record["Index"] = entry.get("index")
+                if entry.get("oligo_index") is not None:
+                    record["Oligo Index"] = entry.get("oligo_index")
+                if entry.get("length") is not None:
+                    record["Length"] = entry.get("length")
+                if entry.get("types"):
+                    types_val = entry["types"]
+                    if isinstance(types_val, list):
+                        record["Types"] = ", ".join(str(v) for v in types_val if str(v))
+                    else:
+                        record["Types"] = str(types_val)
+                elif entry.get("type"):
+                    record["Type"] = str(entry["type"])
+                if record:
+                    detail_records.append(record)
         has_data = not (
-            original_value is None and not sequences and not type_counts and count == 0
+            original_value is None
+            and not sequences
+            and not type_counts
+            and not detail_records
+            and count == 0
         )
         if has_data:
             st.metric("Constraint Violations", f"{count}")
             if sequences:
                 st.write("Offending sequence IDs:", ", ".join(sequences))
-            if not type_counts and count:
+            if type_counts:
+                st.bar_chart(type_counts)
+            elif count:
                 st.bar_chart({"Violations": count})
+            if detail_records:
+                st.dataframe(detail_records)
         else:
             st.write("No constraint violation data.")
 

--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -17,10 +17,11 @@
   "constraint_violations": {
     "count": 3,
     "violations": [
-      {"sequence_id": "seq-1", "type": "gc_high"},
-      {"sequence_id": "seq-1", "type": "homopolymer"},
-      {"sequence_id": "seq-2", "type": "gc_low"}
-    ]
+      {"sequence_id": "seq-1", "type": "gc_high", "length": 100},
+      {"sequence_id": "seq-1", "type": "homopolymer", "length": 100},
+      {"sequence_id": "seq-2", "type": "gc_low", "length": 80}
+    ],
+    "type_counts": {"gc_high": 1, "homopolymer": 1, "gc_low": 1}
   },
   "oligo_metrics": {
     "gc_percentages": [0.45, 0.52, 0.61],

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from typing import Any, Mapping, Sequence
+from typing import Mapping, Sequence
 
 from genecoder.core import encode, simulate, decode, metrics as gather_metrics, run_pipeline
 from genecoder.formats import SequenceBatch
@@ -30,7 +30,7 @@ class _BatchAwareCodec(Codec):
         self.last_batch_metadata: Mapping[str, str] | None = None
         self.last_oligo_metadata: list[Mapping[str, str]] | None = None
 
-    def encode(self, data: bytes, /, **kwargs: Any) -> SequenceBatch:  # type: ignore[override]
+    def encode(self, data: bytes, /, **kwargs: object) -> SequenceBatch:  # type: ignore[override]
         from genecoder.encoders import encode_base4_direct
 
         dna = encode_base4_direct(data)
@@ -48,7 +48,7 @@ class _BatchAwareCodec(Codec):
         *,
         batch_metadata: Mapping[str, str] | None = None,
         oligo_metadata: Sequence[Mapping[str, str]] | None = None,
-        **_kwargs: Any,
+        **_kwargs: object,
     ) -> bytes:  # type: ignore[override]
         from genecoder.encoders import decode_base4_direct
 
@@ -127,3 +127,32 @@ def test_metrics_helper() -> None:
     assert "gc_content" in m
     assert m["oligo_metrics"]["dropout_flags"] == [False]
     assert m["oligo_metrics"]["coverage"] == [None]
+
+
+def test_metrics_constraint_violations_per_oligo() -> None:
+    init_plugins()
+    sequences = ["ACGT" * 20] * 4  # Each oligo valid but combined length exceeds constraints
+    records = [
+        (f"batch_id=batch-valid oligo_index={idx+1}", seq)
+        for idx, seq in enumerate(sequences)
+    ]
+    batch = SequenceBatch.build(records, batch_id="batch-valid")
+
+    result = gather_metrics(batch, b"payload", b"payload", None)
+    violations = result.get("constraint_violations")
+    assert isinstance(violations, dict)
+    assert violations["count"] == 0
+    assert violations["violations"] == []
+
+    failing_records = records[:]
+    failing_records[1] = ("batch_id=batch-valid oligo_index=2", "AT" * 20)
+    failing_batch = SequenceBatch.build(failing_records, batch_id="batch-valid")
+    failing = gather_metrics(failing_batch, b"payload", b"payload", None)
+    failing_violations = failing.get("constraint_violations")
+    assert isinstance(failing_violations, dict)
+    assert failing_violations["count"] == 1
+    assert failing_violations["type_counts"].get("gc_low") == 1
+    assert failing_violations["violations"]
+    first_violation = failing_violations["violations"][0]
+    assert "gc_low" in (first_violation.get("types") or [first_violation.get("type")])
+    assert first_violation.get("sequence_id")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,13 +9,16 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
-    calls: dict[str, list] = {"metric": [], "bar_chart": []}
+    calls: dict[str, list] = {"metric": [], "bar_chart": [], "dataframe": []}
 
     def metric(*args, **kwargs) -> None:
         calls["metric"].append((args, kwargs))
 
     def bar_chart(*args, **kwargs) -> None:
         calls["bar_chart"].append((args, kwargs))
+
+    def dataframe(*args, **kwargs) -> None:
+        calls["dataframe"].append((args, kwargs))
 
     dummy = SimpleNamespace(
         title=lambda *a, **k: None,
@@ -25,7 +28,7 @@ def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
         metric=metric,
         bar_chart=bar_chart,
         error=lambda *a, **k: None,
-        dataframe=lambda *a, **k: None,
+        dataframe=dataframe,
     )
     monkeypatch.setitem(sys.modules, "streamlit", dummy)
     return calls
@@ -119,7 +122,19 @@ def test_display_coverage_and_constraint_metrics(
 ) -> None:
     data = {
         "coverage_distribution": [1, 3, 2],
-        "constraint_violations": 2,
+        "constraint_violations": {
+            "count": 2,
+            "violations": [
+                {"sequence_id": "oligo-1", "type": "gc_low", "length": 48},
+                {
+                    "sequence_id": "oligo-2",
+                    "types": ["length_short", "gc_low"],
+                    "type": "length_short",
+                    "length": 10,
+                },
+            ],
+            "type_counts": {"gc_low": 2, "length_short": 1},
+        },
     }
     path = tmp_path / "metrics.json"
     path.write_text(json.dumps(data))
@@ -131,7 +146,11 @@ def test_display_coverage_and_constraint_metrics(
     assert dummy_streamlit["bar_chart"], "bar_chart not called"
     charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
     assert [1, 3, 2] in charts
-    assert {"Violations": 2} in charts
+    assert {"gc_low": 2, "length_short": 1} in charts
+    assert dummy_streamlit["dataframe"], "dataframe not called"
+    rows = dummy_streamlit["dataframe"][0][0][0]
+    assert isinstance(rows, list)
+    assert any(row.get("Sequence ID") == "oligo-1" for row in rows)
 
 
 def test_error_histograms_rendered(

--- a/tests/test_rs_illumina_pipeline.py
+++ b/tests/test_rs_illumina_pipeline.py
@@ -38,4 +38,9 @@ def test_rs_illumina_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
 
     assert result == data
     assert outp.read_bytes() == data
-    assert metrics["constraint_violations"] == 0
+    violations = metrics.get("constraint_violations")
+    if isinstance(violations, dict):
+        assert violations.get("count") == 0
+        assert violations.get("violations") == []
+    else:
+        assert violations == 0

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -37,7 +37,17 @@ def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
                 "insertions": 1,
                 "deletions": 1,
                 "coverage": 5,
-                "constraint_violations": 1,
+                "constraint_violations": {
+                    "count": 1,
+                    "violations": [
+                        {
+                            "sequence_id": "oligo-1",
+                            "type": "gc_low",
+                            "length": 42,
+                        }
+                    ],
+                    "type_counts": {"gc_low": 1},
+                },
             },
         })
     )


### PR DESCRIPTION
## Summary
- compute per-oligo synthesis constraint violations in `core.metrics`, returning structured counts and metadata instead of a bare integer
- update bundle aggregation and dashboard views to consume the richer violation payload and surface type summaries plus detailed records
- extend regression coverage for multi-oligo batches and dashboard parsing to ensure the new reporting avoids false positives while preserving real violations

## Testing
- pytest tests/test_core_pipeline.py::test_metrics_constraint_violations_per_oligo
- pytest tests/test_dashboard.py::test_display_coverage_and_constraint_metrics
- ruff check src/genecoder/core.py src/genecoder/dashboard.py src/genecoder/bundle_metrics.py tests/test_dashboard.py tests/test_core_pipeline.py tests/test_rs_illumina_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68f8ed51c5c0832689d56d765f526167