### PR TITLE
Add per-base substitution/insertion/deletion rates to metrics and dashboards

### DIFF
--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -605,6 +605,7 @@ def metrics(
             if ratios:
                 ecc_map[str(name)] = ratios
 
+    opportunities = max(0, sum(len(seq) for seq in sequences))
     result: Dict[str, Any] = {
         "gc_distribution": gc_dist,
         "gc_content": gc_content,
@@ -615,6 +616,11 @@ def metrics(
         "decode_success_rate": success,
         "coverage": coverage,
         "constraint_violations": constraint_violations,
+        "error_bases": opportunities,
+        "substitution_rate": 0.0,
+        "insertion_rate": 0.0,
+        "deletion_rate": 0.0,
+        "error_rate": 0.0,
         "oligo_metrics": {
             "gc_percentages": per_oligo_gc,
             "max_homopolymers": per_oligo_hp,
@@ -625,7 +631,22 @@ def metrics(
         },
     }
     if subs is not None and ins is not None and dels is not None:
-        result.update({"substitutions": subs, "insertions": ins, "deletions": dels})
+        denom = max(1, opportunities)
+        substitution_rate = float(subs) / denom
+        insertion_rate = float(ins) / denom
+        deletion_rate = float(dels) / denom
+        result.update(
+            {
+                "substitutions": subs,
+                "insertions": ins,
+                "deletions": dels,
+                "error_bases": opportunities,
+                "substitution_rate": substitution_rate,
+                "insertion_rate": insertion_rate,
+                "deletion_rate": deletion_rate,
+                "error_rate": substitution_rate + insertion_rate + deletion_rate,
+            }
+        )
     return result
 
 

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -37,15 +37,18 @@ _DEF_METRICS: dict[str, Any] = {
     "substitutions": None,
     "insertions": None,
     "deletions": None,
+    "substitution_rate": None,
+    "insertion_rate": None,
+    "deletion_rate": None,
     "coverage": None,
     "coverage_distribution": [],
     "oligo_metrics": {},
 }
 
-_ERROR_METRICS: tuple[tuple[str, str], ...] = (
-    ("substitutions", "Substitutions"),
-    ("insertions", "Insertions"),
-    ("deletions", "Deletions"),
+_ERROR_METRICS: tuple[tuple[str, str, str], ...] = (
+    ("substitutions", "substitution_rate", "Substitutions"),
+    ("insertions", "insertion_rate", "Insertions"),
+    ("deletions", "deletion_rate", "Deletions"),
 )
 _DEFAULT_GC_MIN = 0.4
 _DEFAULT_GC_MAX = 0.6
@@ -278,10 +281,13 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
         if longest is not None:
             hp_rows.append({"Run": label, "Value": longest})
 
-        for metric_key, metric_label in _ERROR_METRICS:
-            value = _to_float(data.get(metric_key))
-            if value is not None:
-                error_rows.append({"Run": label, "Metric": metric_label, "Value": value})
+        for count_key, rate_key, metric_label in _ERROR_METRICS:
+            count_value = _to_float(data.get(count_key))
+            rate_value = _to_float(data.get(rate_key))
+            if count_value is not None:
+                error_rows.append({"Run": label, "Metric": f"{metric_label} (count)", "Value": count_value})
+            if rate_value is not None:
+                error_rows.append({"Run": label, "Metric": f"{metric_label} (rate)", "Value": rate_value})
 
         coverage = _coverage_value(data)
         if coverage is not None:
@@ -446,6 +452,24 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
                 )
         else:
             st.write("No ECC data.")
+
+        st.subheader("Error Metrics")
+        error_table_rows: list[dict[str, float | str]] = []
+        for count_key, rate_key, metric_label in _ERROR_METRICS:
+            count_value = _to_float(data.get(count_key))
+            rate_value = _to_float(data.get(rate_key))
+            if count_value is not None:
+                error_table_rows.append({"Metric": metric_label, "Count": count_value})
+            if rate_value is not None:
+                row = next((entry for entry in error_table_rows if entry.get("Metric") == metric_label), None)
+                if row is None:
+                    row = {"Metric": metric_label}
+                    error_table_rows.append(row)
+                row["Rate"] = rate_value
+        if error_table_rows:
+            st.table(error_table_rows)
+        else:
+            st.write("No error metrics.")
 
         st.subheader("Coverage")
         coverage_value = _to_float(data.get("coverage"))

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -129,17 +129,23 @@ def generate_html_report(manifest_path: str) -> str:
             f"<p><strong>Max Homopolymer Length:</strong> {int(max_hp)}</p>"
         )
 
-    error_metrics: list[tuple[str, str]] = [
-        ("substitutions", "Substitutions"),
-        ("insertions", "Insertions"),
-        ("deletions", "Deletions"),
+    error_metrics: list[tuple[str, str, str]] = [
+        ("substitutions", "substitution_rate", "Substitutions"),
+        ("insertions", "insertion_rate", "Insertions"),
+        ("deletions", "deletion_rate", "Deletions"),
     ]
     error_lines: list[str] = []
-    for key, label in error_metrics:
-        value = metrics.get(key)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
+    for count_key, rate_key, label in error_metrics:
+        count_value = metrics.get(count_key)
+        rate_value = metrics.get(rate_key)
+        line_parts: list[str] = []
+        if isinstance(count_value, (int, float)) and not isinstance(count_value, bool):
+            line_parts.append(f"count {_format_numeric(count_value)}")
+        if isinstance(rate_value, (int, float)) and not isinstance(rate_value, bool):
+            line_parts.append(f"rate {float(rate_value):.4%}")
+        if line_parts:
             error_lines.append(
-                f"<li><strong>{label}:</strong> {_format_numeric(value)}</li>"
+                f"<li><strong>{label}:</strong> {'; '.join(line_parts)}</li>"
             )
 
     coverage = metrics.get("coverage")

--- a/tests/data/metrics.json
+++ b/tests/data/metrics.json
@@ -1,9 +1,19 @@
 {
-  "gc_distribution": [0.1, 0.2, 0.3, 0.4],
+  "gc_distribution": [
+    0.1,
+    0.2,
+    0.3,
+    0.4
+  ],
   "gc_content": 0.25,
   "gc_variance": 0.0125,
   "max_homopolymer": 4,
-  "homopolymer_runs": [1, 2, 1, 0],
+  "homopolymer_runs": [
+    1,
+    2,
+    1,
+    0
+  ],
   "ecc_success_rates": {
     "rs": 0.98,
     "bch": 0.95
@@ -13,20 +23,63 @@
   "insertions": 0,
   "deletions": 0,
   "coverage": 30,
-  "coverage_distribution": [1, 3, 2],
+  "coverage_distribution": [
+    1,
+    3,
+    2
+  ],
   "constraint_violations": {
     "count": 3,
     "violations": [
-      {"sequence_id": "seq-1", "type": "gc_high", "length": 100},
-      {"sequence_id": "seq-1", "type": "homopolymer", "length": 100},
-      {"sequence_id": "seq-2", "type": "gc_low", "length": 80}
+      {
+        "sequence_id": "seq-1",
+        "type": "gc_high",
+        "length": 100
+      },
+      {
+        "sequence_id": "seq-1",
+        "type": "homopolymer",
+        "length": 100
+      },
+      {
+        "sequence_id": "seq-2",
+        "type": "gc_low",
+        "length": 80
+      }
     ],
-    "type_counts": {"gc_high": 1, "homopolymer": 1, "gc_low": 1}
+    "type_counts": {
+      "gc_high": 1,
+      "homopolymer": 1,
+      "gc_low": 1
+    }
   },
   "oligo_metrics": {
-    "gc_percentages": [0.45, 0.52, 0.61],
-    "max_homopolymers": [4, 5, 9],
-    "dropout_flags": [false, false, true],
-    "ecc_success": {"rs": [0.98, 0.97, 0.0]}
-  }
+    "gc_percentages": [
+      0.45,
+      0.52,
+      0.61
+    ],
+    "max_homopolymers": [
+      4,
+      5,
+      9
+    ],
+    "dropout_flags": [
+      false,
+      false,
+      true
+    ],
+    "ecc_success": {
+      "rs": [
+        0.98,
+        0.97,
+        0.0
+      ]
+    }
+  },
+  "error_bases": 400,
+  "substitution_rate": 0.005,
+  "insertion_rate": 0.0,
+  "deletion_rate": 0.0,
+  "error_rate": 0.005
 }

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -127,6 +127,11 @@ def test_metrics_helper() -> None:
     assert "gc_content" in m
     assert m["oligo_metrics"]["dropout_flags"] == [False]
     assert m["oligo_metrics"]["coverage"] == [None]
+    assert m["error_bases"] == len(dna.primary_sequence())
+    assert m["substitution_rate"] == 0.0
+    assert m["insertion_rate"] == 0.0
+    assert m["deletion_rate"] == 0.0
+    assert m["error_rate"] == 0.0
 
 
 def test_metrics_constraint_violations_per_oligo() -> None:

--- a/tests/test_dashboard_httpx.py
+++ b/tests/test_dashboard_httpx.py
@@ -32,11 +32,14 @@ def test_dashboard_metrics() -> None:
         )
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data) >= {"gc_content", "gc_variance", "max_homopolymer", "error_rate", "plot"}
+    assert set(data) >= {"gc_content", "gc_variance", "max_homopolymer", "error_rate", "plot", "substitution_rate", "insertion_rate", "deletion_rate"}
     assert isinstance(data["gc_content"], float)
     assert isinstance(data["gc_variance"], float)
     assert isinstance(data["max_homopolymer"], int)
     assert isinstance(data["error_rate"], float)
+    assert isinstance(data["substitution_rate"], float)
+    assert isinstance(data["insertion_rate"], float)
+    assert isinstance(data["deletion_rate"], float)
     assert isinstance(data["plot"], str)
 
 

--- a/tests/test_dashboard_streamlit.py
+++ b/tests/test_dashboard_streamlit.py
@@ -126,6 +126,27 @@ def test_dashboard_summary_tables_rendered(
         isinstance(table, list)
         and any(
             isinstance(row, dict)
+            and row.get("Metric") == "Substitutions"
+            and row.get("Rate") == pytest.approx(0.005)
+            for row in table
+        )
+        for table in tables
+    )
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Metric") == "Substitutions"
+            and row.get("Count") == pytest.approx(2.0)
+            and row.get("Rate") == pytest.approx(0.005)
+            for row in table
+        )
+        for table in tables
+    )
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
             and row.get("Window") == 1
             and row.get("GC%") == pytest.approx(10.0)
             for row in table
