### PR TITLE
Fix legacy pipeline decode flow

### DIFF
--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -7,7 +7,6 @@ import logging
 import random
 import shutil
 from typing import Any, Callable, Mapping
-from typing import Callable, Sequence
 
 from .api import Simulator
 from .formats import SequenceBatch, from_fasta
@@ -333,9 +332,6 @@ def simulate_desp(
     stage_parameters: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> str | SequenceBatch:
     """Use ``desp`` if available, else fall back to internal simulators."""
-    extra_args: Sequence[str] | None = None,
-) -> str:
-    """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
         rng = make_rng()
@@ -345,7 +341,6 @@ def simulate_desp(
 
     extra_args = _stage_cli_args(_normalise_stage_config(stage_parameters))
     return _simulate_adapter(_DeSP.command, sequence, error_rate, rng, extra_args)
-    return _simulate_adapter("desp", sequence, error_rate, rng, extra_args)
 
 
 class DeSPChannel(Simulator):
@@ -361,28 +356,11 @@ class DeSPChannel(Simulator):
         self.stage_parameters = stage_parameters
 
     def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:
-        stage: str | None = None,
-        options: Sequence[str] | None = None,
-    ) -> None:
-        self.error_rate = error_rate
-        self.stage = stage.strip() if isinstance(stage, str) and stage.strip() else None
-        if options is None:
-            self.options: tuple[str, ...] = ()
-        else:
-            self.options = tuple(str(opt) for opt in options if str(opt))
-
-    def simulate(self, sequence: str) -> str:
-        extra_args: list[str] = []
-        if self.stage:
-            extra_args.extend(["--stage", self.stage])
-        if self.options:
-            extra_args.extend(self.options)
         return simulate_desp(
             sequence,
             error_rate=self.error_rate,
             rng=make_rng(),
             stage_parameters=self.stage_parameters,
-            extra_args=extra_args or None,
         )
 
 

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -193,7 +193,9 @@ def run_pipeline(
         )
 
     decode_input: SequenceBatch | str = simulated_batch
-    survivor_batch = simulated_batch if isinstance(simulated_batch, SequenceBatch) else None
+    survivor_batch: SequenceBatch | None = (
+        simulated_batch if isinstance(simulated_batch, SequenceBatch) else None
+    )
     if survivor_batch is not None:
         filtered = [
             oligo
@@ -213,17 +215,15 @@ def run_pipeline(
                 seed=survivor_batch.seed,
                 oligos=list(filtered),
             )
-    decoded = core.decode(
-        codec,
-        fec_backend,
-        decode_input,
-        fec_info,
-        survivor_batch=survivor_batch,
-    )
+            survivor_batch = decode_input
+        else:
+            decode_input = survivor_batch
+
+    channel_source = simulated_batch if isinstance(simulated_batch, SequenceBatch) else None
     channel_report: dict[str, Any] | None = None
     dropout_flags: list[bool] = []
-    if isinstance(simulated_batch, SequenceBatch):
-        channel_report, dropout_flags = _channel_report(simulated_batch)
+    if channel_source is not None:
+        channel_report, dropout_flags = _channel_report(channel_source)
     if (
         fec_backend == "fountain"
         and channel_report is not None
@@ -234,9 +234,14 @@ def run_pipeline(
         channel_report.setdefault("status", "pending")
         fec_info["channel"] = channel_report
 
-    decode_input = simulated_batch
     try:
-        decoded = core.decode(codec, fec_backend, decode_input, fec_info)
+        decoded = core.decode(
+            codec,
+            fec_backend,
+            decode_input,
+            fec_info,
+            survivor_batch=survivor_batch,
+        )
     except Exception:
         if (
             fec_backend == "fountain"

--- a/tests/test_pipeline_roundtrip.py
+++ b/tests/test_pipeline_roundtrip.py
@@ -244,11 +244,17 @@ def test_fountain_channel_dropout_manifest_success(
     decode_calls: list[SequenceBatch] = []
 
     def _fake_decode(
-        codec: str, fec_backend: str | None, dna: SequenceBatch, info: dict[str, object]
+        codec: str,
+        fec_backend: str | None,
+        dna: SequenceBatch,
+        info: dict[str, object],
+        **kwargs: object,
     ) -> bytes:
         decode_calls.append(dna)
-        assert dna is mutated_batch
+        assert isinstance(dna, SequenceBatch)
+        assert [ol.sequence for ol in dna.oligos] == ["AAAT", "GGGT"]
         assert info is fec_info
+        assert kwargs.get("survivor_batch") is dna
         return b"dropout-success"
 
     monkeypatch.setattr(core, "decode", _fake_decode)
@@ -262,7 +268,7 @@ def test_fountain_channel_dropout_manifest_success(
         "base4", "fountain", "simple", str(inp), str(outp)
     )
 
-    assert decode_calls == [mutated_batch]
+    assert len(decode_calls) == 1
     assert result == data
     assert outp.read_bytes() == data
 
@@ -312,11 +318,17 @@ def test_fountain_channel_dropout_manifest_failure(
     decode_calls: list[SequenceBatch] = []
 
     def _failing_decode(
-        codec: str, fec_backend: str | None, dna: SequenceBatch, info: dict[str, object]
+        codec: str,
+        fec_backend: str | None,
+        dna: SequenceBatch,
+        info: dict[str, object],
+        **kwargs: object,
     ) -> bytes:
         decode_calls.append(dna)
-        assert dna is mutated_batch
+        assert isinstance(dna, SequenceBatch)
+        assert [ol.sequence for ol in dna.oligos] == ["GGGA"]
         assert info is fec_info
+        assert kwargs.get("survivor_batch") is dna
         return b"corrupted-output"
 
     monkeypatch.setattr(core, "decode", _failing_decode)
@@ -330,7 +342,7 @@ def test_fountain_channel_dropout_manifest_failure(
         "base4", "fountain", "simple", str(inp), str(outp)
     )
 
-    assert decode_calls == [mutated_batch]
+    assert len(decode_calls) == 1
     assert result == b"corrupted-output"
     assert outp.read_bytes() == b"corrupted-output"
 


### PR DESCRIPTION
## Summary
- update the legacy `run_pipeline` helper to filter the simulated batch once, call `core.decode` a single time, and always thread the surviving `SequenceBatch` into FEC metadata handling
- repair the `desp_adapter` module so that the simulator wrapper and `simulate_desp` helper have valid signatures again
- refresh the fountain dropout tests so that they exercise the new survivor-aware decode contract

## Testing
- `poetry run pytest tests/test_pipeline_roundtrip.py tests/test_fountain_nanopore_pipeline.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc51337088326963d4b74259543d8)