### PR TITLE
Respect explicit indel rates when using adapter profiles

### DIFF
--- a/configs/fountain_nanopore_pipeline.yaml
+++ b/configs/fountain_nanopore_pipeline.yaml
@@ -16,7 +16,7 @@ simulate:
     min_length: 25
     max_length: 600
   pipeline:
-    nanopore_profile: r10
+    nanopore_profile: r10.4
 decode:
   method: gc_balanced
 

--- a/configs/pipeline_demo.yaml
+++ b/configs/pipeline_demo.yaml
@@ -11,7 +11,7 @@ encode:
 simulate:
   simulators:
     - name: indel
-      profile: illumina_adapter
+      profile: illumina_adapter  # Delegates to IlluminaChannel (MiSeq V3 preset)
   pipeline:
     parallel: false
     workers: null

--- a/configs/pipeline_metrics.yaml
+++ b/configs/pipeline_metrics.yaml
@@ -14,7 +14,7 @@ encode:
 simulate:
   simulators:
     - name: indel
-      profile: nanopore_adapter
+      profile: nanopore_adapter  # Delegates to NanoporeChannel (R10.4 preset)
   synthesis:
     gc_min: 0.0
     gc_max: 1.0

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,13 +149,16 @@ The ``indel`` simulator now defaults to richer adapter presets that route to the
 technology-specific simulators:
 
 * ``illumina_adapter`` (default) delegates to ``IlluminaChannel`` with the
-  ``miseq`` profile.
+  MiSeq V3 profile and approximates its rates when falling back to probability
+  mode.
 * ``nanopore_adapter`` delegates to ``NanoporeChannel`` with the ``r10.4``
-  profile.
+  profile and reuses its probability estimates when the full simulator is not
+  available.
 
-Override the default with ``--indel-profile nanopore_adapter`` or fall back to
+Override the defaults with ``--indel-profile nanopore_adapter`` or fall back to
 the legacy probability-only profiles with ``--indel-profile illumina`` or
-``--indel-profile nanopore``.
+``--indel-profile nanopore``. Passing ``--indel-profile`` with a legacy name
+explicitly keeps the older behaviour.
 
 Pass `--seed <int>` to `genecli encode`, `genecli decode`, `genecli channel`, or
 `genecli pipeline` to seed random components for reproducible runs.

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -26,7 +26,7 @@ NUCLEOTIDES = ["A", "T", "C", "G"]
 
 
 # Preset substitution/indel probability profiles for :class:`Channel`.
-INDEL_PROFILES: dict[str, dict[str, float]] = {
+LEGACY_INDEL_PROFILES: dict[str, dict[str, float]] = {
     # Typical Illumina error characteristics favour substitutions over indels.
     "illumina": {
         "substitution_prob": 0.002,
@@ -39,23 +39,33 @@ INDEL_PROFILES: dict[str, dict[str, float]] = {
         "insertion_prob": 0.02,
         "deletion_prob": 0.02,
     },
-    # Higher-level adapters that delegate to richer simulators.
-    "illumina_adapter": {
-        "substitution_prob": 0.0,
-        "insertion_prob": 0.0,
-        "deletion_prob": 0.0,
-    },
-    "nanopore_adapter": {
-        "substitution_prob": 0.0,
-        "insertion_prob": 0.0,
-        "deletion_prob": 0.0,
-    },
 }
 
 # Adapter presets that delegate to richer simulator implementations.
-ADAPTER_PROFILES: dict[str, tuple[str, str]] = {
-    "illumina_adapter": ("illumina", "miseq"),
-    "nanopore_adapter": ("nanopore", "r10.4"),
+ADAPTER_PROFILES: dict[str, dict[str, object]] = {
+    "illumina_adapter": {
+        "family": "illumina",
+        "profile": "miseq_v3",
+        "fallback": {
+            "substitution_prob": 0.0009,
+            "insertion_prob": 0.0001,
+            "deletion_prob": 0.0001,
+        },
+    },
+    "nanopore_adapter": {
+        "family": "nanopore",
+        "profile": "r10.4",
+        "fallback": {
+            "substitution_prob": 0.045,
+            "insertion_prob": 0.015,
+            "deletion_prob": 0.025,
+        },
+    },
+}
+
+INDEL_PROFILES: dict[str, dict[str, float]] = {
+    **LEGACY_INDEL_PROFILES,
+    **{name: profile["fallback"] for name, profile in ADAPTER_PROFILES.items()},
 }
 
 DEFAULT_ADAPTER_PROFILE = "illumina_adapter"
@@ -157,35 +167,42 @@ class Channel(Simulator):
 
     def __init__(
         self,
-        substitution_prob: float = 0.0,
-        insertion_prob: float = 0.0,
-        deletion_prob: float = 0.0,
+        substitution_prob: float | None = None,
+        insertion_prob: float | None = None,
+        deletion_prob: float | None = None,
         error_rate: float | None = None,
         profile: str | None = None,
     ) -> None:
         self._delegate: Simulator | None = None
+        sub_prob = substitution_prob
+        ins_prob = insertion_prob
+        del_prob = deletion_prob
+
         if profile is not None:
             params = INDEL_PROFILES.get(profile.lower())
             if params is not None:
-                substitution_prob = params["substitution_prob"]
-                insertion_prob = params["insertion_prob"]
-                deletion_prob = params["deletion_prob"]
+                sub_prob = params["substitution_prob"] if sub_prob is None else sub_prob
+                ins_prob = params["insertion_prob"] if ins_prob is None else ins_prob
+                del_prob = params["deletion_prob"] if del_prob is None else del_prob
             adapter = ADAPTER_PROFILES.get(profile.lower())
             if adapter is not None:
-                family, preset = adapter
+                family = adapter["family"]
+                preset = adapter["profile"]
                 if family == "illumina":
                     from .simulators.illumina import IlluminaChannel
 
-                    self._delegate = IlluminaChannel(profile=preset)
+                    self._delegate = IlluminaChannel(profile=str(preset))
                 elif family == "nanopore":
                     from .simulators.nanopore import NanoporeChannel
 
-                    self._delegate = NanoporeChannel(profile=preset)
+                    self._delegate = NanoporeChannel(profile=str(preset))
+
         if error_rate is not None:
-            substitution_prob = error_rate
-        self._substitution_prob = substitution_prob
-        self.insertion_prob = insertion_prob
-        self.deletion_prob = deletion_prob
+            sub_prob = error_rate
+
+        self._substitution_prob = 0.0 if sub_prob is None else sub_prob
+        self.insertion_prob = 0.0 if ins_prob is None else ins_prob
+        self.deletion_prob = 0.0 if del_prob is None else del_prob
 
     @property
     def substitution_prob(self) -> float:


### PR DESCRIPTION
## Summary
- add adapter presets that delegate indel simulation to Illumina and Nanopore channels with profile-aligned fallbacks
- refresh pipeline configuration examples to highlight richer adapter-based defaults
- document the default adapter behaviour for CLI users
- preserve explicit indel probability overrides when adapter profiles are requested

## Testing
- ruff check src/genecoder/error_simulation.py
- pytest tests/test_error_simulation.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f8eb9608326966c52c63550e5e8)