### PR TITLE
Consolidate Illumina simulator logic and expose canonical simulator alias

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -56,7 +56,6 @@ def register_builtin_plugins() -> None:
     _load_and_register(
         [
             "genecoder.error_simulation",
-            "genecoder.illumina_sim",
             "genecoder.simulators.decay",
             "genecoder.simulators.illumina",
             "genecoder.insilicoseq_adapter",
@@ -75,4 +74,3 @@ def register_builtin_plugins() -> None:
         register_visualizer,
         "builtin",
     )
-

--- a/src/genecoder/illumina_sim.py
+++ b/src/genecoder/illumina_sim.py
@@ -4,20 +4,25 @@ This module implements a small Illumina error model dominated by base
 substitutions.  Earlier versions exposed a single ``error_rate`` parameter
 from which insertion and deletion probabilities were derived.  The model now
 accepts separate ``substitution_rate``, ``insertion_rate`` and
-``deletion_rate`` values which can also be loaded from named profiles defined
-in :mod:`configs/illumina.yml`.
+``deletion_rate`` values which can also be loaded from named profiles.
 """
 from __future__ import annotations
 
 import random
-import math
-from pathlib import Path
-from typing import Callable, Sequence, Mapping
+from typing import Callable, Sequence
 
-from .error_simulation import NUCLEOTIDES, _random_substitution
-from .random_utils import make_rng
 from .api import Simulator
+from .random_utils import make_rng
 from .simulators import register_simulator as _register_simulator
+from .simulators.illumina.mutations import mutate_read
+from .simulators.illumina.profiles import (
+    ILLUMINA_PROFILES as _ILLUMINA_PROFILES,
+    IlluminaProfile,
+    _resolve_profile,
+)
+from .simulators.illumina.utils import consensus, poisson
+
+ILLUMINA_PROFILES = _ILLUMINA_PROFILES
 
 __all__ = ["simulate", "Channel", "register", "ILLUMINA_PROFILES"]
 
@@ -25,63 +30,7 @@ __all__ = ["simulate", "Channel", "register", "ILLUMINA_PROFILES"]
 def _poisson(lam: float, rng: random.Random) -> int:
     """Return a Poisson-distributed integer with mean ``lam``."""
 
-    L = math.exp(-lam)
-    k = 0
-    p = 1.0
-    while p > L:
-        k += 1
-        p *= rng.random()
-    return k - 1
-
-
-_DEFAULT_PROFILES: dict[str, dict[str, float | int]] = {
-    "hiseq": {
-        "substitution_rate": 0.0005,
-        "insertion_rate": 0.00005,
-        "deletion_rate": 0.00005,
-        "coverage_depth": 1,
-    },
-    "miseq": {
-        "substitution_rate": 0.001,
-        "insertion_rate": 0.0001,
-        "deletion_rate": 0.0001,
-        "coverage_depth": 1,
-    },
-    "novaseq": {
-        "substitution_rate": 0.0003,
-        "insertion_rate": 0.00003,
-        "deletion_rate": 0.00003,
-        "coverage_depth": 1,
-    },
-    "nova": {
-        "substitution_rate": 0.0003,
-        "insertion_rate": 0.00003,
-        "deletion_rate": 0.00003,
-        "coverage_depth": 1,
-    },
-}
-
-try:  # pragma: no cover - optional dependency
-    import yaml
-
-    _cfg_dir = Path(__file__).resolve().parents[2] / "configs"
-    with open(_cfg_dir / "illumina.yml", "r", encoding="utf-8") as _fh:
-        _data = yaml.safe_load(_fh) or {}
-    if isinstance(_data, Mapping):
-        ILLUMINA_PROFILES: dict[str, dict[str, float | int]] = {
-            str(name): {
-                "substitution_rate": float(params.get("substitution_rate", 0.001)),
-                "insertion_rate": float(params.get("insertion_rate", 0.0001)),
-                "deletion_rate": float(params.get("deletion_rate", 0.0001)),
-                "coverage_depth": float(params.get("coverage_depth", 1)),
-            }
-            for name, params in _data.items()
-            if isinstance(params, Mapping)
-        }
-    else:  # pragma: no cover - unexpected structure
-        ILLUMINA_PROFILES = _DEFAULT_PROFILES
-except Exception:  # pragma: no cover - fall back to defaults
-    ILLUMINA_PROFILES = _DEFAULT_PROFILES
+    return poisson(lam, rng)
 
 
 def _mutate_read(
@@ -95,44 +44,23 @@ def _mutate_read(
 ) -> str:
     """Return ``sequence`` mutated using the provided probabilities."""
 
-    mutated: list[str] = []
-    for idx, nt in enumerate(sequence):
-        if rng.random() < deletion_prob:
-            continue
-
-        if quality_profile is not None and idx < len(quality_profile):
-            sub_prob = quality_profile[idx]
-        elif quality_distribution is not None and len(quality_distribution) > 0:
-            sub_prob = rng.choice(quality_distribution)
+    if quality_distribution is not None and quality_profile is None:
+        if quality_distribution:
+            quality_profile = tuple(
+                rng.choice(quality_distribution) for _ in range(len(sequence))
+            )
         else:
-            sub_prob = substitution_prob
-        if rng.random() < sub_prob:
-            nt = _random_substitution(nt, rng)
+            quality_profile = None
 
-        mutated.append(nt)
-
-        if rng.random() < insertion_prob:
-            mutated.append(rng.choice(NUCLEOTIDES))
-
-    return "".join(mutated)
-
-
-def _consensus(reads: Sequence[str]) -> str:
-    """Return the per-base majority sequence from ``reads``."""
-
-    if not reads:
-        return ""
-    length = max(len(r) for r in reads)
-    result: list[str] = []
-    for i in range(length):
-        counts: dict[str, int] = {}
-        for r in reads:
-            if i < len(r):
-                base = r[i]
-                counts[base] = counts.get(base, 0) + 1
-        if counts:
-            result.append(max(counts, key=lambda b: counts.get(b, 0)))
-    return "".join(result)
+    return mutate_read(
+        sequence,
+        quality_profile,
+        rng,
+        substitution_rate=substitution_prob,
+        insertion_rate=insertion_prob,
+        deletion_rate=deletion_prob,
+        context_errors={},
+    )
 
 
 def simulate(
@@ -170,34 +98,35 @@ def simulate(
         Optional profile name defined in :data:`ILLUMINA_PROFILES`.
     """
 
-    prof = ILLUMINA_PROFILES.get(profile or "hiseq", {})
+    prof_defaults, prof_data = _resolve_profile(profile or "hiseq")
+    prof = prof_defaults
     substitution_rate = float(
         substitution_rate
         if substitution_rate is not None
-        else prof.get("substitution_rate", 0.001)
+        else (prof.substitution_rate if prof is not None else 0.001)
     )
     insertion_rate = float(
         insertion_rate
         if insertion_rate is not None
-        else prof.get("insertion_rate", 0.0001)
+        else (prof.insertion_rate if prof is not None else 0.0001)
     )
     deletion_rate = float(
         deletion_rate
         if deletion_rate is not None
-        else prof.get("deletion_rate", 0.0001)
+        else (prof.deletion_rate if prof is not None else 0.0001)
     )
     coverage_depth = float(
         coverage_depth
         if coverage_depth is not None
-        else float(prof.get("coverage_depth", 1))
+        else (prof.coverage if prof is not None else 1)
     )
+    if prof_data:
+        quality_profile = prof_data.get("quality_profile", quality_profile)
 
     if rng is None:
         rng = make_rng()
 
-    coverage = _poisson(coverage_depth, rng)
-    if coverage <= 0:
-        return ""
+    coverage = max(1, poisson(coverage_depth, rng))
     reads = [
         _mutate_read(
             sequence,
@@ -212,7 +141,7 @@ def simulate(
     ]
     if coverage == 1:
         return reads[0]
-    return _consensus(reads)
+    return consensus(reads)
 
 
 class Channel(Simulator):
@@ -229,27 +158,30 @@ class Channel(Simulator):
         quality_distribution: Sequence[float] | None = None,
         profile: str | None = None,
     ) -> None:
-        prof = ILLUMINA_PROFILES.get(profile or "hiseq", {})
+        prof_defaults, prof_data = _resolve_profile(profile or "hiseq")
+        prof: IlluminaProfile | None = prof_defaults
         self.substitution_rate = float(
             substitution_rate
             if substitution_rate is not None
-            else prof.get("substitution_rate", 0.001)
+            else (prof.substitution_rate if prof is not None else 0.001)
         )
         self.insertion_rate = float(
             insertion_rate
             if insertion_rate is not None
-            else prof.get("insertion_rate", 0.0001)
+            else (prof.insertion_rate if prof is not None else 0.0001)
         )
         self.deletion_rate = float(
             deletion_rate
             if deletion_rate is not None
-            else prof.get("deletion_rate", 0.0001)
+            else (prof.deletion_rate if prof is not None else 0.0001)
         )
         self.coverage_depth = float(
             coverage_depth
             if coverage_depth is not None
-            else float(prof.get("coverage_depth", 1))
+            else (prof.coverage if prof is not None else 1)
         )
+        if prof_data:
+            quality_profile = prof_data.get("quality_profile", quality_profile)
         self.quality_profile = (
             tuple(quality_profile) if quality_profile is not None else None
         )

--- a/src/genecoder/simulators/illumina/__init__.py
+++ b/src/genecoder/simulators/illumina/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
 def register(
     registrar: Callable[[str, Simulator], None] = _register_simulator,
 ) -> None:
-    registrar("illumina", IlluminaChannel())
+    channel = IlluminaChannel()
+    registrar("illumina", channel)
+    registrar("illumina_builtin", channel)
     registrar("illumina_d2sim", IlluminaD2SimChannel())
     registrar("illumina_insilicoseq", IlluminaInSilicoSeqChannel())

--- a/src/genecoder/simulators/illumina/channel.py
+++ b/src/genecoder/simulators/illumina/channel.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Mapping, Sequence, cast
+from typing import Dict, Sequence, cast
 import random
 
 from ..base import BaseSimulator
@@ -14,8 +14,8 @@ from .mutations import mutate_read
 from .profiles import (
     ILLUMINA_PROFILES,
     IlluminaProfile,
-    _load_profile_file,
     _parse_quality_profile,
+    _resolve_profile,
     _validate_profile,
 )
 from .utils import consensus, poisson
@@ -40,16 +40,7 @@ class IlluminaChannel(BaseSimulator):
         context_errors: Dict[str, float] | None = None,
         profile: str | None = None,
     ) -> None:
-        profile_data: Mapping[str, Any] = {}
-        profile_defaults: IlluminaProfile | None = None
-        if profile is not None:
-            path = Path(profile)
-            if path.is_file():
-                profile_data = _load_profile_file(path) or {}
-            else:
-                profile_data = ILLUMINA_PROFILES.get(profile.lower(), {})
-            if profile_data:
-                profile_defaults = _validate_profile(profile_data)
+        profile_defaults, profile_data = _resolve_profile(profile)
 
         substitution_rate = float(
             substitution_rate

--- a/src/genecoder/simulators/illumina/profiles.py
+++ b/src/genecoder/simulators/illumina/profiles.py
@@ -20,6 +20,7 @@ __all__ = [
     "_parse_quality_profile",
     "_validate_profile",
     "_load_profile_file",
+    "_resolve_profile",
 ]
 
 
@@ -124,6 +125,22 @@ def _load_profile_file(path: str | Path) -> Mapping[str, Any]:
     if not isinstance(data, Mapping):
         raise ValueError("Profile file must map keys to values")
     return data
+
+
+def _resolve_profile(
+    profile: str | None,
+) -> tuple[IlluminaProfile | None, Mapping[str, Any]]:
+    """Return resolved profile defaults and raw data for ``profile``."""
+
+    if profile is None:
+        return None, {}
+    path = Path(profile)
+    if path.is_file():
+        profile_data = _load_profile_file(path) or {}
+    else:
+        profile_data = ILLUMINA_PROFILES.get(profile.lower(), {})
+    profile_defaults = _validate_profile(profile_data) if profile_data else None
+    return profile_defaults, profile_data
 
 
 # Preset parameter profiles for :class:`IlluminaChannel`.

--- a/tests/test_illumina_builtin_sim.py
+++ b/tests/test_illumina_builtin_sim.py
@@ -61,7 +61,7 @@ def test_coverage_influences_read_count(monkeypatch):
         rng=rng,
         coverage_depth=5.0,
     )
-    expected = illumina_sim._poisson(5.0, random.Random(0))
+    expected = max(1, illumina_sim._poisson(5.0, random.Random(0)))
     assert len(calls) == expected
     assert out == seq
 
@@ -75,5 +75,6 @@ def test_coverage_influences_read_count(monkeypatch):
         rng=rng,
         coverage_depth=0.1,
     )
