### PR TITLE
Handle missing Streamlit dashboard dependencies gracefully

### DIFF
--- a/src/genecoder/cli/dashboard.py
+++ b/src/genecoder/cli/dashboard.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def register_subcommand(
@@ -18,6 +22,12 @@ def register_subcommand(
 
 
 def _handle_command(args: argparse.Namespace) -> None:
-    from genecoder.dashboard_streamlit import launch
+    try:
+        from genecoder.dashboard_streamlit import launch
 
-    launch(*args.results_json)
+        launch(*args.results_json)
+    except (ImportError, RuntimeError) as exc:
+        logger.warning(
+            "Streamlit dashboard unavailable (%s). Install streamlit or use the HTML report workflow instead.",
+            exc,
+        )

--- a/tests/test_bundle_dashboard_launch.py
+++ b/tests/test_bundle_dashboard_launch.py
@@ -42,3 +42,21 @@ def test_bundle_launches_dashboard(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     )
     assert result.returncode == 0, result.stderr
     assert calls == [(str(metrics_path),)]
+
+
+def test_dashboard_missing_streamlit_warns(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = types.ModuleType("genecoder.dashboard_streamlit")
+
+    def _raise_missing(*_args: str) -> None:
+        raise RuntimeError("streamlit is required to launch the dashboard")
+
+    module.launch = _raise_missing  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "genecoder.dashboard_streamlit", module)
+
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text("{}")
+
+    result = run_cli_command(["dashboard", str(metrics_path)])
+
+    assert result.returncode == 0, result.stderr
+    assert "Streamlit dashboard unavailable" in result.stderr


### PR DESCRIPTION
### Motivation
- Prevent the CLI from crashing when `streamlit` is not installed or the Streamlit dashboard fails to start by emitting a clear, actionable warning. 
- Provide a test to ensure the dashboard subcommand remains non-crashing and communicates the problem to the user.

### Description
- Wrap the import and call to `genecoder.dashboard_streamlit.launch` in `src/genecoder/cli/dashboard.py` with a `try/except (ImportError, RuntimeError)` and log a warning suggesting to install `streamlit` or use the HTML report workflow. 
- Add a module-level `logger` and use `logger.warning` to emit the graceful message when launch is unavailable. 
- Add `tests/test_bundle_dashboard_launch.py::test_dashboard_missing_streamlit_warns` which monkeypatches `genecoder.dashboard_streamlit.launch` to raise `RuntimeError`, invokes the `dashboard` CLI, and asserts a zero exit code and the expected warning in `stderr`.

### Testing
- Ran `python -m pytest tests/test_bundle_dashboard_launch.py` which completed successfully (2 tests passed). 
- Ran `python -m ruff check src tests` and received `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e39f123c48326b87cb6234477c87d)