### PR TITLE
Harden dashboard dropout flag boolean parsing

### DIFF
--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -110,6 +110,29 @@ def _iterable(val: Iterable[str] | str | None) -> list[str]:
     return list(val)
 
 
+def _parse_bool(value: object) -> bool:
+    """Parse a broad set of boolean-like values.
+
+    Recognizes booleans, numeric values, and common string representations.
+    Unrecognized values return ``False``.
+    """
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        try:
+            return float(value) != 0.0
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return False
+
+
 def _gc_percentages(dist: object) -> list[float]:
     """Return GC distribution values expressed as percentages."""
 
@@ -189,10 +212,7 @@ def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
     hp_vals = [
         float(v) for v in oligo.get("max_homopolymers", []) if isinstance(v, (int, float))
     ]
-    dropout_flags = [
-        bool(v) if isinstance(v, bool) else bool(int(v))
-        for v in oligo.get("dropout_flags", [])
-    ]
+    dropout_flags = [_parse_bool(v) for v in oligo.get("dropout_flags", [])]
     ecc = oligo.get("ecc_success")
     ecc_map: dict[str, list[float]] = {}
     if isinstance(ecc, dict):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -217,3 +217,40 @@ def test_custom_constraint_limits_drive_flagged_oligos(
     assert flagged_tables, "flagged oligo table not written"
     flagged = flagged_tables[-1]
     assert [row.get("Index") for row in flagged] == [2]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("1", True),
+        ("0", False),
+        ("true", True),
+        ("false", False),
+        ("yes", True),
+        ("no", False),
+        ("bad-value", False),
+    ],
+)
+def test_parse_bool(value: object, expected: bool) -> None:
+    from genecoder import dashboard
+
+    assert dashboard._parse_bool(value) is expected
+
+
+def test_extract_oligo_records_handles_malformed_dropout_flags() -> None:
+    from genecoder import dashboard
+
+    records = dashboard._extract_oligo_records(
+        {
+            "oligo_metrics": {
+                "gc_percentages": [0.4, 0.5, 0.6],
+                "dropout_flags": ["true", "invalid", "off", None, object()],
+            }
+        }
+    )
+
+    assert [record.get("Dropout") for record in records] == [True, False, False, False, False]


### PR DESCRIPTION
### Motivation
- The dashboard currently used `bool(int(v))` when building `oligo_metrics.dropout_flags`, which is fragile for non-numeric or malformed inputs and can raise exceptions or misinterpret values.
- The goal is to robustly accept booleans, numeric, and common string representations (e.g. `true/false/1/0/yes/no/on/off`) and treat unrecognized values as `False` so malformed entries do not break rendering.

### Description
- Added a helper ` _parse_bool` in `src/genecoder/dashboard.py` that parses `bool`, numeric, and string forms and defaults unrecognized inputs to `False`.
- Replaced the previous `bool(int(v))` conversion in `_extract_oligo_records` with ` _parse_bool(v)` so `oligo_metrics.dropout_flags` are parsed safely.
- Added focused tests in `tests/test_dashboard.py` including a parametrized test for representative inputs (`True`, `False`, `1`, `0`, `"1"`, `"0"`, `"true"`, `"false"`, `"yes"`, `"no"`, and an invalid string) and a test asserting malformed dropout flag entries are handled without raising.

### Testing
- Ran `pytest -q tests/test_dashboard.py`, which passed: `21 passed`.
- Ran `ruff check src/genecoder/dashboard.py tests/test_dashboard.py`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989de2c039883269afabee22cf163a9)