### PR TITLE
Add bundle CLI integration coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -371,3 +371,44 @@ jobs:
           path: |
             sbom.xml
             licenses.csv
+
+  bundle-integration:
+    needs: [changes, check-comments, lint]
+    if: needs.changes.outputs.src == 'true' && needs['check-comments'].outputs.only_comments != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select lock file
+        id: lockfile_bundle
+        shell: bash
+        run: |
+          file=poetry.lock
+          echo "file=$file" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache Poetry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~\AppData\Local\pypoetry
+          key: poetry-${{ runner.os }}-${{ hashFiles(steps.lockfile_bundle.outputs.file) }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --with dev --no-interaction --no-root
+
+      - name: Run bundle integration tests
+        env:
+          GENECODER_SIM_SEED: "5"
+        run: |
+          poetry run pytest -vv tests/test_bundle_cli_integration.py

--- a/tests/test_bundle_cli_integration.py
+++ b/tests/test_bundle_cli_integration.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from genecoder.reed_solomon_codec import _HAS_REEDSOLO
+from tests.test_cli import run_cli_command
+
+yaml = pytest.importorskip("yaml")
+
+
+def _prepare_trimmed_config(
+    base_config: Path, tmp_path: Path, simulator: str, seed: int = 1
+) -> tuple[Path, dict[str, Any], Path]:
+    config = yaml.safe_load(base_config.read_text(encoding="utf-8")) or {}
+
+    payload_path = tmp_path / f"{base_config.stem}_payload.txt"
+    payload_path.write_text(f"{base_config.stem} bundle payload", encoding="utf-8")
+
+    encode_cfg = config.get("encode", {}) if isinstance(config, dict) else {}
+    if isinstance(encode_cfg, dict):
+        encode_cfg["input_files"] = [str(payload_path)]
+        config["encode"] = encode_cfg
+
+    simulate_cfg = config.get("simulate", {}) if isinstance(config, dict) else {}
+    if isinstance(simulate_cfg, dict):
+        simulators = simulate_cfg.get("simulators")
+        if isinstance(simulators, list):
+            simulate_cfg["simulators"] = [simulator]
+        else:
+            simulate_cfg["simulators"] = [simulator]
+        simulate_cfg["seed"] = seed
+        pipeline_cfg = simulate_cfg.get("pipeline")
+        if isinstance(pipeline_cfg, dict):
+            pipeline_cfg.setdefault("coverage_distribution", {1: 1.0})
+        else:
+            simulate_cfg["pipeline"] = {"coverage_distribution": {1: 1.0}}
+        config["simulate"] = simulate_cfg
+
+    trimmed = tmp_path / f"{base_config.stem}_trimmed.yaml"
+    trimmed.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return trimmed, config, payload_path
+
+
+def _run_bundle_with_cache(
+    config_path: Path, config_dict: dict[str, Any], cache_dir: Path, env: dict[str, str]
+) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    args = [
+        "bundle",
+        "run",
+        str(config_path),
+        "--cache-dir",
+        str(cache_dir),
+        "--emit-manifest-report",
+    ]
+    result = run_cli_command(args, env=env)
+    assert result.returncode == 0, result.stderr
+
+    config_hash = hashlib.sha256(json.dumps(config_dict, sort_keys=True).encode("utf-8"))
+    run_root = cache_dir / config_hash.hexdigest()
+    run_dirs = sorted(run_root.iterdir())
+    assert run_dirs, "no bundle run recorded"
+    return run_dirs[-1]
+
+
+def _verify_decoded_output(run_dir: Path, payload_path: Path) -> None:
+    decoded_dir = run_dir / "decoded"
+    decoded_file = decoded_dir / f"{payload_path.name}_decoded.bin"
+    manifest_json = decoded_file.with_suffix(".bin.manifest.json")
+    manifest_html = manifest_json.with_suffix(".html")
+
+    assert decoded_file.exists(), "decoded payload missing"
+    assert decoded_file.read_text(encoding="utf-8") == payload_path.read_text(encoding="utf-8")
+    assert manifest_json.exists(), "decoded manifest missing"
+    assert manifest_html.exists(), "decoded manifest report missing"
+
+
+@pytest.mark.parametrize(
+    "config_name, simulator, requires_reedsolo",
+    [
+        ("gold", "illumina", True),
+        ("rs_illumina_pipeline", "illumina", True),
+        ("fountain_nanopore_pipeline", "nanopore", False),
+    ],
+)
+@pytest.mark.skipif(not yaml.safe_load("foo: 1"), reason="Functional YAML parser required")
+def test_bundle_cli_roundtrip(
+    config_name: str, simulator: str, requires_reedsolo: bool, tmp_path: Path
+) -> None:
+    if requires_reedsolo and not _HAS_REEDSOLO:
+        pytest.skip("reedsolo not installed")
+
+    base_config = Path(__file__).resolve().parents[1] / "configs" / f"{config_name}.yaml"
+    config_path, config_dict, payload_path = _prepare_trimmed_config(
+        base_config, tmp_path, simulator
+    )
+    cache_dir = tmp_path / "bundle_cache"
+    env = {"GENECODER_SIM_SEED": "3"}
+
+    run_dir = _run_bundle_with_cache(config_path, config_dict, cache_dir, env)
+
+    _verify_decoded_output(run_dir, payload_path)
+
+    encoded_manifest = run_dir / "encoded" / f"{payload_path.name}.manifest.json"
+    assert encoded_manifest.exists(), "encoded manifest missing"
+
+    simulated_dir = run_dir / "simulated"
+    simulated_manifests = list(simulated_dir.glob("*.manifest.json"))
+    if simulated_manifests:
+        assert all(manifest.exists() for manifest in simulated_manifests)
+    else:
+        # Optional simulators may be unavailable in minimal environments.
+        assert not any(simulated_dir.iterdir()), "simulated outputs present without manifest"


### PR DESCRIPTION
## Summary
- add integration tests that exercise `genecli bundle run` for gold, Reed–Solomon Illumina, and fountain Nanopore presets with small temporary payloads
- ensure tests tolerate missing optional simulators while still verifying decode output and manifests
- wire a CI job that installs dependencies and runs the new bundle integration suite with cached Poetry setup

## Testing
- ruff check tests/test_bundle_cli_integration.py
- pytest tests/test_bundle_cli_integration.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd552f7308326ada502ed77be9122)