### PR TITLE
Add adapter-backed indel presets

### DIFF
--- a/configs/pipeline_demo.yaml
+++ b/configs/pipeline_demo.yaml
@@ -10,8 +10,8 @@ encode:
   fec: hamming_7_4
 simulate:
   simulators:
-    - name: simple
-      error_rate: 0.01
+    - name: indel
+      profile: illumina_adapter
   pipeline:
     parallel: false
     workers: null

--- a/configs/pipeline_metrics.yaml
+++ b/configs/pipeline_metrics.yaml
@@ -13,8 +13,8 @@ encode:
   fec: hamming_7_4
 simulate:
   simulators:
-    - name: simple
-      error_rate: 0.01
+    - name: indel
+      profile: nanopore_adapter
   synthesis:
     gc_min: 0.0
     gc_max: 1.0

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,6 +145,18 @@ genecli channel --input-file encoded.fasta --output-file corrupted.fasta \
 genecli decode corrupted.fasta --output-file decoded.bin
 ```
 
+The ``indel`` simulator now defaults to richer adapter presets that route to the
+technology-specific simulators:
+
+* ``illumina_adapter`` (default) delegates to ``IlluminaChannel`` with the
+  ``miseq`` profile.
+* ``nanopore_adapter`` delegates to ``NanoporeChannel`` with the ``r10.4``
+  profile.
+
+Override the default with ``--indel-profile nanopore_adapter`` or fall back to
+the legacy probability-only profiles with ``--indel-profile illumina`` or
+``--indel-profile nanopore``.
+
 Pass `--seed <int>` to `genecli encode`, `genecli decode`, `genecli channel`, or
 `genecli pipeline` to seed random components for reproducible runs.
 Alternatively set the `GENECODER_SIM_SEED` environment variable.

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -22,7 +22,11 @@ from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES, DNARSIM_RATE_TABLES
-from genecoder.error_simulation import INDEL_PROFILES
+from genecoder.error_simulation import (
+    ADAPTER_PROFILES,
+    DEFAULT_ADAPTER_PROFILE,
+    INDEL_PROFILES,
+)
 from genecoder.simulators.decay import DegradationChannel
 from genecoder.simulators.batch_utils import (
     RESULT_COVERAGE_KEY,
@@ -878,11 +882,17 @@ def run_channel(args: argparse.Namespace) -> None:
             if name == "nanopore_dnarsim" and opts.dnarsim_profile:
                 new_params.setdefault("profile", opts.dnarsim_profile)
         if name == "indel":
-            if opts.indel_profile is not None:
-                if opts.indel_profile not in INDEL_PROFILES:
-                    logger.error("Unknown indel profile: %s", opts.indel_profile)
+            indel_profile = opts.indel_profile
+            if indel_profile is None and not any(
+                rate is not None
+                for rate in (opts.sub_rate, opts.ins_rate, opts.del_rate)
+            ):
+                indel_profile = DEFAULT_ADAPTER_PROFILE
+            if indel_profile is not None:
+                if indel_profile not in INDEL_PROFILES and indel_profile not in ADAPTER_PROFILES:
+                    logger.error("Unknown indel profile: %s", indel_profile)
                     raise SystemExit(1)
-                new_params.setdefault("profile", opts.indel_profile)
+                new_params.setdefault("profile", indel_profile)
             if opts.sub_rate is not None:
                 new_params["substitution_prob"] = opts.sub_rate
             if opts.ins_rate is not None:
@@ -945,12 +955,21 @@ def _handle_run(args: argparse.Namespace) -> None:
             if name == "nanopore_dnarsim":
                 params.setdefault("profile", args.dnarsim_profile)
     if args.indel_profile is not None:
-        if args.indel_profile not in INDEL_PROFILES:
+        if args.indel_profile not in INDEL_PROFILES and args.indel_profile not in ADAPTER_PROFILES:
             logger.error("Unknown indel profile: %s", args.indel_profile)
             raise SystemExit(1)
         for name, params in simulators:
             if name == "indel":
                 params.setdefault("profile", args.indel_profile)
+    else:
+        for name, params in simulators:
+            if name == "indel" and "profile" not in params:
+                if any(
+                    key in params
+                    for key in ("substitution_prob", "insertion_prob", "deletion_prob", "error_rate")
+                ):
+                    continue
+                params.setdefault("profile", DEFAULT_ADAPTER_PROFILE)
     if args.nanopore_profile_file is not None:
         prof = _load_profile_file(args.nanopore_profile_file)
         for name, params in simulators:

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -18,6 +18,8 @@ __all__ = [
     "Channel",
     "register",
     "INDEL_PROFILES",
+    "ADAPTER_PROFILES",
+    "DEFAULT_ADAPTER_PROFILE",
 ]
 
 NUCLEOTIDES = ["A", "T", "C", "G"]
@@ -37,7 +39,26 @@ INDEL_PROFILES: dict[str, dict[str, float]] = {
         "insertion_prob": 0.02,
         "deletion_prob": 0.02,
     },
+    # Higher-level adapters that delegate to richer simulators.
+    "illumina_adapter": {
+        "substitution_prob": 0.0,
+        "insertion_prob": 0.0,
+        "deletion_prob": 0.0,
+    },
+    "nanopore_adapter": {
+        "substitution_prob": 0.0,
+        "insertion_prob": 0.0,
+        "deletion_prob": 0.0,
+    },
 }
+
+# Adapter presets that delegate to richer simulator implementations.
+ADAPTER_PROFILES: dict[str, tuple[str, str]] = {
+    "illumina_adapter": ("illumina", "miseq"),
+    "nanopore_adapter": ("nanopore", "r10.4"),
+}
+
+DEFAULT_ADAPTER_PROFILE = "illumina_adapter"
 
 
 def _random_substitution(nucleotide: str, rng: random.Random) -> str:
@@ -142,12 +163,24 @@ class Channel(Simulator):
         error_rate: float | None = None,
         profile: str | None = None,
     ) -> None:
+        self._delegate: Simulator | None = None
         if profile is not None:
             params = INDEL_PROFILES.get(profile.lower())
             if params is not None:
                 substitution_prob = params["substitution_prob"]
                 insertion_prob = params["insertion_prob"]
                 deletion_prob = params["deletion_prob"]
+            adapter = ADAPTER_PROFILES.get(profile.lower())
+            if adapter is not None:
+                family, preset = adapter
+                if family == "illumina":
+                    from .simulators.illumina import IlluminaChannel
+
+                    self._delegate = IlluminaChannel(profile=preset)
+                elif family == "nanopore":
+                    from .simulators.nanopore import NanoporeChannel
+
+                    self._delegate = NanoporeChannel(profile=preset)
         if error_rate is not None:
             substitution_prob = error_rate
         self._substitution_prob = substitution_prob
@@ -182,6 +215,8 @@ class Channel(Simulator):
         self._substitution_prob = value
 
     def simulate(self, sequence: str) -> str:
+        if self._delegate is not None:
+            return self._delegate.simulate(sequence)
         return simulate_errors(
             sequence,
             substitution_prob=self.substitution_prob,

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -359,6 +359,62 @@ def test_cli_indel_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     )]
 
 
+def test_cli_indel_default_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_fasta = tmp_path / "in_indel_default.fasta"
+    create_fasta(input_fasta)
+    output_fasta = tmp_path / "out_indel_default.fasta"
+    observed_profiles: list[str | None] = []
+
+    from genecoder.error_simulation import (
+        Channel as IndelChannel,
+        DEFAULT_ADAPTER_PROFILE,
+    )
+
+    def fake_init(
+        self: IndelChannel,
+        substitution_prob: float = 0.0,
+        insertion_prob: float = 0.0,
+        deletion_prob: float = 0.0,
+        error_rate: float | None = None,
+        profile: str | None = None,
+    ) -> None:
+        observed_profiles.append(profile)
+        self._delegate = None
+        self._substitution_prob = substitution_prob if error_rate is None else error_rate
+        self.insertion_prob = insertion_prob
+        self.deletion_prob = deletion_prob
+
+    monkeypatch.setattr(IndelChannel, "__init__", fake_init)
+    monkeypatch.setattr(IndelChannel, "simulate", lambda self, seq: seq)
+
+    env = os.environ.copy()
+    from pathlib import Path as _Path
+    src_path = _Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--input-file",
+            str(input_fasta),
+            "--output-file",
+            str(output_fasta),
+            "--simulator",
+            "indel",
+            "--min-length",
+            "1",
+        ],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    adapter_profiles = [p for p in observed_profiles if p is not None]
+    assert adapter_profiles[-1:] == [DEFAULT_ADAPTER_PROFILE]
+
+
 def test_channel_cli_yaml(tmp_path: Path) -> None:
     input_fasta = tmp_path / "in.fasta"
     create_fasta(input_fasta)


### PR DESCRIPTION
## Summary
- add adapter presets that delegate the indel channel to Illumina and Nanopore simulators with sensible defaults
- default the CLI to adapter-backed indel profiles unless legacy probability-only profiles are requested
- refresh pipeline configuration examples and usage docs to highlight the new presets

## Testing
- ruff check src/genecoder/error_simulation.py src/genecoder/cli/channel.py tests/test_cli_channel.py
- pytest tests/test_cli_channel.py::test_cli_indel_rates tests/test_cli_channel.py::test_cli_indel_profile tests/test_cli_indel_default_adapter


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403e1137c08326a9ff1c4d94118edf)