### PR TITLE
docs: clarify Nanopore manifest & dashboard fields

### DIFF
--- a/docs/channel_profiles.md
+++ b/docs/channel_profiles.md
@@ -52,12 +52,12 @@ run a profile such as `r10.4` (`genecli channel --nanopore-profile r10.4`), the
 resulting `.manifest.json` captures:
 
 * The GC guardrails in effect (`gc_min`/`gc_max`, defaulting to 45–55%).
-* The enforced homopolymer limit (`max_homopolymer`, default 3).
+* The enforced homopolymer cap (`max_homopolymer`, default 3).
 * The preset coverage target for the selected profile (30× unless overridden).
 
-View the same fields in the generated HTML report (`genecli html-report` against
-the manifest) or in the Streamlit dashboard via `genecli dashboard <manifest>`
-or `--launch-dashboard` during a bundle run. Both UIs surface GC and
-homopolymer gauges next to coverage and dropout panels for Nanopore runs. See
-the [`dnarsim` preset file](../configs/dnarsim_rates.yaml) for the rates that
+View the same fields in the generated manifest HTML report (via
+`genecli html-report`) or in the Streamlit dashboard (`genecli dashboard
+<manifest>` or `--launch-dashboard` during bundle runs). Both UIs surface GC
+range and homopolymer panels alongside coverage gauges for Nanopore runs. See
+[`configs/nanopore.yml`](../configs/nanopore.yml) for the preset defaults that
 back each profile.


### PR DESCRIPTION
### Motivation

- Make it explicit which manifest fields and dashboard panels Nanopore presets populate (GC range, homopolymer cap, coverage defaults).
- Guide users how to run a Nanopore preset from the CLI and where to view the resulting fields.
- Point readers to the canonical preset file for context so rates and defaults are discoverable.

### Description

- Updated `docs/channel_profiles.md` to document the Nanopore preset fields recorded in manifests: `gc_min`/`gc_max`, `max_homopolymer` (described as a cap), and the preset coverage target (default 30×).
- Clarified how to view these fields via the generated manifest HTML report (`genecli html-report`) and the Streamlit dashboard (`genecli dashboard <manifest>` / `--launch-dashboard`).
- Replaced the previous preset link with the authoritative file reference `configs/nanopore.yml` and adjusted wording for clarity (e.g., "homopolymer cap").

### Testing

- No automated tests or linters were run because this is a documentation-only change.
- File modified: `docs/channel_profiles.md` (content update only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a01f89088326b0697417dd29380c)