### PR TITLE
feat: add bundle metrics flags and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ GeneCoder is an educational toolkit for exploring DNA-based data storage. It pro
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
-The configuration at `configs/pipeline_metrics.yaml` shows how to run the pipeline while recording metrics.
+The configuration at `configs/pipeline_metrics.yaml` shows how to run the pipeline while recording metrics. Supply the metrics destination and optional extras directly via CLI flags:
+
+```bash
+genecli bundle run configs/pipeline_metrics.yaml \
+  --cache-dir pipeline_runs \
+  --metrics-path examples/pipeline_metrics.json \
+  --emit-manifest-report
+```
+
+Append `--launch-dashboard` to open the Streamlit dashboard for the captured metrics immediately after the run completes.
 For deployment instructions including building the React dashboard see the
 [deployment guide](docs/deployment.md).
 

--- a/configs/pipeline_demo.yaml
+++ b/configs/pipeline_demo.yaml
@@ -1,7 +1,8 @@
 # Pipeline demonstration configuration that performs encoding, simulated sequencing,
-# decoding and metrics export. Set GENECODER_METRICS_PATH before running to capture
-# metrics:
-#   GENECODER_METRICS_PATH=examples/pipeline_metrics.json genecli bundle run configs/pipeline_demo.yaml
+# decoding and metrics export. Provide --metrics-path when invoking the bundle command
+# to capture metrics:
+#   genecli bundle run configs/pipeline_demo.yaml --metrics-path examples/pipeline_metrics.json \
+#     --emit-manifest-report
 encode:
   input_files:
     - examples/pipeline_demo_input.txt

--- a/configs/pipeline_metrics.yaml
+++ b/configs/pipeline_metrics.yaml
@@ -1,6 +1,7 @@
 # Sample pipeline configuration demonstrating metric collection.
-# Set GENECODER_METRICS_PATH to specify the metrics file before running:
-#   GENECODER_METRICS_PATH=metrics.json genecli bundle run configs/pipeline_metrics.yaml
+# Pass --metrics-path to specify the metrics file before running:
+#   genecli bundle run configs/pipeline_metrics.yaml --metrics-path metrics.json \
+#     --emit-manifest-report
 # Inspect the dropout-aware outputs afterwards with commands such as:
 #   jq '.metrics.channel.dropout' decoded.txt.json
 #   jq '.metrics.oligo_metrics.dropout_flags' decoded.txt.json

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,8 +9,11 @@ GeneCoder records basic usage statistics in a `metrics.json` file located in `~/
   aggregation.
 - `oligos_per_week` – aggregated counts of simulated sequences per ISO week.
 
-Set the `GENECODER_METRICS_PATH` environment variable to override the default
-metrics file location.
+Pass `--metrics-path /path/to/metrics.json` to `genecli bundle run` or
+`genecli pipeline` to override the default metrics destination for a specific
+invocation. Set the `GENECODER_METRICS_PATH` environment variable to update the
+default location for every command (useful for web dashboards or headless
+deployments).
 
 GeneCoder's north-star goal is to accelerate DNA storage research by enabling more oligos to be simulated each week. The `oligos_per_week` metric aggregates `oligos_simulated_ts` into ISO weeks, providing a clear view of weekly usage trends.
 

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -33,10 +33,11 @@ The commands below also write metrics for later inspection.
 ### RaptorQ FEC
 
 ```bash
-GENECODER_METRICS_PATH=examples/raptorq_metrics.json \
-  genecli pipeline examples/pipeline_demo_input.txt decoded_raptorq.txt \
-    --codec base4_direct --fec raptorq \
-    --channel illumina --profile hiseq
+genecli pipeline examples/pipeline_demo_input.txt decoded_raptorq.txt \
+  --codec base4_direct --fec raptorq \
+  --channel illumina --profile hiseq \
+  --metrics-path examples/raptorq_metrics.json \
+  --emit-manifest-report
 ```
 
 After the run finishes inspect the dropout-aware metrics that accompany the decoded payload:
@@ -52,10 +53,11 @@ jq '.metrics.sequence_batch.metadata.sim_dropout_total' decoded_raptorq.txt.json
 ### Fountain FEC
 
 ```bash
