### PR TITLE
docs: align Vision and Current State with implemented simulators and ECC support

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,3 +1,33 @@
 # Vision & Core Concept
 
-GeneCoder aims to demystify DNA-based data storage. The toolkit lets users encode arbitrary data into simulated DNA sequences, decode them back and explore the trade-offs of different encoding strategies. By providing an accessible, hands-on environment, GeneCoder highlights both the promise and the challenges of molecular storage technologies.
+GeneCoder aims to make DNA data storage experimentation practical and reproducible by combining encoding, channel simulation, and decoding workflows in one toolkit.
+
+## Vision and Current State
+
+GeneCoder already ships an end-to-end simulation path for common DNA storage experiments. The current implementation includes:
+
+- **Built-in sequencing simulators and presets** for **Illumina** and **Nanopore** workflows, including profile-driven runs in the bundled pipeline examples.
+- A **storage decay stage** that can be chained after sequencing simulations in the preset bundles.
+- End-to-end CLI presets in `configs/` (for example, the Gold, RS+Illumina, and Fountain+Nanopore pipelines) that exercise encode → simulate/decay → decode flows.
+
+At the same time, the project still has fidelity work to do. The main gaps are not simulator availability, but:
+
+- stronger calibration against wet-lab or public benchmark datasets,
+- tighter reproducibility controls for cross-run benchmarking,
+- and clearer parity validation versus external simulators under matched conditions.
+
+### ECC and codec support status
+
+GeneCoder currently documents and ships support for:
+
+- **Reed–Solomon** and **Fountain** workflows in core presets/checklists,
+- additional codec families through optional extras (for example Chamaeleo-backed schemes),
+- and optional advanced integrations such as **LDPC**, **RaptorQ**, and AI-assisted **DNAformer/DeepDNA** components.
+
+### Known limitations
+
+Current limitations are primarily around validation depth and benchmarking rigor rather than missing baseline features:
+
+- comparative validation datasets are still limited,
+- benchmark reproducibility across environments can be improved,
+- and advanced calibration workflows for profile tuning are still maturing.


### PR DESCRIPTION
### Motivation

- Ensure the public project vision and "Current State" documentation accurately reflect the shipped implementation described elsewhere in `README.md` and `docs/mvp_checklist.md`.
- Clarify that sequencing simulation is available via built-in Illumina and Nanopore presets (plus a decay stage) while distinguishing remaining fidelity gaps from missing simulators.
- Bring the ECC/codec status text into parity with documented support for Reed–Solomon, Fountain and optional advanced extras.

### Description

- Replaced the brief vision text in `docs/vision.md` with a new **Vision and Current State** section that enumerates available simulator presets, the storage decay stage, and example end-to-end CLI pipelines in `configs/`.
- Updated ECC/codec status language to document core Reed–Solomon and Fountain workflows and to list optional extras such as Chamaeleo-backed codecs, LDPC, RaptorQ, and AI-assisted DNAformer/DeepDNA integrations.
- Reframed earlier statements about missing sequencing simulation into a short list of remaining fidelity gaps (calibration, benchmark parity and reproducibility) rather than implying absent built-in simulators.
- Added a concise **Known limitations** subsection concentrating on real gaps: limited comparative validation datasets, benchmark reproducibility across environments, and immature advanced calibration workflows.

### Testing

- No automated test suite or linters were run because this is a documentation-only change per the project policy for docs edits.
- Performed basic repository hygiene checks (`git diff --check` and `git status --short`) which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698649be7c3883269da161d9497fb58f)