@@ -176,6 +197,17 @@ def test_dashboard_homopolymer_chart_rendered(
             isinstance(row, dict)
             and row.get("Metric") == "Coverage"
             and row.get("Value") == pytest.approx(30.0)
+            for row in table
+        )
+        for table in tables
+    )
+    assert any(
+        isinstance(table, list)
+        and any(
+            isinstance(row, dict)
+            and row.get("Metric") == "Substitutions"
+            and row.get("Count") == pytest.approx(2.0)
+            and row.get("Rate") == pytest.approx(0.005)
             for row in table
         )
         for table in tables

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -17,6 +17,9 @@ def _make_manifest(path: Path) -> Path:
             "substitutions": 7,
             "insertions": 2,
             "deletions": 3,
+            "substitution_rate": 0.07,
+            "insertion_rate": 0.02,
+            "deletion_rate": 0.03,
             "coverage": 42,
         },
     }
@@ -32,9 +35,9 @@ def test_generate_html_report(tmp_path: Path) -> None:
     assert "Max Homopolymer Length" in html
     assert "rs" in html
     assert "<h2>Error Metrics</h2>" in html
-    assert "Substitutions:</strong> 7" in html
-    assert "Insertions:</strong> 2" in html
-    assert "Deletions:</strong> 3" in html
+    assert "Substitutions:</strong> count 7; rate 7.0000%" in html
+    assert "Insertions:</strong> count 2; rate 2.0000%" in html
+    assert "Deletions:</strong> count 3; rate 3.0000%" in html
     assert "Coverage:</strong> 42" in html
 
 
