### PR TITLE
Add tests to verify custom constraint limits affect GC/HP flagging

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,7 +9,13 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
-    calls: dict[str, list] = {"metric": [], "bar_chart": [], "dataframe": []}
+    calls: dict[str, list] = {
+        "metric": [],
+        "bar_chart": [],
+        "dataframe": [],
+        "write": [],
+        "subheader": [],
+    }
 
     def metric(*args, **kwargs) -> None:
         calls["metric"].append((args, kwargs))
@@ -20,10 +26,17 @@ def dummy_streamlit(monkeypatch: pytest.MonkeyPatch) -> dict[str, list]:
     def dataframe(*args, **kwargs) -> None:
         calls["dataframe"].append((args, kwargs))
 
+    def write(*args, **kwargs) -> None:
+        calls["write"].append((args, kwargs))
+
+    def subheader(*args, **kwargs) -> None:
+        calls["subheader"].append((args, kwargs))
+
     dummy = SimpleNamespace(
         title=lambda *a, **k: None,
-        write=lambda *a, **k: None,
+        write=write,
         header=lambda *a, **k: None,
+        subheader=subheader,
         line_chart=lambda *a, **k: None,
         metric=metric,
         bar_chart=bar_chart,
@@ -169,3 +182,38 @@ def test_error_histograms_rendered(
     charts = [args[0] for args, _ in dummy_streamlit["bar_chart"]]
     assert [1, 2, 1] in charts
     assert [2, 1] in charts
+
+
+def test_custom_constraint_limits_drive_flagged_oligos(
+    tmp_path: Path, dummy_streamlit: dict[str, list]
+) -> None:
+    data = {
+        "oligo_metrics": {
+            "gc_percentages": [0.7, 0.1],
+            "max_homopolymers": [4, 4],
+            "dropout_flags": [0, 0],
+        },
+        "constraint_violations": {
+            "limits": {"gc_min": 0.2, "gc_max": 0.8, "max_homopolymer": 6}
+        },
+    }
+    path = tmp_path / "metrics.json"
+    path.write_text(json.dumps(data))
+
+    mod = importlib.reload(importlib.import_module("genecoder.dashboard"))
+    mod.pd = None
+    mod.alt = None
+    mod.main(str(path))
+
+    flagged_tables = [
+        args[0]
+        for args, _ in dummy_streamlit["write"]
+        if args
+        and isinstance(args[0], list)
+        and args[0]
+        and isinstance(args[0][0], dict)
+        and "Index" in args[0][0]
+    ]
+    assert flagged_tables, "flagged oligo table not written"
+    flagged = flagged_tables[-1]
+    assert [row.get("Index") for row in flagged] == [2]

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -248,3 +248,46 @@ def test_dashboard_summary_plots_with_plotting_deps(
 
     assert charts
     assert all(isinstance(chart, FakeChart) for chart in charts)
+
+
+def test_dashboard_flagged_oligos_use_custom_limits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = {
+        "oligo_metrics": {
+            "gc_percentages": [0.7, 0.1],
+            "max_homopolymers": [4, 4],
+            "dropout_flags": [0, 0],
+        },
+        "constraint_violations": {
+            "limits": {"gc_min": 0.2, "gc_max": 0.8, "max_homopolymer": 6}
+        },
+    }
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(data))
+
+    tables: list[object] = []
+
+    def capture_table(data: object, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple capture
+        tables.append(data)
+
+    monkeypatch.setattr(streamlit, "table", capture_table)
+
+    from genecoder import dashboard_streamlit as dash
+
+    monkeypatch.setattr(dash, "pd", None)
+    monkeypatch.setattr(dash, "alt", None)
+
+    dash.main(str(results))
+
+    flagged_tables = [
+        table
+        for table in tables
+        if isinstance(table, list)
+        and table
+        and isinstance(table[0], dict)
+        and "Index" in table[0]
+    ]
+    assert flagged_tables, "flagged oligo table not rendered"
+    flagged = flagged_tables[-1]
+    assert [row.get("Index") for row in flagged] == [2]


### PR DESCRIPTION
### Motivation
- Ensure the dashboard respects per-run `constraint_violations.limits` (GC min/max and max homopolymer) when deciding which oligos are flagged, instead of relying on module-level defaults.

### Description
- Added assertions to the `dummy_streamlit` fixture in `tests/test_dashboard.py` to capture `write` and `subheader` calls used by the dashboard UI. 
- Added `test_custom_constraint_limits_drive_flagged_oligos` to `tests/test_dashboard.py` which feeds metrics including `constraint_violations.limits` and verifies the flagged oligo output follows those limits. 
- Added `test_dashboard_flagged_oligos_use_custom_limits` to `tests/test_dashboard_streamlit.py` which runs the Streamlit dashboard fallback path and asserts the flagged-oligo `table` honors custom GC/HP limits. 

### Testing
- Ran `pytest tests/test_dashboard.py tests/test_dashboard_streamlit.py`, resulting in `9 passed, 1 skipped` because `streamlit` was unavailable for the Streamlit-specific module-level tests; the unit tests passed. 
- Ran `ruff check .`, which returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978372653bc8326874959690604c44f)