### PR TITLE
docs: expand GeneCoder product strategy and roadmap

### DIFF
--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -1,51 +1,156 @@
-# Product Strategy & Delivery Status
+# GeneCoder Product Strategy and Roadmap
 
-This document is the canonical status snapshot for what GeneCoder ships today versus what is still missing.
+## Vision and Current State
 
-## Current Capabilities
+GeneCoder is envisioned as a comprehensive DNA data storage simulation platform, addressing the need for an integrated “virtual laboratory” in this emerging field. The goal is to simulate the entire DNA storage pipeline—from digital data encoding into DNA sequences, through molecular processes (synthesis, storage degradation, sequencing errors), and back to decoding—within one unified toolkit. Such a platform promises to accelerate research by enabling system-level insights and rapid in silico experimentation, something fragmented single-purpose tools cannot easily provide. This vision positions GeneCoder as a central hub for DNA storage innovation, fostering collaboration and standardizing how new techniques are evaluated.
 
-### 1) Built-in sequencing + decay simulation
+### Current Capabilities (MVP)
 
-GeneCoder currently ships first-party simulation support for:
+GeneCoder’s latest prototype delivers a basic but functional feature set focused on encoding and decoding data to/from DNA sequences. Via a command-line interface (and an optional GUI), users can convert binary/text files into simulated DNA sequences and back, using several methods and simple error controls.
 
-- **Illumina** channels via the `genecoder.simulators.illumina` package and the bundled Illumina-focused presets.
-- **Nanopore** channels via built-in nanopore simulator modules and profile support.
-- **Storage decay** via the built-in decay stage that can be chained with sequencing simulation in preset pipelines.
+Implemented encoding schemes include direct base-4 mapping and Huffman coding, as well as a GC-balanced encoding that ensures sequences meet simple biophysical constraints (target ~50% GC content and limited homopolymer runs). Basic error correction options are available (e.g., a triple nucleotide repeat scheme with majority-vote decoding, and a Hamming(7,4) code for binary data) to simulate rudimentary error resilience.
 
-These paths are exercised by shipped bundle presets such as:
+Outputs are provided in standard FASTA format with metadata in headers, and the tool reports metrics like compression ratio, GC content, and homopolymer lengths for each encoding. A lightweight GUI (built with Flet) allows interactive use of these features and visualizes results (e.g., nucleotide distribution, GC content across the sequence, homopolymer locations) for learning and analysis.
 
-- `configs/gold.yaml` (MiSeq-style + decay)
-- `configs/rs_illumina_pipeline.yaml` (Illumina profile + decay)
-- `configs/fountain_nanopore_pipeline.yaml` (Nanopore profile + decay)
+This MVP has validated the core concept and generated early interest, but key capabilities are still missing: notably, detailed simulation of DNA synthesis/sequencing errors or biochemical processes is not yet implemented, and the current focus is more educational than predictive. These gaps point to the next development priorities to fulfill GeneCoder’s full vision.
 
-### 2) ECC and codec breadth (core + optional extras)
+## User Needs and Market Demand
 
-GeneCoder supports a broad codec/FEC surface area:
+The target users—academic researchers, bioinformatics developers, and DNA data storage innovators—are seeking a platform that makes DNA storage experiments faster, cheaper, and more insightful.
 
-- **Core presets/checklists:** Reed–Solomon and Fountain workflows.
-- **Built-in encoding options:** base5/base6 alphabet modes.
-- **Optional extras:**
-  - Chamaeleo-backed codecs: GC, Fountain, Goldman, Church, Grass, Blawat.
-  - Advanced ECC integrations: LDPC, BCH, RaptorQ.
-  - AI-assisted plugins: DNAformer and DeepDNA.
+### Key user needs
 
