### PR TITLE
Add integration tests for optional external simulators

### DIFF
--- a/tests/test_external_simulators_integration.py
+++ b/tests/test_external_simulators_integration.py
@@ -1,0 +1,66 @@
+"""Integration checks for optional external simulators."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from genecoder import (
+    d2sim_adapter,
+    desp_adapter,
+    dnarsim_adapter,
+    insilicoseq_adapter,
+    squigulator_adapter,
+)
+
+
+TEST_SEQUENCE = "ACGTACGTACGT"
+
+
+@pytest.mark.skipif(shutil.which("d2sim") is None, reason="d2sim not installed")
+def test_d2sim_integration() -> None:
+    result = d2sim_adapter.simulate_d2sim(TEST_SEQUENCE, error_rate=0.1)
+
+    assert isinstance(result, str)
+    assert result
+
+
+@pytest.mark.skipif(shutil.which("squigulator") is None, reason="squigulator not installed")
+def test_squigulator_integration() -> None:
+    result = squigulator_adapter.simulate_squigulator(TEST_SEQUENCE, error_rate=0.1)
+
+    assert isinstance(result, str)
+    assert result
+
+
+@pytest.mark.skipif(shutil.which("dnarsim") is None, reason="dnarsim not installed")
+def test_dnarsim_integration_with_profile() -> None:
+    result = dnarsim_adapter.simulate_dnarsim(
+        TEST_SEQUENCE,
+        error_rate=0.1,
+        profile="r9",
+    )
+
+    assert isinstance(result, str)
+    assert result
+
+
+@pytest.mark.skipif(shutil.which("insilicoseq") is None, reason="insilicoseq not installed")
+def test_insilicoseq_integration_with_profile() -> None:
+    result = insilicoseq_adapter.simulate_insilicoseq(
+        TEST_SEQUENCE,
+        error_rate=0.1,
+        profile="miseq",
+    )
+
+    assert isinstance(result, str)
+    assert result
+
+
+@pytest.mark.skipif(shutil.which("desp") is None, reason="desp not installed")
+def test_desp_integration() -> None:
+    result = desp_adapter.simulate_desp(TEST_SEQUENCE, error_rate=0.1)
+
+    assert isinstance(result, str)
+    assert result


### PR DESCRIPTION
### Motivation
- Provide lightweight integration coverage for optional external simulator adapters to detect regressions when those binaries are available.
- Ensure profile-aware adapters propagate profile parameters correctly to external CLIs.
- Avoid causing CI failures when external tools are not installed by skipping tests conditionally.
- Validate that adapter outputs are non-empty when the external tool runs.

### Description
- Add `tests/test_external_simulators_integration.py` containing integration tests for `d2sim`, `squigulator`, `dnarsim` (profile), `insilicoseq` (profile) and `desp` adapters.
- Each test is guarded with `pytest.mark.skipif(shutil.which("<cmd>") is None, ...)` to only run when the corresponding binary is on `PATH`.
- Tests call the adapter functions (e.g. `simulate_d2sim`, `simulate_dnarsim`, `simulate_insilicoseq`, `simulate_squigulator`, `simulate_desp`) and assert the result is a non-empty `str`.
- Imports adapters from `genecoder` and use a shared `TEST_SEQUENCE` for consistency.

### Testing
- Ran `ruff check .` and it passed.
- Ran `pytest tests/test_external_simulators_integration.py` and the test run completed successfully with all tests skipped when the external binaries were absent.
- No failing tests were produced by the new test module in the current environment.
- Linting and the targeted pytest run both exited cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e95a5f19483268cfd6dc0517be505)