### PR TITLE
Require license metadata for plugin registry entries

### DIFF
--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -1,10 +1,12 @@
 # Example plugin registry used in documentation
 packages:
   - spec: https://example.com/mycodec-1.0.0-py3-none-any.whl
+    license: MIT
     checksum: "91b6d490..."
     signature: "MEUCIQDf..."
   - spec: myplugin==0.2.4
+    license: Apache-2.0
     checksum: "5733a819..."
   - spec: https://example.com/vis-0.3.2-py3-none-any.whl
+    license: BSD-3-Clause
     signature: "MEQCIAID..."
-

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -128,10 +128,22 @@ Loading external plugins executes arbitrary Python code. GeneCoder provides seve
 
 - **Network opt-in:** package downloads from registry URLs are blocked unless `GENECODER_ALLOW_NETWORK=1` is set. Setting `GENECODER_OFFLINE=1` forces offline mode even if network access is allowed.
 - **Signature and checksum verification:** registry entries can include a Base64 signature (`signature`) and checksum (`checksum`). Signatures are verified using the public key specified in `GENECODER_PLUGIN_PUBLIC_KEY`. Failing verification aborts installation.
+- **License allowlist:** registry entries must declare a `license` field using an SPDX identifier, and it must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
 - **Safe URLs and packages:** plugin registry entries are validated to ensure package names and URLs match safe patterns.
 - **Duplicate protection:** the plugin catalog rejects duplicate names to avoid silently overriding unrelated plugins.
 
 Only install plugins from sources you trust, and prefer signed packages when distributing plugins externally.
