### PR TITLE
Clarify current vs exploratory interoperability in strategy and plugin docs

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -94,8 +94,31 @@ criteria and evidence artifacts are complete.
 ### Long-term interoperability strategy
 
 To make ecosystem growth concrete, external tools should integrate through the
-existing plugin entry points and registry workflows rather than bespoke
-adapters. The implementation anchors are:
+existing plugin entry points and registry workflows rather than bespoke,
+one-off pathways.
+
+#### Available now (implemented interoperability hooks)
+
+- Adapter-backed optional integrations for D2Sim, DeSP, and DNArSim already
+  exist in `src/genecoder/d2sim_adapter.py`,
+  `src/genecoder/desp_adapter.py`, and `src/genecoder/dnarsim_adapter.py`.
+- Shared plugin/registry hooks are already operational in
+  `src/genecoder/plugin_manager.py`, including simulator registration and
+  entry-point loading paths used by built-in and external plugins.
+- The current plugin workflow for authoring/registering extensions is already
+  documented in [`docs/plugins.md`](plugins.md).
+
+#### Future deep integrations (exploratory and phase-gated)
+
+- Production hardening for external adapters/plugins (reliability, rollout,
+  and failure-handling maturity) beyond current fallback-capable operation.
+- Broader benchmark validation across standardized datasets/runners before
+  external integrations are treated as release-gate evidence.
+- Tightened policy/security governance for registry publication and supply-chain
+  controls as part of Phase 4 automation criteria.
+
+The implementation anchors for moving from available hooks to release-grade
+interoperability are:
 
 - [`docs/plugins.md`](plugins.md) for entry point groups, `register_*` hooks,
   and runtime loading rules.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,6 +13,22 @@ GeneCoder exposes four plugin interfaces defined in [`genecoder.api`](../src/gen
 
 Registries for each interface live in [`genecoder.plugin_manager`](../src/genecoder/plugin_manager.py) and are populated by built-in plugins, Python entry points, and optional local modules. Later registrations override earlier ones, letting users replace bundled defaults with custom implementations.
 
+## Interoperability status: available now vs exploratory
+
+### Available now
+
+- Optional external simulator adapters are already implemented for D2Sim, DeSP, and DNArSim in [`src/genecoder/d2sim_adapter.py`](../src/genecoder/d2sim_adapter.py), [`src/genecoder/desp_adapter.py`](../src/genecoder/desp_adapter.py), and [`src/genecoder/dnarsim_adapter.py`](../src/genecoder/dnarsim_adapter.py).
+- These adapters register simulator hooks into the shared plugin/registry layer in [`src/genecoder/plugin_manager.py`](../src/genecoder/plugin_manager.py), so integration is exposed through the same simulator interface used by built-in channels.
+- Current adapters include fallback behavior when external binaries are missing, enabling practical workflow interoperability without hard runtime coupling.
+
+### Future deep integrations (exploratory)
+
+- Production hardening for third-party simulator integrations (operational reliability, packaging discipline, and stricter release gates).
+- Broader benchmark validation across datasets/profiles/runners before treating external integrations as phase-exit evidence for roadmap promotion.
+- Expanded policy/security enforcement for distributed plugin artifacts beyond local or ad hoc experimentation.
+
+See also [`docs/development_roadmap.md` (Long-term interoperability strategy)](development_roadmap.md#long-term-interoperability-strategy) for the phase-governed expectations that move integrations from available hooks to release-grade ecosystem support.
+
 ## Writing a plugin module
 
 A plugin module must expose registration helpers that accept the corresponding registry function. Each registry helper receives the appropriate registrar (for example, `register_codec`) and should call it with a unique name and an object that implements the required interface.

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -76,7 +76,9 @@ The DNA storage tooling ecosystem is active but fragmented, with each tool focus
 
 ### Strategic implication
 
-No single tool currently combines realistic channel simulation, flexible coding plugin architecture, constraint handling, and approachable analysis in one open platform. GeneCoder’s opportunity is to unify these capabilities.
+GeneCoder already ships **available-now interoperability** for optional external nanopore simulators through concrete adapters in `src/genecoder/d2sim_adapter.py`, `src/genecoder/desp_adapter.py`, and `src/genecoder/dnarsim_adapter.py`, plus registry/entry-point hooks in `src/genecoder/plugin_manager.py`. This means users can run external simulator binaries behind stable GeneCoder interfaces today (with built-in fallbacks when tools are unavailable), rather than waiting for bespoke rewrites.
+
+The **exploratory/future-deep integration** work is different: production hardening, stricter policy/security governance for third-party distribution, and broader benchmark validation across datasets and environments as tracked in `docs/plugins.md` and the interoperability strategy subsection of `docs/development_roadmap.md`. Those initiatives determine how far current interoperability can scale from “works in research workflows now” to “release-gated, ecosystem-wide reliability.”
 
 ## Recommended Features and Improvements (Near-Term)
 


### PR DESCRIPTION
### Motivation

- Make the competitive-landscape and roadmap guidance explicit about what interoperability is already available versus what remains exploratory and phase-gated. 
- Surface concrete references to the adapter implementations and plugin registry so readers can find the code that already enables optional external simulators.

### Description

- Updated `docs/product_strategy.md` to state that adapter-backed integrations for D2Sim/DeSP/DNArSim are "available now" and to contrast that with "exploratory/future-deep integrations" work. 
- Added an **Interoperability status: available now vs exploratory** section to `docs/plugins.md` that references `src/genecoder/d2sim_adapter.py`, `src/genecoder/desp_adapter.py`, `src/genecoder/dnarsim_adapter.py`, and `src/genecoder/plugin_manager.py`, and clarifies fallback behavior and the planned hardening/validation work. 
- Revised the interoperability subsection in `docs/development_roadmap.md` to separate implemented hooks from future deep integrations (production hardening, broader benchmark validation, and tightened policy/security governance). 

### Testing

- No automated tests or linters were run because these changes are documentation-only and introduce no code modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4c7b93fc8326ba5b223b9a1346da)