### PR TITLE
Add canonical product strategy/status document and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 GeneCoder is an educational toolkit for exploring DNA-based data storage. It provides a command line interface and a GUI for encoding and decoding files into simulated DNA sequences.
 
 For full usage instructions and additional documentation see the [docs/](docs/) directory or the hosted documentation linked above. The [MVP coverage checklist](docs/mvp_checklist.md) maps roadmap requirements to the shipped presets and example CLI commands. Developers adding new codecs, FEC backends, simulators, or visualizers can follow the [plugin development guide](docs/plugins.md) for step-by-step instructions and entry point examples.
+For the canonical shipped-vs-gap status snapshot, see [docs/product_strategy.md](docs/product_strategy.md).
 Plugin metadata and plugin registries now enforce a conservative default license policy: `MIT`, `BSD-2-Clause`, `BSD-3-Clause`, or `Apache-2.0`.
 For instructions on launching the GUI see the [usage guide](docs/usage.md#launching-the-flet-app).
 For a quick end-to-end demo see [docs/vertical_slice.md](docs/vertical_slice.md).

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -1,0 +1,51 @@
+# Product Strategy & Delivery Status
+
+This document is the canonical status snapshot for what GeneCoder ships today versus what is still missing.
+
+## Current Capabilities
+
+### 1) Built-in sequencing + decay simulation
+
+GeneCoder currently ships first-party simulation support for:
+
+- **Illumina** channels via the `genecoder.simulators.illumina` package and the bundled Illumina-focused presets.
+- **Nanopore** channels via built-in nanopore simulator modules and profile support.
+- **Storage decay** via the built-in decay stage that can be chained with sequencing simulation in preset pipelines.
+
+These paths are exercised by shipped bundle presets such as:
+
+- `configs/gold.yaml` (MiSeq-style + decay)
+- `configs/rs_illumina_pipeline.yaml` (Illumina profile + decay)
+- `configs/fountain_nanopore_pipeline.yaml` (Nanopore profile + decay)
+
+### 2) ECC and codec breadth (core + optional extras)
+
+GeneCoder supports a broad codec/FEC surface area:
+
+- **Core presets/checklists:** Reed–Solomon and Fountain workflows.
+- **Built-in encoding options:** base5/base6 alphabet modes.
+- **Optional extras:**
+  - Chamaeleo-backed codecs: GC, Fountain, Goldman, Church, Grass, Blawat.
+  - Advanced ECC integrations: LDPC, BCH, RaptorQ.
+  - AI-assisted plugins: DNAformer and DeepDNA.
+
+### 3) CLI bundles, dashboard, and reporting paths
+
+Operational workflow paths already shipped:
+
+- End-to-end pipeline orchestration via `genecli`/`genecoder`:
+  - `bundle run` for a single preset
+  - `bundle sweep` for side-by-side preset runs
+- Metrics capture and manifest indexing via `--metrics-path`, `--manifest-index`, and `--emit-manifest-report`.
+- Dashboard launch support with `--launch-dashboard`.
+- HTML reporting path through `genecli html-report` for manifest summaries.
+
+## Known Gaps
+
+The primary missing capabilities are quality and scale hardening layers, not baseline feature coverage:
+
+- **Model calibration quality:** stronger calibration and parity validation against wet-lab/public benchmark datasets.
+- **Large-scale HPC orchestration:** robust multi-node scheduling/orchestration beyond current MPI-oriented integrations.
+- **Economic cost modeling:** first-class synthesis/sequencing/storage cost models for scenario planning and tradeoff analysis.
+
+_Last validated against codebase: 2026-02-09._


### PR DESCRIPTION
### Motivation

- Provide a single, canonical snapshot that maps shipped functionality to known gaps for product planning and user guidance. 
- Ensure the “Current Capabilities” section accurately reflects what is actually present in the codebase (simulators, ECC/codec options, and CLI/reporting paths). 
- Surface only the true missing capabilities so roadmap and prioritization focus on quality and scale hardening rather than baseline features.

### Description

- Add a new document `docs/product_strategy.md` containing `Current Capabilities`, `Known Gaps`, and a `Last validated against codebase` date line. 
- Rewrite the `Current Capabilities` section to call out built-in Illumina/Nanopore/decay simulation support, ECC/codec breadth (core + optional extras), and CLI bundle/dashboard/reporting paths. 
- Add a concise `Known Gaps` section listing model calibration quality, large-scale HPC orchestration, and economic cost modeling as the primary missing capabilities. 
- Link the new document from `README.md` near the top-level documentation references; no source code changes were made (documentation-only change).

### Testing

- No automated tests or linters were run because this change is documentation-only per the repository rule that skips test/linter execution for comment/documentation edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d68c4b948326a89d4f75f0bd0ab3)