### PR TITLE
Ensure metrics honor configured synthesis constraints

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -52,6 +52,7 @@ from genecoder.core import metrics as gather_metrics
 from genecoder.manifest import generate_manifest
 from genecoder.plugin_manager import FEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.synthesis import SynthesisConstraints
 
 
 @dataclass
@@ -72,6 +73,23 @@ class ChannelArgs:
     processes: int | None = None
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_int(value: object) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+
+def _parse_float(value: object) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _load_bundle_schema() -> dict[str, Any]:
@@ -379,6 +397,56 @@ def _expand_histogram(histogram: Mapping[str, object]) -> list[int]:
     return counts
 
 
+def _derive_constraints(
+    enc_cfg: Mapping[str, object] | None, sim_cfg: Mapping[str, object] | None
+) -> SynthesisConstraints | None:
+    """Return synthesis constraints from encoding and simulation configs."""
+
+    params: dict[str, float | int] = {}
+
+    def _apply_int(key: str, raw: object, *, prefer_min: bool = False) -> None:
+        val = _parse_int(raw)
+        if val is None:
+            return
+        if prefer_min and key in params:
+            try:
+                params[key] = min(int(params[key]), val)
+            except Exception:
+                params[key] = val
+        else:
+            params[key] = val
+
+    def _apply_float(key: str, raw: object) -> None:
+        val = _parse_float(raw)
+        if val is not None:
+            params[key] = val
+
+    if isinstance(sim_cfg, Mapping):
+        synth_cfg = sim_cfg.get("synthesis") if isinstance(sim_cfg, Mapping) else None
+        if isinstance(synth_cfg, Mapping):
+            _apply_int("min_length", synth_cfg.get("min_length"))
+            _apply_int("max_length", synth_cfg.get("max_length"))
+            _apply_int("max_homopolymer", synth_cfg.get("max_homopolymer"))
+            _apply_float("gc_min", synth_cfg.get("gc_min"))
+            _apply_float("gc_max", synth_cfg.get("gc_max"))
+
+    if isinstance(enc_cfg, Mapping):
+        _apply_int("min_length", enc_cfg.get("min_length"))
+        _apply_int("max_length", enc_cfg.get("max_length"))
+        _apply_int("max_homopolymer", enc_cfg.get("max_homopolymer"), prefer_min=True)
+        _apply_float("gc_min", enc_cfg.get("gc_min"))
+        _apply_float("gc_max", enc_cfg.get("gc_max"))
+
+    if not params:
+        return None
+
+    try:
+        return SynthesisConstraints(**params)
+    except Exception:
+        logger.warning("Ignoring invalid synthesis constraints in bundle config")
+        return None
+
+
 def _write_decoded_metrics(
     original_path: Path,
     simulated_path: Path,
@@ -388,6 +456,7 @@ def _write_decoded_metrics(
     *,
     emit_manifest_report: bool = False,
 ) -> None:
+    constraints = _derive_constraints(enc_cfg, sim_cfg)
     try:
         batch = SequenceBatch.from_fasta(
             simulated_path.read_text(encoding="utf-8")
@@ -498,6 +567,7 @@ def _write_decoded_metrics(
         decoded_bytes,
         str(fec) if fec else None,
         coverage=int(round(average_cov_float)),
+        constraints=constraints,
         oligos=oligos,
         dropout_flags=dropout_flags,
     )
@@ -723,15 +793,15 @@ def _run_single_bundle(
     ).hexdigest()
     config_name = config_path.name
 
-    enc_cfg = config.get("encode", {})
-    if not isinstance(enc_cfg, dict):
+    enc_cfg_raw = config.get("encode", {})
+    if not isinstance(enc_cfg_raw, dict):
         raise TypeError("encode section must be a mapping")
+    enc_cfg = dict(enc_cfg_raw)
     fec_downgraded = False
     if enc_cfg.get("fec") == "reed_solomon" and importlib.util.find_spec("reedsolo") is None:
         logger.warning(
             "reedsolo is unavailable; running bundle encode without Reed-Solomon FEC"
         )
-        enc_cfg = dict(enc_cfg)
         enc_cfg["fec"] = None
         fec_downgraded = True
     sim_cfg_raw = config.get("simulate")
@@ -781,6 +851,12 @@ def _run_single_bundle(
             ecc_type=str(enc_cfg.get("fec")) if enc_cfg.get("fec") else None,
             summary_path=summary_path,
         )
+
+    constraints = _derive_constraints(enc_cfg, sim_cfg_raw if isinstance(sim_cfg_raw, dict) else None)
+    if constraints is not None:
+        enc_cfg["gc_min"] = constraints.gc_min
+        enc_cfg["gc_max"] = constraints.gc_max
+        enc_cfg["max_homopolymer"] = constraints.max_homopolymer
 
     timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     run_dir = hash_dir / timestamp

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
@@ -36,6 +36,7 @@ from genecoder.simulators.batch_utils import (
     mutation_counts,
 )
 from genecoder.metrics import metrics as aggregate_metrics, set_metrics_path
+from genecoder.synthesis import SynthesisConstraints
 
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,34 @@ def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]
     return codec, fec, channel, channel_params
 
 
+def _build_constraints_from_channel(channel_params: Mapping[str, Any]) -> SynthesisConstraints | None:
+    """Return synthesis constraints defined in ``channel_params`` when present."""
+
+    constraint_fields = {
+        "min_length": _parse_int,
+        "max_length": _parse_int,
+        "max_homopolymer": _parse_int,
+        "gc_min": _parse_float,
+        "gc_max": _parse_float,
+    }
+    values: dict[str, float | int] = {}
+    for key, parser in constraint_fields.items():
+        if key not in channel_params:
+            continue
+        parsed = parser(channel_params.get(key))
+        if parsed is not None:
+            values[key] = parsed
+
+    if not values:
+        return None
+
+    try:
+        return SynthesisConstraints(**values)
+    except Exception:
+        logger.warning("Ignoring invalid synthesis constraints in channel config")
+        return None
+
+
 def _run_with_params(
     codec: str,
     fec: str | None,
@@ -141,6 +170,7 @@ def _run_with_params(
         raise SystemExit(1)
 
     channel_params = dict(channel_params)
+    constraints = _build_constraints_from_channel(channel_params)
     config_candidates = {
         key: channel_params.pop(key)
         for key in list(channel_params)
@@ -378,6 +408,7 @@ def _run_with_params(
         ins_total,
         dels_total,
         coverage_value,
+        constraints=constraints,
         oligos=[ol.sequence for ol in mutated_batch.oligos],
         dropout_flags=dropout_flags,
     )

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -7,7 +7,7 @@ import json
 import os
 from collections import Counter
 from pathlib import Path
-from typing import Any, Mapping, Tuple, Dict, List, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence, Tuple
 from typing import get_args, get_origin
 
 from .gc_constrained_encoder import calculate_gc_content
@@ -16,13 +16,15 @@ from .utils import get_max_homopolymer_length
 from .plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from .random_utils import reset_rng
 from .simulators import SIMULATOR_REGISTRY
-from .random_utils import reset_rng
 from .formats import SequenceBatch, SequenceOligo
 from .simulators.batch_utils import (
     RESULT_COVERAGE_KEY,
     RESULT_DROPOUT_FLAG_KEY,
     RESULT_MUTATION_TOTALS_KEY,
 )
+
+if TYPE_CHECKING:
+    from .synthesis import SynthesisConstraints
 
 __all__ = ["encode", "simulate", "decode", "metrics", "run_pipeline"]
 
@@ -405,6 +407,7 @@ def metrics(
     ins: int | None = None,
     dels: int | None = None,
     coverage: int | None = None,
+    constraints: SynthesisConstraints | None = None,
     *,
     oligos: Sequence[str] | None = None,
     dropout_flags: Sequence[bool] | None = None,
@@ -491,7 +494,7 @@ def metrics(
     try:
         from .synthesis import SynthesisConstraints, validate_sequence
 
-        constraints = SynthesisConstraints()
+        constraint_limits = constraints or SynthesisConstraints()
         violation_records: list[dict[str, Any]] = []
         type_counts: Counter[str] = Counter()
 
@@ -520,7 +523,7 @@ def metrics(
 
         for idx, sequence, info in target_oligos:
             try:
-                is_valid = validate_sequence(sequence, constraints)
+                is_valid = validate_sequence(sequence, constraint_limits)
             except Exception:
                 continue
             if is_valid:
@@ -528,19 +531,19 @@ def metrics(
 
             reasons: list[str] = []
             length = len(sequence)
-            if length < constraints.min_length:
+            if length < constraint_limits.min_length:
                 reasons.append("length_short")
-            elif length > constraints.max_length:
+            elif length > constraint_limits.max_length:
                 reasons.append("length_long")
 
             homopolymer = get_max_homopolymer_length(sequence)
-            if homopolymer > constraints.max_homopolymer:
+            if homopolymer > constraint_limits.max_homopolymer:
                 reasons.append("homopolymer")
 
             gc_fraction = calculate_gc_content(sequence) if sequence else 0.0
-            if gc_fraction < constraints.gc_min:
+            if gc_fraction < constraint_limits.gc_min:
                 reasons.append("gc_low")
-            elif gc_fraction > constraints.gc_max:
+            elif gc_fraction > constraint_limits.gc_max:
                 reasons.append("gc_high")
 
             if not reasons:


### PR DESCRIPTION
## Summary
- add an optional synthesis constraints parameter to `core.metrics` and honor provided thresholds
- propagate configured synthesis constraints through pipeline and bundle metric gathering
- align bundle encode invocations with derived constraints to keep manifests consistent

## Testing
- ruff check src/genecoder/core.py src/genecoder/cli/pipeline.py src/genecoder/cli/bundle.py
- pytest tests/test_preset_constraint_metrics.py::test_preset_constraint_metrics

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eadbc4c8c83268753a9afe27bef14)