### PR TITLE
Add bundle schema validation and documentation

### DIFF
--- a/configs/schema/bundle.schema.json
+++ b/configs/schema/bundle.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GeneCoder bundle configuration",
+  "type": "object",
+  "required": ["encode"],
+  "additionalProperties": false,
+  "properties": {
+    "encode": {"$ref": "#/$defs/encode"},
+    "simulate": {"$ref": "#/$defs/simulate"},
+    "decode": {"$ref": "#/$defs/decode"}
+  },
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "stringOrNumber": {
+      "type": ["string", "number"]
+    },
+    "primitiveValue": {
+      "type": ["string", "number", "boolean", "null"]
+    },
+    "encode": {
+      "type": "object",
+      "required": ["input_files", "method"],
+      "additionalProperties": false,
+      "properties": {
+        "input_files": {"$ref": "#/$defs/stringList"},
+        "method": {"type": "string"},
+        "fec": {"type": "string", "enum": []}
+      }
+    },
+    "decode": {
+      "type": "object",
+      "required": ["method"],
+      "additionalProperties": false,
+      "properties": {
+        "method": {"type": "string"}
+      }
+    },
+    "pipeline": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "parallel": {"type": ["boolean", "null"]},
+        "workers": {"type": ["integer", "null"]},
+        "use_process_pool": {"type": ["boolean", "null"]},
+        "use_mpi": {"type": ["boolean", "null"]},
+        "illumina_profile": {"type": ["string", "null"]},
+        "nanopore_profile": {"type": ["string", "null"]},
+        "dropout_rate": {"type": ["number", "null"]},
+        "coverage_distribution": {
+          "oneOf": [
+            {"type": "object"},
+            {"type": "array"},
+            {"type": "null"}
+          ]
+        },
+        "synthesis_loss": {"type": ["number", "null"]},
+        "profile": {"type": ["string", "null"]},
+        "name": {"type": ["string", "null"]}
+      }
+    },
+    "simulatorName": {
+      "type": "string",
+      "enum": []
+    },
+    "simulator": {
+      "anyOf": [
+        {"$ref": "#/$defs/simulatorName"},
+        {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {"$ref": "#/$defs/simulatorName"},
+            "stage": {"type": "string"},
+            "options": {
+              "type": "array",
+              "items": {"$ref": "#/$defs/primitiveValue"}
+            }
+          },
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "array", "object", "null"]
+          }
+        }
+      ]
+    },
+    "simulate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "simulators": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/simulator"},
+          "minItems": 1
+        },
+        "pipeline": {"$ref": "#/$defs/pipeline"},
+        "config": {"type": "string"},
+        "sub_prob": {"type": ["number", "null"]},
+        "ins_prob": {"type": ["number", "null"]},
+        "del_prob": {"type": ["number", "null"]},
+        "seed": {"type": ["integer", "null"]},
+        "min_length": {"type": ["integer", "null"]},
+        "max_length": {"type": ["integer", "null"]},
+        "max_homopolymer": {"type": ["integer", "null"]},
+        "parallel": {"type": ["boolean", "null"]},
+        "threads": {"type": ["integer", "null"]},
+        "processes": {"type": ["integer", "null"]}
+      }
+    }
+  }
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -586,6 +586,45 @@ Simulator profiles used by external tools are cached under
 location. Provide pre-downloaded profiles via `GENECODER_PROFILE_DIR` to
 run simulators without network access.
 
+### Validating bundle configurations
+
+Bundle runs are validated against `configs/schema/bundle.schema.json` before
+execution. A minimal configuration demonstrating valid `encode`, `simulate` and
+`decode` blocks looks like:
+
+```yaml
+encode:
+  input_files:
+    - examples/pipeline_demo_input.txt
+  method: base4_direct
+  fec: hamming_7_4
+simulate:
+  simulators:
+    - illumina
+  pipeline:
+    illumina_profile: hiseq
+decode:
+  method: base4_direct
+```
+
+To lint a bundle without running it, load the YAML and apply the schema:
+
+```bash
+python - <<'PY'
+import json
+import yaml
+from jsonschema import Draft202012Validator
+
+schema = json.load(open("configs/schema/bundle.schema.json", "r", encoding="utf-8"))
+data = yaml.safe_load(open("configs/pipeline_demo.yaml", "r", encoding="utf-8"))
+Draft202012Validator(schema).validate(data)
+print("bundle config is valid")
+PY
+```
+
+`genecli bundle run` will emit a clear error if the schema is violated (for
+example, due to unknown keys or type mismatches).
+
 ## Graphical User Interface (GUI)
 
 ### Launching the Flet App

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pyfinite = {version = ">=1.9,<2.0", optional = true}
 bchlib = {version = ">=2.1,<3.0", optional = true}
 raptorq = {version = ">=2.0,<3.0", optional = true}
 httpx = "<0.28"
