### PR TITLE
Use constraint limits for GC and homopolymer checks

### DIFF
--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -30,6 +30,10 @@ except Exception:  # pragma: no cover
 pd = cast(Any, _pd)
 alt = cast(Any, _alt)
 
+_DEFAULT_GC_MIN = 0.4
+_DEFAULT_GC_MAX = 0.6
+_DEFAULT_MAX_HOMOPOLYMER = 8
+
 
 _DEF_METRICS: dict[str, Any] = {
     "gc_distribution": [],
@@ -225,6 +229,27 @@ def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
                 record[f"ECC:{name}"] = values[idx]
         records.append(record)
     return records
+
+
+def _constraint_limits(data: dict[str, Any]) -> tuple[float, float, int]:
+    gc_min = _DEFAULT_GC_MIN
+    gc_max = _DEFAULT_GC_MAX
+    max_hp = _DEFAULT_MAX_HOMOPOLYMER
+
+    violations = data.get("constraint_violations")
+    if isinstance(violations, dict):
+        limits = violations.get("limits")
+        if isinstance(limits, dict):
+            gc_min_val = limits.get("gc_min")
+            gc_max_val = limits.get("gc_max")
+            max_hp_val = limits.get("max_homopolymer")
+            if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
+                gc_min = float(gc_min_val)
+            if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
+                gc_max = float(gc_max_val)
+            if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
+                max_hp = int(max_hp_val)
+    return gc_min, gc_max, max_hp
 
 
 def _parse_constraint_violations(value: object) -> dict[str, Any]:
@@ -433,6 +458,8 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         st.write("No results files provided.")
         return
 
+    limits_by_run = {name: _constraint_limits(data) for name, data in datasets.items()}
+
     names = list(datasets.keys())
     multiselect = getattr(sidebar, "multiselect", lambda *a, **k: names)
     selected = multiselect("Datasets", names, default=names)
@@ -497,15 +524,18 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
                 for row in relevant:
                     st.write(row)
 
-            flagged = [
-                row
-                for row in relevant
-                if (
-                    ("GC%" in row and (row["GC%"] < 0.4 or row["GC%"] > 0.6))
-                    or ("Max Homopolymer" in row and row["Max Homopolymer"] > 8)
-                    or row.get("Dropout")
+            def is_flagged(row: dict[str, Any]) -> bool:
+                gc_min, gc_max, max_hp = limits_by_run.get(
+                    row.get("Run", ""),
+                    (_DEFAULT_GC_MIN, _DEFAULT_GC_MAX, _DEFAULT_MAX_HOMOPOLYMER),
                 )
-            ]
+                if "GC%" in row and (row["GC%"] < gc_min or row["GC%"] > gc_max):
+                    return True
+                if "Max Homopolymer" in row and row["Max Homopolymer"] > max_hp:
+                    return True
+                return bool(row.get("Dropout"))
+
+            flagged = [row for row in relevant if is_flagged(row)]
             if flagged:
                 st.subheader("Out-of-bounds oligos")
                 if pd:

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -47,6 +47,9 @@ _ERROR_METRICS: tuple[tuple[str, str], ...] = (
     ("insertions", "Insertions"),
     ("deletions", "Deletions"),
 )
+_DEFAULT_GC_MIN = 0.4
+_DEFAULT_GC_MAX = 0.6
+_DEFAULT_MAX_HOMOPOLYMER = 8
 
 def _iterable(val: Iterable[str] | str | None) -> list[str]:
     if val is None:
@@ -146,6 +149,27 @@ def _coverage_value(data: dict[str, Any]) -> float | None:
     return None
 
 
+def _constraint_limits(data: dict[str, Any]) -> tuple[float, float, int]:
+    gc_min = _DEFAULT_GC_MIN
+    gc_max = _DEFAULT_GC_MAX
+    max_hp = _DEFAULT_MAX_HOMOPOLYMER
+
+    violations = data.get("constraint_violations")
+    if isinstance(violations, dict):
+        limits = violations.get("limits")
+        if isinstance(limits, dict):
+            gc_min_val = limits.get("gc_min")
+            gc_max_val = limits.get("gc_max")
+            max_hp_val = limits.get("max_homopolymer")
+            if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
+                gc_min = float(gc_min_val)
+            if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
+                gc_max = float(gc_max_val)
+            if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
+                max_hp = int(max_hp_val)
+    return gc_min, gc_max, max_hp
+
+
 def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
     oligo = data.get("oligo_metrics")
     if not isinstance(oligo, dict):
@@ -237,8 +261,10 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
     error_rows: list[dict[str, float | str]] = []
     coverage_rows: list[dict[str, float | str]] = []
     oligo_rows: list[dict[str, Any]] = []
+    limits_by_run: dict[str, tuple[float, float, int]] = {}
     for name, data in datasets.items():
         label = Path(name).stem
+        limits_by_run[label] = _constraint_limits(data)
         min_gc, mean_gc, max_gc = _gc_stats(data.get("gc_distribution"))
         if min_gc is not None and mean_gc is not None and max_gc is not None:
             gc_rows.extend(
@@ -307,16 +333,18 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         else:  # pragma: no cover - basic fallback
             st.table(oligo_rows)
 
-        # Highlight out-of-bounds oligos (GC outside [0.4,0.6] or HP > 8)
-        flagged = [
-            row
-            for row in oligo_rows
-            if (
-                ("GC%" in row and (row["GC%"] < 0.4 or row["GC%"] > 0.6))
-                or ("Max Homopolymer" in row and row["Max Homopolymer"] > 8)
-                or row.get("Dropout")
+        def is_flagged(row: dict[str, Any]) -> bool:
+            gc_min, gc_max, max_hp = limits_by_run.get(
+                row.get("Run", ""),
+                (_DEFAULT_GC_MIN, _DEFAULT_GC_MAX, _DEFAULT_MAX_HOMOPOLYMER),
             )
-        ]
+            if "GC%" in row and (row["GC%"] < gc_min or row["GC%"] > gc_max):
+                return True
+            if "Max Homopolymer" in row and row["Max Homopolymer"] > max_hp:
+                return True
+            return bool(row.get("Dropout"))
+
+        flagged = [row for row in oligo_rows if is_flagged(row)]
         if flagged:
             st.subheader("Out-of-bounds oligos")
             st.table(flagged)

--- a/src/genecoder/flet_handlers.py
+++ b/src/genecoder/flet_handlers.py
@@ -22,7 +22,6 @@ from .gc_constrained_encoder import calculate_gc_content
 from .manifest import generate_manifest
 from .options import EncodeOptions
 from .utils import get_max_homopolymer_length
-from .synthesis import SynthesisConstraints
 from .cli.encode import reverse_complement
 from .formats import to_fasta, from_fasta
 from .plotting import (
@@ -39,6 +38,53 @@ logger = logging.getLogger(__name__)
 
 
 decoded_bytes_to_save: bytes = b""
+_DEFAULT_GC_MIN = 0.4
+_DEFAULT_GC_MAX = 0.6
+_DEFAULT_MAX_HOMOPOLYMER = 8
+_LAST_CONSTRAINT_LIMITS: tuple[float, float, int] = (
+    _DEFAULT_GC_MIN,
+    _DEFAULT_GC_MAX,
+    _DEFAULT_MAX_HOMOPOLYMER,
+)
+
+
+def _constraint_limits_from_payload(payload: object) -> tuple[float, float, int]:
+    gc_min = _DEFAULT_GC_MIN
+    gc_max = _DEFAULT_GC_MAX
+    max_hp = _DEFAULT_MAX_HOMOPOLYMER
+
+    def apply_limits(limits: dict[str, object]) -> None:
+        nonlocal gc_min, gc_max, max_hp
+        gc_min_val = limits.get("gc_min")
+        gc_max_val = limits.get("gc_max")
+        max_hp_val = limits.get("max_homopolymer")
+        if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
+            gc_min = float(gc_min_val)
+        if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
+            gc_max = float(gc_max_val)
+        if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
+            max_hp = int(max_hp_val)
+
+    metrics: dict[str, object] | None = None
+    if isinstance(payload, str):
+        try:
+            parsed = json.loads(payload)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            payload = parsed
+    if isinstance(payload, dict):
+        if "metrics" in payload and isinstance(payload["metrics"], dict):
+            metrics = payload["metrics"]
+        else:
+            metrics = payload
+    if isinstance(metrics, dict):
+        violations = metrics.get("constraint_violations")
+        if isinstance(violations, dict):
+            limits = violations.get("limits")
+            if isinstance(limits, dict):
+                apply_limits(limits)
+    return gc_min, gc_max, max_hp
 
 
 def make_encode_handler(
@@ -176,6 +222,9 @@ def make_encode_handler(
             encode_manifest_save_button.visible = True
 
             metrics = result.metrics
+            global _LAST_CONSTRAINT_LIMITS
+            _LAST_CONSTRAINT_LIMITS = _constraint_limits_from_payload(metrics)
+            gc_min_limit, gc_max_limit, max_hp_limit = _LAST_CONSTRAINT_LIMITS
             encode_orig_size_text.value = (
                 f"Original size: {metrics['original_size']} bytes"
             )
@@ -220,8 +269,10 @@ def make_encode_handler(
                 drop_text = "yes" if drop else "no"
                 out_of_bounds = (
                     isinstance(gc_val, float)
-                    and (gc_val < 0.4 or gc_val > 0.6)
-                ) or (isinstance(hp_val, float) and hp_val > 8) or bool(drop)
+                    and (gc_val < gc_min_limit or gc_val > gc_max_limit)
+                ) or (
+                    isinstance(hp_val, float) and hp_val > max_hp_limit
+                ) or bool(drop)
                 suffix = " ⚠️" if out_of_bounds else ""
                 summary_lines.append(
                     f"Oligo {idx}: GC {gc_text}, HP {hp_text}, dropout {drop_text}{suffix}"
@@ -265,17 +316,16 @@ def make_encode_handler(
 
             gc_val = calculate_gc_content(forward_seq)
             hp_len = get_max_homopolymer_length(forward_seq)
-            constraints = SynthesisConstraints()
             if (
-                gc_val < 0.4
-                or gc_val > 0.6
-                or hp_len > constraints.max_homopolymer
+                gc_val < gc_min_limit
+                or gc_val > gc_max_limit
+                or hp_len > max_hp_limit
             ):
                 fixed = fix_sequence(
                     forward_seq,
-                    target_gc_min=0.4,
-                    target_gc_max=0.6,
-                    max_homopolymer=constraints.max_homopolymer,
+                    target_gc_min=gc_min_limit,
+                    target_gc_max=gc_max_limit,
+                    max_homopolymer=max_hp_limit,
                 )
                 fix_gc = calculate_gc_content(fixed)
                 fix_hp = get_max_homopolymer_length(fixed)
@@ -335,12 +385,12 @@ def make_fix_handler(
             page.update()
             return
 
-        constraints = SynthesisConstraints()
+        gc_min_limit, gc_max_limit, max_hp_limit = _LAST_CONSTRAINT_LIMITS
         fixed = fix_sequence(
             seq,
-            target_gc_min=0.4,
-            target_gc_max=0.6,
-            max_homopolymer=constraints.max_homopolymer,
+            target_gc_min=gc_min_limit,
+            target_gc_max=gc_max_limit,
+            max_homopolymer=max_hp_limit,
         )
 
         encode_hidden_sequence.value = fixed


### PR DESCRIPTION
### Motivation
- Replace hard-coded GC bounds and homopolymer thresholds with values read from metrics/manifest payloads (e.g., `constraint_violations.limits`) so dashboards and UI handlers respect reported synthesis limits.
- Fall back to sane defaults only when limits are not present in the payload.

### Description
- Added default constants `_DEFAULT_GC_MIN`, `_DEFAULT_GC_MAX`, and `_DEFAULT_MAX_HOMOPOLYMER` and implemented `_constraint_limits` in `src/genecoder/dashboard.py` and `src/genecoder/dashboard_streamlit.py` to extract `gc_min`, `gc_max`, and `max_homopolymer` from `constraint_violations.limits`.
- Use a per-run `limits_by_run` mapping in both dashboards and replace the previous hard-coded checks (`0.4/0.6` and `HP > 8`) with limit-aware checks to flag out-of-bounds oligos.
- In `src/genecoder/flet_handlers.py` added `_constraint_limits_from_payload`, a `_LAST_CONSTRAINT_LIMITS` cache, and updated encode/fix handlers to read limits from the `metrics` payload and apply them to per-oligo warnings and `fix_sequence` parameters, removing the local dependence on `SynthesisConstraints` for these UI checks.

### Testing
- Ran linting with `python -m ruff check src/genecoder` and all checks passed.
- Ran the test suite with `python -m pytest`; the majority of tests passed but there is one failing test: `tests/test_plugin_pipeline_integration.py::test_plugin_pipeline_roundtrip` which fails with `TypeError: legacy simulator must return a string when given a string input`, while the rest of the suite completed (887 passed, 100 skipped, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f2f83a548326a7fc20f26a395eee)