### PR TITLE
Normalize vision doc references across roadmap and code comments

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -111,6 +111,6 @@ The roadmap supports three primary integration archetypes:
 - Provide at least one runnable example under `plugins-examples/` (or equivalent
   structure) so maintainers can validate the entry point contract quickly.
 6. **Documentation Updates**
-   - Inline comments in `encoders.py` and `flet_app.py` now point to sections of the Development Vision PDF (Sections III and IV) for added context.
+   - Inline comments in `encoders.py` and `flet_app.py` now point to `docs/vision.md` ("Vision and Current State") for added context.
 
 Refer to the [manifest format](manifest.md) for the current encoding metadata structure and the [plugin guide](plugins.md) for extension points that inform future roadmap items.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,3 +31,11 @@ For more details, explore the sections below.
 * [Plugin System](plugins.md) – Step-by-step guide to writing codecs, FEC modules and simulators.
 * [Plugin Packaging Tutorial](../notebooks/lessons/6_plugin_packaging.ipynb) – Interactive walkthrough of entry points.
 * [Example Plugins](../plugins-examples) – Installable packages demonstrating each entry point group.
+
+## Canonical strategy documents
+
+To avoid duplicate or drifting references, treat these as the canonical planning docs:
+
+* [Vision & Core Concept](vision.md) – primary product vision and near-term priorities.
+* [Product Strategy](product_strategy.md) – strategic positioning and direction.
+* [Roadmap Execution](roadmap_execution.md) – milestones, delivery sequence, and KPI-linked execution.

--- a/src/genecoder/encoders.py
+++ b/src/genecoder/encoders.py
@@ -5,7 +5,7 @@ Each 2-bit segment of a byte corresponds to one nucleotide. The processing
 occurs from the Most Significant Bit (MSB) to the Least Significant Bit (LSB)
 of each byte.
 """
-# See the Development Vision PDF, Section III for background on the encoder architecture.
+# See `docs/vision.md` ("Vision and Current State") for encoder design context.
 from typing import Tuple, List, Iterable, Iterator  # For type hints
 from genecoder.error_detection import (
     add_parity_to_sequence,

--- a/src/genecoder/flet_app.py
+++ b/src/genecoder/flet_app.py
@@ -10,10 +10,10 @@ The application relies heavily on the :mod:`genecoder` package
 `plotting` utilities which themselves use `matplotlib`).  It runs most
 heavy tasks asynchronously with :mod:`asyncio` so the interface remains
 responsive.
-See `docs/DEVELOPMENT_VISION.md` for how the GUI fits into the project's
-integrated pipeline and extensible design.
+See `docs/vision.md` ("Vision and Current State") for how the GUI
+fits into the project's integrated pipeline and extensible design.
 """
-# Refer to Section IV of the Development Vision PDF for the UI architecture overview.
+# For UI architecture context, see `docs/vision.md` ("Vision and Current State").
 
 import flet as ft
 import os


### PR DESCRIPTION
### Motivation

- Remove stale references to an external "Development Vision PDF" and consolidate cross-references to the in-repo canonical vision document to avoid broken or inconsistent links.
- Ensure code inline comments and top-level docs consistently point to a single canonical markdown file to reduce future duplication and drift.

### Description

- Updated `src/genecoder/encoders.py` comment to reference `docs/vision.md` ("Vision and Current State") instead of the PDF section number.
- Updated `src/genecoder/flet_app.py` module docstring and inline comment to reference `docs/vision.md` ("Vision and Current State") instead of the external PDF/section IV.
- Rewrote the Documentation Updates item in `docs/development_roadmap.md` to reference `docs/vision.md` ("Vision and Current State").
- Added a brief `## Canonical strategy documents` note to `docs/index.md` listing `vision.md`, `product_strategy.md`, and `roadmap_execution.md` as the canonical planning docs.

### Testing

- Ran `git diff` to verify the intended changes to `docs/development_roadmap.md`, `docs/index.md`, `src/genecoder/encoders.py`, and `src/genecoder/flet_app.py`, and the diff matched the described edits.
- Ran `git status --short` to confirm the working tree changes were staged and committed successfully.
- No unit tests or linters were executed because the changes are documentation and inline comments only, per the project guidance for doc-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b343a83408326809b478e77276c62)