-### 3) CLI bundles, dashboard, and reporting paths
+- **End-to-End Simulation:** Model synthesis errors, degradation, sequencing read errors, and full lifecycle corruption behavior in one place.
+- **New Coding Scheme Evaluation:** Rapidly test novel encoding/ECC methods tailored to DNA-specific error profiles.
+- **Performance and Efficiency Analysis:** Compare storage density, decode error rates, and overhead/resource trade-offs across approaches.
+- **Biophysical Constraint Management:** Apply/adjust constraints (GC, homopolymers, etc.) and run what-if experiments.
+- **Cost and Parameter Optimization:** Explore cost-per-bit, read depth requirements, and physical vs. logical redundancy trade-offs prior to wet-lab investment.
 
-Operational workflow paths already shipped:
+In short, users want GeneCoder to be a one-stop sandbox where they can experiment virtually with DNA storage systems: try new ideas, anticipate failure modes, and tune methods with high realism and low cost.
 
-- End-to-end pipeline orchestration via `genecli`/`genecoder`:
-  - `bundle run` for a single preset
-  - `bundle sweep` for side-by-side preset runs
-- Metrics capture and manifest indexing via `--metrics-path`, `--manifest-index`, and `--emit-manifest-report`.
-- Dashboard launch support with `--launch-dashboard`.
-- HTML reporting path through `genecli html-report` for manifest summaries.
+## Competitive Landscape
 
-## Known Gaps
+The DNA storage tooling ecosystem is active but fragmented, with each tool focused on part of the workflow.
 
-The primary missing capabilities are quality and scale hardening layers, not baseline feature coverage:
+### Major projects
 
-- **Model calibration quality:** stronger calibration and parity validation against wet-lab/public benchmark datasets.
-- **Large-scale HPC orchestration:** robust multi-node scheduling/orchestration beyond current MPI-oriented integrations.
-- **Economic cost modeling:** first-class synthesis/sequencing/storage cost models for scenario planning and tradeoff analysis.
+- **D2Sim:** Strong nanopore channel simulation; narrow sequencing-only scope.
+- **DNAformer / Deep-DNA-based-storage:** AI decoding speed/accuracy strengths; specialized and less general-purpose.
+- **FrameD:** End-to-end, fault-injection, HPC-strength workflows; high complexity and infrastructure burden.
+- **DNAsmart:** Excellent post-hoc visual ranking/analysis; not a simulator/encoder.
 
