### PR TITLE
Fix DeSP adapter fallback and stabilize channel demo test

### DIFF
--- a/src/genecoder/desp_adapter.py
+++ b/src/genecoder/desp_adapter.py
@@ -7,7 +7,6 @@ import logging
 import random
 import shutil
 from typing import Any, Callable, Mapping
-from typing import Callable, Sequence
 
 from .api import Simulator
 from .formats import SequenceBatch, from_fasta
@@ -333,9 +332,6 @@ def simulate_desp(
     stage_parameters: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> str | SequenceBatch:
     """Use ``desp`` if available, else fall back to internal simulators."""
-    extra_args: Sequence[str] | None = None,
-) -> str:
-    """Use ``desp`` if available, else fall back to :func:`simulate_errors`."""
 
     if rng is None:
         rng = make_rng()
@@ -345,7 +341,6 @@ def simulate_desp(
 
     extra_args = _stage_cli_args(_normalise_stage_config(stage_parameters))
     return _simulate_adapter(_DeSP.command, sequence, error_rate, rng, extra_args)
-    return _simulate_adapter("desp", sequence, error_rate, rng, extra_args)
 
 
 class DeSPChannel(Simulator):
@@ -361,28 +356,11 @@ class DeSPChannel(Simulator):
         self.stage_parameters = stage_parameters
 
     def simulate(self, sequence: str | SequenceBatch) -> str | SequenceBatch:
-        stage: str | None = None,
-        options: Sequence[str] | None = None,
-    ) -> None:
-        self.error_rate = error_rate
-        self.stage = stage.strip() if isinstance(stage, str) and stage.strip() else None
-        if options is None:
-            self.options: tuple[str, ...] = ()
-        else:
-            self.options = tuple(str(opt) for opt in options if str(opt))
-
-    def simulate(self, sequence: str) -> str:
-        extra_args: list[str] = []
-        if self.stage:
-            extra_args.extend(["--stage", self.stage])
-        if self.options:
-            extra_args.extend(self.options)
         return simulate_desp(
             sequence,
             error_rate=self.error_rate,
             rng=make_rng(),
             stage_parameters=self.stage_parameters,
-            extra_args=extra_args or None,
         )
 
 