+jsonschema = ">=4.0"
 deepdna = {version = "*", optional = true}
 chamaeleo = {version = "*", optional = true}
 dnachisel = {version = "*", optional = true}

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -14,12 +14,17 @@ from pathlib import Path
 from dataclasses import dataclass, fields, asdict
 from typing import Any, Mapping, Sequence, cast
 
+from jsonschema import Draft202012Validator, ValidationError
+from jsonschema.exceptions import best_match
+
 from . import cli as cli_module
 from genecoder.formats import SequenceBatch
 from genecoder.html_report import generate_html_report
 from genecoder.metrics import metrics, set_metrics_path
 from genecoder.core import metrics as gather_metrics
 from genecoder.manifest import generate_manifest
+from genecoder.plugin_manager import FEC_REGISTRY
+from genecoder.simulators import SIMULATOR_REGISTRY
 
 
 @dataclass
@@ -40,6 +45,84 @@ class ChannelArgs:
     processes: int | None = None
 
 logger = logging.getLogger(__name__)
+
+
+def _load_bundle_schema() -> dict[str, Any]:
+    schema_path = (
+        Path(__file__).resolve().parents[3]
+        / "configs"
+        / "schema"
+        / "bundle.schema.json"
+    )
+    with open(schema_path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _augment_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    schema = copy.deepcopy(schema)
+    defs = schema.setdefault("$defs", {})
+
+    fec_choices = sorted({"triple_repeat", "hamming_7_4", *FEC_REGISTRY.keys()})
+    fec_prop = defs.get("encode", {}).get("properties", {}).get("fec")
+    if isinstance(fec_prop, dict):
+        if fec_choices:
+            fec_prop["enum"] = fec_choices
+        else:
+            fec_prop.pop("enum", None)
+
+    simulator_choices = sorted(SIMULATOR_REGISTRY.keys())
+    sim_name_def = defs.get("simulatorName")
+    if isinstance(sim_name_def, dict):
+        if simulator_choices:
+            sim_name_def["enum"] = simulator_choices
+        else:
+            sim_name_def.pop("enum", None)
+
+    return schema
+
+
+def _format_schema_error(error: ValidationError) -> str:
+    params = getattr(error, "params", {}) or {}
+    extra = params.get("additionalProperties") if isinstance(params, dict) else None
+    if error.validator == "additionalProperties":
+        extras: list[str] = []
+        if isinstance(extra, list):
+            extras = [str(item) for item in extra]
+        elif isinstance(error.instance, Mapping):
+            instance_keys = {str(k) for k in error.instance}
+            schema_props = (
+                error.schema.get("properties") if isinstance(error.schema, dict) else {}
+            )
+            allowed = {str(k) for k in schema_props} if isinstance(schema_props, Mapping) else set()
+            extras = sorted(instance_keys - allowed)
+        if not extras and "'" in error.message:
+            parts = [seg for seg in error.message.split("'") if seg.strip()]
+            if parts:
+                extras = [parts[0]]
+
+        if not error.path:
+            return f"Unknown top-level keys: {', '.join(extras)}"
+        section = str(error.path[0]) if error.path else ""
+        return f"Unknown {section} options: {', '.join(extras)}"
+
+    if error.validator == "type" and error.validator_value == "object" and error.path:
+        section = str(error.path[0])
+        return f"{section} section must be a mapping"
+
+    path = "".join(f"[{p!r}]" if isinstance(p, int) else f".{p}" for p in error.path)
+    prefix = path.lstrip(".") or "<root>"
+    return f"{prefix}: {error.message}"
+
+
+def _validate_bundle_config(config: Mapping[str, object], config_path: Path) -> None:
+    schema = _augment_schema(_load_bundle_schema())
+    validator = Draft202012Validator(schema)
+    error = best_match(validator.iter_errors(config))
+    if error is None:
+        return
+
+    message = _format_schema_error(error)
+    raise ValueError(f"Invalid bundle config at {config_path} ({message})")
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -213,7 +296,7 @@ def _create_archive(
     metrics_target: Path | None = None,
 ) -> None:
     """Create a gzipped tar archive of ``run_dir`` with a summary manifest."""
-    summary_path = _write_summary_file(
+    _write_summary_file(
         run_dir,
         config_hash,
         batch_metadata=batch_metadata,
@@ -580,6 +663,8 @@ def _run_single_bundle(
 
     if not isinstance(config, dict):
         raise TypeError("Top level YAML must be a mapping")
+
+    _validate_bundle_config(config, config_path)
 
     allowed_sections = {"encode", "simulate", "decode"}
     unknown_sections = set(config) - allowed_sections


### PR DESCRIPTION
## Summary
- add a JSON schema for bundle configurations and enforce validation before runs
- provide clearer errors for unknown or invalid bundle options using registry-derived enums
- document schema usage and add jsonschema dependency

## Testing
- python -m pytest tests/test_bundle.py
- ruff check src/genecoder/cli/bundle.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693989aa7198832686175534bed48003)