### PR TITLE
Add legacy pipeline tests and fix decode regression

### DIFF
--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -6,8 +6,7 @@ import json
 import logging
 import random
 import shutil
-from typing import Any, Callable, Mapping
-from typing import Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from .api import Simulator
 from .formats import SequenceBatch, from_fasta
@@ -333,9 +332,6 @@ def simulate_desp(
     stage_parameters: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> str | SequenceBatch:
     """Use ``desp`` if available, else fall back to internal simulators."""
-    extra_args: Sequence[str] | None = None,
-) -> str:
-    """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
         rng = make_rng()
@@ -343,9 +339,9 @@ def simulate_desp(
     if isinstance(sequence, SequenceBatch):
         return _simulate_desp_batch(sequence, error_rate, rng, stage_parameters)
 
-    extra_args = _stage_cli_args(_normalise_stage_config(stage_parameters))
+    stage_config = _normalise_stage_config(stage_parameters)
+    extra_args = _stage_cli_args(stage_config)
     return _simulate_adapter(_DeSP.command, sequence, error_rate, rng, extra_args)
-    return _simulate_adapter("desp", sequence, error_rate, rng, extra_args)
 
 
 class DeSPChannel(Simulator):
@@ -361,28 +357,11 @@ class DeSPChannel(Simulator):
         self.stage_parameters = stage_parameters
 
     def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:
-        stage: str | None = None,
-        options: Sequence[str] | None = None,
-    ) -> None:
-        self.error_rate = error_rate
-        self.stage = stage.strip() if isinstance(stage, str) and stage.strip() else None
-        if options is None:
-            self.options: tuple[str, ...] = ()
-        else:
-            self.options = tuple(str(opt) for opt in options if str(opt))
-
-    def simulate(self, sequence: str) -> str:
-        extra_args: list[str] = []
-        if self.stage:
-            extra_args.extend(["--stage", self.stage])
-        if self.options:
-            extra_args.extend(self.options)
         return simulate_desp(
             sequence,
             error_rate=self.error_rate,
             rng=make_rng(),
             stage_parameters=self.stage_parameters,
-            extra_args=extra_args or None,
         )
 
 

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -213,13 +213,6 @@ def run_pipeline(
                 seed=survivor_batch.seed,
                 oligos=list(filtered),
             )
-    decoded = core.decode(
-        codec,
-        fec_backend,
-        decode_input,
-        fec_info,
-        survivor_batch=survivor_batch,
-    )
     channel_report: dict[str, Any] | None = None
     dropout_flags: list[bool] = []
     if isinstance(simulated_batch, SequenceBatch):
@@ -234,9 +227,14 @@ def run_pipeline(
         channel_report.setdefault("status", "pending")
         fec_info["channel"] = channel_report
 
-    decode_input = simulated_batch
     try:
-        decoded = core.decode(codec, fec_backend, decode_input, fec_info)
+        decoded = core.decode(
+            codec,
+            fec_backend,
+            decode_input,
+            fec_info,
+            survivor_batch=survivor_batch,
+        )
     except Exception:
         if (
             fec_backend == "fountain"

--- a/tests/test_pipeline_legacy.py
+++ b/tests/test_pipeline_legacy.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import genecoder.pipeline as pipeline_mod
+from genecoder.pipeline import run_pipeline
+from genecoder.api import Codec
+from genecoder.encoders import decode_base4_direct, encode_base4_direct
+from genecoder.formats import SequenceBatch
+from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.channel_sim import Channel
+from genecoder.simulators.nanopore import NanoporeChannel
+from genecoder.simulators.batch_utils import RESULT_DROPOUT_FLAG_KEY
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+
+SAMPLE_DATA = Path("tests/data/sample.txt")
+
+
+class _BatchCodec(Codec):
+    def __init__(self) -> None:
+        self.extra_metadata: dict[str, str] = {}
+
+    def encode(self, data: bytes, /, **_kwargs: object) -> SequenceBatch:  # type: ignore[override]
+        dna_sequence = encode_base4_direct(data)
+        header = "batch_id=legacy-batch input_file=tests/data/sample.txt"
+        records = [
+            (f"{header} oligo_index=1 sentinel=true", ""),
+            (f"{header} oligo_index=2", dna_sequence),
+        ]
+        batch = SequenceBatch.build(records, batch_id="legacy-batch")
+        if self.extra_metadata:
+            batch.metadata.update({str(k): str(v) for k, v in self.extra_metadata.items()})
+        return batch
+
+    def decode(self, encoded: str, /, **_kwargs: object) -> bytes:  # type: ignore[override]
+        return decode_base4_direct(encoded)[0]
+
+
+@pytest.fixture()
+def legacy_codec(monkeypatch: pytest.MonkeyPatch) -> tuple[str, _BatchCodec]:
+    init_plugins()
+    codec = _BatchCodec()
+    codec_name = "legacy_batch_base4"
+    monkeypatch.setitem(
+        CODEC_REGISTRY,
+        codec_name,
+        {"encode": codec.encode, "decode": codec.decode},
+    )
+
+    def _fountain_encode(data: bytes, /, **_kwargs: object) -> tuple[bytes, dict[str, Any]]:
+        length = len(data)
+        info = {
+            "orig_len": length,
+            "chunk_size": max(1, length),
+            "seed": 0,
+            "batch_metadata": {"batch_id": "legacy-batch"},
+        }
+        return data, info
+
+    def _fountain_decode(
+        encoded: bytes,
+        info: Mapping[str, Any],
+        /,
+        **_kwargs: object,
+    ) -> tuple[bytes, int]:
+        orig_len = int(info.get("orig_len", len(encoded)))
+        return encoded[:orig_len], orig_len
+
+    monkeypatch.setitem(
+        FEC_REGISTRY,
+        "fountain",
+        {"encode": _fountain_encode, "decode": _fountain_decode},
+    )
+    return codec_name, codec
+
+
+@pytest.mark.skipif(not _HAS_REEDSOLO, reason="reedsolo not installed")
+def test_pipeline_legacy_reed_solomon_roundtrip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, legacy_codec: tuple[str, _BatchCodec]
+) -> None:
+    codec_name, codec = legacy_codec
+    codec.extra_metadata.clear()
+    monkeypatch.setenv("GENECODER_SIM_SEED", "5")
+    monkeypatch.setitem(SIMULATOR_REGISTRY, "simple", Channel(error_rate=0.0))
+
+    payload = SAMPLE_DATA.read_bytes()
+    inp = tmp_path / "sample.bin"
+    outp = tmp_path / "roundtrip.bin"
+    inp.write_bytes(payload)
+
+    decoded, metrics, fec_info = run_pipeline(
+        codec_name,
+        "reed_solomon",
+        "simple",
+        str(inp),
+        str(outp),
+    )
+
+    assert decoded == payload
+    assert outp.read_bytes() == payload
+    assert metrics["gc_content"] >= 0.0
+    assert fec_info is not None
+    assert "nsym" in fec_info
+
+
+def test_pipeline_legacy_fountain_nanopore_dropouts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, legacy_codec: tuple[str, _BatchCodec]
+) -> None:
+    codec_name, codec = legacy_codec
+    monkeypatch.setenv("GENECODER_SIM_SEED", "9")
+
+    class _DropoutNanopore(NanoporeChannel):
+        def __init__(self) -> None:
+            super().__init__(profile="rapid")
+            self.error_rate = 0.0
+            self.substitution_rate = 0.0
+            self.insertion_rate = 0.0
+            self.deletion_rate = 0.0
+
+        def simulate(self, sequence: SequenceBatch | str) -> SequenceBatch | str:  # type: ignore[override]
+            result = super().simulate(sequence)
+            if isinstance(result, SequenceBatch) and result.oligos:
+                result.oligos[0].metadata[RESULT_DROPOUT_FLAG_KEY] = "true"
+            return result
+
+    monkeypatch.setitem(SIMULATOR_REGISTRY, "nanopore", _DropoutNanopore())
+
+    payload = SAMPLE_DATA.read_bytes()
+    inp = tmp_path / "sample.bin"
+    outp = tmp_path / "fountain.bin"
+    inp.write_bytes(payload)
+
+    decode_calls: list[SequenceBatch | str] = []
+    original_decode = pipeline_mod.core.decode
+
+    def _recording_decode(*args, **kwargs):  # type: ignore[no-untyped-def]
+        decode_calls.append(args[2])
+        return original_decode(*args, **kwargs)
+
+    monkeypatch.setattr(pipeline_mod.core, "decode", _recording_decode)
+
+    decoded, metrics, fec_info = run_pipeline(
+        codec_name,
+        "fountain",
+        "nanopore",
+        str(inp),
+        str(outp),
+    )
+
+    assert decoded == payload
+    assert outp.read_bytes() == payload
+    assert len(decode_calls) == 1
+    assert fec_info is not None
+    channel_info = fec_info.get("channel") if isinstance(fec_info, Mapping) else None
+    assert isinstance(channel_info, dict)
+    dropout_info = channel_info.get("dropout")
+    assert isinstance(dropout_info, dict)
+    assert dropout_info.get("count", 0) >= 1
+    assert 0.0 < float(dropout_info.get("fraction", 0.0)) <= 1.0
+    assert channel_info.get("status") in {"success", "failed"}
+    assert channel_info.get("decode_success_rate") == metrics.get("decode_success_rate")


### PR DESCRIPTION
## Summary
- ensure the legacy pipeline uses a single decode call while still passing survivor batch context
- repair the `desp_adapter` helpers so they expose a valid `simulate_desp` implementation and channel wrapper
- add regression tests that exercise the legacy pipeline for Reed–Solomon and Fountain presets with Nanopore dropouts

## Testing
- `poetry run pytest tests/test_pipeline_legacy.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc513ac0483268d5ddcee328fbd3e)