### PR TITLE
Clarify offline plugin catalog test coverage

### DIFF
--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -77,7 +77,9 @@ def test_load_catalog_bad_signature(monkeypatch: pytest.MonkeyPatch, caplog: pyt
     assert not plugins.PLUGIN_CATALOG
 
 
-def test_load_catalog_offline_skips_remote(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_load_catalog_offline_uses_local_entries(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     import genecoder.plugin_manager as plugins
 
     calls: list[str] = []
@@ -88,7 +90,11 @@ def test_load_catalog_offline_skips_remote(monkeypatch: pytest.MonkeyPatch, capl
 
     monkeypatch.setattr(plugins.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setenv("GENECODER_OFFLINE", "1")
-    monkeypatch.setattr(plugins, "_collect_installed_plugins", lambda: ({"local": {"version": "1.0"}}, []))
+    monkeypatch.setattr(
+        plugins,
+        "_collect_installed_plugins",
+        lambda: ({"local": {"version": "1.0"}}, []),
+    )
 
     plugins.PLUGIN_CATALOG.clear()
     with caplog.at_level(logging.INFO):
@@ -97,3 +103,4 @@ def test_load_catalog_offline_skips_remote(monkeypatch: pytest.MonkeyPatch, capl
     assert "offline: skipped remote catalog" in caplog.text
     assert calls == []
     assert plugins.PLUGIN_CATALOG == {"local": {"version": "1.0"}}
+    assert plugins.PLUGIN_CATALOG["local"]["version"] == "1.0"


### PR DESCRIPTION
### Motivation

- Improve the offline catalog test to explicitly verify network fetches are skipped when `GENECODER_OFFLINE` is set.
- Ensure locally discovered plugin metadata is preserved and surfaced in the catalog while offline.

### Description

- Rename the test to `test_load_catalog_offline_uses_local_entries` and keep the existing `urllib.request.urlopen` monkeypatch to assert remote fetch is never called.
- Set `GENECODER_OFFLINE=1` in the test and monkeypatch `_collect_installed_plugins` to return a local plugin entry.
- Assert the log message `offline: skipped remote catalog` is emitted and that `PLUGIN_CATALOG` contains the locally discovered entry.
- Add an explicit assertion that the local entry version equals `"1.0"`.

### Testing

- Ran `pytest tests/test_plugin_catalog.py`, which was skipped due to missing `fastapi` (skipped tests reported).
- Ran `ruff check tests/test_plugin_catalog.py`, which passed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665c67eef88326b7d978428f1b5258)