### PR TITLE
Define legacy error_rate behavior for Channel

### DIFF
--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -765,7 +765,11 @@ def register_subcommand(
             "--sub-rate",
             type=float,
             default=None,
-            help="Substitution rate for generic simulators",
+            help=(
+                "Substitution rate for generic simulators. "
+                "When mapped to legacy error_rate, the value is applied to "
+                "substitution/insertion/deletion equally (clamped so total ≤ 1.0)."
+            ),
         )
         target.add_argument(
             "--ins-rate",

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -168,7 +168,12 @@ def apply_deletions(sequence: str, prob: float, rng: random.Random | None = None
 
 
 class Channel(Simulator):
-    """Channel applying substitution, insertion and deletion errors."""
+    """Channel applying substitution, insertion and deletion errors.
+
+    ``error_rate`` is a legacy convenience parameter. When provided, any unset
+    substitution/insertion/deletion probabilities are set to the same clamped
+    rate (0.0 to 1/3) so the total error probability never exceeds 1.0.
+    """
 
     supports_batches = True
 
@@ -205,7 +210,10 @@ class Channel(Simulator):
                     self._delegate = NanoporeChannel(profile=str(preset))
 
         if error_rate is not None:
-            sub_prob = error_rate
+            clamped_rate = min(max(error_rate, 0.0), 1.0 / 3.0)
+            sub_prob = clamped_rate if sub_prob is None else sub_prob
+            ins_prob = clamped_rate if ins_prob is None else ins_prob
+            del_prob = clamped_rate if del_prob is None else del_prob
 
         self._substitution_prob = 0.0 if sub_prob is None else sub_prob
         self.insertion_prob = 0.0 if ins_prob is None else ins_prob
@@ -236,7 +244,10 @@ class Channel(Simulator):
             DeprecationWarning,
             stacklevel=2,
         )
-        self._substitution_prob = value
+        clamped_rate = min(max(value, 0.0), 1.0 / 3.0)
+        self._substitution_prob = clamped_rate
+        self.insertion_prob = clamped_rate
+        self.deletion_prob = clamped_rate
 
     def _simulate_string(self, sequence: str) -> str:
         if self._delegate is not None:

--- a/tests/test_error_simulation.py
+++ b/tests/test_error_simulation.py
@@ -1,6 +1,6 @@
 import random
 import pytest
-from genecoder.error_simulation import simulate_errors
+from genecoder.error_simulation import Channel, simulate_errors
 from genecoder.random_utils import reset_rng
 
 
@@ -140,3 +140,14 @@ def test_simulate_errors_probability_sum_exceeds_one() -> None:
             deletion_prob=0.2,
             rng=random.Random(0),
         )
+
+
+def test_channel_error_rate_clamping() -> None:
+    channel = Channel(error_rate=0.6)
+    assert channel.substitution_prob == pytest.approx(1.0 / 3.0)
+    assert channel.insertion_prob == pytest.approx(1.0 / 3.0)
+    assert channel.deletion_prob == pytest.approx(1.0 / 3.0)
+    assert (
+        channel.substitution_prob + channel.insertion_prob + channel.deletion_prob
+        <= 1.0
+    )


### PR DESCRIPTION
### Motivation

- Provide explicit, deterministic semantics for the legacy `error_rate` parameter so callers know how it maps to substitution/insertion/deletion probabilities. 
- Ensure legacy usage cannot configure a total error probability > 1.0 by clamping and distributing the rate.
- Update CLI help and tests to document and validate the new semantics.

### Description

- Change `Channel.__init__` to map a provided `error_rate` to substitution/insertion/deletion probabilities by clamping it to the range [0.0, 1/3] and applying that value to any unset per-operation probability. 
- Update the `Channel.error_rate` setter to warn (deprecated) and set all three probabilities to the clamped value so the total remains ≤ 1.0. 
- Add explanatory text to the `Channel` docstring describing the legacy `error_rate` semantics. 
- Update CLI help for `--sub-rate` in `src/genecoder/cli/channel.py` to describe how values are interpreted when mapped to the legacy `error_rate`. 
- Add a deterministic unit test `test_channel_error_rate_clamping` to `tests/test_error_simulation.py` that validates the clamping and that the sum of configured rates is ≤ 1.0.

### Testing

- Ran `ruff check .` which completed with no issues. 
- Ran `pytest` which completed successfully with `852 passed, 106 skipped` and `26 warnings` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3cb0bb4c8326b590d00fa3dd65c3)