@@ -46,7 +49,7 @@ def test_cli_html_report_stdout(tmp_path: Path) -> None:
     assert "50.00%" in result.stdout
     assert "GC Variance" in result.stdout
     assert "<h2>Error Metrics</h2>" in result.stdout
-    assert "Substitutions:</strong> 7" in result.stdout
-    assert "Insertions:</strong> 2" in result.stdout
-    assert "Deletions:</strong> 3" in result.stdout
+    assert "Substitutions:</strong> count 7; rate 7.0000%" in result.stdout
+    assert "Insertions:</strong> count 2; rate 2.0000%" in result.stdout
+    assert "Deletions:</strong> count 3; rate 3.0000%" in result.stdout
     assert "Coverage:</strong> 42" in result.stdout

--- a/tests/test_web_api_analyze_report.py
+++ b/tests/test_web_api_analyze_report.py
@@ -47,7 +47,7 @@ def test_dashboard_metrics_with_token() -> None:
     r = client.post("/dashboard/metrics", headers=AUTH_HEADERS, json=payload)
     assert r.status_code == 200
     data = r.json()
-    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot", "oligo_metrics"}
+    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot", "oligo_metrics", "substitution_rate", "insertion_rate", "deletion_rate"}
     assert data["oligo_metrics"]["gc_percentages"]
 
 

