### PR TITLE
Add cached nanopore fountain bundle test

### DIFF
--- a/tests/test_bundle_nanopore_fountain.py
+++ b/tests/test_bundle_nanopore_fountain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from typing import Sequence
 
 import pytest
 
@@ -14,11 +15,11 @@ if yaml.safe_load("foo: 1") == {}:
     pytest.skip("Functional YAML parser required for bundle tests", allow_module_level=True)
 
 
-def _prepare_config(tmp_path: Path) -> tuple[Path, dict[str, object], Path]:
+def _prepare_config(base_dir: Path) -> tuple[Path, dict[str, object], Path]:
     base_config = Path(__file__).resolve().parents[1] / "configs" / "fountain_nanopore_pipeline.yaml"
     config = yaml.safe_load(base_config.read_text(encoding="utf-8")) or {}
 
-    input_file = tmp_path / "nanopore_payload.txt"
+    input_file = base_dir / "nanopore_payload.txt"
     input_file.write_text("nanopore fountain bundle")
 
     encode_cfg = config.get("encode", {}) if isinstance(config, dict) else {}
@@ -27,35 +28,58 @@ def _prepare_config(tmp_path: Path) -> tuple[Path, dict[str, object], Path]:
     simulate_cfg = config.get("simulate") if isinstance(config, dict) else None
     if isinstance(simulate_cfg, dict):
         simulate_cfg["seed"] = 7
-    trimmed_config = tmp_path / "fountain_nanopore.yaml"
+    trimmed_config = base_dir / "fountain_nanopore.yaml"
     trimmed_config.write_text(yaml.safe_dump(config))
     return trimmed_config, config, input_file
 
 
-def test_bundle_nanopore_fountain(tmp_path: Path) -> None:
-    cache_dir = tmp_path / "bundle_cache"
-    cache_dir.mkdir()
-
-    config_path, config_dict, input_path = _prepare_config(tmp_path)
-
-    result = run_cli_command(
-        [
-            "bundle",
-            "run",
-            str(config_path),
-            "--cache-dir",
-            str(cache_dir),
-            "--emit-manifest-report",
-        ],
-        env={"GENECODER_SIM_SEED": "7"},
-    )
-    assert result.returncode == 0, result.stderr
-
+def _bundle_run_with_cache(
+    cache_dir: Path,
+    config_path: Path,
+    config_dict: dict[str, object],
+    extra_args: Sequence[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
     config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode("utf-8")).hexdigest()
     run_root = cache_dir / config_hash
-    run_dirs = sorted(run_root.iterdir())
+    run_dirs = sorted(run_root.iterdir()) if run_root.exists() else []
+    if not run_dirs:
+        args: list[str] = ["bundle", "run", str(config_path), "--cache-dir", str(cache_dir)]
+        if extra_args:
+            args.extend(extra_args)
+        result = run_cli_command(args, env=env)
+        assert result.returncode == 0, result.stderr
+        run_dirs = sorted(run_root.iterdir())
     assert run_dirs, "bundle run directory missing"
-    run_dir = run_dirs[-1]
+    return run_dirs[-1]
+
+
+@pytest.fixture(scope="session")
+def bundle_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    cache_dir = tmp_path_factory.mktemp("bundle_cache")
+    cache_dir.mkdir(exist_ok=True)
+    return cache_dir
+
+
+@pytest.fixture(scope="session")
+def nanopore_bundle_config(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, dict[str, object], Path]:
+    base_dir = tmp_path_factory.mktemp("nanopore_bundle")
+    return _prepare_config(base_dir)
+
+
+def test_bundle_nanopore_fountain(
+    bundle_cache_dir: Path, nanopore_bundle_config: tuple[Path, dict[str, object], Path]
+) -> None:
+    config_path, config_dict, input_path = nanopore_bundle_config
+
+    run_dir = _bundle_run_with_cache(
+        cache_dir=bundle_cache_dir,
+        config_path=config_path,
+        config_dict=config_dict,
+        extra_args=("--emit-manifest-report",),
+        env={"GENECODER_SIM_SEED": "7"},
+    )
 
     decoded_dir = run_dir / "decoded"
     decoded_payload = decoded_dir / f"{input_path.name}_decoded.bin"


### PR DESCRIPTION
## Summary
- add session-scoped fixtures for nanopore fountain bundle inputs and cache reuse
- run the fountain nanopore bundle with a fixed seed and assert decoded payload and manifests exist

## Testing
- pytest tests/test_bundle_nanopore_fountain.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f8fca2c8326a7da8ddccb64399d)