### PR TITLE
Ensure DNArSim nanopore profiles default to 30x coverage

### DIFF
--- a/configs/dnarsim_rates.yaml
+++ b/configs/dnarsim_rates.yaml
@@ -3,6 +3,7 @@ r9:
   substitution_rate: 0.09
   insertion_rate: 0.03
   deletion_rate: 0.04
+  coverage: 30
   context_errors:
     AC: 2.0
   insertion_profile:
@@ -33,6 +34,7 @@ r9:
   substitution_rate: 0.06
   insertion_rate: 0.02
   deletion_rate: 0.035
+  coverage: 30
   context_insertions:
     AAAA:
       4: 0.4
@@ -55,6 +57,7 @@ r9:
   substitution_rate: 0.045
   insertion_rate: 0.015
   deletion_rate: 0.025
+  coverage: 30
   context_insertions:
     AAAA:
       4: 0.35

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -111,6 +111,8 @@ _FALLBACK_PROFILE_DATA: dict[
     },
 }
 
+_DEFAULT_NANOPORE_COVERAGE = 30.0
+
 # ---------------------------------------------------------------------------
 # Profile configuration helpers
 
@@ -188,11 +190,21 @@ def _load_profiles_from_directory(
             if isinstance(tbl, Mapping):
                 dnarsim_tables[str(name)] = _parse_rate_table(tbl)
 
-    combined = {
-        key: deepcopy(params) for key, params in profiles.items()
-    }
+    combined = {key: deepcopy(params) for key, params in profiles.items()}
     for name, table in dnarsim_tables.items():
-        combined[str(name).lower()] = deepcopy(table)
+        key = str(name).lower()
+        base_profile = combined.get(key, {})
+        merged = _merge_profiles(base_profile, table)
+        if "coverage" not in merged:
+            for candidate in (
+                base_profile.get("coverage") if isinstance(base_profile, Mapping) else None,
+                _FALLBACK_PROFILE_DATA.get(key, {}).get("coverage"),
+                _DEFAULT_NANOPORE_COVERAGE,
+            ):
+                if isinstance(candidate, (int, float)):
+                    merged["coverage"] = float(candidate)
+                    break
+        combined[key] = merged
 
     return combined, dnarsim_tables
 

--- a/src/genecoder/simulators/nanopore_profiles.py
+++ b/src/genecoder/simulators/nanopore_profiles.py
@@ -323,6 +323,8 @@ def parse_rate_table(tbl: Mapping[str, object]) -> dict[str, object]:
         "insertion_rate": float(tbl.get("insertion_rate", 0.0)),
         "deletion_rate": float(tbl.get("deletion_rate", 0.0)),
     }
+    if "coverage" in tbl:
+        parsed["coverage"] = float(tbl.get("coverage", 0.0))
     if "context_errors" in tbl and isinstance(tbl["context_errors"], Mapping):
         parsed["context_errors"] = {
             str(k).upper(): float(v)

--- a/tests/test_nanopore_dnarsim_profiles.py
+++ b/tests/test_nanopore_dnarsim_profiles.py
@@ -50,6 +50,21 @@ def test_loader_falls_back_to_context_defaults(tmp_path: Path) -> None:
     assert tables == {}
 
 
+def test_dnarsim_profiles_gain_default_coverage(tmp_path: Path) -> None:
+    dnarsim_rates = tmp_path / "dnarsim_rates.yaml"
+    dnarsim_rates.write_text(
+        "r9:\n"
+        "  substitution_rate: 0.1\n"
+        "  insertion_rate: 0.01\n"
+        "  deletion_rate: 0.02\n"
+    )
+
+    profiles, tables = nanopore._load_profiles_from_directory(tmp_path, yaml)
+
+    assert profiles["r9"]["coverage"] == pytest.approx(30.0)
+    assert "coverage" not in tables["r9"]
+
+
 def test_parse_valid_rate_table() -> None:
     data = yaml.safe_load((DATA_DIR / "dnarsim_rates_valid.yaml").read_text())
     tbl = next(iter(data.values()))


### PR DESCRIPTION
## Summary
- add explicit 30x coverage defaults to DNArSim nanopore rate presets
- merge DNArSim-derived profiles with fallback coverage and context metadata when missing
- extend profile tests to cover default coverage inheritance

## Testing
- pytest tests/test_nanopore_dnarsim_profiles.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bce80f4a88326a81aaf76450d9a5e)