-_Last validated against codebase: 2026-02-09._
+### Positioning summary
+
+| Tool | Primary Focus & Strengths | Limitations / Gaps |
+| --- | --- | --- |
+| **GeneCoder (MVP)** | End-to-end encode/decode simulation with basic constraints and error correction; user-friendly CLI/GUI. | No deep synthesis/sequencing error modeling yet; advanced ECC and scale support still maturing. |
+| **D2Sim** | Realistic nanopore error profiles and redundancy analyses. | Sequencing-channel only; no full encode-store-decode workflow. |
+| **DNAformer** | AI-based reconstruction and high-speed noisy-read decoding. | Specialized/training-heavy; limited as a general simulator. |
+| **FrameD** | HPC-scale full-pipeline fault-injection simulation. | Heavy setup, steep learning curve, not optimized for interactive use. |
+| **DNAsmart** | Interactive multi-attribute ranking of outcomes. | Post-analysis only; relies on upstream simulation/encoding tools. |
+
+### Strategic implication
+
+No single tool currently combines realistic channel simulation, flexible coding plugin architecture, constraint handling, and approachable analysis in one open platform. GeneCoder’s opportunity is to unify these capabilities.
+
+## Recommended Features and Improvements (Near-Term)
+
+1. **Realistic Error Channel Simulation**
+   - Add configurable synthesis/sequencing error injection.
+   - Start with one robust profile (e.g., Illumina), while designing extensibility for nanopore and future models.
+
+2. **Expanded Codec and ECC Library**
+   - Prioritize Reed–Solomon and Fountain/LT support.
+   - Add stronger ECC options over time (e.g., convolutional/LDPC), and broaden constrained encoders.
+
+3. **Advanced Biophysical Constraints and Sequence Optimization**
+   - Support customizable rule sets (GC ranges, homopolymer limits, motif restrictions).
+   - Add validation and optional automated correction guidance.
+
+4. **Data Visualization and Analysis Tools**
+   - Add richer error-distribution and comparative performance visualizations.
+   - Provide simulation dashboards and structured export (CSV/JSON).
+
+5. **API and Scripting Support**
+   - Strengthen Python API for parameter sweeps and workflow integration.
+   - Improve logging/configuration ergonomics and developer documentation.
+
+6. **Modularity for Future Integration**
+   - Keep encoding/ECC/error models pluggable.
+   - Prepare clean integration seams for external simulators and AI decoders.
+
+## Product Strategy for Long-Term Growth
+
+### Positioning and unique value proposition
+
+GeneCoder should be positioned as an integrated platform for DNA data storage research: the place where encoding, error modeling, and biophysical constraints meet in one coherent workflow.
+
+Key USPs:
+
+- **Breadth:** End-to-end scope in one environment.
+- **Consistency:** Standardized metrics and comparable benchmarks.
+- **Ease of use:** CLI/GUI with strong docs and approachable workflows.
+- **Open-source momentum:** Community-driven extensibility and longevity.
+
+## Open-Source Community and Ecosystem Development
+
+To grow adoption and velocity:
+
+- **Outreach:** Present at relevant conferences; publish tutorials and technical writeups.
+- **Workshops/Hackathons:** Run practical onboarding sessions and contribution events.
+- **Documentation quality:** Maintain quickstarts, API references, reproducible examples, and contribution guides.
+- **Community channels/governance:** Establish discussion venues and contributor pathways to maintainer roles.
+
+## Scalability and Deployment Considerations
+
+### Scalability
+
+- Optimize core performance paths for larger simulations.
+- Support parallel execution where practical.
+- Prepare architecture for batch/distributed workflows and HPC/cloud interoperability.
+
+### Deployment model
+
+- **Near-term:** Focus on robust local deployment.
+- **Long-term:** Explore hybrid local+web experience (easy UI plus optional remote execution).
+- **Security/integrity:** Include data integrity checks and secure service design principles for any future hosted mode.
+
+## Phased Roadmap
+
+### Phase 1 — Core MVP Completion
+
+- Complete robust channel simulation for at least one key workflow.
+- Add foundational high-impact codecs/ECC.
+- Ensure CLI/batch workflows are reliable for encode-simulate-decode loops.
+
+### Phase 2 — Feature Expansion and Usability
+
+- Add additional error models and parameter controls.
+- Expand coding options and constraint tooling.
+- Improve visualization/reporting and stabilize API/documentation.
+
+### Phase 3 — Advanced Capabilities and Ecosystem Growth
+
+- Integrate optional AI/ML-assisted components.
+- Add support for emerging storage paradigms.
+- Expand collaboration tooling and community-driven plugin ecosystem.
+
+## Key Differentiators and Success Factors
+
+- **Holistic simulation** across lifecycle stages.
+- **Modular extensibility** for fast adoption of new methods.
+- **Accessible UX** for both experts and newcomers.
+- **Community-led evolution** for long-term relevance.
+- **Benchmarking rigor** through reproducible, validated workflows.
+
+## Conclusion and Strategic Recommendations
+
+To establish leadership in DNA storage simulation, GeneCoder should:
+
+1. Prioritize realistic end-to-end simulation capabilities.
+2. Differentiate through integrated workflows over niche point solutions.
+3. Invest in usability, modular architecture, and reproducible benchmarking.
+4. Build an active open-source contributor ecosystem.
+5. Execute in phases with strong feedback loops and adaptive prioritization.
+
+With this strategy, GeneCoder can evolve from a promising prototype into foundational infrastructure for DNA data storage R&D.


### PR DESCRIPTION
## Summary
- Rewrote `docs/product_strategy.md` into a comprehensive strategy document aligned with the provided roadmap narrative.
- Added clear sections for vision/current state, user needs, competitive landscape, near-term recommendations, long-term strategy, community/ecosystem, scalability/deployment, phased roadmap, differentiators, and conclusion.
- Included a competitor comparison table and prioritized recommendations to improve readability and planning utility.

## Testing
- Not run (documentation-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989db47c6d0832690edc4f9b478eb2e)