-GENECODER_METRICS_PATH=examples/fountain_metrics.json \
-  genecli pipeline examples/pipeline_demo_input.txt decoded_fountain.txt \
-    --codec base4_direct --fec fountain \
-    --channel nanopore --profile r10
+genecli pipeline examples/pipeline_demo_input.txt decoded_fountain.txt \
+  --codec base4_direct --fec fountain \
+  --channel nanopore --profile r10 \
+  --metrics-path examples/fountain_metrics.json \
+  --emit-manifest-report
 ```
 
 The Fountain pipeline emits the same `sequence_batch` manifest metadata, making it easy to compare per-oligo dropout between
@@ -99,8 +101,9 @@ decode:
 Run the pipeline while capturing metrics:
 
 ```bash
-GENECODER_METRICS_PATH=examples/illumina_metrics.json \
-  genecli bundle run configs/rs_illumina_pipeline.yaml
+genecli bundle run configs/rs_illumina_pipeline.yaml \
+  --metrics-path examples/illumina_metrics.json \
+  --emit-manifest-report
 ```
 Set `GENECODER_SIM_SEED` (as described in the
 [Reproducibility Guide](reproducibility.md#seeding-the-simulation-rng)) and pin
@@ -134,8 +137,9 @@ Run the preset with metrics enabled to mirror the MiSeq 18× coverage and 150 bp
 read defaults highlighted in the channel walkthrough:
 
 ```bash
-GENECODER_METRICS_PATH=examples/gold_metrics.json \
-  genecli bundle run configs/gold.yaml
+genecli bundle run configs/gold.yaml \
+  --metrics-path examples/gold_metrics.json \
+  --emit-manifest-report
 ```
 
 `genecli` will prefer the external
@@ -167,8 +171,9 @@ decode:
 Execute with metrics enabled:
 
 ```bash
-GENECODER_METRICS_PATH=examples/nanopore_metrics.json \
-  genecli bundle run configs/fountain_nanopore_pipeline.yaml
+genecli bundle run configs/fountain_nanopore_pipeline.yaml \
+  --metrics-path examples/nanopore_metrics.json \
+  --emit-manifest-report
 ```
 
 ### DeSP Nanopore Simulation
@@ -216,8 +221,9 @@ Run the preset while capturing metrics and writing artefacts to a temporary
 bundle cache:
 
 ```bash
-GENECODER_METRICS_PATH=examples/desp_metrics.json \
-  genecli bundle run configs/desp_pipeline.yaml --cache-dir runs/desp
+genecli bundle run configs/desp_pipeline.yaml --cache-dir runs/desp \
+  --metrics-path examples/desp_metrics.json \
+  --emit-manifest-report
 ```
 
 If the `desp` executable is missing the adapter falls back to the deterministic
@@ -271,6 +277,6 @@ genecli html-report --manifest simulated_multi_oligo.fasta.manifest.json \
   `PATH`.
 - **Simulator errors** – install optional dependencies such as `pyfinite`
   for Fountain codes or provide valid profile names like `hiseq` or `r10`.
-- **No metrics output** – set `GENECODER_METRICS_PATH` to a writable file
+- **No metrics output** – pass `--metrics-path` to the command and ensure the path is writable
   before running the pipeline.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -582,13 +582,16 @@ configuration and then launch the Streamlit interface:
 
 ```bash
 poetry install --with gui --no-interaction
