### PR TITLE
Add starter plugin template example

### DIFF
--- a/plugins-examples/README.md
+++ b/plugins-examples/README.md
@@ -14,6 +14,8 @@ Each subdirectory is an installable Python package using PEP 621 metadata:
   full ``SequenceBatch`` with coverage statistics in the metadata.
 - `example_visualizer` – registers a visualizer named `example`.
 - `advanced_fec` – registers an LDPC FEC backend named `advanced_ldpc`.
+- `starter_plugin` – a commented template that exposes metadata for the plugin
+  catalog and registers a reversible codec named `starter_template`.
 
 Install any of the packages with `pip` to experiment locally, e.g.:
 

--- a/plugins-examples/starter_plugin/README.md
+++ b/plugins-examples/starter_plugin/README.md
@@ -1,0 +1,46 @@
+# Starter Plugin Template
+
+This directory contains a minimal, installable GeneCoder plugin package that
+registers a codec via the ``genecoder.plugins`` entry point group. Use it as a
+starting point for your own codec or simulator implementations.
+
+## How to adapt the template
+
+1. Update ``PLUGIN_METADATA`` and the class name in
+   ``starter_plugin/__init__.py`` to reflect your plugin's identity.
+2. Replace the example codec logic with your own encode/decode behavior or swap
+   the interface to a simulator by following the inline comments in the module.
+3. Adjust the entry point name in ``pyproject.toml`` if you change the public
+   identifier for the plugin.
+
+## Run locally
+
+Install the example from the repository root:
+
+```bash
+python -m pip install ./plugins-examples/starter_plugin
+```
+
+Then run a quick encode/decode round trip:
+
+```bash
+python - <<'PY'
+from genecoder import CODEC_REGISTRY, load_plugins
+load_plugins()
+codec = CODEC_REGISTRY["starter_template"]
+encoded = codec["encode"](b"hello")
+print(encoded, codec["decode"](encoded))
+PY
+```
+
+## Verify discovery with ``genecli``
+
+After installation, ``genecli`` will surface the metadata the plugin exports via
+``PLUGIN_METADATA`` when you ask for the plugin catalog:
+
+```bash
+genecli plugin list
+```
+
+You should see ``starter-template`` in the output. Use the same command to
+confirm your own plugin appears once you rename the metadata.

--- a/plugins-examples/starter_plugin/pyproject.toml
+++ b/plugins-examples/starter_plugin/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[project]
+name = "genecoder-starter-plugin"
+version = "0.1.0"
+description = "Starter template for GeneCoder plugins"
+dependencies = ["genecoder>=0.2.0"]
+readme = "README.md"
+
+[tool.poetry]
+packages = [{ include = "starter_plugin" }]
+
+[project.entry-points."genecoder.plugins"]
+starter_template = "starter_plugin"

--- a/plugins-examples/starter_plugin/starter_plugin/__init__.py
+++ b/plugins-examples/starter_plugin/starter_plugin/__init__.py
@@ -1,0 +1,48 @@
+"""Starter plugin showing the minimal codec hook surface.
+
+The :data:`PLUGIN_METADATA` dictionary is used to populate the plugin catalog
+that ``genecli plugin list`` displays. Adjust the fields to match your plugin's
+name, version and supported interfaces. For simulators, change the interface to
+``"simulator"`` and wire up the registration call accordingly.
+"""
+
+from typing import Callable
+
+from genecoder.api import Codec
+
+# Metadata that will show up in the plugin catalog; keep the interfaces list
+# aligned with the entry point group(s) used below.
+PLUGIN_METADATA = {
+    "name": "starter-template",
+    "version": "0.1.0",
+    "interfaces": ["codec"],
+}
+
+
+class StarterTemplateCodec(Codec):  # type: ignore[misc]
+    """A minimal codec that reverses bytes to create a string payload.
+
+    Replace this class with your own codec implementation. For a simulator
+    template, import :class:`genecoder.api.Simulator` instead of
+    :class:`genecoder.api.Codec` and update the :func:`register` hook to call
+    ``register_simulator``.
+    """
+
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
+        # Provide any custom encode logic here; keep kwargs for forward-compat.
+        return data[::-1].decode("utf-8")
+
+    def decode(self, text: str, /, **kwargs: object) -> bytes:
+        # Mirror the encode path so round trips succeed in quick demos/tests.
+        return text[::-1].encode("utf-8")
+
+
+def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
+    """Entry point that GeneCoder calls to register the plugin.
+
+    The ``register_codec`` callable is provided by the plugin manager. Swap this
+    out for ``register_simulator`` in the function signature if you build a
+    simulator plugin.
+    """
+
+    register_codec("starter_template", StarterTemplateCodec)

--- a/tests/test_plugin_starter_template.py
+++ b/tests/test_plugin_starter_template.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _venv_paths(root: Path) -> tuple[Path, Path]:
+    """Return (python_bin, genecli_bin) for the created virtual environment."""
+
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    python_bin = root / bin_dir / "python"
+    genecli_bin = root / bin_dir / "genecli"
+    return python_bin, genecli_bin
+
+
+def test_starter_plugin_present_in_catalog(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    venv_dir = tmp_path / "starter-plugin-venv"
+
+    subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+    python_bin, genecli_bin = _venv_paths(venv_dir)
+
+    subprocess.check_call([python_bin, "-m", "pip", "install", "-e", str(project_root)])
+    subprocess.check_call(
+        [
+            python_bin,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "-e",
+            str(project_root / "plugins-examples" / "starter_plugin"),
+        ]
+    )
+
+    env = dict(os.environ)
+    env.setdefault("GENECODER_PLUGIN_CATALOG_URL", "")
+    env.setdefault("PYTHONWARNINGS", "ignore")
+
+    result = subprocess.run(
+        [genecli_bin, "plugin", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "starter-template" in result.stdout


### PR DESCRIPTION
## Summary
- add a starter plugin template package with metadata, entry points, and inline guidance
- document the new template alongside existing plugin examples
- add a test that installs the template in isolation and confirms genecli catalog discovery

## Testing
- ruff check plugins-examples/starter_plugin tests/test_plugin_starter_template.py
- python -m pytest tests/test_plugin_starter_template.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d202352a883268b4501d3ecd72e12)