### PR TITLE
Add tests for web index Pyodide configuration

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -25,6 +25,31 @@ def test_root_route_serves_index_html() -> None:
     assert "GeneCoder Web" in response.text
 
 
+def test_index_injects_default_pyodide_src() -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert f'const PYODIDE_SRC = "{main.PYODIDE_SRC}";' in response.text
+    assert "__PYODIDE_SRC__" not in response.text
+
+
+def test_index_offline_mode_disables_pyodide(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GENECODER_OFFLINE", "1")
+    monkeypatch.setattr(main, "GENECODER_OFFLINE", True)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'const GENECODER_OFFLINE = "true" === "true";' in response.text
+    assert "Pyodide disabled (offline mode)" in response.text
+
+
+def test_index_injects_custom_pyodide_src(monkeypatch: pytest.MonkeyPatch) -> None:
+    custom_src = "/static/pyodide/custom/pyodide.js"
+    monkeypatch.setenv("GENECODER_PYODIDE_SRC", custom_src)
+    monkeypatch.setattr(main, "PYODIDE_SRC", custom_src)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert f'const PYODIDE_SRC = "{custom_src}";' in response.text
+
+
 def test_static_index_served() -> None:
     response = client.get("/static/index.html")
     assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Ensure the web UI `index.html` correctly receives the Pyodide source path and offline flag at runtime.
- Verify that setting `GENECODER_OFFLINE` disables Pyodide loading and that a custom `GENECODER_PYODIDE_SRC` is injected when provided.

### Description
- Added `test_index_injects_default_pyodide_src` to assert the default `PYODIDE_SRC` is substituted into the served HTML and the placeholder token is removed.
- Added `test_index_offline_mode_disables_pyodide` which uses `monkeypatch` to set `GENECODER_OFFLINE` and asserts the offline flag and the "Pyodide disabled (offline mode)" status appear in the response.
- Added `test_index_injects_custom_pyodide_src` which sets a custom `GENECODER_PYODIDE_SRC` via `monkeypatch` and asserts the custom path is injected into the HTML.

### Testing
- Ran `pytest tests/test_web_app.py`, which was skipped due to missing `fastapi` (test collection skipped); no test failures in the added tests themselves under the environment used.
- Ran `ruff check tests/test_web_app.py`, which passed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e43f7fc3c8326ae612c2a3ffbb244)