--- a/web/main.py
+++ b/web/main.py
@@ -28,6 +28,7 @@ from genecoder.plotting import (
     generate_sequence_analysis_plot,
 )
 from genecoder.error_simulation import introduce_errors
+from genecoder.simulators.batch_utils import mutation_counts
 from genecoder import constraint_fixer
 from genecoder.app_helpers import EncodeResult, DecodeResult
 from genecoder.report import (
@@ -346,6 +347,7 @@ async def dashboard_metrics(
             tuple[bytes, list[int]], decode_base4_direct(corrupted)
         )
         ber = bit_error_rate(orig_bytes, dec_bytes)
+        substitutions, insertions, deletions = mutation_counts(seq, corrupted)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     oligo_metrics = {
@@ -354,11 +356,22 @@ async def dashboard_metrics(
         "dropout_flags": [False],
         "ecc_success": {"decode": [max(0.0, min(1.0, 1.0 - ber))]},
     }
+    total_bases = max(1, len(seq))
+    substitution_rate = substitutions / total_bases
+    insertion_rate = insertions / total_bases
+    deletion_rate = deletions / total_bases
     return {
         "gc_content": gc,
         "gc_variance": gc_var,
         "max_homopolymer": max_hp,
         "error_rate": ber,
+        "substitutions": substitutions,
+        "insertions": insertions,
+        "deletions": deletions,
+        "error_bases": len(seq),
+        "substitution_rate": substitution_rate,
+        "insertion_rate": insertion_rate,
+        "deletion_rate": deletion_rate,
         "plot": plot_b64,
         "oligo_metrics": oligo_metrics,
     }


### PR DESCRIPTION
### Motivation

- Provide per-base error rates (substitution/insertion/deletion) derived from mutation counts so consumers can inspect rates (errors / total bases) in addition to raw counts.

### Description

- Compute and expose `error_bases`, `substitution_rate`, `insertion_rate`, `deletion_rate`, and aggregated `error_rate` in the core metrics payload returned by `genecoder.core.metrics` (and included in pipeline outputs) by dividing mutation totals by total bases when available and by including defaults otherwise (`0.0`).
- Surface these fields in the Streamlit dashboard by adding rate keys to `_DEF_METRICS`, extending `_ERROR_METRICS` to include the rate key, and rendering both counts and rates in the cross-run charts and per-run error tables in `src/genecoder/dashboard_streamlit.py`.
- Update the HTML manifest report `src/genecoder/html_report.py` to display combined lines showing both count and formatted per-base rate for substitutions/insertions/deletions.
- Extend the web dashboard `/dashboard/metrics` endpoint in `web/main.py` to compute mutation counts for the provided sequence and include counts, `error_bases`, and per-base rates in the JSON response.
- Update tests and fixture data to assert the presence and rendering of the new JSON keys and dashboard/report outputs, including `tests/data/metrics.json`, `tests/test_core_pipeline.py`, `tests/test_html_report.py`, `tests/test_dashboard_streamlit.py`, `tests/test_dashboard_httpx.py`, and `tests/test_web_api_analyze_report.py`.

### Testing

- Ran linting with `ruff check` on the modified modules and it completed with no issues.
- Ran the selected pytest suite `pytest tests/test_core_pipeline.py tests/test_html_report.py tests/test_dashboard_streamlit.py tests/test_web_api_analyze_report.py tests/test_dashboard_httpx.py` and the run completed with the targeted tests passing: `8 passed, 4 skipped` (skips are due to optional runtime deps such as `streamlit`, `fastapi`, and `reedsolo` being unavailable in the execution environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698631dffad08326a7b65433ec92bcbf)