### PR TITLE
Add multi-stage DeSP pipeline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
   minimum dependency of ``genecoder>=0.2.0``.
 - Removed the deprecated FrameD wrapper and documented LDPC, Fountain and
   RaptorQ extras as the supported advanced FEC alternatives.
+- DeSP adapter now supports multi-stage presets with per-stage CLI options.
+  Generated manifests include a ``stages`` section summarising each
+  invocation, and the ``configs/desp_pipeline.yaml`` preset documents the
+  synthesis and sequencing passes.
 
 ## [0.1.0] - 2025-06-12
 ### Added

--- a/configs/desp_pipeline.yaml
+++ b/configs/desp_pipeline.yaml
@@ -11,7 +11,15 @@ encode:
 simulate:
   simulators:
     - name: desp
-      error_rate: 0.12  # Typical R10.x DeSP runs land between 8–15% aggregate error.
+      stage: synthesis
+      error_rate: 0.08  # Synthesis-focused stage draws from low-error presets.
+      options:
+        - --model
+        - r10
+    - name: desp
+      stage: sequencing
+      error_rate: 0.12  # Sequencing stage mirrors the R10.x aggregate error range.
+      options: --temperature 5
   pipeline:
     parallel: false
     workers: null

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -175,10 +175,10 @@ GENECODER_METRICS_PATH=examples/nanopore_metrics.json \
 
 ```yaml
 # configs/desp_pipeline.yaml
-# Pipeline preset using the external DeSP nanopore simulator. The default
-# error rate of 0.12 mirrors common R10.4 flow cell runs (~12% aggregate
-# substitutions+insertions+deletions). Adjust between 0.08 and 0.15 to match
-# other DeSP profiles.
+# Pipeline preset using the external DeSP nanopore simulator with stage-aware
+# options. The synthesis pass uses a lower error rate, while the sequencing
+# stage mirrors typical R10.4 aggregate errors. Both invocations forward stage-
+# specific flags to the binary so manifests capture the provenance.
 encode:
   input_files:
     - examples/pipeline_demo_input.txt
@@ -187,7 +187,15 @@ encode:
 simulate:
   simulators:
     - name: desp
+      stage: synthesis
+      error_rate: 0.08
+      options:
+        - --model
+        - r10
+    - name: desp
+      stage: sequencing
       error_rate: 0.12  # Typical R10.x DeSP runs land between 8–15% aggregate error.
+      options: --temperature 5
   pipeline:
     parallel: false
     workers: null
@@ -198,9 +206,11 @@ decode:
 ```
 
 Install the [DeSP](https://github.com/atcg/deSP) binary and ensure it is on your
-`PATH` before running the preset. GeneCoder forwards the aggregated error rate
-to the adapter, so start with the included 12% setting for R10.4 data and tweak
-between 0.08 and 0.15 for other pore models.
+`PATH` before running the preset. GeneCoder invokes the simulator once per
+stage, forwarding both the stage label and any `options` entries. The resulting
+`*.manifest.json` contains a `stages` section summarising the error rates,
+options and stage names so downstream analysis can reason about each
+invocation.
 
 Run the preset while capturing metrics and writing artefacts to a temporary
 bundle cache:

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -80,10 +80,20 @@ genecli channel --simulator nanopore_desp --profile promethion <other options>
 
 Use `--desp-options` or set `GENECODER_DESP_OPTIONS` to forward additional
 flags to the `desp` binary. Arguments are validated for safety before being
-passed through. If the executable exits with an error or is not present the
-channel automatically reverts to the built-in Nanopore fallback described
-above, so decode commands succeed with deterministic settings even without the
-external dependency.
+passed through. The adapter also honours per-stage options defined in YAML
+pipelines: every DeSP entry can include a `stage` label and a list (or string)
+of `options`. The runner will invoke DeSP once per stage with the specified
+flags and record the resulting metadata in the manifest. For example, the
+updated [`configs/desp_pipeline.yaml`](../configs/desp_pipeline.yaml) preset
+contains two stages—`synthesis` and `sequencing`—with distinct error rates and
+CLI arguments. When the pipeline finishes the emitted
+`*.manifest.json` contains a `stages` array summarising the parameters and
+flags used for each invocation.
+
+If the executable exits with an error or is not present the channel
+automatically reverts to the built-in Nanopore fallback described above, so
+decode commands succeed with deterministic settings even without the external
+dependency.
 
 ### Installation tips
 

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 from dataclasses import dataclass, fields, asdict
-from typing import Any, Mapping, cast
+from typing import Any, Mapping, Sequence, cast
 
 from . import cli as cli_module
 from genecoder.formats import SequenceBatch
@@ -206,6 +206,24 @@ def _write_decoded_metrics(
     manifest_path = simulated_path.with_suffix(".manifest.json")
     manifest_data = _load_simulated_manifest(manifest_path)
 
+    stages_raw = manifest_data.get("stages", [])
+    stage_metadata: list[dict[str, Any]] = []
+    if isinstance(stages_raw, Sequence):
+        for item in stages_raw:
+            if isinstance(item, Mapping):
+                normalized: dict[str, Any] = {"name": item.get("name", "")}
+                if item.get("stage"):
+                    normalized["stage"] = item.get("stage")
+                params = item.get("parameters")
+                if isinstance(params, Mapping):
+                    normalized["parameters"] = dict(params)
+                opts = item.get("options")
+                if isinstance(opts, Sequence) and not isinstance(opts, (str, bytes, bytearray)):
+                    normalized["options"] = [str(opt) for opt in opts if str(opt)]
+                elif isinstance(opts, str) and opts:
+                    normalized["options"] = [opt for opt in opts.split() if opt]
+                stage_metadata.append(normalized)
+
     coverage_info = manifest_data.get("coverage", {})
     histogram_raw = (
         coverage_info.get("histogram", {})
@@ -329,6 +347,8 @@ def _write_decoded_metrics(
         channel_metrics["configuration"] = pipeline_cfg
     if channel_config:
         channel_metrics["parameters"] = channel_config
+    if stage_metadata:
+        channel_metrics["stages"] = stage_metadata
 
     sequence_metadata: dict[str, Any] = {
         "sim_dropout_total": str(dropout_count),
@@ -337,6 +357,8 @@ def _write_decoded_metrics(
         "sim_total_reads": str(total_reads_int),
         "sim_average_coverage": f"{average_cov_float:.6f}",
     }
+    if stage_metadata:
+        sequence_metadata["sim_stages"] = json.dumps(stage_metadata)
     if pipeline_cfg:
         if "dropout_rate" in pipeline_cfg:
             sequence_metadata["sim_dropout_rate"] = str(pipeline_cfg["dropout_rate"])

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import random
+import shlex
 from pathlib import Path
 from typing import Sequence, Dict, Any, Mapping
 from difflib import SequenceMatcher
@@ -51,6 +52,46 @@ PROFILE_MAP: dict[str, tuple[str, str]] = {
     "r10.3": ("nanopore_dnarsim", "r10.3"),
     "r10.4": ("nanopore_dnarsim", "r10.4"),
 }
+
+
+def _normalize_stage_options(value: object) -> list[str]:
+    """Return ``value`` as a list of command-line options."""
+
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        try:
+            return [opt for opt in shlex.split(value) if opt]
+        except ValueError:
+            return [chunk for chunk in value.split() if chunk]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [str(opt) for opt in value if str(opt)]
+    return [str(value)]
+
+
+def _extract_stage_parameters(
+    params: Dict[str, Any]
+) -> tuple[Dict[str, Any], str | None, list[str]]:
+    """Split stage-related keys from simulator ``params``."""
+
+    clean_params = dict(params)
+    stage_raw = None
+    for key in ("stage", "stage_name"):
+        if key in clean_params:
+            stage_raw = clean_params.pop(key)
+            break
+    stage = None
+    if stage_raw is not None:
+        stage = str(stage_raw).strip() or None
+
+    options_raw = None
+    for key in ("options", "stage_options", "flags", "cli_options"):
+        if key in clean_params:
+            options_raw = clean_params.pop(key)
+            break
+
+    options = _normalize_stage_options(options_raw)
+    return clean_params, stage, options
 
 
 def _load_config(
@@ -164,29 +205,61 @@ def _apply_simulators(
     ],
     *,
     config: ChannelConfig,
-) -> SequenceBatch:
+) -> tuple[SequenceBatch, list[dict[str, Any]]]:
     channels: list[BaseChannel] = []
+    stages: list[dict[str, Any]] = []
     for item in simulators:
         if isinstance(item, BaseChannel):
             channel = item
             name = channel.__class__.__name__
+            stage_label = getattr(channel, "stage", None)
+            options = list(getattr(channel, "options", ()))
+            params_view: dict[str, Any] = {}
+            if hasattr(channel, "error_rate"):
+                params_view["error_rate"] = getattr(channel, "error_rate")
+            stage_info: dict[str, Any] = {"name": name}
+            if stage_label:
+                stage_info["stage"] = stage_label
+            if params_view:
+                stage_info["parameters"] = params_view
+            if options:
+                stage_info["options"] = options
+            if any(key in stage_info for key in ("stage", "parameters", "options")):
+                stages.append(stage_info)
         else:
             name, params = item
             if name not in SIMULATOR_REGISTRY:
                 logger.error("Unknown simulator: %s", name)
                 raise SystemExit(1)
-            channel = SIMULATOR_REGISTRY[name]
-            if params:
-                try:
-                    channel = type(channel)(**params)
-                except Exception as exc:
-                    logger.error("Invalid parameters for %s: %s", name, exc)
-                    raise SystemExit(1)
+            channel_template = SIMULATOR_REGISTRY[name]
+            clean_params, stage, options = _extract_stage_parameters(params)
+            stage_info: dict[str, Any] = {"name": name}
+            if clean_params:
+                stage_info["parameters"] = clean_params
+            if stage:
+                stage_info["stage"] = stage
+            if options:
+                stage_info["options"] = options
+            try:
+                if name == "desp":
+                    channel = type(channel_template)(
+                        **clean_params,
+                        stage=stage,
+                        options=options or None,
+                    )
+                else:
+                    channel = type(channel_template)(**clean_params)
+            except Exception as exc:
+                logger.error("Invalid parameters for %s: %s", name, exc)
+                raise SystemExit(1)
+            if any(key in stage_info for key in ("stage", "parameters", "options")):
+                stages.append(stage_info)
         channels.append(channel)
         logger.info("Applied %s simulator", name)
     pipeline = ChannelPipeline(channels)
     result = pipeline.simulate(batch, config=config)
-    return result if isinstance(result, SequenceBatch) else _batch_from_string(result)
+    final = result if isinstance(result, SequenceBatch) else _batch_from_string(result)
+    return final, stages
 
 
 def _batch_from_string(sequence: str) -> SequenceBatch:
@@ -367,8 +440,11 @@ def process_channel(
         synth = SynthesisConstraints()
 
     cfg = config or ChannelConfig()
+    stage_metadata: list[dict[str, Any]] = []
     if simulators:
-        processed_batch = _apply_simulators(batch, simulators, config=cfg)
+        processed_batch, stage_metadata = _apply_simulators(
+            batch, simulators, config=cfg
+        )
     else:
         processed_batch = _simulate_probabilities(
             batch,
@@ -416,6 +492,9 @@ def process_channel(
     os.makedirs(os.path.dirname(output_file) or ".", exist_ok=True)
     with open(output_file, "w", encoding="utf-8") as f_out:
         f_out.write(fasta_out)
+
+    if stage_metadata:
+        processed_batch.metadata["sim_stages"] = json.dumps(stage_metadata)
 
     coverage_hist = {}
     coverage_raw = processed_batch.metadata.get("sim_coverage_histogram")
@@ -491,6 +570,8 @@ def process_channel(
     }
     if mutation_totals is not None:
         manifest["mutation_totals"] = mutation_totals
+    if stage_metadata:
+        manifest["stages"] = stage_metadata
 
     manifest_path = os.path.splitext(output_file)[0] + ".manifest.json"
     with open(manifest_path, "w", encoding="utf-8") as m_out:

--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import random
-from typing import Callable
+from typing import Callable, Sequence
 
 from .api import Simulator
 from .random_utils import make_rng
@@ -25,23 +25,46 @@ def simulate_desp(
     sequence: str,
     error_rate: float = 0.05,
     rng: random.Random | None = None,
+    *,
+    extra_args: Sequence[str] | None = None,
 ) -> str:
     """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
         rng = make_rng()
 
-    return _simulate_adapter("desp", sequence, error_rate, rng)
+    return _simulate_adapter("desp", sequence, error_rate, rng, extra_args)
 
 
 class DeSPChannel(Simulator):
     """Channel wrapper for the optional ``DeSP`` simulator."""
 
-    def __init__(self, error_rate: float = 0.05) -> None:
+    def __init__(
+        self,
+        error_rate: float = 0.05,
+        *,
+        stage: str | None = None,
+        options: Sequence[str] | None = None,
+    ) -> None:
         self.error_rate = error_rate
+        self.stage = stage.strip() if isinstance(stage, str) and stage.strip() else None
+        if options is None:
+            self.options: tuple[str, ...] = ()
+        else:
+            self.options = tuple(str(opt) for opt in options if str(opt))
 
     def simulate(self, sequence: str) -> str:
-        return simulate_desp(sequence, error_rate=self.error_rate, rng=make_rng())
+        extra_args: list[str] = []
+        if self.stage:
+            extra_args.extend(["--stage", self.stage])
+        if self.options:
+            extra_args.extend(self.options)
+        return simulate_desp(
+            sequence,
+            error_rate=self.error_rate,
+            rng=make_rng(),
+            extra_args=extra_args or None,
+        )
 
 
 def register(

--- a/tests/test_desp_pipeline.py
+++ b/tests/test_desp_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import pytest
 
@@ -12,6 +13,7 @@ from genecoder.encoders import decode_base4_direct, encode_base4_direct
 from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
 from genecoder.reed_solomon_codec import _HAS_REEDSOLO
 from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.formats import SequenceBatch
 import genecoder.desp_adapter as desp_adapter
 from tests.test_cli import PROJECT_ROOT
 
@@ -72,3 +74,99 @@ def test_desp_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert isinstance(metrics.get("substitutions"), int)
     assert isinstance(metrics.get("insertions"), int)
     assert isinstance(metrics.get("deletions"), int)
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_desp_multi_stage_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Run a multi-stage DeSP channel config and ensure stages propagate."""
+
+    input_fasta = tmp_path / "input.fasta"
+    input_fasta.write_text(">seq\nACGTACGTACGT\n", encoding="utf-8")
+    output_fasta = tmp_path / "output.fasta"
+
+    config_data = {
+        "input": str(input_fasta),
+        "output": str(output_fasta),
+        "simulators": [
+            {
+                "name": "desp",
+                "stage": "synthesis",
+                "error_rate": 0.08,
+                "options": ["--model", "r10"],
+            },
+            {
+                "name": "desp",
+                "stage": "sequencing",
+                "error_rate": 0.12,
+                "options": "--temperature 5",
+            },
+        ],
+        "pipeline": {
+            "dropout_rate": 0.05,
+        },
+    }
+
+    config_path = tmp_path / "multi_stage.yaml"
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf-8")
+
+    calls: list[tuple[str, float, tuple[str, ...]]] = []
+
+    def _stub_simulate_adapter(
+        command: str,
+        sequence: str,
+        rate: float,
+        rng,
+        extra_args=None,
+    ) -> str:
+        extra: tuple[str, ...] = tuple(extra_args or ())
+        calls.append((command, rate, extra))
+        return sequence
+
+    monkeypatch.setattr(desp_adapter, "_simulate_adapter", _stub_simulate_adapter)
+    monkeypatch.setenv("GENECODER_SIM_SEED", "11")
+
+    init_plugins()
+
+    from genecoder.cli import channel as channel_cli
+
+    simulators, constraints, cfg, extra = channel_cli._load_config(str(config_path))
+    channel_cli.process_channel(
+        extra["input_file"],
+        extra["output_file"],
+        simulators,
+        constraints,
+        sub_prob=extra.get("sub_prob", 0.0),
+        ins_prob=extra.get("ins_prob", 0.0),
+        del_prob=extra.get("del_prob", 0.0),
+        seed=extra.get("seed"),
+        config=cfg,
+        batch_workers=extra.get("batch_workers"),
+    )
+
+    assert len(calls) == 2
+    assert calls[0][0] == "desp"
+    assert calls[1][0] == "desp"
+    assert "--stage" in calls[0][2]
+    assert "--stage" in calls[1][2]
+    assert set(calls[0][2]) >= {"--stage", "synthesis", "--model", "r10"}
+    assert set(calls[1][2]) >= {"--stage", "sequencing", "--temperature", "5"}
+
+    manifest_path = output_fasta.with_suffix(".manifest.json")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    stages = manifest.get("stages", [])
+    assert isinstance(stages, list)
+    assert len(stages) == 2
+    first_stage = stages[0]
+    assert first_stage.get("stage") == "synthesis"
+    assert first_stage.get("parameters", {}).get("error_rate") == 0.08
+    assert "--model" in first_stage.get("options", [])
+    second_stage = stages[1]
+    assert second_stage.get("stage") == "sequencing"
+    assert second_stage.get("parameters", {}).get("error_rate") == 0.12
+    assert "--temperature" in second_stage.get("options", [])
+
+    batch = SequenceBatch.from_fasta(output_fasta.read_text(encoding="utf-8"))
+    stage_meta_raw = batch.metadata.get("sim_stages")
+    assert stage_meta_raw is not None
+    parsed_stage_meta = json.loads(stage_meta_raw)
+    assert parsed_stage_meta[0]["stage"] == "synthesis"


### PR DESCRIPTION
## Summary
- allow DeSP simulator stages to supply per-stage options and record stage metadata in manifests
- propagate stage metadata through bundle metrics and documentation, including updated DeSP preset
- add a multi-stage DeSP regression test and changelog entry describing the advanced workflow

## Testing
- pytest tests/test_desp_pipeline.py
- ruff check src/genecoder/desp_adapter.py src/genecoder/cli/channel.py src/genecoder/cli/bundle.py tests/test_desp_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915fc9f23a8832698e5e0ef3ee72c95)