-GENECODER_METRICS_PATH=examples/pipeline_metrics.json \
-    genecli bundle run configs/pipeline_demo.yaml
-genecli dashboard examples/pipeline_metrics.json
+genecli bundle run configs/pipeline_demo.yaml \
+    --metrics-path examples/pipeline_metrics.json \
+    --emit-manifest-report \
+    --launch-dashboard
 ```
 
 This encodes and decodes `examples/pipeline_demo_input.txt`, stores metrics in
-`examples/pipeline_metrics.json` and opens the dashboard with the results.
+`examples/pipeline_metrics.json` and opens the dashboard with the results. Drop
+`--launch-dashboard` if you prefer to open the file later via
+`genecli dashboard examples/pipeline_metrics.json`.
 
 The interface visualizes key metrics:
 

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -16,7 +16,8 @@ from typing import Any, Mapping, Sequence, cast
 
 from . import cli as cli_module
 from genecoder.formats import SequenceBatch
-from genecoder.metrics import metrics
+from genecoder.html_report import generate_html_report
+from genecoder.metrics import metrics, set_metrics_path
 from genecoder.core import metrics as gather_metrics
 from genecoder.manifest import generate_manifest
 
@@ -70,6 +71,21 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--description",
         type=str,
         help="Description to include in summary.json",
+    )
+    run_parser.add_argument(
+        "--metrics-path",
+        type=str,
+        help="Path to the aggregate metrics JSON file",
+    )
+    run_parser.add_argument(
+        "--emit-manifest-report",
+        action="store_true",
+        help="Generate HTML reports for decoded manifests",
+    )
+    run_parser.add_argument(
+        "--launch-dashboard",
+        action="store_true",
+        help="Launch the dashboard for the metrics file after the run",
     )
     run_parser.set_defaults(func=_handle_run)
 
@@ -191,6 +207,8 @@ def _write_decoded_metrics(
     decoded_path: Path,
     enc_cfg: Mapping[str, object],
     sim_cfg: Mapping[str, object] | None,
+    *,
+    emit_manifest_report: bool = False,
 ) -> None:
     try:
         batch = SequenceBatch.from_fasta(
@@ -400,13 +418,33 @@ def _write_decoded_metrics(
     manifest = generate_manifest(original_path, manifest_params, metrics_data)
     manifest_output = metrics_path.with_suffix(".manifest.json")
     manifest_output.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    if emit_manifest_report:
+        html_report_path = manifest_output.with_suffix(".html")
+        html = generate_html_report(str(manifest_output))
+        html_report_path.write_text(html, encoding="utf-8")
 
 def _handle_run(args: argparse.Namespace) -> None:
     import yaml
 
+    metrics_override: Path | None = None
+    if args.metrics_path:
+        metrics_override = Path(args.metrics_path)
+        set_metrics_path(metrics_override)
+
+    def _launch_dashboard_if_requested() -> None:
+        if not args.launch_dashboard:
+            return
+        target = metrics_override or metrics.path
+        if not target.exists():
+            logger.warning(
+                "Metrics file %s not found, skipping dashboard launch", target
+            )
+            return
+        _run_cli(["dashboard", str(target)])
+
     with open(args.config, "r", encoding="utf-8") as fh:
         try:
-            config = yaml.safe_load(fh) or {}
+            config = yaml.safe_load(fh.read()) or {}
         except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML path
             logger.error("Invalid YAML in %s: %s", args.config, exc)
             raise SystemExit(1)
@@ -438,6 +476,7 @@ def _handle_run(args: argparse.Namespace) -> None:
                     args.description,
                     batch_metadata=None,
                 )
+        _launch_dashboard_if_requested()
         return
 
     timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
@@ -572,6 +611,7 @@ def _handle_run(args: argparse.Namespace) -> None:
                     decoded_file,
                     enc_cfg,
                     sim_cfg if isinstance(sim_cfg, dict) else None,
+                    emit_manifest_report=args.emit_manifest_report,
                 )
 
     logger.info("Bundle output written to %s", run_dir)
@@ -586,3 +626,4 @@ def _handle_run(args: argparse.Namespace) -> None:
         )
 
     metrics.increment("bundle_runs")
+    _launch_dashboard_if_requested()

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -35,6 +35,7 @@ from genecoder.simulators.batch_utils import (
     load_coverage_distribution,
     mutation_counts,
 )
+from genecoder.metrics import metrics as aggregate_metrics, set_metrics_path
 
 
 logger = logging.getLogger(__name__)
@@ -523,6 +524,21 @@ def register_subcommand(
         default=None,
         help="Distribute encoding tasks across MPI workers",
     )
+    parser.add_argument(
+        "--metrics-path",
+        type=str,
+        help="Path to the aggregate metrics JSON file",
+    )
+    parser.add_argument(
+        "--emit-manifest-report",
+        action="store_true",
+        help="Generate HTML reports for decoded manifests",
+    )
+    parser.add_argument(
+        "--launch-dashboard",
+        action="store_true",
+        help="Launch the dashboard for the metrics file after the run",
+    )
 
     parser.set_defaults(func=_handle_command)
 
@@ -530,6 +546,24 @@ def register_subcommand(
 def _handle_command(args: argparse.Namespace) -> None:
     if args.seed is not None:
         os.environ["GENECODER_SIM_SEED"] = str(args.seed)
+    metrics_override: Path | None = None
+    if args.metrics_path:
+        metrics_override = Path(args.metrics_path)
+        set_metrics_path(metrics_override)
+
+    def _launch_dashboard_if_requested() -> None:
+        if not args.launch_dashboard:
+            return
+        target = metrics_override or aggregate_metrics.path
+        if not target.exists():
+            logger.warning(
+                "Metrics file %s not found, skipping dashboard launch", target
+            )
+            return
+        from genecoder.dashboard_streamlit import launch
+
+        launch(str(target))
+
     cfg_codec = cfg_fec = cfg_channel = None
     cfg_params: Dict[str, Any] = {}
 
@@ -598,7 +632,10 @@ def _handle_command(args: argparse.Namespace) -> None:
     manifest_path.write_text(json.dumps(manifest, indent=2))
     logger.info("Manifest written to %s", manifest_path)
 
-    html_report_path = metrics_path.with_suffix(".html")
-    html = generate_html_report(str(manifest_path))
-    html_report_path.write_text(html, encoding="utf-8")
-    logger.info("HTML report written to %s", html_report_path)
+    if args.emit_manifest_report:
+        html_report_path = metrics_path.with_suffix(".html")
+        html = generate_html_report(str(manifest_path))
+        html_report_path.write_text(html, encoding="utf-8")
+        logger.info("HTML report written to %s", html_report_path)
+
+    _launch_dashboard_if_requested()

--- a/src/genecoder/metrics.py
+++ b/src/genecoder/metrics.py
@@ -4,6 +4,7 @@ import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, IO, Mapping, Sequence, cast
+from os import PathLike
 
 try:  # pragma: no cover - optional dependency
     import portalocker
@@ -37,6 +38,7 @@ __all__ = [
     "append_gc_distribution",
     "append_homopolymer_runs",
     "append_oligo_metrics",
+    "set_metrics_path",
 ]
 
 
@@ -92,14 +94,20 @@ def _save(path: Path, metrics: dict[str, object], fh: IO[str] | None = None) -> 
 class Metrics:
     """Simple metrics manager for atomic updates."""
 
-    def __init__(self, path: Path | None = None) -> None:
-        self._path = path
+    def __init__(self, path: Path | str | PathLike[str] | None = None) -> None:
+        self._path = Path(path) if path is not None else None
         self._lock = threading.Lock()
 
     @property
     def path(self) -> Path:
         """Metrics file path, respecting environment overrides."""
         return self._path or _get_metrics_path()
+
+    def set_path(self, path: Path | str | PathLike[str] | None) -> None:
+        """Override the metrics destination used by this manager."""
+
+        with self._lock:
+            self._path = Path(path) if path is not None else None
 
     def increment(self, key: str, counts: Sequence[float | int] | None = None) -> None:
         with self._lock:
@@ -242,5 +250,9 @@ def get_metrics() -> dict[str, object]:
 
 def oligos_per_week() -> dict[str, int]:
     return metrics.oligos_per_week()
+
+
+def set_metrics_path(path: Path | str | PathLike[str] | None) -> None:
+    metrics.set_path(path)
 
 

--- a/tests/test_bundle_dashboard_launch.py
+++ b/tests/test_bundle_dashboard_launch.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_cli import run_cli_command
+
+yaml = pytest.importorskip("yaml")
+if yaml.safe_load("foo: 1") != {"foo": 1}:
+    pytest.skip("Functional YAML parser required for bundle tests", allow_module_level=True)
+
+
+def test_bundle_launches_dashboard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = Path(__file__).resolve().parents[1] / "configs" / "pipeline_metrics.yaml"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    metrics_path = tmp_path / "bundle_metrics.json"
+
+    calls: list[tuple[str, ...]] = []
+    module = types.ModuleType("genecoder.dashboard_streamlit")
+
+    def _record_launch(*paths: str) -> None:
+        calls.append(tuple(paths))
+
+    module.launch = _record_launch  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "genecoder.dashboard_streamlit", module)
+
+    result = run_cli_command(
+        [
+            "bundle",
+            "run",
+            str(config_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--metrics-path",
+            str(metrics_path),
+            "--launch-dashboard",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert calls == [(str(metrics_path),)]

--- a/tests/test_bundle_pipeline_metrics_config.py
+++ b/tests/test_bundle_pipeline_metrics_config.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -8,6 +7,8 @@ import pytest
 from tests.test_cli import run_cli_command
 
 yaml = pytest.importorskip("yaml")
+if yaml.safe_load("foo: 1") != {"foo": 1}:
+    pytest.skip("Functional YAML parser required for bundle tests", allow_module_level=True)
 
 
 def test_bundle_pipeline_metrics_config(tmp_path: Path) -> None:
@@ -16,11 +17,17 @@ def test_bundle_pipeline_metrics_config(tmp_path: Path) -> None:
     cache_dir.mkdir()
     metrics_path = tmp_path / "metrics.json"
 
-    env = os.environ.copy()
-    env["GENECODER_METRICS_PATH"] = str(metrics_path)
-
     result = run_cli_command(
-        ["bundle", "run", str(config_path), "--cache-dir", str(cache_dir)], env=env
+        [
+            "bundle",
+            "run",
+            str(config_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--metrics-path",
+            str(metrics_path),
+            "--emit-manifest-report",
+        ]
     )
     assert result.returncode == 0, result.stderr
 
@@ -40,6 +47,14 @@ def test_bundle_pipeline_metrics_config(tmp_path: Path) -> None:
 
     decoded_metrics_file = next(decoded_dir.glob("*.bin.json"))
     decoded_metrics = json.loads(decoded_metrics_file.read_text(encoding="utf-8"))
+    manifest_path = decoded_metrics_file.with_suffix(".manifest.json")
+    assert manifest_path.exists(), "decoded manifest missing"
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_data.get("metrics"), "manifest missing metrics payload"
+    html_report_path = manifest_path.with_suffix(".html")
+    assert html_report_path.exists(), "HTML manifest report missing"
+    html_content = html_report_path.read_text(encoding="utf-8")
+    assert "<html" in html_content.lower()
     metrics = decoded_metrics.get("metrics", {})
 
     channel = metrics.get("channel", {})

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,6 +11,8 @@ from genecoder.metrics import (
     Metrics,
     append_gc_distribution,
     append_homopolymer_runs,
+    metrics,
+    set_metrics_path,
 )
 
 
@@ -178,3 +180,14 @@ def test_metrics_accumulate_across_runs(tmp_path: Path, monkeypatch) -> None:
     data = json.loads(metrics_path.read_text())
     assert data["gc_distribution"] == [0.1, 0.2, 0.3]
     assert data["homopolymer_runs"] == [3, 3, 1]
+
+
+def test_set_metrics_path_override(tmp_path: Path) -> None:
+    override_path = tmp_path / "override.json"
+    set_metrics_path(override_path)
+    try:
+        metrics.increment("bundle_runs")
+        data = json.loads(override_path.read_text())
+        assert data["bundle_runs"] == 1
+    finally:
+        set_metrics_path(None)


### PR DESCRIPTION
## Summary
- add `--metrics-path`, `--emit-manifest-report`, and `--launch-dashboard` flags to `bundle run` and the pipeline CLI so cached metrics and HTML summaries can be generated without environment variables
- expose a runtime metrics destination override in `genecoder.metrics`, generate decoded HTML manifests on demand, and refresh the README/docs to describe the new workflow
- extend the CLI tests to cover the new behaviors (skipping when YAML support is unavailable) and add a dashboard launch regression test

## Testing
- `pytest tests/test_bundle_pipeline_metrics_config.py tests/test_bundle_dashboard_launch.py -s` *(skipped: missing YAML support)*
- `pytest tests/test_metrics.py -k set_metrics_path_override` *(skipped: missing FastAPI dependency)*
- `ruff check src/genecoder/metrics.py src/genecoder/cli/bundle.py src/genecoder/cli/pipeline.py tests/test_bundle_pipeline_metrics_config.py tests/test_bundle_dashboard_launch.py tests/test_metrics.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddf78cc4883268c38ab65d09606ed)