### PR TITLE
Normalize dropout flag parsing for HTML report aggregation

### DIFF
--- a/src/genecoder/bool_parsing.py
+++ b/src/genecoder/bool_parsing.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Helpers for normalizing boolean-like values across GeneCoder surfaces."""
+
+
+def parse_bool_like(value: object) -> bool | None:
+    """Return a normalized bool for common JSON forms, else ``None``.
+
+    Recognizes native booleans, numeric values, and common string literals.
+    """
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        try:
+            return float(value) != 0.0
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return None

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -13,6 +13,8 @@ import math
 from collections import Counter
 from pathlib import Path
 from typing import IO, Any, Iterable, Callable, cast
+
+from .bool_parsing import parse_bool_like
 from types import ModuleType
 
 try:  # pragma: no cover - optional dependency for tests
@@ -117,20 +119,7 @@ def _parse_bool(value: object) -> bool:
     Unrecognized values return ``False``.
     """
 
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        try:
-            return float(value) != 0.0
-        except (TypeError, ValueError):  # pragma: no cover - defensive
-            return False
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off"}:
-            return False
-    return False
+    return bool(parse_bool_like(value))
 
 
 def _gc_percentages(dist: object) -> list[float]:

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -6,6 +6,8 @@ from html import escape
 import json
 from typing import Any
 
+from .bool_parsing import parse_bool_like
+
 __all__ = ["generate_html_report"]
 
 
@@ -54,7 +56,8 @@ def _render_oligo_section(metrics: dict[str, Any], html_lines: list[str]) -> Non
         return
     gc_vals = [float(v) for v in oligo.get("gc_percentages", []) if isinstance(v, (int, float))]
     hp_vals = [float(v) for v in oligo.get("max_homopolymers", []) if isinstance(v, (int, float))]
-    dropout_flags = [flag for flag in oligo.get("dropout_flags", []) if isinstance(flag, bool)]
+    parsed_dropout_flags = [parse_bool_like(flag) for flag in oligo.get("dropout_flags", [])]
+    dropout_flags = [flag for flag in parsed_dropout_flags if flag is not None]
     ecc = oligo.get("ecc_success")
 
     if not (gc_vals or hp_vals or dropout_flags or ecc):

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -53,3 +53,19 @@ def test_cli_html_report_stdout(tmp_path: Path) -> None:
     assert "Insertions:</strong> count 2; rate 2.0000%" in result.stdout
     assert "Deletions:</strong> count 3; rate 3.0000%" in result.stdout
     assert "Coverage:</strong> 42" in result.stdout
+
+
+def test_generate_html_report_normalizes_dropout_flags(tmp_path: Path) -> None:
+    manifest = tmp_path / "m_dropout.json"
+    data = {
+        "metrics": {
+            "oligo_metrics": {
+                "dropout_flags": [True, "1", 0, "false", 2, "invalid", None]
+            }
+        }
+    }
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+
+    html = generate_html_report(str(manifest))
+
+    assert "Dropouts:</strong> 3 of 5 oligos (60.00%)" in html


### PR DESCRIPTION
### Motivation
- HTML report aggregation previously filtered `dropout_flags` by strict `bool` type which caused counts to diverge for JSON payloads that use numeric or string forms. 
- The goal is to ensure `Y` (total) counts all valid parseable entries and `X` (dropped) counts truthy values across boolean/int/float/string forms while preserving the existing `X of Y oligos (Z%)` output.

### Description
- Added `src/genecoder/bool_parsing.py` with `parse_bool_like` to normalize boolean-like values and return `None` for unparseable inputs. 
- Reused the new parser in `src/genecoder/dashboard.py` by delegating `_parse_bool` to `parse_bool_like` to keep semantics consistent across UI and reporting. 
- Updated `src/genecoder/html_report.py::_render_oligo_section` to parse `dropout_flags` via `parse_bool_like`, treat only non-`None` parsed values as valid entries for the total `Y`, and count truthy parsed flags for `X`, leaving the output format unchanged. 
- Added `tests/test_html_report.py::test_generate_html_report_normalizes_dropout_flags` to validate mixed-form `dropout_flags` payloads produce the expected "X of Y oligos (Z%)" text.

### Testing
- Ran style checks with `ruff` on the changed files via `ruff check src/genecoder/bool_parsing.py src/genecoder/dashboard.py src/genecoder/html_report.py tests/test_html_report.py` which passed. 
- Executed unit tests with `pytest -q tests/test_html_report.py tests/test_dashboard.py` and they all passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989df49b660832694ad745eca1a372e)