### PR TITLE
docs: align roadmap execution module paths with current code layout

### DIFF
--- a/docs/roadmap_execution.md
+++ b/docs/roadmap_execution.md
@@ -51,8 +51,9 @@ default profiles before broad expansion.
 
 ### Milestone 1.2: CLI and manifest UX hardening
 
-- **Repository modules:** `src/genecoder/cli`, `src/genecoder/reporting`,
-  `src/genecoder/manifest`
+- **Repository modules:** `src/genecoder/cli/pipeline.py`,
+  `src/genecoder/cli/bundle.py`, `src/genecoder/cli/report.py`,
+  `src/genecoder/report.py`, `src/genecoder/manifest.py`
 - **Scope:** Improve CLI error clarity, manifest generation consistency, and
   quick artifact inspection workflows for first-time users.
 - **Owner role:** CLI and DX maintainer
@@ -79,7 +80,9 @@ MVP reliability and performance budgets.
 ### Milestone 2.1: Simulator/profile breadth with performance guardrails
 
 - **Repository modules:** `src/genecoder/simulators`,
-  `src/genecoder/channel_profiles`, `src/genecoder/pipeline`
+  `src/genecoder/simulators/illumina/profiles.py`,
+  `src/genecoder/simulators/nanopore_profiles.py`,
+  `src/genecoder/pipeline.py`
 - **Scope:** Expand Illumina/Nanopore profile coverage and expose richer channel
   options without regressing runtime behavior.
 - **Owner role:** Simulation systems maintainer
@@ -99,7 +102,8 @@ MVP reliability and performance budgets.
 
 ### Milestone 2.2: Dashboard and API expansion for comparative analysis
 
-- **Repository modules:** `src/genecoder/dashboard*`, `src/genecoder/web`,
+- **Repository modules:** `src/genecoder/dashboard.py`,
+  `src/genecoder/dashboard_streamlit.py`, `src/genecoder/api.py`,
   `src/genecoder/cli`
 - **Scope:** Support side-by-side run comparison, richer KPI surfacing, and
   smoother dashboard launch paths from bundle workflows.
@@ -145,8 +149,9 @@ quality governance for a research-grade ecosystem.
 
 ### Milestone 3.2: Cloud/distributed execution and reproducible research bundles
 
-- **Repository modules:** `src/genecoder/cloud`, `src/genecoder/worker`,
-  `src/genecoder/pipeline`, `src/genecoder/dashboard*`
+- **Repository modules:** `src/genecoder/cloud`,
+  `src/genecoder/cloud/worker.py`, `src/genecoder/pipeline.py`,
+  `src/genecoder/dashboard.py`, `src/genecoder/dashboard_streamlit.py`
 - **Scope:** Enable scalable batch execution with reproducible manifests and KPI
   telemetry suitable for collaborative research programs.
 - **Owner role:** Platform reliability maintainer
@@ -171,3 +176,5 @@ quality governance for a research-grade ecosystem.
 - Keep acceptance criteria tied to repository artifacts (tests, benchmarks,
   example configs) so progress is auditable.
 - Update this document whenever module boundaries or extension contracts change.
+- Doc-maintenance check for every roadmap PR: verify each listed
+  `Repository modules` path exists in the current tree.


### PR DESCRIPTION
### Motivation
- The roadmap referenced outdated module paths (for reporting, simulator profiles, and cloud workers) that no longer match the repository layout, which can confuse maintainers and reviewers. 
- The change ensures roadmap entries point to concrete files so ownership and validation artifacts are discoverable and auditable.

### Description
- Updated Milestone 1.2 to reference the concrete manifest/report handlers: `src/genecoder/cli/pipeline.py`, `src/genecoder/cli/bundle.py`, `src/genecoder/cli/report.py`, `src/genecoder/report.py`, and `src/genecoder/manifest.py`. 
- Replaced stale simulator/profile and pipeline references in Milestone 2.1 with `src/genecoder/simulators/illumina/profiles.py`, `src/genecoder/simulators/nanopore_profiles.py`, and `src/genecoder/pipeline.py`. 
- Made Dashboard/API targets explicit in Milestone 2.2 by naming `src/genecoder/dashboard.py`, `src/genecoder/dashboard_streamlit.py`, and `src/genecoder/api.py`. 
- Corrected Phase 3 cloud ownership to include `src/genecoder/cloud/worker.py` and explicit dashboard files, and added a doc-maintenance check requiring roadmap PRs to verify listed `Repository modules` paths exist.

### Testing
- Verified all referenced paths exist with a local path-check script which returned no missing entries (`missing []`).
- Inspected the file diff (`git diff -- docs/roadmap_execution.md`) and committed the documentation update successfully. 
- No unit tests or linters were run because this is a documentation-only change per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b42f5df648326ae24b3e2d8782b5c)