### PR TITLE
Default Pyodide to local bundle with offline guidance

### DIFF
--- a/docs/offline_usage.md
+++ b/docs/offline_usage.md
@@ -9,6 +9,11 @@ manage the optional plugin registry.
 Most CLI commands accept `--offline` to disable all network operations.
 The same behaviour can be enabled globally by setting `GENECODER_OFFLINE=1`.
 
+The web UI uses a local Pyodide bundle by default. Place the Pyodide
+distribution under `web/static/pyodide/` so it is served from
+`/static/pyodide/pyodide.js`. To point the UI at a different (possibly remote)
+bundle, set `GENECODER_PYODIDE_SRC` to the desired `pyodide.js` URL.
+
 ## Profile Paths
 
 Sequencing simulators may download profile files the first time they run.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,17 +27,19 @@ genecli --help
 
 ## Web UI offline mode
 
-The web interface loads Pyodide (used for in-browser Python execution) from a CDN by default. If you
-need to run without network access, set `GENECODER_OFFLINE=1` when starting the web server to skip
-loading Pyodide and keep the UI functional offline:
+The web interface loads Pyodide (used for in-browser Python execution) from a **local** bundle by
+default. Populate `web/static/pyodide/` with the Pyodide distribution so it can be served from
+`/static/pyodide/pyodide.js`. If you need to run without network access, set `GENECODER_OFFLINE=1`
+when starting the web server to skip loading Pyodide and keep the UI functional offline:
 
 ```bash
 GENECODER_OFFLINE=1 uvicorn web.main:app --host 0.0.0.0 --port 8000
 ```
 
 When `GENECODER_OFFLINE` is enabled, the status banner will show that Pyodide is disabled and any
-features that depend on it will remain inactive until you run without the flag. If you host a local
-Pyodide bundle, set `GENECODER_PYODIDE_SRC=/static/pyodide/pyodide.js` (or similar) to use it.
+features that depend on it will remain inactive until you run without the flag. If you want to
+load Pyodide from a custom URL (for example a CDN or internal mirror), set
+`GENECODER_PYODIDE_SRC=https://.../pyodide.js` to override the default local asset path.
 
 Example output:
 

--- a/web/main.py
+++ b/web/main.py
@@ -59,7 +59,7 @@ GENECODER_OFFLINE = os.getenv("GENECODER_OFFLINE", "").lower() in {
 }
 PYODIDE_SRC = os.getenv(
     "GENECODER_PYODIDE_SRC",
-    "https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js",
+    "/static/pyodide/pyodide.js",
 )
 
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>GeneCoder Web</h1>
-    <p id="status">Loading Pyodide...</p>
+    <p id="status">Checking Pyodide bundle...</p>
     <iframe src="/helix?seq=ACGT" width="600" height="400" style="border:none;"></iframe>
     <p>
         See the <a href="../README.md#disclaimer">Disclaimer</a> before using this tool.
@@ -25,16 +25,48 @@
             });
         }
 
-        async function main() {
+        function setStatus(message, isError = false) {
             const statusEl = document.getElementById("status");
+            statusEl.textContent = message;
+            statusEl.style.color = isError ? "crimson" : "inherit";
+        }
+
+        async function main() {
             if (GENECODER_OFFLINE) {
-                statusEl.textContent = "Pyodide disabled (offline mode)";
+                setStatus("Pyodide disabled (offline mode)");
                 return;
             }
 
-            await loadScript(PYODIDE_SRC);
-            const pyodide = await loadPyodide();
-            statusEl.textContent = "Pyodide loaded";
+            try {
+                await loadScript(PYODIDE_SRC);
+            } catch (error) {
+                setStatus(
+                    "Pyodide bundle not found locally. Copy the Pyodide distribution into /static/pyodide/ " +
+                    "or set GENECODER_PYODIDE_SRC to a custom URL.",
+                    true
+                );
+                return;
+            }
+
+            if (typeof loadPyodide !== "function") {
+                setStatus(
+                    "Pyodide bundle is missing required files. Rebuild or copy the full Pyodide distribution " +
+                    "into /static/pyodide/ or set GENECODER_PYODIDE_SRC to a custom URL.",
+                    true
+                );
+                return;
+            }
+
+            try {
+                await loadPyodide();
+                setStatus("Pyodide loaded");
+            } catch (error) {
+                setStatus(
+                    "Pyodide failed to initialize from the local bundle. Verify the files in /static/pyodide/ " +
+                    "or set GENECODER_PYODIDE_SRC to a custom URL.",
+                    true
+                );
+            }
         }
 
         main();

--- a/web/static/pyodide/README.md
+++ b/web/static/pyodide/README.md
@@ -1,0 +1,34 @@
+# Local Pyodide Bundle
+
+This directory should contain the Pyodide distribution that the web UI loads by
+default. Copy the *full* `pyodide` release contents into this directory so the
+files are served at `/static/pyodide/`.
+
+## Build / Copy Instructions
+
+1. Download the Pyodide release assets (example below uses v0.24.0):
+
+   ```bash
+   mkdir -p /tmp/pyodide
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/ -o /tmp/pyodide/index.html
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js -o /tmp/pyodide/pyodide.js
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm -o /tmp/pyodide/pyodide.asm.wasm
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.data -o /tmp/pyodide/pyodide.asm.data
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide_py.tar -o /tmp/pyodide/pyodide_py.tar
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/packages.json -o /tmp/pyodide/packages.json
+   curl -L https://cdn.jsdelivr.net/pyodide/v0.24.0/full/repodata.json -o /tmp/pyodide/repodata.json
+   ```
+
+2. Copy the downloaded files into this directory:
+
+   ```bash
+   cp /tmp/pyodide/* /path/to/GeneCoder/web/static/pyodide/
+   ```
+
+3. Start the web server normally. The UI will load Pyodide from
+   `/static/pyodide/pyodide.js`. Override the default by setting
+   `GENECODER_PYODIDE_SRC` to another URL.
+
+> Note: The list above includes the minimum assets needed for the default
+> `full` Pyodide build. If you use a different build or version, copy the
+> matching files here.

--- a/web/static/pyodide/pyodide.js
+++ b/web/static/pyodide/pyodide.js
@@ -1,0 +1,5 @@
+/*
+ * Placeholder for the local Pyodide bundle.
+ * Replace this file (and the accompanying .wasm/.data/.tar assets) with the
+ * official Pyodide distribution as documented in README.md.
+ */


### PR DESCRIPTION
### Motivation

- Make the web UI offline-first by default so it does not attempt to fetch Pyodide from a CDN, and provide clear status and guidance when a local bundle is missing or fails to initialize.
- Provide an easy-to-populate local bundle location and document how to build/copy the Pyodide distribution for air-gapped deployments.

### Description

- Change the default `PYODIDE_SRC` to the local asset path by setting `GENECODER_PYODIDE_SRC` default to `/static/pyodide/pyodide.js` in `web/main.py`.
- Improve `web/static/index.html` to show explicit status messages, avoid silent failures, and surface actionable errors when the local Pyodide bundle is missing or incomplete.
- Add a `web/static/pyodide/` directory containing `README.md` with build/copy instructions and a placeholder `pyodide.js` to indicate where to place the official Pyodide distribution.
- Update documentation in `docs/usage.md` and `docs/offline_usage.md` to explain the new local-default behavior and how to override it with `GENECODER_PYODIDE_SRC`.

### Testing

- Ran the full test suite with `python -m pytest` which completed successfully with `852 passed, 106 skipped`.
- Ran the linter checks with `python -m ruff check .` which exited with `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e406effc4832696424ee7cb85bb99)