--- a/tests/test_channel_demo_config.py
+++ b/tests/test_channel_demo_config.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import re
+import types
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_channel_demo_config(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    config_template = repo_root / "configs" / "channel_demo.yaml"
+    config_text = config_template.read_text(encoding="utf-8")
+    min_length_match = re.search(r"min_length:\s*(\d+)", config_text)
+    max_length_match = re.search(r"max_length:\s*(\d+)", config_text)
+    max_homopolymer_match = re.search(r"max_homopolymer:\s*(\d+)", config_text)
+    read_length_match = re.search(r"read_length:\s*(\d+)", config_text)
+    sub_rate_match = re.search(r"substitution_rate:\s*([0-9.eE+-]+)", config_text)
+    ins_rate_match = re.search(r"insertion_rate:\s*([0-9.eE+-]+)", config_text)
+    del_rate_match = re.search(r"deletion_rate:\s*([0-9.eE+-]+)", config_text)
+    coverage_match = re.search(r"coverage:\s*([0-9.eE+-]+)", config_text)
+    parallel_match = re.search(r"parallel:\s*(true|false)", config_text)
+    workers_match = re.search(r"workers:\s*(null|\d+)", config_text)
+    process_pool_match = re.search(r"use_process_pool:\s*(true|false)", config_text)
+    mpi_match = re.search(r"use_mpi:\s*(true|false)", config_text)
+    assert (
+        min_length_match
+        and max_length_match
+        and max_homopolymer_match
+        and read_length_match
+        and sub_rate_match
+        and ins_rate_match
+        and del_rate_match
+        and coverage_match
+        and parallel_match
+        and workers_match
+        and process_pool_match
+        and mpi_match
+    ), "Channel demo YAML is missing expected fields"
+    min_length = int(min_length_match.group(1))
+    max_length = int(max_length_match.group(1))
+    max_homopolymer = int(max_homopolymer_match.group(1))
+    read_length = int(read_length_match.group(1))
+    substitution_rate = float(sub_rate_match.group(1))
+    insertion_rate = float(ins_rate_match.group(1))
+    deletion_rate = float(del_rate_match.group(1))
+    coverage = float(coverage_match.group(1))
+    parallel = parallel_match.group(1).lower() == "true"
+    workers_raw = workers_match.group(1)
+    workers = None if workers_raw.lower() == "null" else int(workers_raw)
+    use_process_pool = process_pool_match.group(1).lower() == "true"
+    use_mpi = mpi_match.group(1).lower() == "true"
+
+    input_path = tmp_path / "input.fasta"
+    input_path.write_text(">seq1\nACGTACGTACGTACGTACGTACGTAC\n", encoding="utf-8"
+    )
+
+    output_path = tmp_path / "output.fasta"
+
+    config_path = tmp_path / "channel_demo.yaml"
+    config_data = {
+        "input": input_path.as_posix(),
+        "output": output_path.as_posix(),
+        "synthesis": {
+            "min_length": min_length,
+            "max_length": max_length,
+            "max_homopolymer": max_homopolymer,
+        },
+        "simulators": [
+            {
+                "name": "illumina",
+                "substitution_rate": substitution_rate,
+                "insertion_rate": insertion_rate,
+                "deletion_rate": deletion_rate,
+                "coverage": coverage,
+                "read_length": read_length,
+            }
+        ],
+        "pipeline": {
+            "parallel": parallel,
+            "workers": workers,
+            "use_process_pool": use_process_pool,
+            "use_mpi": use_mpi,
+        },
+    }
+    config_path.write_text(json.dumps(config_data, indent=2), encoding="utf-8")
+
+    env = os.environ.copy()
+    env["GENECODER_SIM_SEED"] = "123"
+    src_path = repo_root / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+
+    json_yaml = types.ModuleType("yaml")
+
+    def _safe_load(source: object) -> dict[str, object]:
+        if hasattr(source, "read"):
+            text = source.read()
+        else:
+            text = str(source)
+        text = text.strip()
+        if not text:
+            return {}
+        return json.loads(text)
+
+    def _safe_dump(data: object) -> str:
+        return json.dumps(data)
+
+    class _YamlError(Exception):
+        pass
+
+    json_yaml.safe_load = _safe_load  # type: ignore[attr-defined]
+    json_yaml.safe_dump = _safe_dump  # type: ignore[attr-defined]
+    json_yaml.YAMLError = _YamlError  # type: ignore[attr-defined]
+
+    original_yaml = sys.modules.get("yaml")
+    sys.modules["yaml"] = json_yaml
+    try:
+        result = run_cli_command(["channel", "run", str(config_path)], env=env)
+    finally:
+        if original_yaml is not None:
+            sys.modules["yaml"] = original_yaml
+        else:
+            sys.modules.pop("yaml", None)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+
+    manifest_path = output_path.with_suffix("")
+    manifest_path = manifest_path.with_name(manifest_path.name + ".manifest.json")
+    assert manifest_path.exists()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    constraints = manifest.get("constraints", {})
+    assert constraints.get("min_length") == min_length
+    assert constraints.get("max_length") == max_length
+    assert constraints.get("max_homopolymer") == max_homopolymer
+
+    stages = manifest.get("stages")
+    assert isinstance(stages, list) and stages
+    illumina_stage = next((stage for stage in stages if stage.get("name") == "illumina"), None)
+    assert illumina_stage is not None
+    parameters = illumina_stage.get("parameters")
+    assert isinstance(parameters, dict)
+    assert parameters.get("read_length") == read_length
+


### PR DESCRIPTION
## Summary
- repair the `simulate_desp` helper and `DeSPChannel` wrapper so the optional simulator can import cleanly
- make the channel demo regression test robust to missing PyYAML by rewriting the config in JSON and patching a JSON-backed yaml module

## Testing
- pytest tests/test_channel_demo_config.py
- ruff check src/genecoder/desp_adapter.py tests/test_channel_demo_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163cc7df308326a08dd50311332409)