+
+### Declaring license metadata in the registry
+
+Each plugin registry entry must include a `license` field alongside `spec` and the checksum or signature. Use the SPDX identifier for your chosen license:
+
+```yaml
+packages:
+  - spec: https://example.com/mycodec-1.0.0-py3-none-any.whl
+    license: MIT
+    checksum: "<sha256>"
+```
 
 ## Troubleshooting
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -331,6 +331,14 @@ def _load_entry_point_module(
         raise
 
 _VALID_INTERFACES = {"codec", "FEC", "simulator", "visualizer"}
+_ALLOWED_LICENSES = {
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+}
 
 # re-export for tests
 compute_checksum = plugin_security.compute_checksum
@@ -347,6 +355,24 @@ def _validate_spec(spec: str) -> None:
     if _SAFE_PKG_RE.fullmatch(spec) or _SAFE_URL_RE.fullmatch(spec):
         return
     raise ValueError("Unsafe plugin spec")
+
+
+def _validate_registry_license(entry: Mapping[str, Any], *, spec: str) -> str:
+    license_value = entry.get("license")
+    if not isinstance(license_value, str) or not license_value.strip():
+        message = f"Missing license for plugin entry {spec}"
+        logger.error(message)
+        raise ValueError(message)
+    normalized = license_value.strip()
+    if normalized not in _ALLOWED_LICENSES:
+        allowed = ", ".join(sorted(_ALLOWED_LICENSES))
+        message = (
+            f"Disallowed license {normalized!r} for plugin entry {spec}. "
+            f"Allowed licenses: {allowed}"
+        )
+        logger.error(message)
+        raise ValueError(message)
+    return normalized
 
 
 def _check_signature(
@@ -709,6 +735,13 @@ def install_registry_plugins(
             logger.warning("Missing spec for plugin entry %s", entry)
             continue
 
+        if isinstance(entry, dict):
+            _validate_registry_license(entry, spec=spec)
+        else:
+            message = f"Missing license for plugin entry {spec}"
+            logger.error(message)
+            raise ValueError(message)
+
         _validate_spec(spec)
 
         if checksum is None and sig_b64 is None:
@@ -900,8 +933,6 @@ def load_entry_point_plugins() -> list[str]:
     for loaders in _ENTRY_POINT_LOADERS.values():
         loaders.clear()
     offline = bool(os.getenv("GENECODER_OFFLINE"))
-
-    lazy_load = bool(os.getenv("GENECODER_OFFLINE"))
 
     groups: dict[str, tuple[Callable[..., Any], str]] = {
         "genecoder.plugins": (register_codec, "codec"),

--- a/tests/data/plugin_registry_version.yaml
+++ b/tests/data/plugin_registry_version.yaml
@@ -1,4 +1,5 @@
 packages:
   - spec: example_pkg
+    license: MIT
     checksum: 45095df41e6342cabf37e17e4d88855c15b0a186469716949153a53367706787
     version: "1.0.0"

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -32,7 +32,7 @@ def _fake_urlopen(data: str) -> Callable[[str], DummyResponse]:
 
 @pytest.mark.parametrize("bad", ["bad;rm", "foo bar", "evil&&stuff"])
 def test_install_registry_bad_spec(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
-    data = f"packages:\n  - spec: {bad}\n"
+    data = f"packages:\n  - spec: {bad}\n    license: MIT\n    checksum: deadbeef\n"
     monkeypatch.setattr(plugins.urllib.request, "urlopen", _fake_urlopen(data))
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -40,8 +40,12 @@ def test_registry_install(monkeypatch: pytest.MonkeyPatch) -> None:
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgA.whl\n    checksum: {checksum}\n"
-                f"  - spec: https://example.com/pkgB.whl\n    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkgA.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkgB.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
             ).encode()
             return DummyResponse(data)
         elif url in ("https://example.com/pkgA.whl", "https://example.com/pkgB.whl"):
@@ -70,7 +74,9 @@ def test_registry_install_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytes
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgC.whl\n    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkgC.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgC.whl":
@@ -122,7 +128,7 @@ def test_registry_install_offline_local(tmp_path: Path, monkeypatch: pytest.Monk
 
     registry = tmp_path / "registry.yaml"
     registry.write_text(
-        "packages:\n  - spec: {pkg}\n    checksum: {chk}\n".format(
+        "packages:\n  - spec: {pkg}\n    license: MIT\n    checksum: {chk}\n".format(
             pkg=pkg_path.as_uri(), chk=checksum
         )
     )
@@ -153,7 +159,7 @@ def test_registry_install_offline_local_env(monkeypatch: pytest.MonkeyPatch, tmp
 
     registry = tmp_path / "registry.yaml"
     registry.write_text(
-        "packages:\n  - spec: {pkg}\n    checksum: {chk}\n".format(
+        "packages:\n  - spec: {pkg}\n    license: MIT\n    checksum: {chk}\n".format(
             pkg=pkg_path.as_uri(), chk=checksum
         )
     )
@@ -204,7 +210,9 @@ def test_registry_install_via_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
         if request.url.path == "/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
             )
             return httpx.Response(200, text=data)
         elif request.url.path == "/pkg.whl":
@@ -269,7 +277,9 @@ def test_registry_network_failure(
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkgD.whl\n    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkgD.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkgD.whl":
@@ -279,7 +289,11 @@ def test_registry_network_failure(
     class FakeYAML:
         @staticmethod
         def safe_load(raw: bytes) -> dict[str, list[dict[str, str]]]:
-            return {"packages": [{"spec": "https://example.com/pkgD.whl", "checksum": checksum}]}
+            return {
+                "packages": [
+                    {"spec": "https://example.com/pkgD.whl", "license": "MIT", "checksum": checksum}
+                ]
+            }
 
     monkeypatch.setattr(plugins.subprocess, "check_call", fake_check_call)
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -32,7 +32,9 @@ def test_load_plugins_with_registry(monkeypatch: pytest.MonkeyPatch) -> None:
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -81,7 +83,9 @@ def test_load_plugins_with_signed_registry(
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    signature: {sig_b64}\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    signature: {sig_b64}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -111,7 +115,11 @@ def test_registry_entry_missing_signature_checksum(
     def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         if url == "https://example.com/plugins.yaml":
-            data = "packages:\n  - spec: https://example.com/pkg.whl\n".encode()
+            data = (
+                "packages:\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+            ).encode()
             return DummyResponse(data)
         raise AssertionError(url)
 
@@ -119,6 +127,45 @@ def test_registry_entry_missing_signature_checksum(
     monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
 
     with pytest.raises(ValueError):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml", allow_network=True)
+
+
+def test_registry_entry_missing_license(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    checksum: deadbeef\n"
+            ).encode()
+            return DummyResponse(data)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+
+    with pytest.raises(ValueError, match="Missing license for plugin entry https://example.com/pkg.whl"):
+        plugins.install_registry_plugins("https://example.com/plugins.yaml", allow_network=True)
+
+
+def test_registry_entry_disallowed_license(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
+        assert timeout == 30
+        if url == "https://example.com/plugins.yaml":
+            data = (
+                "packages:\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: Proprietary\n"
+                "    checksum: deadbeef\n"
+            ).encode()
+            return DummyResponse(data)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(plugins.subprocess, "check_call", lambda cmd: None)
+
+    with pytest.raises(ValueError, match="Disallowed license"):
         plugins.install_registry_plugins("https://example.com/plugins.yaml", allow_network=True)
 
 
@@ -172,7 +219,9 @@ def test_load_plugins_with_base64_checksum(monkeypatch: pytest.MonkeyPatch) -> N
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum_b64}\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum_b64}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -197,7 +246,9 @@ def test_registry_base64_checksum_mismatch(
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}\n"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {wrong_checksum}\n"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -36,7 +36,10 @@ def test_registry_invalid_signature(monkeypatch: pytest.MonkeyPatch, caplog: pyt
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig_b64}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
+                f"    signature: {sig_b64}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -82,7 +85,10 @@ def test_registry_valid_checksum_and_signature(monkeypatch: pytest.MonkeyPatch) 
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig_b64}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
+                f"    signature: {sig_b64}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -123,7 +129,9 @@ def test_registry_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, caplog: pyt
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {wrong_checksum}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -148,7 +156,11 @@ def test_registry_missing_checksum_signature(monkeypatch: pytest.MonkeyPatch) ->
     def fake_urlopen(url: str, *, timeout: int | None = None) -> DummyResponse:
         assert timeout == 30
         assert url == "https://example.com/plugins.yaml"
-        data = "packages:\n  - spec: https://example.com/pkg.whl\n".encode()
+        data = (
+            "packages:\n"
+            "  - spec: https://example.com/pkg.whl\n"
+            "    license: MIT\n"
+        ).encode()
         return DummyResponse(data)
 
     monkeypatch.setenv("GENECODER_PLUGIN_REGISTRY_URL", "https://example.com/plugins.yaml")
@@ -177,7 +189,10 @@ def test_registry_real_signature(monkeypatch: pytest.MonkeyPatch) -> None:
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {sig_b64}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
+                f"    signature: {sig_b64}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -207,7 +222,10 @@ def test_registry_real_invalid_signature(monkeypatch: pytest.MonkeyPatch, caplog
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {checksum}\n    signature: {bad_sig_b64}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {checksum}\n"
+                f"    signature: {bad_sig_b64}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":
@@ -239,7 +257,10 @@ def test_registry_real_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, caplog
         if url == "https://example.com/plugins.yaml":
             data = (
                 "packages:\n"
-                f"  - spec: https://example.com/pkg.whl\n    checksum: {wrong_checksum}\n    signature: {sig_b64}"
+                "  - spec: https://example.com/pkg.whl\n"
+                "    license: MIT\n"
+                f"    checksum: {wrong_checksum}\n"
+                f"    signature: {sig_b64}"
             ).encode()
             return DummyResponse(data)
         elif url == "https://example.com/pkg.whl":


### PR DESCRIPTION
### Motivation

- Ensure plugin registry entries declare a license so third-party packages meet an approved policy.
- Prevent installing plugins with missing or unsupported licenses by validating registry metadata early.
- Surface clear, actionable error messages when license metadata is absent or disallowed.

### Description

- Add an SPDX-based allowlist `_ALLOWED_LICENSES` and a helper `_validate_registry_license` in `src/genecoder/plugin_manager.py` to validate `license` per entry. 
- Enforce license validation during registry processing in `install_registry_plugins` and raise `ValueError` with logged errors for missing or disallowed licenses. 
- Update `configs/registry.yaml` and `docs/plugins.md` to document the required `license` field and allowed SPDX identifiers, and add examples.
- Update test fixtures and add tests (`tests/test_plugin_registry_loading.py`, `tests/test_plugin_registry.py`, `tests/test_plugin_security.py`, `tests/test_plugin_manager.py`) to cover missing and disallowed license cases and adjust registry test data accordingly.

### Testing

- Run `ruff check .` which passed (no lint errors after fixing an unused variable).
- Run `pytest` for the plugin registry related tests (`tests/test_plugin_registry_loading.py`, `tests/test_plugin_registry.py`, `tests/test_plugin_security.py`, `tests/test_plugin_manager.py`, `tests/test_plugin_registry_offline.py`, `tests/test_plugin_manager_offline.py`, `tests/test_plugin_install_malformed.py`) resulting in 16 passed and 2 skipped tests (skips due to optional `httpx` and `portalocker` dependencies).
- Confirmed the new license validation raises `ValueError` with clear messages on missing or disallowed licenses in the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e911325b08326af1881ec238b762d)