### PR TITLE
Require PLUGIN_METADATA.license for entry-point and local plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,7 +83,7 @@ PLUGIN_METADATA = {
 }
 ```
 
-Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog. When you provide metadata, `license` is required and must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
+Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog. When you provide metadata (for entry-point plugins or local `plugins/` modules), `license` is required and must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
 
 ## Loading local plugins for development
 

--- a/plugins-examples/starter_plugin/README.md
+++ b/plugins-examples/starter_plugin/README.md
@@ -7,7 +7,8 @@ starting point for your own codec or simulator implementations.
 ## How to adapt the template
 
 1. Update ``PLUGIN_METADATA`` and the class name in
-   ``starter_plugin/__init__.py`` to reflect your plugin's identity.
+   ``starter_plugin/__init__.py`` to reflect your plugin's identity
+   (including setting an approved SPDX ``license`` such as ``MIT``).
 2. Replace the example codec logic with your own encode/decode behavior or swap
    the interface to a simulator by following the inline comments in the module.
 3. Adjust the entry point name in ``pyproject.toml`` if you change the public

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -270,6 +270,7 @@ def _record_entry_point_metadata(entry_name: str, kind: str, entry_point: object
         module_name = value.split(":", 1)[0]
     if module_name:
         meta.setdefault("module", module_name)
+    meta.setdefault("entry_point", entry_point)
 
 
 def _update_entry_point_metadata(entry_name: str, module: ModuleType) -> None:
@@ -798,25 +799,29 @@ def _validate_plugin_metadata(meta: object) -> Dict[str, Any]:
     """Validate plugin metadata structure."""
 
     if not isinstance(meta, dict):
-        raise TypeError("metadata must be a dict")
+        raise TypeError("PLUGIN_METADATA must be a dict")
     name = meta.get("name")
     version = meta.get("version")
     interfaces = meta.get("interfaces")
     license_value = meta.get("license")
     if not isinstance(name, str) or not name:
-        raise ValueError("missing or invalid name")
+        raise ValueError("PLUGIN_METADATA.name is required and must be a non-empty string")
     if not isinstance(version, str) or not version:
-        raise ValueError("missing or invalid version")
+        raise ValueError("PLUGIN_METADATA.version is required and must be a non-empty string")
     if not isinstance(interfaces, (list, tuple)) or not interfaces:
-        raise ValueError("missing interfaces")
+        raise ValueError("PLUGIN_METADATA.interfaces is required and must be a non-empty list")
     if any(i not in _VALID_INTERFACES for i in interfaces):
-        raise ValueError("unknown interface")
+        raise ValueError("PLUGIN_METADATA.interfaces contains an unknown interface")
     if not isinstance(license_value, str) or not license_value.strip():
-        raise ValueError("missing or invalid license")
+        raise ValueError(
+            "PLUGIN_METADATA.license is required and must be a non-empty SPDX identifier"
+        )
     normalized = license_value.strip()
     if normalized not in _ALLOWED_LICENSES:
         allowed = ", ".join(sorted(_ALLOWED_LICENSES))
-        raise ValueError(f"disallowed license {normalized!r}. Allowed licenses: {allowed}")
+        raise ValueError(
+            f"PLUGIN_METADATA.license {normalized!r} is not allowed. Allowed licenses: {allowed}"
+        )
     return {
         "name": name,
         "version": version,
@@ -860,9 +865,17 @@ def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
         if cached.get("metadata_name") and cached.get("metadata_name") != cached.get("entry_name"):
             continue
         module_name = cached.get("module")
-        if not module_name:
+        entry_point = cached.get("entry_point")
+        if not module_name and entry_point is None:
             continue
-        module = sys.modules.get(str(module_name))
+        module = sys.modules.get(str(module_name)) if module_name else None
+        if module is None and entry_point is not None:
+            try:
+                module = cast(ModuleType, entry_point.load())
+            except Exception as exc:
+                failures.append(f"entry_point:{entry_name}")
+                logger.warning("Failed to import entry point metadata for %s: %s", entry_name, exc)
+                continue
         if module is not None:
             _update_entry_point_metadata(entry_name, module)
 

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -34,8 +34,58 @@ def test_entry_point_metadata_missing_license(
     plugins.PLUGIN_CATALOG.clear()
     with caplog.at_level(logging.WARNING):
         plugins.load_plugin_catalog()
-    assert "missing or invalid license" in caplog.text
+    assert "PLUGIN_METADATA.license is required" in caplog.text
     assert "ep-no-license" not in plugins.PLUGIN_CATALOG
+
+
+def test_entry_point_metadata_disallowed_license(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = types.ModuleType("ep_bad_license")
+    module.PLUGIN_METADATA = {
+        "name": "ep-bad-license",
+        "version": "0.1.0",
+        "interfaces": ["codec"],
+        "license": "Proprietary",
+    }
+    monkeypatch.setitem(sys.modules, "ep_bad_license", module)
+
+    class EP:
+        name = "ep_bad_license"
+        group = "genecoder.plugins"
+        value = "ep_bad_license"
+
+        def load(self) -> types.ModuleType:
+            return module
+
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda group=None: [EP()] if group in (None, "genecoder.plugins") else [],
+    )
+    plugins.PLUGIN_CATALOG.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugin_catalog()
+    assert "PLUGIN_METADATA.license 'Proprietary' is not allowed" in caplog.text
+    assert "ep-bad-license" not in plugins.PLUGIN_CATALOG
+
+
+def test_local_plugin_missing_license(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = types.ModuleType("plugins")
+    module.PLUGIN_METADATA = {
+        "name": "local-no-license",
+        "version": "0.1.0",
+        "interfaces": ["codec"],
+    }
+    monkeypatch.setitem(sys.modules, "plugins", module)
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [])
+    plugins.PLUGIN_CATALOG.clear()
+    with caplog.at_level(logging.WARNING):
+        plugins.load_plugin_catalog()
+    assert "PLUGIN_METADATA.license is required" in caplog.text
+    assert "local-no-license" not in plugins.PLUGIN_CATALOG
 
 
 def test_local_plugin_disallowed_license(
@@ -53,5 +103,5 @@ def test_local_plugin_disallowed_license(
     plugins.PLUGIN_CATALOG.clear()
     with caplog.at_level(logging.WARNING):
         plugins.load_plugin_catalog()
-    assert "disallowed license" in caplog.text
+    assert "PLUGIN_METADATA.license 'Proprietary' is not allowed" in caplog.text
     assert "local-bad-license" not in plugins.PLUGIN_CATALOG


### PR DESCRIPTION
### Motivation
- Make plugin metadata validation consistent across all sources so entry-point modules and local `plugins/` modules enforce the same SPDX license allowlist as registry YAML entries.  
- Provide clearer, schema-style error messages that point to failing `PLUGIN_METADATA` fields to improve diagnostics.  
- Ensure the plugin catalog cannot be populated with plugins missing or using disallowed licenses.

### Description
- Require and validate `PLUGIN_METADATA["license"]` in `_validate_plugin_metadata`, normalizing against the internal `_ALLOWED_LICENSES` set and raising clearer `PLUGIN_METADATA.<field>` error messages.  
- Persist entry-point handles in `_record_entry_point_metadata` and attempt to load entry-point modules during catalog collection in `_collect_installed_plugins` so entry-point metadata is validated (not just registry YAML).  
- Propagate validated `license` into entry-point metadata caching and include license in the assembled `PLUGIN_CATALOG`.  
- Update docs and example plugin template to include the required `license` guidance, and expand unit tests in `tests/test_plugin_metadata.py` to cover missing/disallowed license cases for both entry-point and local plugins.

### Testing
- Ran linter checks with `ruff` on `src/genecoder/plugin_manager.py` and `tests/test_plugin_metadata.py`, which passed.  
- Ran targeted unit tests with `pytest -q tests/test_plugin_metadata.py tests/test_plugin_registry_loading.py`, and all tests passed (`13 passed`).  
- Verified the changed code paths for entry-point metadata loading and catalog assembly by exercising `load_plugin_catalog()` in the tests which assert proper warnings and catalog exclusion for invalid metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862e447d7c8326b667faa1896c63df)