### PR TITLE
Detect plotting deps at runtime and add dashboard fallback/tests

### DIFF
--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -48,12 +48,6 @@ _ERROR_METRICS: tuple[tuple[str, str], ...] = (
     ("deletions", "Deletions"),
 )
 
-_PLOT_DEPS: tuple[tuple[str, Any], ...] = (
-    ("pandas", pd),
-    ("altair", alt),
-)
-
-
 def _iterable(val: Iterable[str] | str | None) -> list[str]:
     if val is None:
         return []
@@ -208,7 +202,11 @@ def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _plotting_status() -> tuple[bool, list[str]]:
-    missing = [name for name, module in _PLOT_DEPS if module is None]
+    missing = []
+    if pd is None:
+        missing.append("pandas")
+    if alt is None:
+        missing.append("altair")
     return not missing, missing
 
 

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -44,25 +44,54 @@ def test_dashboard_cli_starts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert called
 
 
-def test_dashboard_summary_plots_rendered(
+def test_dashboard_missing_plot_deps_emit_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     metrics_file = Path(__file__).parent / "data" / "metrics.json"
     results = tmp_path / "results.json"
     results.write_text(metrics_file.read_text())
 
-    charts: list[object] = []
+    from genecoder import dashboard_streamlit as dash
+
+    # Force fallback chart rendering in case pandas/altair are installed
+    monkeypatch.setattr(dash, "pd", None)
+    monkeypatch.setattr(dash, "alt", None)
+
+    errors: list[str] = []
+
+    def capture_error(message: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        errors.append(str(message))
+
+    monkeypatch.setattr(streamlit, "error", capture_error)
+
+    dash.main(str(results))
+
+    assert errors
+    assert any(
+        "Plotting dependencies missing" in message
+        and "pandas" in message
+        and "altair" in message
+        for message in errors
+    )
+
+
+def test_dashboard_summary_tables_rendered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    metrics_file = Path(__file__).parent / "data" / "metrics.json"
+    results = tmp_path / "results.json"
+    results.write_text(metrics_file.read_text())
+
+    tables: list[object] = []
     writes: list[object] = []
 
-    def capture_bar_chart(
-        data: object, *args: object, **kwargs: object
-    ) -> None:  # pragma: no cover - simple capture
-        charts.append(data)
+    def capture_table(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        tables.append(data)
 
     def capture_write(*args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
         writes.extend(args)
 
-    monkeypatch.setattr(streamlit, "bar_chart", capture_bar_chart)
+    monkeypatch.setattr(streamlit, "table", capture_table)
     monkeypatch.setattr(streamlit, "write", capture_write)
 
     from genecoder import dashboard_streamlit as dash
@@ -73,24 +102,36 @@ def test_dashboard_summary_plots_rendered(
 
     dash.main(str(results))
 
-    def contains_chart(target: object) -> bool:
-        return any(chart == target for chart in charts)
-
-    assert contains_chart({"results": pytest.approx(10.0)})
-    assert contains_chart({"results": pytest.approx(25.0)})
-    assert contains_chart({"results": pytest.approx(40.0)})
-    assert contains_chart({"results (Substitutions)": pytest.approx(2.0)})
-    assert contains_chart({"results (Insertions)": pytest.approx(0.0)})
-    assert contains_chart({"results (Deletions)": pytest.approx(0.0)})
-    assert contains_chart({"results (Coverage)": pytest.approx(30.0)})
-    assert [1, 3, 2] in charts
-    expected_gc_chart = {
-        "Window 1": pytest.approx(10.0),
-        "Window 2": pytest.approx(20.0),
-        "Window 3": pytest.approx(30.0),
-        "Window 4": pytest.approx(40.0),
-    }
-    assert any(chart == expected_gc_chart for chart in charts)
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Metric") == "mean"
+            and row.get("Value") == pytest.approx(25.0)
+            for row in table
+        )
+        for table in tables
+    )
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Metric") == "Coverage"
+            and row.get("Value") == pytest.approx(30.0)
+            for row in table
+        )
+        for table in tables
+    )
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Window") == 1
+            and row.get("GC%") == pytest.approx(10.0)
+            for row in table
+        )
+        for table in tables
+    )
     assert any(isinstance(entry, dict) and "GC%" in entry for entry in writes)
 
 
