### PR TITLE
Gate plugin catalog network access

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1043,18 +1043,18 @@ def load_plugin_catalog(url: str | None = None) -> None:
         url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
     catalog: Dict[str, Dict[str, Any]] = {}
     offline = bool(os.getenv("GENECODER_OFFLINE"))
-
-    if offline:
-        logger.info("offline: skipped remote catalog")
-        url = None
+    allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
+    network_ok = allow_network and not offline
 
     if url:
-        try:
-            with urllib.request.urlopen(url, timeout=30) as response:
-                raw = response.read()
-        except Exception as exc:
-            logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
-            raw = b""
+        raw = b""
+        if (url.startswith("http://") or url.startswith("https://")) and not network_ok:
+            logger.info("Network access disabled; skipped remote catalog %s", url)
+        else:
+            try:
+                raw = _fetch_catalog(url, allow_network=network_ok)
+            except Exception as exc:
+                logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
 
         if raw:
             try:


### PR DESCRIPTION
### Motivation
- Ensure `load_plugin_catalog()` honors `GENECODER_ALLOW_NETWORK` and `GENECODER_OFFLINE` so HTTP(S) catalog fetches are never attempted when offline, matching the gating used by `install_registry_plugins()`.

### Description
- Read `GENECODER_ALLOW_NETWORK` and compute `network_ok = allow_network and not offline`, skip HTTP(S) catalog fetches with an informational log when `network_ok` is false, and otherwise fetch via `_fetch_catalog(url, allow_network=network_ok)` to centralize network gating.

### Testing
- Ran `python -m ruff check .` which passed. 
- Ran `python -m pytest` (full test suite) which completed with tests passing (all tests run successfully, skipped expected optional tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697831e847188326aae3d829c7da2f7a)