### PR TITLE
Tighten plugin license policy to MIT/BSD/Apache defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 GeneCoder is an educational toolkit for exploring DNA-based data storage. It provides a command line interface and a GUI for encoding and decoding files into simulated DNA sequences.
 
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above. The [MVP coverage checklist](docs/mvp_checklist.md) maps roadmap requirements to the shipped presets and example CLI commands. Developers adding new codecs, FEC backends, simulators, or visualizers can follow the [plugin development guide](docs/plugins.md) for step-by-step instructions and entry point examples.
+Plugin metadata and plugin registries now enforce a conservative default license policy: `MIT`, `BSD-2-Clause`, `BSD-3-Clause`, or `Apache-2.0`.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).
 The CLI installs two equivalent entry points, `genecli` and `genecoder`, so you can use either in the examples below and in the documentation.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,7 +83,7 @@ PLUGIN_METADATA = {
 }
 ```
 
-Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog. When you provide metadata (for entry-point plugins or local `plugins/` modules), `license` is required and must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
+Metadata is optional but recommended so GeneCoder can report compatibility information and detect duplicates when building a plugin catalog. When you provide metadata (for entry-point plugins or local `plugins/` modules), `license` is required and must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `MIT`.
 
 ## Loading local plugins for development
 
@@ -129,7 +129,7 @@ Loading external plugins executes arbitrary Python code. GeneCoder provides seve
 
 - **Network opt-in:** package downloads from registry URLs are blocked unless `GENECODER_ALLOW_NETWORK=1` is set. Setting `GENECODER_OFFLINE=1` forces offline mode even if network access is allowed.
 - **Signature and checksum verification:** registry entries can include a Base64 signature (`signature`) and checksum (`checksum`). Signatures are verified using the public key specified in `GENECODER_PLUGIN_PUBLIC_KEY`. Failing verification aborts installation.
-- **License allowlist:** registry entries must declare a `license` field using an SPDX identifier, and it must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`, `MPL-2.0`.
+- **License allowlist:** registry entries must declare a `license` field using an SPDX identifier, and it must be one of: `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `MIT`.
 - **Safe URLs and packages:** plugin registry entries are validated to ensure package names and URLs match safe patterns.
 - **Duplicate protection:** the plugin catalog rejects duplicate names to avoid silently overriding unrelated plugins.
 

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -337,9 +337,7 @@ _ALLOWED_LICENSES = {
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "ISC",
     "MIT",
-    "MPL-2.0",
 }
 
 # re-export for tests


### PR DESCRIPTION
### Motivation
- Reduce the default plugin license allowlist to a conservative set of permissive SPDX licenses (`MIT`, `BSD-2-Clause`, `BSD-3-Clause`, `Apache-2.0`) by removing `ISC` and `MPL-2.0` from the built-in policy. 
- Ensure documentation reflects the narrower default so developers and registries know the enforced policy.

### Description
- Update `src/genecoder/plugin_manager.py` by removing `ISC` and `MPL-2.0` from the `_ALLOWED_LICENSES` set so only `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, and `MIT` remain. 
- Update `docs/plugins.md` to list the new approved SPDX identifiers in the metadata guidance and security section. 
- Add a short note in `README.md` announcing the conservative default plugin license policy.

### Testing
- Ran unit tests with `pytest -q tests/test_plugin_metadata.py tests/test_plugin_registry_loading.py tests/test_plugin_manager.py` and all tests passed (`16 passed`).
- Ran the linter with `ruff check src/genecoder/plugin_manager.py` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986308056f08326b95b31296b54e843)