### PR TITLE
Add CLI bundle metrics stats command

### DIFF
--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -226,6 +226,13 @@ genecli bundle run configs/desp_pipeline.yaml --cache-dir runs/desp \
   --emit-manifest-report
 ```
 
+Summaries for dashboard plots can be generated offline by pointing
+`genecli stats bundle` at the cache directory:
+
+```bash
+genecli stats bundle --runs runs/desp --output runs/desp/bundle_metrics.json
+```
+
 If the `desp` executable is missing the adapter falls back to the deterministic
 internal Nanopore error model, ensuring the preset still runs for documentation
 and CI scenarios.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -619,6 +619,16 @@ Example metrics snippet:
 }
 ```
 
+If you prefer to analyze bundles without running the FastAPI service, export the
+aggregated manifest metrics directly from the cache directory:
+
+```bash
+genecli stats bundle --runs runs/desp --output runs/desp/bundle_metrics.json
+```
+
+The resulting JSON mirrors the `/bundle-metrics` endpoint output and can be
+passed to `genecli dashboard` for offline comparison plots.
+
 ### Constraint Fix Suggestions
 
 Both the CLI `analyze` command and the GUI provide simple suggestions when a

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -1,20 +1,49 @@
 from __future__ import annotations
 
 import argparse
-
-from genecoder.metrics import get_metrics, oligos_per_week
+import json
+from pathlib import Path
 from typing import TypeAlias, cast
+
+from genecoder.bundle_metrics import aggregate_metrics
+from genecoder.metrics import get_metrics, oligos_per_week
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     parser = subparsers.add_parser("stats", help="Show usage metrics including simulation counts")
     parser.set_defaults(func=_handle_command)
 
+    stats_subparsers = parser.add_subparsers(dest="stats_command")
+
+    bundle_parser = stats_subparsers.add_parser(
+        "bundle", help="Aggregate metrics from cached bundle runs"
+    )
+    bundle_parser.add_argument(
+        "--runs",
+        required=True,
+        type=Path,
+        help="Path to bundle cache directory containing manifest files",
+    )
+    bundle_parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON file to write aggregated metrics",
+    )
+    bundle_parser.set_defaults(func=_handle_bundle_command)
+
 
 def _handle_command(_: argparse.Namespace) -> None:
     data = collect_stats()
     for k, v in data.items():
         print(f"{k}: {v}")
+
+
+def _handle_bundle_command(args: argparse.Namespace) -> None:
+    metrics = aggregate_metrics(args.runs)
+    output = json.dumps(metrics, indent=2)
+    if args.output:
+        args.output.write_text(output + "\n", encoding="utf-8")
+    print(output)
 
 
 StatsData: TypeAlias = dict[str, int | list[str] | dict[str, int]]

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from genecoder.bundle_metrics import aggregate_metrics
+from tests.test_cli import run_cli_command
+
+
+def _write_manifest(run_dir: Path) -> None:
+    manifest = {
+        "file": "sample.bin",
+        "encoding_parameters": {"method": "base4_direct"},
+        "metrics": {
+            "original_size": 10,
+            "dna_length": 20,
+            "bits_per_nt": 1.5,
+            "substitutions": 2,
+            "insertions": 1,
+            "deletions": 1,
+            "coverage": 5,
+            "constraint_violations": {"count": 1},
+        },
+    }
+    (run_dir / "file.manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def test_cli_bundle_stats_matches_endpoint(tmp_path: Path) -> None:
+    mdir = tmp_path / "run"
+    mdir.mkdir()
+    _write_manifest(mdir)
+
+    expected = aggregate_metrics(tmp_path)
+
+    result = run_cli_command(["stats", "bundle", "--runs", str(tmp_path)])
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout)
+
+    assert output == expected


### PR DESCRIPTION
## Summary
- add a `genecli stats bundle` subcommand that aggregates cached bundle manifests and can write JSON output
- verify the CLI aggregation matches the existing bundle metrics endpoint with a dedicated test
- document the offline bundle metrics workflow in the usage and pipeline guides

## Testing
- python -m pytest tests/test_cli_stats.py
- ruff check src/genecoder/cli/stats.py tests/test_cli_stats.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692476d36dbc83269845f475fd01d2ca)