-    assert out == ""
-    assert len(calls) == 0
+    expected = max(1, illumina_sim._poisson(0.1, random.Random(0)))
+    assert len(calls) == expected
+    assert out == seq

--- a/tests/test_illumina_profiles.py
+++ b/tests/test_illumina_profiles.py
@@ -1,0 +1,16 @@
+from genecoder.simulators import SIMULATOR_REGISTRY, simulate_reads
+from genecoder.simulators.illumina import register as illumina_register
+
+
+def test_illumina_profile_alias_matches_canonical(monkeypatch) -> None:
+    SIMULATOR_REGISTRY.clear()
+    illumina_register()
+    assert "illumina" in SIMULATOR_REGISTRY
+    assert "illumina_builtin" in SIMULATOR_REGISTRY
+
+    sequence = "ACGT" * 25
+    monkeypatch.setenv("GENECODER_SIM_SEED", "2024")
+    legacy = simulate_reads(sequence, "illumina_builtin", profile="hiseq")
+    monkeypatch.setenv("GENECODER_SIM_SEED", "2024")
+    canonical = simulate_reads(sequence, "illumina", profile="hiseq")
+    assert legacy == canonical


### PR DESCRIPTION
### Motivation
- Ensure the legacy `illumina_sim` helper and the canonical `simulators.illumina` channel use identical profile parsing, coverage handling, and consensus/mutation logic to avoid drift. 
- Centralize profile resolution and shared helpers so behaviour and presets are consistent across the codebase. 
- Provide a single canonical simulator name while keeping the historical `illumina_builtin` alias for compatibility. 
- Add a small regression test to prevent future divergence between the two entrypoints.

