### PR TITLE
Support offline Web UI and configurable Pyodide source

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,20 @@ network features and avoid loading cloud integrations:
 genecli --help
 ```
 
+## Web UI offline mode
+
+The web interface loads Pyodide (used for in-browser Python execution) from a CDN by default. If you
+need to run without network access, set `GENECODER_OFFLINE=1` when starting the web server to skip
+loading Pyodide and keep the UI functional offline:
+
+```bash
+GENECODER_OFFLINE=1 uvicorn web.main:app --host 0.0.0.0 --port 8000
+```
+
+When `GENECODER_OFFLINE` is enabled, the status banner will show that Pyodide is disabled and any
+features that depend on it will remain inactive until you run without the flag. If you host a local
+Pyodide bundle, set `GENECODER_PYODIDE_SRC=/static/pyodide/pyodide.js` (or similar) to use it.
+
 Example output:
 
 A quick sanity check is to run the command and ensure the usage header appears.

--- a/web/main.py
+++ b/web/main.py
@@ -51,6 +51,16 @@ API_TOKEN: str | None = os.getenv("GENECODER_API_TOKEN")
 CORS_ORIGINS = os.getenv("GENECODER_CORS_ORIGINS", "*")
 security = HTTPBearer(auto_error=False)
 BUNDLE_DIR = Path(os.getenv("GENECODER_BUNDLE_DIR", "bundle_runs"))
+GENECODER_OFFLINE = os.getenv("GENECODER_OFFLINE", "").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+PYODIDE_SRC = os.getenv(
+    "GENECODER_PYODIDE_SRC",
+    "https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js",
+)
 
 
 
@@ -125,7 +135,12 @@ if not design_index_path.is_file():
 
 @app.get("/", response_class=HTMLResponse)
 async def index() -> str:
-    return index_path.read_text(encoding="utf-8")
+    html = index_path.read_text(encoding="utf-8")
+    return (
+        html.replace(
+            "__GENECODER_OFFLINE__", "true" if GENECODER_OFFLINE else "false"
+        ).replace("__PYODIDE_SRC__", PYODIDE_SRC)
+    )
 
 
 @app.get("/helix", response_class=HTMLResponse)

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8" />
     <title>GeneCoder Web</title>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js"></script>
 </head>
 <body>
     <h1>GeneCoder Web</h1>
@@ -13,10 +12,31 @@
         See the <a href="../README.md#disclaimer">Disclaimer</a> before using this tool.
     </p>
     <script type="text/javascript">
-        async function main() {
-            const pyodide = await loadPyodide();
-            document.getElementById("status").textContent = "Pyodide loaded";
+        const GENECODER_OFFLINE = "__GENECODER_OFFLINE__" === "true";
+        const PYODIDE_SRC = "__PYODIDE_SRC__";
+
+        function loadScript(src) {
+            return new Promise((resolve, reject) => {
+                const script = document.createElement("script");
+                script.src = src;
+                script.onload = resolve;
+                script.onerror = reject;
+                document.head.appendChild(script);
+            });
         }
+
+        async function main() {
+            const statusEl = document.getElementById("status");
+            if (GENECODER_OFFLINE) {
+                statusEl.textContent = "Pyodide disabled (offline mode)";
+                return;
+            }
+
+            await loadScript(PYODIDE_SRC);
+            const pyodide = await loadPyodide();
+            statusEl.textContent = "Pyodide loaded";
+        }
+
         main();
     </script>
 </body>


### PR DESCRIPTION
### Motivation

- Allow the web UI to run without fetching Pyodide from a CDN so the app can function in offline or air-gapped environments.
- Provide a way to point the UI at a locally-hosted Pyodide bundle when offline or when bundling is preferred.
- Expose simple environment-driven behavior so deployments can opt out of in-browser Python features.

### Description

- Add `GENECODER_OFFLINE` and `GENECODER_PYODIDE_SRC` environment variables in `web/main.py` to control offline mode and the Pyodide source URL, with a CDN default for backward compatibility.
- Change the `/` endpoint to inject `__GENECODER_OFFLINE__` and `__PYODIDE_SRC__` placeholders into the served `web/static/index.html` at request time.
- Update `web/static/index.html` to dynamically load Pyodide via a script loader and skip initialization when offline (shows a status banner instead).
- Document the web UI offline mode and how to point to a local bundle in `docs/usage.md` (instructions use `GENECODER_OFFLINE=1` and `GENECODER_PYODIDE_SRC=/static/pyodide/pyodide.js`).

### Testing

- Ran `python -m pytest` (full test suite): 905 collected, 847 passed, 2 failed, 102 skipped; failures were `tests/test_nanopore_dnarsim_channel.py::test_cli_invocation` and `tests/test_plugin_registry_loading.py::test_entry_point_plugin_invalid_metadata`.
- Ran `ruff check .` and it completed successfully with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696656a3a92483269d5b0bcbdde3c94a)