### PR TITLE
Add dry-run sweep verification test

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -175,6 +175,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         action="store_true",
         help="Launch the dashboard for the metrics file after the run",
     )
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate configs and create placeholder outputs without running the pipeline",
+    )
     run_parser.set_defaults(func=_handle_run)
 
     sweep_parser = bundle_sub.add_parser(
@@ -225,6 +230,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--launch-dashboard",
         action="store_true",
         help="Launch the dashboard for the metrics file after the sweep",
+    )
+    sweep_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate configs and create placeholder outputs without running the pipeline",
     )
     sweep_parser.set_defaults(func=_handle_sweep)
 
@@ -653,6 +663,7 @@ def _run_single_bundle(
     emit_manifest_report: bool,
     metrics_override: Path | None,
     launch_dashboard: bool,
+    dry_run: bool,
 ) -> BundleRunResult:
     import yaml
 
@@ -694,7 +705,7 @@ def _run_single_bundle(
         raise TypeError("decode section must be a mapping")
 
     hash_dir = cache_dir / config_hash
-    if hash_dir.exists():
+    if hash_dir.exists() and not dry_run:
         logger.info("Cached result found in %s", hash_dir)
         run_dirs = sorted(hash_dir.iterdir())
         if not run_dirs:
@@ -741,6 +752,50 @@ def _run_single_bundle(
     decoded_dir = run_dir / "decoded"
     encoded_dir.mkdir(parents=True, exist_ok=True)
     decoded_dir.mkdir(parents=True, exist_ok=True)
+
+    if dry_run:
+        simulated_dir.mkdir(parents=True, exist_ok=True)
+        placeholder_manifest = encoded_dir / "dry_run.manifest.json"
+        placeholder_manifest.write_text(
+            json.dumps(
+                {
+                    "config": config_name,
+                    "dry_run": True,
+                    "config_hash": config_hash,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        decoded_placeholder = decoded_dir / "dry_run.json"
+        decoded_placeholder.write_text(
+            json.dumps({"config": config_name, "dry_run": True}, indent=2),
+            encoding="utf-8",
+        )
+        metrics_target = metrics_override or metrics.path
+        metrics_target.parent.mkdir(parents=True, exist_ok=True)
+        if not metrics_target.exists():
+            metrics_target.write_text("{}", encoding="utf-8")
+
+        summary_path = _write_summary_file(
+            run_dir,
+            config_hash,
+            author=author,
+            description=description,
+            config_name=config_name,
+            channel_profile=_extract_channel_profile(sim_cfg_raw),
+            ecc_type=str(enc_cfg.get("fec")) if enc_cfg.get("fec") else None,
+            metrics_target=metrics_override or metrics.path,
+        )
+        return BundleRunResult(
+            config_path=config_path,
+            config_hash=config_hash,
+            run_dir=run_dir,
+            config_name=config_name,
+            channel_profile=_extract_channel_profile(sim_cfg_raw),
+            ecc_type=str(enc_cfg.get("fec")) if enc_cfg.get("fec") else None,
+            summary_path=summary_path,
+        )
 
     enc_args = _simple_args("encode", enc_cfg, {"input_files", "method", "fec"})
     enc_args += ["--output-dir", str(encoded_dir)]
@@ -974,6 +1029,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         emit_manifest_report=args.emit_manifest_report,
         metrics_override=metrics_override,
         launch_dashboard=args.launch_dashboard,
+        dry_run=args.dry_run,
     )
 
 
@@ -998,6 +1054,7 @@ def _handle_sweep(args: argparse.Namespace) -> None:
                 emit_manifest_report=args.emit_manifest_report,
                 metrics_override=metrics_override,
                 launch_dashboard=False,
+                dry_run=args.dry_run,
             )
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,33 @@ except Exception:  # pragma: no cover - import guard
     yaml_stub.YAMLError = YAMLError
     sys.modules.setdefault("yaml", yaml_stub)
 
+# Provide minimal jsonschema shims when dependency is absent
+try:  # pragma: no cover - exercised only when jsonschema is absent
+    import jsonschema  # noqa: F401
+    import jsonschema.exceptions  # noqa: F401
+except Exception:  # pragma: no cover - import guard
+    class ValidationError(Exception):
+        pass
+
+    class Draft202012Validator:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def iter_errors(self, *_args, **_kwargs):
+            return []
+
+    def best_match(errors):
+        return None
+
+    js_mod = types.ModuleType("jsonschema")
+    js_mod.Draft202012Validator = Draft202012Validator
+    js_mod.ValidationError = ValidationError
+    js_exc = types.ModuleType("jsonschema.exceptions")
+    js_exc.best_match = best_match
+    js_exc.ValidationError = ValidationError
+    sys.modules.setdefault("jsonschema", js_mod)
+    sys.modules.setdefault("jsonschema.exceptions", js_exc)
+
 
 from genecoder.api import Codec
 from genecoder.encoders import decode_base4_direct, encode_base4_direct

--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from tests.test_cli import run_cli_command
+
+
+def test_readme_sweep_example_dry_run(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "sweep_runs"
+    metrics_path = tmp_path / "metrics.json"
+    manifest_index = tmp_path / "manifest_index.json"
+
+    result = run_cli_command(
+        [
+            "bundle",
+            "sweep",
+            "configs/rs_illumina_pipeline.yaml",
+            "configs/fountain_nanopore_pipeline.yaml",
+            "--cache-dir",
+            str(cache_dir),
+            "--metrics-path",
+            str(metrics_path),
+            "--manifest-index",
+            str(manifest_index),
+            "--dry-run",
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert metrics_path.exists()
+    assert manifest_index.exists()
+
+    index_data = json.loads(manifest_index.read_text(encoding="utf-8"))
+    runs = index_data.get("runs", [])
+    assert len(runs) == 2
+    for entry in runs:
+        run_dir = Path(entry["run_dir"])
+        assert run_dir.exists()
+        assert any(run_dir.glob("encoded/*.manifest.json"))
+        assert any(run_dir.glob("decoded/*.json"))


### PR DESCRIPTION
## Summary
- add a dry-run option for bundle run and sweep commands to create placeholder outputs
- stub jsonschema dependency for tests when missing
- add a README sweep smoke test that runs with dry-run and checks manifest index outputs

## Testing
- pytest tests/test_readme_commands.py
- ruff check src/genecoder/cli/bundle.py tests/test_readme_commands.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944254543c48326a4c2f0e88879a58a)