### PR TITLE
Add MVP checklist mapping configs to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 GeneCoder is an educational toolkit for exploring DNA-based data storage. It provides a command line interface and a GUI for encoding and decoding files into simulated DNA sequences.
 
-For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above.
+For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above. The [MVP coverage checklist](docs/mvp_checklist.md) maps roadmap requirements to the shipped presets and example CLI commands.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
 The configuration at `configs/pipeline_metrics.yaml` shows how to run the pipeline while recording metrics. Supply the metrics destination and optional extras directly via CLI flags:

--- a/docs/mvp_checklist.md
+++ b/docs/mvp_checklist.md
@@ -1,0 +1,12 @@
+# MVP coverage checklist
+
+This checklist maps the roadmap requirements to the current presets and CLI entrypoints.
+
+| Requirement | Where it appears | CLI coverage |
+| --- | --- | --- |
+| Error correction choices | `configs/gold.yaml` locks the GC-balanced encoder with Reed–Solomon FEC, while `configs/rs_illumina_pipeline.yaml` pairs the same encoder with Reed–Solomon and `configs/fountain_nanopore_pipeline.yaml` swaps in Fountain codes for the constraint-aware encoder. | `genecli bundle run configs/gold.yaml --cache-dir gold_runs` exercises the Reed–Solomon path, and the sweep helper `genecli bundle sweep configs/rs_illumina_pipeline.yaml configs/fountain_nanopore_pipeline.yaml --cache-dir pipeline_runs --metrics-path examples/pipeline_metrics.json --manifest-index pipeline_runs/manifest_index.json --emit-manifest-report` covers both Reed–Solomon and Fountain options. |
+| Illumina and Nanopore models | `configs/rs_illumina_pipeline.yaml` locks the Illumina simulator with the `hiseq` profile, and `configs/gold.yaml` targets MiSeq through InSilicoSeq. `configs/fountain_nanopore_pipeline.yaml` pins the Nanopore simulator with the `r10.4` profile. | Run Illumina pipelines with `genecli bundle run configs/rs_illumina_pipeline.yaml --cache-dir pipeline_runs` (or the MiSeq-based `configs/gold.yaml` example above). The Nanopore sweep entry in the bundle command above launches the `nanopore` simulator with the configured profile. |
+| Constraint metrics and limits | `configs/rs_illumina_pipeline.yaml` constrains GC balance (0–1), homopolymers (≤3), and sequence lengths (25–300 bp) under `synthesis`. `configs/fountain_nanopore_pipeline.yaml` keeps GC 0–1, homopolymers ≤100, and lengths 25–600 bp. Manifests emitted by `configs/gold.yaml` record GC balance and coverage statistics for quick verification. | Include `--emit-manifest-report` when running the sweep so each encode stage produces a manifest and HTML summary. Individual manifests can also be converted with `genecli html-report --manifest <path> --output-file <report.html>`. |
+| CLI and dashboard availability | The CLI bundle runs above drive the end-to-end pipelines. Adding `--launch-dashboard` to any `genecli bundle run` or `genecli bundle sweep` command starts the Streamlit dashboard for the captured metrics. | Use the sweep invocation above with `--launch-dashboard` to open the dashboard for both Illumina and Nanopore presets once metrics are written. |
+
+Use this checklist to verify that the MVP expectations are covered by the shipped presets and example commands.


### PR DESCRIPTION
## Summary
- add an MVP coverage checklist that maps roadmap requirements to shipped presets and CLI commands
- link the checklist from the README for easy discovery

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c4ff0e348326bc5fa44a111f1cfa)