### PR TITLE
Add MVP checklist validation script and CI job

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,6 +12,8 @@ on:
       - 'ruff.toml'
       - '.github/workflows/**'
       - 'scripts/**'
+      - 'configs/**'
+      - 'docs/mvp_checklist.md'
 
 # Ensure only a single workflow run per PR or branch
 concurrency:
@@ -26,6 +28,7 @@ jobs:
     runs-on: self-hosted
     outputs:
       src: ${{ steps.filter.outputs.src }}
+      mvp_checklist: ${{ steps.filter.outputs.mvp_checklist }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
@@ -40,6 +43,10 @@ jobs:
               - 'ruff.toml'
               - '.github/workflows/**'
               - 'scripts/**'
+            mvp_checklist:
+              - 'configs/**'
+              - 'docs/mvp_checklist.md'
+              - 'scripts/validate_mvp_checklist.py'
 
   check-comments:
     runs-on: self-hosted
@@ -172,6 +179,28 @@ jobs:
 
     - name: Check glossary terms
       run: python scripts/check_glossary_terms.py
+
+  mvp-checklist:
+    needs: [changes, check-comments]
+    if: needs.changes.outputs.mvp_checklist == 'true' && needs['check-comments'].outputs.only_comments != 'true'
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+
+    - name: Validate MVP checklist
+      run: python scripts/validate_mvp_checklist.py
 
   build:
     needs: [changes, check-comments, lint]

--- a/scripts/validate_mvp_checklist.py
+++ b/scripts/validate_mvp_checklist.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+CHECKLIST_PATH = Path(__file__).resolve().parents[1] / "docs" / "mvp_checklist.md"
+CODE_SNIPPET_RE = re.compile(r"`([^`]+)`")
+CONFIG_PATH_RE = re.compile(r"configs/[A-Za-z0-9_./-]+\.ya?ml")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_checklist() -> str:
+    try:
+        return CHECKLIST_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Checklist not found at {CHECKLIST_PATH}") from exc
+
+
+def extract_config_paths(text: str) -> list[str]:
+    return sorted(set(CONFIG_PATH_RE.findall(text)))
+
+
+def extract_cli_commands(text: str) -> list[str]:
+    commands: list[str] = []
+    for snippet in CODE_SNIPPET_RE.findall(text):
+        snippet = snippet.strip()
+        if snippet.startswith("genecli"):
+            commands.append(snippet)
+    return commands
+
+
+def validate_config_paths(paths: list[str], repo_root: Path) -> list[str]:
+    missing = []
+    for rel_path in paths:
+        if not (repo_root / rel_path).exists():
+            missing.append(rel_path)
+    return missing
+
+
+def _prepare_command(tokens: list[str]) -> list[str]:
+    if not tokens or tokens[0] != "genecli":
+        raise ValueError(f"Unsupported CLI command: {' '.join(tokens)}")
+    args = tokens[1:]
+    is_bundle = len(args) >= 2 and args[0] == "bundle" and args[1] in {"run", "sweep"}
+    if is_bundle:
+        if "--dry-run" not in args:
+            args.append("--dry-run")
+    else:
+        if "--help" not in args and "-h" not in args:
+            args.append("--help")
+    return [sys.executable, "-m", "genecoder.cli", *args]
+
+
+def validate_cli_commands(commands: list[str], repo_root: Path) -> list[str]:
+    failures: list[str] = []
+    env = os.environ.copy()
+    pythonpath = str(repo_root / "src")
+    if env.get("PYTHONPATH"):
+        pythonpath = f"{pythonpath}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = pythonpath
+    for command in commands:
+        tokens = shlex.split(command)
+        cmd = _prepare_command(tokens)
+        result = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            failures.append(
+                "\n".join(
+                    [
+                        f"Command failed: {command}",
+                        f"Exit code: {result.returncode}",
+                        f"Stdout: {result.stdout.strip()}",
+                        f"Stderr: {result.stderr.strip()}",
+                    ]
+                )
+            )
+    return failures
+
+
+def main() -> int:
+    text = load_checklist()
+    repo_root = _repo_root()
+
+    config_paths = extract_config_paths(text)
+    cli_commands = extract_cli_commands(text)
+
+    errors: list[str] = []
+
+    missing_configs = validate_config_paths(config_paths, repo_root)
+    if missing_configs:
+        errors.append(
+            "Missing config paths:\n" + "\n".join(f"- {path}" for path in missing_configs)
+        )
+
+    if not cli_commands:
+        errors.append("No genecli commands found in the checklist.")
+    else:
+        failures = validate_cli_commands(cli_commands, repo_root)
+        if failures:
+            errors.append("CLI command validation failures:\n" + "\n\n".join(failures))
+
+    if errors:
+        sys.stderr.write("\n\n".join(errors) + "\n")
+        return 1
+
+    print("MVP checklist validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure `docs/mvp_checklist.md` stays in sync with the repository by validating referenced config files and example CLI commands automatically.
- Fail PRs early when the checklist drifts from the codebase so documentation remains accurate and runnable.

### Description
- Add a small validator at `scripts/validate_mvp_checklist.py` that:
  - Parses `docs/mvp_checklist.md` for `configs/*.yaml` references and backticked `genecli` commands.
  - Verifies referenced config paths exist in the repo.
  - For CLI snippets, normalizes commands to call the package (`python -m genecoder.cli ...`), appends `--dry-run` to `genecli bundle run|sweep` invocations or `--help` for other subcommands, and ensures they at least parse.
  - Sets `PYTHONPATH` to `src` when invoking commands so the local package is used.
- Wire the validation into CI by updating `.github/workflows/python-ci.yml`:
  - Add `configs/**` and `docs/mvp_checklist.md` to the paths filter and expose a `mvp_checklist` filter output.
  - Add a conditional `mvp-checklist` job which installs the package and runs `python scripts/validate_mvp_checklist.py` when checklist-related files change.

### Testing
- Ran `ruff check .` locally — linting reported existing repository issues and the run failed (no new linter failures introduced by these changes).
- Ran the full test suite with `python -m pytest` — many existing tests in the repo failed/errored (summary observed: `68 failed, 757 passed, 100 skipped, 4 errors`); the new script itself was exercised during validation attempts and is present in CI for further runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a3c7dda88326ae1f4a2a67a32aff)