### PR TITLE
docs: add long-term plugin interoperability strategy

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -20,6 +20,58 @@
    - Interactive dashboards to visualize storage simulations over time.
    - Cloud-friendly architecture for scaling large simulation batches.
    - Continued collaboration with the research community to expand features.
+
+### Long-term interoperability strategy
+
+To make ecosystem growth concrete, external tools should integrate through the
+existing plugin entry points and registry workflows rather than bespoke
+adapters. The implementation anchors are:
+
+- [`docs/plugins.md`](plugins.md) for entry point groups, `register_*` hooks,
+  and runtime loading rules.
+- [`configs/registry.yaml`](../configs/registry.yaml) for registry schema fields
+  (`name`, `version`, `spec`, `license`, `checksum`/`signature`) and trusted
+  distribution patterns.
+- [`plugins-examples/`](../plugins-examples/) for working package layouts,
+  `pyproject.toml` entry point declarations, and minimal registration modules.
+
+The roadmap supports three primary integration archetypes:
+
+1. **External simulator wrapper plugin**
+   - **Entry points:** `genecoder.simulators` and optional
+     `genecoder.channels`.
+   - **Input contract:** sequence payloads plus simulator/channel parameters
+     provided from CLI/config profiles.
+   - **Output contract:** deterministic simulation artifacts (mutated reads,
+     per-read error metrics, and optional summary JSON compatible with pipeline
+     reporting).
+2. **Codec/FEC plugin**
+   - **Entry points:** `genecoder.codecs` or `genecoder.fec`.
+   - **Input contract:** binary/text payload bytes and plugin-specific coding
+     parameters.
+   - **Output contract:** encode/decode methods that round-trip payloads,
+     expose parity/redundancy metadata, and return errors compatible with core
+     validation paths.
+3. **Visualizer plugin**
+   - **Entry points:** `genecoder.visualizers`.
+   - **Input contract:** standardized metrics/report structures produced by core
+     pipeline commands.
+   - **Output contract:** serializable figures or dashboard-ready artifacts that
+     can be embedded in CLI/web reports without altering core data models.
+
+#### External plugin compliance checklist
+
+- Declare complete plugin metadata in packaging and registry records (name,
+  version, entry point target, SPDX license identifier).
+- Use an allowlisted license for registry distribution (see
+  `docs/plugins.md` for accepted SPDX values).
+- Include integrity material in registry entries: checksum is mandatory, and
+  signature verification is required when registry policy enables signed
+  artifacts.
+- Follow safe package/URL constraints from the registry validation workflow
+  before publication.
+- Provide at least one runnable example under `plugins-examples/` (or equivalent
+  structure) so maintainers can validate the entry point contract quickly.
 6. **Documentation Updates**
    - Inline comments in `encoders.py` and `flet_app.py` now point to sections of the Development Vision PDF (Sections III and IV) for added context.
 


### PR DESCRIPTION
### Motivation
- Make the roadmap actionable for external integration by tying long-term interoperability goals to the existing plugin entry point model and registry artifacts.
- Provide clear onboarding guidance so third-party tools can integrate with GeneCoder using documented entry points and packaging examples.

### Description
- Add a new “Long-term interoperability strategy” subsection to `docs/development_roadmap.md` that references `docs/plugins.md`, `configs/registry.yaml`, and `plugins-examples/` as implementation anchors.
- Define three integration archetypes (external simulator wrapper, codec/FEC plugin, visualizer plugin) with concise entry-point, input contract, and output contract expectations.
- Add a minimal external plugin compliance checklist covering metadata, SPDX license allowlist, checksum/signature integrity requirements, safe package/URL constraints, and example packaging guidance.

### Testing
- Ran repository discovery and content checks (`find`, `rg --files`, targeted `rg` for roadmap/plugins references) which completed successfully.
- Verified the edited file via `git diff` and reviewed the file contents, both succeeded.
- No unit tests or linters were run because this is a documentation-only change per the project rule to skip tests for docs/comment-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864d5af9e48326a6681bb39d6f22bf)