### PR TITLE
Add sequencing error rate observers and tests

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -94,3 +94,26 @@ Switch `illumina_profile` to `novaseq` (or any other registered profile) to lock
 in different quality curves. When combined with a fixed `GENECODER_SIM_SEED`,
 MiSeq and NovaSeq simulations yield identical error statistics across repeated
 runs, which is ideal for regression testing and benchmarking new codecs.
+
+## Validating sequencing profile error rates
+
+Both the Nanopore and Illumina simulators now expose helper hooks that emit
+aggregate substitution/insertion/deletion counts for a deterministic run. The
+pytest suite drives these hooks to ensure the bundled configuration files stay
+in sync with the observed behaviour:
+
+- `tests/test_nanopore_context_profile.py` calls
+  `genecoder.simulators.nanopore_batch.observe_error_rates` for each profile in
+  `configs/nanopore.yml` and fails if the measured error rates drift beyond the
+  documented tolerances.
+- `tests/test_illumina_coverage_quality.py` uses
+  `IlluminaChannel.observe_error_rates` together with the presets defined in
+  `src/genecoder/simulators/illumina/profiles.py` to guarantee the short-read
+  channel matches its specification.
+
+When new empirical data arrives you only need to update the profile files and
+adjust the tolerances in the corresponding tests. Use the helper functions to
+measure the new rates (optionally seeding `GENECODER_SIM_SEED` for repeatable
+experiments) and tighten the assertions once the numbers stabilise. This keeps
+future regression runs honest and provides a lightweight checklist for
+contributors submitting improved sequencing statistics.

--- a/src/genecoder/simulators/error_metrics.py
+++ b/src/genecoder/simulators/error_metrics.py
@@ -1,0 +1,60 @@
+"""Helpers for collecting mutation statistics during simulations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from .batch_utils import mutation_counts
+
+__all__ = ["MutationObservation"]
+
+
+@dataclass
+class MutationObservation:
+    """Aggregate substitution, insertion and deletion counts."""
+
+    substitutions: int = 0
+    insertions: int = 0
+    deletions: int = 0
+    opportunities: int = 0
+
+    def record(self, reference: str, observed: str) -> Tuple[int, int, int]:
+        """Record errors between ``reference`` and ``observed`` reads."""
+
+        subs, ins, dels = mutation_counts(reference, observed)
+        self.substitutions += subs
+        self.insertions += ins
+        self.deletions += dels
+        self.opportunities += len(reference)
+        return subs, ins, dels
+
+    def extend(
+        self, substitutions: int, insertions: int, deletions: int, opportunities: int
+    ) -> None:
+        """Extend the observation with pre-counted values."""
+
+        self.substitutions += substitutions
+        self.insertions += insertions
+        self.deletions += deletions
+        self.opportunities += max(0, opportunities)
+
+    def rates(self) -> dict[str, float]:
+        """Return per-base error rates derived from the current counts."""
+
+        denom = self.opportunities or 1
+        return {
+            "substitution_rate": self.substitutions / denom,
+            "insertion_rate": self.insertions / denom,
+            "deletion_rate": self.deletions / denom,
+        }
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a dictionary representation of the current totals."""
+
+        return {
+            "substitutions": self.substitutions,
+            "insertions": self.insertions,
+            "deletions": self.deletions,
+            "opportunities": self.opportunities,
+        }

--- a/src/genecoder/simulators/illumina/channel.py
+++ b/src/genecoder/simulators/illumina/channel.py
@@ -8,6 +8,7 @@ import random
 from ..base import BaseSimulator
 from ...formats import SequenceBatch
 from ...random_utils import make_rng
