### PR TITLE
Add Illumina profile variants and document selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ genecli html-report \
 
 The manifest view highlights GC balance, droplet survival and homopolymer limits so you can confirm the preset behaved as expected before moving on to custom experiments. Re-run the command to refresh the cache or append `--export-archive gold_runs.tar.gz` for an easily shareable bundle complete with a `summary.json` index of cached files.
 
+### Selecting Illumina profiles
+
+The Illumina simulator ships with platform-aware presets covering MiSeq V3, HiSeq high-coverage runs and NovaSeq S4 throughput. Pick a profile on the command line with `--illumina-profile`:
+
+```bash
+# Drive the built-in simulator with NovaSeq-scale coverage
+genecli decode --simulator illumina --illumina-profile novaseq_s4 \
+  --input-file encoded/message.fasta --output-file simulated.fasta
+
+# Override a channel config without editing YAML
+genecli channel run configs/illumina_profile.yaml --illumina-profile hiseq_high_coverage
+```
+
+Bundle configurations can also lock the preset under `pipeline.illumina_profile` so sweeps stay reproducible. For example, `configs/illumina_profile.yaml` now demonstrates the higher-coverage HiSeq preset alongside the quality distribution hook.
+
 ## Introductory notebooks
 
 Introductory Jupyter notebooks with encoding and decoding examples are available in the [notebooks/](notebooks) directory. A small series of lessons covers the basics:

--- a/configs/illumina_profile.yaml
+++ b/configs/illumina_profile.yaml
@@ -2,6 +2,6 @@ simulators:
   - name: insilicoseq
     read_length: 150
 pipeline:
-  illumina_profile: hiseq
+  illumina_profile: hiseq_high_coverage
   illumina_depth: 1
   illumina_quality_distribution: null

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -93,7 +93,7 @@ simulate:
   simulators:
     - illumina
   pipeline:
-    illumina_profile: hiseq
+    illumina_profile: novaseq_s4
 decode:
   method: base4_direct
 ```
@@ -107,8 +107,8 @@ genecli bundle run configs/rs_illumina_pipeline.yaml \
 ```
 Set `GENECODER_SIM_SEED` (as described in the
 [Reproducibility Guide](reproducibility.md#seeding-the-simulation-rng)) and pin
-the `illumina_profile` to reproduce the same dropout and quality score sampling
-across runs.
+the `illumina_profile` (MiSeq V3 for long reads or NovaSeq S4 for high coverage)
+to reproduce the same dropout and quality score sampling across runs.
 
 ### GC-balanced Gold Preset with InSilicoSeq
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -87,13 +87,14 @@ simulate:
   simulators:
     - illumina
   pipeline:
-    illumina_profile: miseq
+    illumina_profile: miseq_v3
 ```
 
-Switch `illumina_profile` to `novaseq` (or any other registered profile) to lock
-in different quality curves. When combined with a fixed `GENECODER_SIM_SEED`,
-MiSeq and NovaSeq simulations yield identical error statistics across repeated
-runs, which is ideal for regression testing and benchmarking new codecs.
+Switch `illumina_profile` to `hiseq_high_coverage`, `novaseq_s4`, or any other
+registered profile to lock in different quality curves. When combined with a
+fixed `GENECODER_SIM_SEED`, MiSeq V3 and NovaSeq S4 simulations yield identical
+error statistics across repeated runs, which is ideal for regression testing and
+benchmarking new codecs.
 
 ## Validating sequencing profile error rates
 

--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -152,12 +152,13 @@ Illumina model otherwise.
 ### Command-line options
 
 ```bash
-genecli decode --simulator illumina_insilicoseq --profile hiseq <other options>
+genecli decode --simulator illumina_insilicoseq --profile novaseq_s4 <other options>
 genecli decode --simulator illumina_insilicoseq --insilicoseq-options "--num_reads 1000" <other options>
 ```
 
-Profiles such as `miseq` and `hiseq` map to the corresponding InSilicoSeq
-presets. Additional flags can be supplied with `--insilicoseq-options`.
+Profiles such as `miseq_v3`, `hiseq_high_coverage`, and `novaseq_s4` map to the
+corresponding built-in presets with adjusted coverage and read-length targets.
+Additional flags can be supplied with `--insilicoseq-options`.
 
 ### Sample quality-profile file
 
@@ -169,7 +170,7 @@ simulators:
   - name: insilicoseq
     read_length: 150
 pipeline:
-  illumina_profile: hiseq
+  illumina_profile: hiseq_high_coverage
   illumina_depth: 1
   illumina_quality_distribution: null
 ```

--- a/docs/vertical_slice.md
+++ b/docs/vertical_slice.md
@@ -154,7 +154,7 @@ decay:
   variation: 0.1
 
 pipeline:
-  illumina_profile: hiseq
+  illumina_profile: novaseq_s4
 ```
 
 The ``half_life`` value indicates the time required for half the DNA to

--- a/src/genecoder/simulators/illumina/profiles.py
+++ b/src/genecoder/simulators/illumina/profiles.py
@@ -1,4 +1,11 @@
-"""Profile utilities for the Illumina simulator."""
+"""Profile utilities for the Illumina simulator.
+
+This module defines :data:`ILLUMINA_PROFILES`, a set of named presets that
+represent common Illumina platforms and quality tiers.  Each profile combines
+substitution, insertion, and deletion rates with default read-length and
+coverage targets so callers can quickly swap between MiSeq-style high-fidelity
+reads and NovaSeq-scale high-throughput runs.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -45,7 +52,12 @@ def _parse_quality_profile(value: str) -> Sequence[float]:
 
 @dataclass
 class IlluminaProfile:
-    """Parameters controlling Illumina simulation behaviour."""
+    """Parameters controlling Illumina simulation behaviour.
+
+    The bundled :data:`ILLUMINA_PROFILES` cover MiSeq V3, HiSeq and NovaSeq
+    quality tiers with adjusted coverage and read-length defaults to mirror each
+    platform's typical output.
+    """
 
     substitution_rate: float
     insertion_rate: float
@@ -143,5 +155,33 @@ ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
         "deletion_rate": 0.00003,
         "read_length": 150,
         "coverage": 1,
+    },
+    "miseq_v3": {
+        "substitution_rate": 0.0009,
+        "insertion_rate": 0.00012,
+        "deletion_rate": 0.00012,
+        "read_length": 300,
+        "coverage": 1.5,
+    },
+    "hiseq_high_coverage": {
+        "substitution_rate": 0.00045,
+        "insertion_rate": 0.00005,
+        "deletion_rate": 0.00005,
+        "read_length": 150,
+        "coverage": 2.5,
+    },
+    "novaseq_s4": {
+        "substitution_rate": 0.00025,
+        "insertion_rate": 0.00002,
+        "deletion_rate": 0.00002,
+        "read_length": 150,
+        "coverage": 3.0,
+    },
+    "nextseq": {
+        "substitution_rate": 0.0006,
+        "insertion_rate": 0.00006,
+        "deletion_rate": 0.00006,
+        "read_length": 100,
+        "coverage": 1.2,
     },
 }


### PR DESCRIPTION
## Summary
- add new Illumina simulator presets covering MiSeq V3, HiSeq high-coverage, NovaSeq S4, and NextSeq defaults
- update README and documentation to show how to select the new profiles from the CLI and pipeline configs
- refresh example configs to demonstrate the new high-coverage Illumina options

## Testing
- python -m pytest tests/test_simulator_profiles.py tests/test_illumina_coverage_quality.py
- ruff check src tests *(fails: existing repository lint issues unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382e7f47448326a966895c7db330f0)