@@ -101,16 +142,16 @@ def test_dashboard_homopolymer_chart_rendered(
     results = tmp_path / "results.json"
     results.write_text(metrics_file.read_text())
 
-    charts: list[object] = []
+    tables: list[object] = []
     writes: list[object] = []
 
-    def capture_bar_chart(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
-        charts.append(data)
+    def capture_table(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        tables.append(data)
 
     def capture_write(*args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
         writes.extend(args)
 
-    monkeypatch.setattr(streamlit, "bar_chart", capture_bar_chart)
+    monkeypatch.setattr(streamlit, "table", capture_table)
     monkeypatch.setattr(streamlit, "write", capture_write)
 
     from genecoder import dashboard_streamlit as dash
@@ -121,7 +162,89 @@ def test_dashboard_homopolymer_chart_rendered(
 
     dash.main(str(results))
 
-    assert charts
-    assert [1, 2, 1, 0] in charts
-    assert any(chart == {"results": pytest.approx(30.0)} for chart in charts)
+    assert tables
+    expected_homopolymer_table = [
+        {"Length": 0, "Count": 1},
+        {"Length": 1, "Count": 2},
+        {"Length": 2, "Count": 1},
+        {"Length": 3, "Count": 0},
+    ]
+    assert any(table == expected_homopolymer_table for table in tables)
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Metric") == "Coverage"
+            and row.get("Value") == pytest.approx(30.0)
+            for row in table
+        )
+        for table in tables
+    )
     assert any(isinstance(entry, dict) and entry.get("Dropout") for entry in writes)
+
+
+def test_dashboard_summary_plots_with_plotting_deps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    metrics_file = Path(__file__).parent / "data" / "metrics.json"
+    results = tmp_path / "results.json"
+    results.write_text(metrics_file.read_text())
+
+    charts: list[object] = []
+
+    def capture_altair_chart(
+        chart: object, *args: object, **kwargs: object
+    ) -> None:  # pragma: no cover - simple capture
+        charts.append(chart)
+
+    monkeypatch.setattr(streamlit, "altair_chart", capture_altair_chart)
+
+    from genecoder import dashboard_streamlit as dash
+
+    class FakeDataFrame:
+        def __init__(self, data: object) -> None:
+            self.data = data
+
+        def dropna(self, *args: object, **kwargs: object) -> "FakeDataFrame":
+            return self
+
+    class FakePandas:
+        DataFrame = FakeDataFrame
+
+    class FakeChart:
+        def __init__(self, data: object) -> None:
+            self.data = data
+
+        def mark_bar(self, *args: object, **kwargs: object) -> "FakeChart":
+            return self
+
+        def mark_line(self, *args: object, **kwargs: object) -> "FakeChart":
+            return self
+
+        def mark_boxplot(self, *args: object, **kwargs: object) -> "FakeChart":
+            return self
+
+        def encode(self, *args: object, **kwargs: object) -> "FakeChart":
+            return self
+
+        def properties(self, *args: object, **kwargs: object) -> "FakeChart":
+            return self
+
+    class FakeAlt:
+        Chart = FakeChart
+
+        class Bin:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+        @staticmethod
+        def X(*args: object, **kwargs: object) -> tuple[object, ...]:
+            return args
+
+    monkeypatch.setattr(dash, "pd", FakePandas)
+    monkeypatch.setattr(dash, "alt", FakeAlt)
+
+    dash.main(str(results))
+
+    assert charts
+    assert all(isinstance(chart, FakeChart) for chart in charts)


### PR DESCRIPTION
### Motivation

- Ensure plotting dependency detection reflects the current runtime availability of `pandas` and `altair` rather than a stale table constant.  
- Surface a clear, user-facing message when plotting deps are missing and exercise the fallback table rendering.  
- Add a happy-path test that mocks `pd.DataFrame` and `alt.Chart` to verify charts render when plotting deps exist.  

### Description

- Update `_plotting_status()` to check the `pd` and `alt` globals directly instead of using `_PLOT_DEPS`.  
- Add `test_dashboard_missing_plot_deps_emit_error` which monkeypatches `dash.pd` and `dash.alt` to `None` and asserts `streamlit.error` is invoked with a helpful message.  
- Add `test_dashboard_summary_tables_rendered` and update homopolymer test to verify fallback `st.table` output when plotting deps are absent.  
- Add `test_dashboard_summary_plots_with_plotting_deps` that injects `FakePandas` and `FakeAlt` to mock chart generation and asserts `st.altair_chart` receives chart objects.  

### Testing

- Ran `ruff check .` and all checks passed.  
- Ran `pytest tests/test_dashboard_streamlit.py` which was skipped due to `streamlit` not being installed in the test environment (1 skipped).  
- No failing automated tests from the commands run locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e95a922c083268bf79bb2423b8d0f)