### PR TITLE
Add bundle CLI test for missing reedsolo FEC dependency

### DIFF
--- a/tests/test_cli_bundle_reedsolo.py
+++ b/tests/test_cli_bundle_reedsolo.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from tests.test_cli import run_cli_command
+
+yaml = pytest.importorskip("yaml")
+
+
+def test_bundle_reedsolo_missing_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    original_find_spec = importlib.util.find_spec
+
+    def _fake_find_spec(name: str, *args, **kwargs):
+        if name == "reedsolo":
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+    input_file = tmp_path / "payload.txt"
+    input_file.write_text("bundle payload")
+
+    config = {
+        "encode": {
+            "input_files": [str(input_file)],
+            "method": "base4_direct",
+            "fec": "reed_solomon",
+        },
+        "decode": {"method": "base4_direct"},
+    }
+    cfg_path = tmp_path / "bundle.yaml"
+    cfg_path.write_text(yaml.safe_dump(config))
+
+    result = run_cli_command(
+        ["bundle", "run", str(cfg_path), "--cache-dir", str(tmp_path / "runs")]
+    )
+
+    assert result.returncode != 0
+    assert (
+        "Reed-Solomon FEC requires the 'reedsolo' package" in result.stderr
+    ), result.stderr


### PR DESCRIPTION
### Motivation
- Ensure the bundle CLI surfaces a clear error when a config requests `fec: reed_solomon` but the `reedsolo` package is not available.
- Prevent silent downgrade or unclear failures by explicitly testing the missing-dependency error path.

### Description
- Add a new test file `tests/test_cli_bundle_reedsolo.py` that simulates `reedsolo` being absent by monkeypatching `importlib.util.find_spec` to return `None` for `"reedsolo"`.
- The test writes a minimal bundle config requesting `fec: "reed_solomon"`, runs the bundle entrypoint via `run_cli_command`, and asserts the CLI exits non-zero with the expected error message.

### Testing
- Ran `ruff check tests/test_cli_bundle_reedsolo.py` and it passed.
- Ran `pytest tests/test_cli_bundle_reedsolo.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665f9186608326958142a801abd41c)