### PR TITLE
Add `genecoder` CLI alias and document both entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GeneCoder is an educational toolkit for exploring DNA-based data storage. It pro
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above. The [MVP coverage checklist](docs/mvp_checklist.md) maps roadmap requirements to the shipped presets and example CLI commands. Developers adding new codecs, FEC backends, simulators, or visualizers can follow the [plugin development guide](docs/plugins.md) for step-by-step instructions and entry point examples.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
+The CLI installs two equivalent entry points, `genecli` and `genecoder`, so you can use either in the examples below and in the documentation.
 The configuration at `configs/pipeline_metrics.yaml` shows how to run the pipeline while recording metrics. Supply the metrics destination and optional extras directly via CLI flags:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,15 +6,19 @@ See the [Disclaimer](../README.md#disclaimer) before using the toolkit.
 
 For a hands-on introduction check the Jupyter notebooks in the [notebooks/](../notebooks) directory.
 
-GeneCoder operations are performed with the `genecoder` CLI:
+GeneCoder operations are performed with the `genecli` CLI (also available as the `genecoder` alias):
 
 ```bash
 genecli <command> --input-files <path1> [<path2> ...] \
     [--output-file <path>] [--output-dir <dir>] \
     --method <method_name> [--fec <fec_method>] [options]
+# or
+genecoder <command> --input-files <path1> [<path2> ...] \
+    [--output-file <path>] [--output-dir <dir>] \
+    --method <method_name> [--fec <fec_method>] [options]
 ```
 
-Run `genecli --help` to see all available commands. Use `--offline` to disable
+Run `genecli --help` (or `genecoder --help`) to see all available commands. Use `--offline` to disable
 network features and avoid loading cloud integrations:
 
 ```bash
@@ -28,6 +32,15 @@ A quick sanity check is to run the command and ensure the usage header appears.
 ```bash
 $ genecli --help | head -n 5
 Usage: genecli [-h] [--version] {encode,decode,analyze,channel} ...
+GeneCoder: Encode and decode data into simulated DNA sequences.
+...
+```
+
+The alias reports the same usage header:
+
+```bash
+$ genecoder --help | head -n 5
+Usage: genecoder [-h] [--version] {encode,decode,analyze,channel} ...
 GeneCoder: Encode and decode data into simulated DNA sequences.
 ...
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ playwright = "*"
 
 [tool.poetry.scripts]
 genecli = "genecoder.cli.cli:main"
+genecoder = "genecoder.cli.cli:main"
 
 [tool.poetry.plugins."genecoder.plugins"]
 reverse = "plugins.reverse_codec"


### PR DESCRIPTION
### Motivation

- Provide an alternative, clearer CLI name so users can run the same interface as either `genecli` or `genecoder`.
- Reduce confusion in documentation and examples by explicitly listing both entrypoints and showing help output for the alias.

### Description

- Added a second console script entry in `pyproject.toml`: `genecoder = "genecoder.cli.cli:main"` to alias the existing `genecli` entrypoint.
- Updated `README.md` to note the CLI installs both `genecli` and `genecoder` as equivalent entrypoints.
- Updated `docs/usage.md` to show both `genecli` and `genecoder` in the usage examples and included the alias help output example.

### Testing

- Ran `ruff check .` and it passed without issues.
- Ran `pytest`; the test run completed but had 2 failing tests: `tests/test_nanopore_dnarsim_channel.py::test_cli_invocation` and `tests/test_plugin_registry_loading.py::test_entry_point_plugin_invalid_metadata`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e92fbf4f883269a03eda7fd86f19d)