### PR TITLE
Require license in PLUGIN_METADATA and validate across plugin sources

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -79,10 +79,11 @@ PLUGIN_METADATA = {
     "name": "my_codec",           # unique plugin name
     "version": "0.1.0",           # semantic version string
     "interfaces": ["codec"],       # one or more of: codec, FEC, simulator, visualizer
+    "license": "MIT",             # SPDX identifier from the approved allowlist
 }
 ```
 
-Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog.
+Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog. When you provide metadata, `license` is required and must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
 
 ## Loading local plugins for development
 

--- a/plugins-examples/example_simulator/example_simulator/__init__.py
+++ b/plugins-examples/example_simulator/example_simulator/__init__.py
@@ -16,6 +16,8 @@ from genecoder.simulators.batch_utils import (
 class PassthroughChannel(Simulator):  # type: ignore[misc]
     """Simple simulator demonstrating the :class:`SequenceBatch` API."""
 
+    supports_batches = True
+
     def simulate(self, sequence: str | SequenceBatch) -> SequenceBatch:
         batch = self._ensure_batch(sequence)
         mutated = clone_batch(batch)

--- a/plugins-examples/starter_plugin/starter_plugin/__init__.py
+++ b/plugins-examples/starter_plugin/starter_plugin/__init__.py
@@ -16,6 +16,7 @@ PLUGIN_METADATA = {
     "name": "starter-template",
     "version": "0.1.0",
     "interfaces": ["codec"],
+    "license": "MIT",
 }
 
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -287,6 +287,7 @@ def _update_entry_point_metadata(entry_name: str, module: ModuleType) -> None:
     cached["metadata_name"] = meta["name"]
     cached["version"] = meta["version"]
     cached["interfaces"] = set(meta["interfaces"])
+    cached["license"] = meta["license"]
 
 
 def _register_lazy_placeholder(kind: str, name: str) -> None:
@@ -801,6 +802,7 @@ def _validate_plugin_metadata(meta: object) -> Dict[str, Any]:
     name = meta.get("name")
     version = meta.get("version")
     interfaces = meta.get("interfaces")
+    license_value = meta.get("license")
     if not isinstance(name, str) or not name:
         raise ValueError("missing or invalid name")
     if not isinstance(version, str) or not version:
@@ -809,7 +811,18 @@ def _validate_plugin_metadata(meta: object) -> Dict[str, Any]:
         raise ValueError("missing interfaces")
     if any(i not in _VALID_INTERFACES for i in interfaces):
         raise ValueError("unknown interface")
-    return {"name": name, "version": version, "interfaces": list(interfaces)}
+    if not isinstance(license_value, str) or not license_value.strip():
+        raise ValueError("missing or invalid license")
+    normalized = license_value.strip()
+    if normalized not in _ALLOWED_LICENSES:
+        allowed = ", ".join(sorted(_ALLOWED_LICENSES))
+        raise ValueError(f"disallowed license {normalized!r}. Allowed licenses: {allowed}")
+    return {
+        "name": name,
+        "version": version,
+        "interfaces": list(interfaces),
+        "license": normalized,
+    }
 
 
 def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
@@ -863,16 +876,20 @@ def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
         interfaces_raw = cached.get("interfaces") or set()
         interfaces = {str(interface) for interface in interfaces_raw}
         version = str(cached.get("version") or "")
+        license_value = str(cached.get("license") or "")
         existing = catalog.get(plugin_name)
         if existing:
             combined = set(existing.get("interfaces", [])) | interfaces
             existing["interfaces"] = sorted(combined)
             if not existing.get("version") and version:
                 existing["version"] = version
+            if not existing.get("license") and license_value:
+                existing["license"] = license_value
         else:
             catalog[plugin_name] = {
                 "version": version,
                 "interfaces": sorted(interfaces) if interfaces else [],
+                "license": license_value,
             }
 
     def _handle_module(module: ModuleType, src: str) -> None:
@@ -887,7 +904,11 @@ def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
             failures.append(src)
             logger.warning("Duplicate plugin name %s from %s", name, src)
             return
-        catalog[name] = {"version": meta["version"], "interfaces": meta["interfaces"]}
+        catalog[name] = {
+            "version": meta["version"],
+            "interfaces": meta["interfaces"],
+            "license": meta["license"],
+        }
 
     # discover local plugins in a ``plugins`` package
     try:

--- a/tests/test_plugin_manager_offline.py
+++ b/tests/test_plugin_manager_offline.py
@@ -38,7 +38,12 @@ def test_entry_point_lazy_loading_offline(monkeypatch: pytest.MonkeyPatch) -> No
         register_codec("lazy", LazyCodec)
 
     module.register = register  # type: ignore[attr-defined]
-    module.PLUGIN_METADATA = {"name": "lazy", "version": "1.0", "interfaces": ["codec"]}
+    module.PLUGIN_METADATA = {
+        "name": "lazy",
+        "version": "1.0",
+        "interfaces": ["codec"],
+        "license": "MIT",
+    }
 
     class EP:
         name = "lazy"

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -1,0 +1,57 @@
+import logging
+import sys
+import types
+
+import pytest
+
+import genecoder.plugin_manager as plugins
+
+
+def test_entry_point_metadata_missing_license(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = types.ModuleType("ep_no_license")
+    module.PLUGIN_METADATA = {
+        "name": "ep-no-license",
+        "version": "1.0",
+        "interfaces": ["codec"],
+    }
+    monkeypatch.setitem(sys.modules, "ep_no_license", module)
+
+    class EP:
+        name = "ep_no_license"
+        group = "genecoder.plugins"
+        value = "ep_no_license"
+
+        def load(self) -> types.ModuleType:
+            return module
+
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda group=None: [EP()] if group in (None, "genecoder.plugins") else [],
+    )
+    plugins.PLUGIN_CATALOG.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugin_catalog()
+    assert "missing or invalid license" in caplog.text
+    assert "ep-no-license" not in plugins.PLUGIN_CATALOG
+
+
+def test_local_plugin_disallowed_license(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = types.ModuleType("plugins")
+    module.PLUGIN_METADATA = {
+        "name": "local-bad-license",
+        "version": "0.1.0",
+        "interfaces": ["codec"],
+        "license": "Proprietary",
+    }
+    monkeypatch.setitem(sys.modules, "plugins", module)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    plugins.PLUGIN_CATALOG.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugin_catalog()
+    assert "disallowed license" in caplog.text
+    assert "local-bad-license" not in plugins.PLUGIN_CATALOG

--- a/tests/test_plugin_registry_loading.py
+++ b/tests/test_plugin_registry_loading.py
@@ -171,7 +171,12 @@ def test_registry_entry_disallowed_license(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_entry_point_plugin_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
     module = types.ModuleType("ep_mod")
-    module.PLUGIN_METADATA = {"name": "ep-demo", "version": "1.0", "interfaces": ["codec"]}
+    module.PLUGIN_METADATA = {
+        "name": "ep-demo",
+        "version": "1.0",
+        "interfaces": ["codec"],
+        "license": "MIT",
+    }
     sys.modules["ep_mod"] = module
 
     class EP:

--- a/tests/test_visualizer_plugin_custom.py
+++ b/tests/test_visualizer_plugin_custom.py
@@ -36,6 +36,7 @@ PLUGIN_METADATA = {
     "name": "temp-genecoder-visualizer",
     "version": "0.1.0",
     "interfaces": ["visualizer"],
+    "license": "MIT",
 }
 
 def register(register_codec):
@@ -72,4 +73,3 @@ include = ["temp_viz", "temp_viz_meta"]
         assert "temp-genecoder-visualizer" in result.stdout
     finally:
         subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", "temp-genecoder-visualizer"])
-


### PR DESCRIPTION
### Motivation

- Ensure plugins declare an SPDX `license` and enforce an allowlist to improve safety and catalog accuracy.

### Description

- Require a `license` field in `PLUGIN_METADATA` and validate it against `_ALLOWED_LICENSES` in `_validate_plugin_metadata` for both entry-point and local plugins in `src/genecoder/plugin_manager.py`.
- Surface normalized `license` values in entry-point metadata and in the produced `PLUGIN_CATALOG` so catalogs include license info.
- Update plugin examples and templates to include a `license` entry by modifying `plugins-examples/starter_plugin/starter_plugin/__init__.py` and add `supports_batches = True` to the example simulator at `plugins-examples/example_simulator/example_simulator/__init__.py` to address legacy/adapter behavior.
- Add unit tests in `tests/test_plugin_metadata.py` and update existing test fixtures to cover missing and disallowed license cases and refresh examples in `tests/*` to include `license` where needed.

### Testing

- Ran linter with `python -m ruff check .` which completed with no issues.
- Ran the full test suite with `python -m pytest`, resulting in `891 passed, 100 skipped` (and warnings), with the plugin metadata tests exercising missing/disallowed license branches and all tests passing after fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cab0185788326afed7e05077c770c)