+from ..error_metrics import MutationObservation
 from .batch import simulate_batch as _simulate_batch
 from .mutations import mutate_read
 from .profiles import (
@@ -165,6 +166,39 @@ class IlluminaChannel(BaseSimulator):
         if coverage == 1:
             return reads[0]
         return self._consensus(reads)
+
+    def observe_error_rates(
+        self,
+        sequence: str,
+        *,
+        reads: int | None = None,
+        seed: int | None = None,
+    ) -> MutationObservation:
+        """Return aggregate mutation counts for ``sequence``.
+
+        This helper enables deterministic regression tests that validate the
+        substitution/insertion/deletion parameters baked into Illumina
+        profiles.
+        """
+
+        rng = random.Random(seed if seed is not None else 0)
+        read_length = self.get_read_length(sequence)
+        template = sequence[:read_length]
+        quality = self.get_quality_profile(sequence, read_length)
+        total_reads = reads if reads is not None else max(1, int(self.coverage))
+        observation = MutationObservation()
+        for _ in range(total_reads):
+            mutate_read(
+                template,
+                quality,
+                rng,
+                substitution_rate=self.substitution_rate,
+                insertion_rate=self.insertion_rate,
+                deletion_rate=self.deletion_rate,
+                context_errors=self.context_errors,
+                observation=observation,
+            )
+        return observation
 
     def with_profile(self, profile: str) -> "IlluminaChannel":
         """Return a new channel configured to use ``profile``.

--- a/src/genecoder/simulators/illumina/mutations.py
+++ b/src/genecoder/simulators/illumina/mutations.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - fallback when numba missing
         return wrapper
 
 from ...error_simulation import _random_substitution, NUCLEOTIDES
+from ..error_metrics import MutationObservation
 
 
 __all__ = ["mutate_read"]
@@ -33,10 +34,15 @@ def _mutate_read_jit(
     deletion_rate: float,
     context_errors: Dict[str, float],
     rng: random.Random,
+    observation: MutationObservation | None = None,
 ) -> str:
     mutated: list[str] = []
+    subs = 0
+    ins = 0
+    dels = 0
     for idx, nt in enumerate(read):
         if rng.random() < deletion_rate:
+            dels += 1
             continue
 
         sub_rate = (
@@ -48,11 +54,15 @@ def _mutate_read_jit(
 
         if rng.random() < sub_rate:
             nt = _random_substitution(nt, rng)
+            subs += 1
 
         mutated.append(nt)
         if rng.random() < insertion_rate:
             mutated.append(rng.choice(NUCLEOTIDES))
+            ins += 1
 
+    if observation is not None:
+        observation.extend(subs, ins, dels, len(read))
     return "".join(mutated)
 
 
@@ -65,6 +75,7 @@ def mutate_read(
     insertion_rate: float,
     deletion_rate: float,
     context_errors: Dict[str, float],
+    observation: MutationObservation | None = None,
 ) -> str:
     """Return a mutated ``read`` using the configured error rates."""
 
@@ -76,4 +87,5 @@ def mutate_read(
         deletion_rate,
         context_errors,
         rng,
+        observation,
     )

--- a/src/genecoder/simulators/nanopore_batch.py
+++ b/src/genecoder/simulators/nanopore_batch.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - fallback when numba missing
 from ..error_simulation import NUCLEOTIDES, _random_substitution
 from ..formats import SequenceBatch
 from ..random_utils import make_rng
+from .error_metrics import MutationObservation
 from .batch_utils import (
     CONFIG_COVERAGE_KEY,
     CONFIG_DROPOUT_KEY,
@@ -47,6 +48,7 @@ __all__ = [
     "mutate_read",
     "consensus",
     "simulate_batch",
+    "observe_error_rates",
 ]
 
 
@@ -86,10 +88,14 @@ def mutate_read_jit(
     deletion_profile: Dict[int, float],
     context_insertions: Dict[str, Dict[int, float]],
     context_deletions: Dict[str, Dict[int, float]],
+    observation: MutationObservation | None = None,
 ) -> str:
     mutated: list[str] = []
     prev = ""
     run_len = 0
+    subs = 0
+    ins = 0
+    dels = 0
 
     for idx, nt in enumerate(read):
         if nt == prev:
@@ -107,6 +113,7 @@ def mutate_read_jit(
                 del_p = ctx_profile.get(run_len, ctx_profile.get(1, del_p))
         del_p = min(1.0, del_p)
         if rng.random() < del_p:
+            dels += 1
             continue
 
         sub_p = (
@@ -117,6 +124,7 @@ def mutate_read_jit(
 
         if rng.random() < sub_p:
             nt = _random_substitution(nt, rng)
+            subs += 1
 
         mutated.append(nt)
         ins_p = insertion_profile.get(run_len, insertion_rate)
@@ -126,7 +134,9 @@ def mutate_read_jit(
                 ins_p = ctx_profile.get(run_len, ctx_profile.get(1, ins_p))
         if rng.random() < ins_p:
             mutated.append(rng.choice(NUCLEOTIDES))
-
+            ins += 1
+    if observation is not None:
+        observation.extend(subs, ins, dels, len(read))
     return "".join(mutated)
 
 
@@ -135,6 +145,8 @@ def mutate_read(
     quality: Sequence[float] | None,
     rng: random.Random,
     channel: NanoporeBatchProtocol,
+    *,
+    observation: MutationObservation | None = None,
 ) -> str:
     """Mutate ``read`` using the provided ``channel`` parameters."""
 
@@ -154,6 +166,7 @@ def mutate_read(
             channel.deletion_profile,
             channel.context_insertions,
             channel.context_deletions,
+            observation,
         ),
     )
 
@@ -294,4 +307,32 @@ def simulate_batch(
         mutated, coverage_counts, dropout_flags, synthesis_flags, consensus_totals
     )
     return mutated
+
+
+def observe_error_rates(
+    channel: NanoporeBatchProtocol,
+    sequence: str,
+    *,
+    reads: int | None = None,
+    seed: int | None = None,
+) -> MutationObservation:
+    """Return aggregate mutation counts observed for ``channel``.
+
+    The helper drives ``channel`` using the same hooks as the production
+    simulator, making it suitable for regression tests that validate profile
+    parameters.
+    """
+
+    rng = random.Random(seed if seed is not None else 0)
+    total_reads = reads if reads is not None else max(1, channel.get_coverage(sequence))
+    observation = MutationObservation()
+    for _ in range(total_reads):
+        mutate_read(
+            sequence,
+            channel.quality_profile,
+            rng,
+            channel,
+            observation=observation,
+        )
+    return observation
 

--- a/tests/test_illumina_coverage_quality.py
+++ b/tests/test_illumina_coverage_quality.py
@@ -1,6 +1,8 @@
 import random
 
 from genecoder import illumina_sim
+from genecoder.simulators.illumina.channel import IlluminaChannel
+from genecoder.simulators.illumina.profiles import ILLUMINA_PROFILES
 
 
 def _hamming(a: str, b: str) -> int:
@@ -56,4 +58,17 @@ def test_quality_distribution_controls_errors() -> None:
     )
     assert out_none == seq
     assert _hamming(seq, out_all) == len(seq)
+
+
+def test_illumina_profile_error_rates() -> None:
+    sequence = "ACGT" * 250
+    for name, params in ILLUMINA_PROFILES.items():
+        channel = IlluminaChannel(profile=name)
+        reads = int(max(1, channel.coverage)) * 500
+        observation = channel.observe_error_rates(sequence, reads=reads, seed=2024)
+        rates = observation.rates()
+        for key in ("substitution_rate", "insertion_rate", "deletion_rate"):
+            expected = float(params[key])
+            tolerance = max(0.0001, expected * 0.5)
+            assert abs(rates[key] - expected) <= tolerance
 

--- a/tests/test_nanopore_context_profile.py
+++ b/tests/test_nanopore_context_profile.py
@@ -6,8 +6,8 @@ from typing import Tuple
 
 import pytest
 
-from genecoder.simulators.nanopore import NanoporeChannel
-from genecoder.simulators.nanopore_batch import mutate_read
+from genecoder.simulators.nanopore import NanoporeChannel, NANOPORE_PROFILES
+from genecoder.simulators.nanopore_batch import mutate_read, observe_error_rates
 
 
 def _simulate_many(
@@ -60,3 +60,16 @@ def test_builtin_profile_context_bias() -> None:
     control_ins, control_del = _simulate_many(channel, "ACGTACGT")
     assert poly_ins > control_ins
     assert poly_del > control_del
+
+
+@pytest.mark.parametrize("profile", sorted(NANOPORE_PROFILES))
+def test_nanopore_profile_error_rates(profile: str) -> None:
+    channel = NanoporeChannel(profile=profile)
+    sequence = "ACGT" * 256
+    reads = int(max(1, channel.coverage)) * 40
+    observation = observe_error_rates(channel, sequence, reads=reads, seed=1234)
+    rates = observation.rates()
+    expected = NANOPORE_PROFILES[profile]
+    for key in ("substitution_rate", "insertion_rate", "deletion_rate"):
+        tolerance = max(0.005, 0.3 * float(expected[key]))
+        assert abs(rates[key] - float(expected[key])) <= tolerance


### PR DESCRIPTION
## Summary
- add a shared `MutationObservation` helper plus Nanopore/Illumina hooks that expose aggregate substitution/insertion/deletion counts for deterministic runs
- extend the Nanopore context profile and Illumina coverage tests to assert observed error rates stay within the tolerances derived from the bundled profiles
- document the new validation workflow so contributors know how to refresh tolerances when updating empirical data

## Testing
- `pytest tests/test_nanopore_context_profile.py tests/test_illumina_coverage_quality.py`
- `ruff check src/genecoder/simulators/error_metrics.py src/genecoder/simulators/nanopore_batch.py src/genecoder/simulators/illumina/channel.py src/genecoder/simulators/illumina/mutations.py tests/test_nanopore_context_profile.py tests/test_illumina_coverage_quality.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddf780cd88326bf829ac3fdf9356b)