### PR TITLE
Add DNArSim nanopore profile coverage test and docs

### DIFF
--- a/docs/channel_profiles.md
+++ b/docs/channel_profiles.md
@@ -32,7 +32,10 @@ The Nanopore channel falls back to `_FALLBACK_PROFILE_DATA` when YAML overrides 
 | --- | --- | --- | --- | --- | --- |
 | `minion` | 0.019 | 0.046 | 0.065 | 30 | Emulate portable MinION runs with elevated indels and a conservative 13% total error rate. |
 | `promethion` | 0.015 | 0.02 | 0.045 | 30 | Larger PromethION flow cells with moderate indels and higher throughput assumptions. |
-| `r10` | 0.01 | 0.015 | 0.025 | 30 | R10 chemistry with the lowest default indels among the presets; good for high-accuracy nanopore studies. |
+| `r9` | 0.09 | 0.03 | 0.04 | 30 | Legacy R9 flow cells with higher basecalling errors; use when matching older MinION/PromethION datasets. |
+| `r10` | 0.01 | 0.015 | 0.025 | 30 | R10 chemistry with lower indels; good for high-accuracy nanopore studies. |
+| `r10.3` | 0.06 | 0.02 | 0.035 | 30 | R10.3 duplex-style tuning; pairs well with consensus polishing pipelines expecting moderate indels. |
+| `r10.4` | 0.045 | 0.015 | 0.025 | 30 | R10.4 Q20+ style chemistry; pick when you want the cleanest Nanopore reads from the DNArSim presets. |
 
 Select a Nanopore profile from the CLI:
 

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -872,6 +872,8 @@ def run_channel(args: argparse.Namespace) -> None:
         simulators = [(sim_name, {})]
         if sim_name == "illumina":
             opts.illumina_profile = prof
+        elif sim_name == "nanopore_dnarsim":
+            opts.dnarsim_profile = prof
         else:
             opts.nanopore_profile = prof
     elif simulators is None:
@@ -904,13 +906,23 @@ def run_channel(args: argparse.Namespace) -> None:
             if opts.illumina_del_rate is not None:
                 new_params["deletion_rate"] = opts.illumina_del_rate
         if name.startswith("nanopore"):
-            if opts.nanopore_profile:
-                prof = NANOPORE_PROFILES.get(opts.nanopore_profile)
+            selected_profile = opts.nanopore_profile
+            profile_source = NANOPORE_PROFILES
+            if name == "nanopore_dnarsim":
+                selected_profile = opts.dnarsim_profile or opts.nanopore_profile
+                profile_source = DNARSIM_RATE_TABLES
+
+            if selected_profile:
+                prof = profile_source.get(selected_profile)
                 if prof is None:
-                    logger.error("Unknown Nanopore profile: %s", opts.nanopore_profile)
+                    label = "DNArSim" if name == "nanopore_dnarsim" else "Nanopore"
+                    logger.error("Unknown %s profile: %s", label, selected_profile)
                     raise SystemExit(1)
                 for k, v in prof.items():
                     new_params.setdefault(k, v)
+                if name == "nanopore_dnarsim":
+                    new_params.setdefault("profile", selected_profile)
+
             if opts.nanopore_profile_file:
                 file_params = _load_profile_file(opts.nanopore_profile_file)
                 for k, v in file_params.items():
@@ -927,8 +939,9 @@ def run_channel(args: argparse.Namespace) -> None:
                 new_params["insertion_rate"] = opts.nanopore_ins_rate
             if opts.nanopore_del_rate is not None:
                 new_params["deletion_rate"] = opts.nanopore_del_rate
