### PR TITLE
Add summary validation to README sweep dry-run test

### DIFF
--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -37,3 +37,7 @@ def test_readme_sweep_example_dry_run(tmp_path: Path) -> None:
         assert run_dir.exists()
         assert any(run_dir.glob("encoded/*.manifest.json"))
         assert any(run_dir.glob("decoded/*.json"))
+        summary_path = Path(entry["summary"])
+        assert summary_path.exists()
+        summary_data = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert summary_data["metrics_path"] == str(metrics_path)


### PR DESCRIPTION
### Motivation

- Keep the README "sweep" example continuously verified by test coverage.
- Ensure the bundle sweep flow writes a `summary.json` that references the shared metrics file when run with `--metrics-path`.
- Use a lightweight `--dry-run` invocation to avoid heavy simulation while still validating output artifacts.

### Description

- Extended `tests/test_readme_commands.py` for the README sweep example to assert the presence of the per-run `summary.json`.
- Added checks that the `summary.json` exists and that its `metrics_path` field equals the provided `--metrics-path` value.
- The test still runs the bundle sweep with `--dry-run`, `--metrics-path`, and `--manifest-index` to produce placeholder outputs.

### Testing

- Ran `ruff check tests/test_readme_commands.py` — all checks passed.
- Ran `pytest tests/test_readme_commands.py` — tests passed (`1 passed`) with unrelated deprecation warnings.
- The new assertions validate that `manifest_index.json` contains two run entries and that each run has `encoded/*.manifest.json`, `decoded/*.json`, and a `summary.json` referencing the metrics file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a3c8e2a88326b91f8dc1f9ead282)