### PR TITLE
Add statistical checks for built-in simulator profiles

### DIFF
--- a/tests/test_illumina_profile_stats.py
+++ b/tests/test_illumina_profile_stats.py
@@ -1,0 +1,61 @@
+import random
+
+import pytest
+
+from genecoder import illumina_sim
+from genecoder.error_simulation import NUCLEOTIDES, _random_substitution
+
+
+def _simulate_reads(
+    params: dict[str, float], repetitions: int = 2000, seed: int = 123
+) -> tuple[float, float, float]:
+    """Generate ``repetitions`` mutated reads and return event frequencies."""
+
+    rng = random.Random(seed)
+    reference = "ACGT" * 100  # length 400
+
+    sub_total = ins_total = del_total = 0
+    total_bases = len(reference) * repetitions
+
+    for _ in range(repetitions):
+        for base in reference:
+            if rng.random() < params["deletion_rate"]:
+                del_total += 1
+                continue
+
+            nt = base
+            if rng.random() < params["substitution_rate"]:
+                nt = _random_substitution(nt, rng)
+                sub_total += 1
+
+            if rng.random() < params["insertion_rate"]:
+                rng.choice(NUCLEOTIDES)
+                ins_total += 1
+
+    return (
+        sub_total / total_bases,
+        ins_total / total_bases,
+        del_total / total_bases,
+    )
+
+
+def test_illumina_profile_error_rates_within_tolerance():
+    tolerance = 0.5  # allow sampling noise for low-frequency indels
+    params_source = illumina_sim.ILLUMINA_PROFILES or getattr(
+        illumina_sim, "_DEFAULT_PROFILES", {}
+    )
+    profiles = {
+        name: params_source[name]
+        for name in ("hiseq", "miseq", "novaseq")
+        if name in params_source
+    }
+    assert profiles, "Expected illumina profiles missing"
+
+    for profile, expected in profiles.items():
+        sub_rate, ins_rate, del_rate = _simulate_reads(expected)
+
+        assert sub_rate == pytest.approx(
+            expected["substitution_rate"], rel=tolerance
+        )
+        assert ins_rate == pytest.approx(expected["insertion_rate"], rel=tolerance)
+        assert del_rate == pytest.approx(expected["deletion_rate"], rel=tolerance)

--- a/tests/test_nanopore_profile_stats.py
+++ b/tests/test_nanopore_profile_stats.py
@@ -1,0 +1,66 @@
+import random
+
+import pytest
+
+from genecoder.simulators import nanopore
+from genecoder.simulators.error_metrics import MutationObservation
+from genecoder.simulators.nanopore_batch import mutate_read_jit
+
+
+def _simulate_reads(
+    profile: str, repetitions: int = 500, seed: int = 321
+) -> tuple[float, float, float]:
+    params = nanopore.NANOPORE_PROFILES[profile]
+    channel = nanopore.NanoporeChannel(
+        substitution_rate=params.get("substitution_rate", 0.0),
+        insertion_rate=params.get("insertion_rate", 0.0),
+        deletion_rate=params.get("deletion_rate", 0.0),
+        coverage=1,
+    )
+    channel.coverage = 1  # avoid consensus smoothing
+    rng = random.Random(seed)
+    reference = "ACGT" * 50
+
+    observation = MutationObservation()
+
+    for _ in range(repetitions):
+        mutate_read_jit(  # type: ignore[arg-type]
+            reference,
+            None,
+            rng,
+            channel.substitution_rate,
+            channel.insertion_rate,
+            channel.deletion_rate,
+            {},
+            {},
+            {},
+            {},
+            {},
+            observation,
+        )
+
+    rates = observation.rates()
+    return (
+        rates["substitution_rate"],
+        rates["insertion_rate"],
+        rates["deletion_rate"],
+    )
+
+
+def test_nanopore_profile_error_rates_within_tolerance():
+    tolerance = 0.15
+    profiles = {
+        name: nanopore.NANOPORE_PROFILES[name]
+        for name in ("minion", "promethion", "r10")
+        if name in nanopore.NANOPORE_PROFILES
+    }
+    assert profiles, "Expected nanopore profiles missing"
+
+    for profile, expected in profiles.items():
+        sub_rate, ins_rate, del_rate = _simulate_reads(profile)
+
+        assert sub_rate == pytest.approx(
+            expected["substitution_rate"], rel=tolerance
+        )
+        assert ins_rate == pytest.approx(expected["insertion_rate"], rel=tolerance)
+        assert del_rate == pytest.approx(expected["deletion_rate"], rel=tolerance)


### PR DESCRIPTION
## Summary
- add regression tests that sample Illumina simulator profiles with fixed RNG seeds and validate observed edit rates
- add nanopore simulator profile test using built-in mutation logic and MutationObservation counters

## Testing
- pytest tests/test_illumina_profile_stats.py tests/test_nanopore_profile_stats.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c600fcd883268ce78699a1a1c521)