### Description
- Replace local mutation/consensus/poisson implementations in `src/genecoder/illumina_sim.py` with shared helpers from `src/genecoder/simulators/illumina` and export `ILLUMINA_PROFILES` from there. 
- Add `_resolve_profile` to `src/genecoder/simulators/illumina/profiles.py` to unify profile file / built-in lookup and validation. 
- Update `src/genecoder/simulators/illumina/__init__.py` to register a single `IlluminaChannel` instance under both `illumina` (canonical) and `illumina_builtin` (legacy alias). 
- Remove the direct builtin import of the old `genecoder.illumina_sim` from `src/genecoder/builtin_plugins.py` and add `tests/test_illumina_profiles.py` plus a small adjustment to `tests/test_illumina_builtin_sim.py` to assert identical outputs and consistent coverage behaviour.

### Testing
- Ran `ruff check src tests` and the linter passed. 
- Executed `pytest` for `tests/test_illumina_builtin_sim.py`, `tests/test_illumina_coverage_quality.py`, `tests/test_illumina_profile_stats.py`, `tests/test_simulator_registry.py`, and `tests/test_illumina_profiles.py`. 
- All selected tests passed (`10 passed`). 
- No regressions observed in the exercised Illumina-related test cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966643668708326b898573f0c1bfea7)