### PR TITLE
Propagate synthesis constraints through metrics outputs

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -447,6 +447,18 @@ def _derive_constraints(
         return None
 
 
+def _constraints_limits(constraints: SynthesisConstraints | None) -> dict[str, float | int]:
+    if constraints is None:
+        return {}
+    return {
+        "min_length": constraints.min_length,
+        "max_length": constraints.max_length,
+        "max_homopolymer": constraints.max_homopolymer,
+        "gc_min": constraints.gc_min,
+        "gc_max": constraints.gc_max,
+    }
+
+
 def _write_decoded_metrics(
     original_path: Path,
     simulated_path: Path,
@@ -571,6 +583,12 @@ def _write_decoded_metrics(
         oligos=oligos,
         dropout_flags=dropout_flags,
     )
+
+    constraint_limits = _constraints_limits(constraints)
+    if constraint_limits:
+        metrics_data.setdefault("constraint_violations", {}).setdefault(
+            "limits", constraint_limits
+        )
 
     oligo_metrics = metrics_data.setdefault("oligo_metrics", {})
     oligo_metrics["coverage_counts"] = coverage_counts

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -147,6 +147,18 @@ def _build_constraints_from_channel(channel_params: Mapping[str, Any]) -> Synthe
         return None
 
 
+def _constraints_limits(constraints: SynthesisConstraints | None) -> dict[str, float | int]:
+    if constraints is None:
+        return {}
+    return {
+        "min_length": constraints.min_length,
+        "max_length": constraints.max_length,
+        "max_homopolymer": constraints.max_homopolymer,
+        "gc_min": constraints.gc_min,
+        "gc_max": constraints.gc_max,
+    }
+
+
 def _run_with_params(
     codec: str,
     fec: str | None,
@@ -412,6 +424,12 @@ def _run_with_params(
         oligos=[ol.sequence for ol in mutated_batch.oligos],
         dropout_flags=dropout_flags,
     )
+
+    constraint_limits = _constraints_limits(constraints)
+    if constraint_limits:
+        metrics.setdefault("constraint_violations", {}).setdefault(
+            "limits", constraint_limits
+        )
 
     oligo_metrics = metrics.setdefault("oligo_metrics", {})
     oligo_metrics.setdefault("coverage_counts", coverage_counts)

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -494,7 +494,14 @@ def metrics(
     try:
         from .synthesis import SynthesisConstraints, validate_sequence
 
-        constraint_limits = constraints or SynthesisConstraints()
+        constraint_limits = constraints if constraints is not None else SynthesisConstraints()
+        constraint_limits_info = {
+            "min_length": constraint_limits.min_length,
+            "max_length": constraint_limits.max_length,
+            "max_homopolymer": constraint_limits.max_homopolymer,
+            "gc_min": constraint_limits.gc_min,
+            "gc_max": constraint_limits.gc_max,
+        }
         violation_records: list[dict[str, Any]] = []
         type_counts: Counter[str] = Counter()
 
@@ -570,9 +577,15 @@ def metrics(
             "count": len(violation_records),
             "violations": violation_records,
             "type_counts": dict(type_counts),
+            "limits": constraint_limits_info,
         }
     except Exception:  # pragma: no cover - optional dependency
-        constraint_violations = {"count": 0, "violations": [], "type_counts": {}}
+        constraint_violations = {
+            "count": 0,
+            "violations": [],
+            "type_counts": {},
+            "limits": {},
+        }
 
     per_oligo_gc = [calculate_gc_content(seq) for seq in sequences]
     per_oligo_hp = [get_max_homopolymer_length(seq) for seq in sequences]


### PR DESCRIPTION
## Summary
- include constraint threshold details in core metrics output to keep manifest data aligned with active synthesis settings
- ensure pipeline and bundle CLI metrics preserve derived synthesis constraints when generating reports

## Testing
- `ruff check src/genecoder/core.py src/genecoder/cli/pipeline.py src/genecoder/cli/bundle.py`
- `pytest tests/test_core_pipeline.py::test_metrics_constraint_violations_per_oligo tests/test_bundle_pipeline_metrics_config.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e58fc7c88326baa3d3e426b53859)