-            if name == "nanopore_dnarsim" and opts.dnarsim_profile:
-                new_params.setdefault("profile", opts.dnarsim_profile)
+            if name == "nanopore_dnarsim":
+                for unsupported in ("insertion_profile", "deletion_profile"):
+                    new_params.pop(unsupported, None)
         if name == "indel":
             indel_profile = opts.indel_profile
             if indel_profile is None and not any(

--- a/src/genecoder/simulators/nanopore.py
+++ b/src/genecoder/simulators/nanopore.py
@@ -113,6 +113,12 @@ _FALLBACK_PROFILE_DATA: dict[
 
 _DEFAULT_NANOPORE_COVERAGE = 30.0
 
+
+def _normalize_profile_name(name: object) -> str:
+    """Return a normalized profile name for lookup keys."""
+
+    return str(name).strip().strip("\"'").lower()
+
 # ---------------------------------------------------------------------------
 # Profile configuration helpers
 
@@ -124,7 +130,7 @@ def _load_profiles_from_directory(
         import yaml as yaml_module  # type: ignore[import]
 
     profiles: dict[str, dict[str, Any]] = {
-        str(name).lower(): deepcopy(params)
+        _normalize_profile_name(name): deepcopy(params)
         for name, params in _FALLBACK_PROFILE_DATA.items()
     }
 
@@ -137,7 +143,7 @@ def _load_profiles_from_directory(
     if isinstance(base_data, Mapping):
         for name, params in base_data.items():
             if isinstance(params, Mapping):
-                key = str(name).lower()
+                key = _normalize_profile_name(name)
                 parsed = _parse_profile(params)
                 existing = profiles.get(key, {})
                 profiles[key] = _merge_profiles(existing, parsed)
@@ -156,7 +162,7 @@ def _load_profiles_from_directory(
             }
         }
         if ctx:
-            context_defaults[str(name).lower()] = ctx
+            context_defaults[_normalize_profile_name(name)] = ctx
 
     context_path = cfg_dir / "nanopore_context.yaml"
     try:
@@ -167,7 +173,7 @@ def _load_profiles_from_directory(
     if not isinstance(context_data, Mapping):
         context_data = {}
     context_defaults.update({
-        str(name).lower(): params
+        _normalize_profile_name(name): params
         for name, params in context_data.items()
         if isinstance(params, Mapping)
     })
@@ -188,11 +194,12 @@ def _load_profiles_from_directory(
     if isinstance(rates_data, Mapping):
         for name, tbl in rates_data.items():
             if isinstance(tbl, Mapping):
-                dnarsim_tables[str(name)] = _parse_rate_table(tbl)
+                key = _normalize_profile_name(name)
+                dnarsim_tables[key] = _parse_rate_table(tbl)
 
     combined = {key: deepcopy(params) for key, params in profiles.items()}
     for name, table in dnarsim_tables.items():
-        key = str(name).lower()
+        key = _normalize_profile_name(name)
         base_profile = combined.get(key, {})
         merged = _merge_profiles(base_profile, table)
         if "coverage" not in merged:

--- a/tests/test_nanopore_dnarsim_profiles.py
+++ b/tests/test_nanopore_dnarsim_profiles.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,7 @@ from genecoder.simulators.nanopore import (
     NANOPORE_PROFILES,
     NanoporeDNArSimChannel,
 )
+from tests.test_cli import run_cli_command
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -123,3 +126,41 @@ def test_profile_simulation_statistics(monkeypatch: pytest.MonkeyPatch) -> None:
     assert subs == len(seq)
     assert ins == 0
     assert dele == 0
+
+
+@pytest.mark.parametrize("profile", ["r9", "r10.3", "r10.4"])
+def test_dnarsim_manifest_records_profile_coverage(tmp_path: Path, profile: str) -> None:
+    env = os.environ.copy()
+    src_path = Path(__file__).resolve().parent.parent / "src"
+    env["PYTHONPATH"] = str(src_path) + os.pathsep + env.get("PYTHONPATH", "")
+    env["GENECODER_SIM_SEED"] = "1"
+
+    input_file = tmp_path / "input.fasta"
+    input_file.write_text(">seq1\n" + "ACGT" * 8 + "\n", encoding="utf-8")
+    output_file = tmp_path / "out.fasta"
+
+    result = run_cli_command(
+        [
+            "channel",
+            "apply",
+            "--profile",
+            profile,
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output_file),
+        ],
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    manifest_path = output_file.with_suffix(".manifest.json")
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    coverage = manifest_data.get("coverage", {})
+
+    expected_coverage = NANOPORE_PROFILES[profile]["coverage"]
+    assert coverage.get("average") == pytest.approx(expected_coverage)
+    histogram = coverage.get("histogram", {})
+    assert histogram.get(str(int(expected_coverage))) == 1
+    assert coverage.get("total_reads") == int(expected_coverage)


### PR DESCRIPTION
## Summary
- Document r9, r10.3, and r10.4 Nanopore DNArSim presets with their coverage defaults
- Normalize DNArSim profile names and route CLI profile flags to the Nanopore DNArSim simulator
- Add a regression test to ensure manifests capture the preset coverage for DNArSim profiles

## Testing
- pytest tests/test_nanopore_dnarsim_profiles.py -k manifest_records_profile_coverage
- ruff check tests/test_nanopore_dnarsim_profiles.py src/genecoder/cli/channel.py src/genecoder/simulators/nanopore.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd0b55ef08326ba3a901ffc2e17ef)