### PR TITLE
docs: remove duplicate top-level MkDocs nav entries

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,12 +37,8 @@ nav:
       - MPI Pipeline Execution: mpi.md
   - Archived:
       - Full Development Vision: archived/DEVELOPMENT_VISION.md
-  - Technology Stack: technology_stack.md
-  - Development Roadmap: development_roadmap.md
-  - Development Vision: DEVELOPMENT_VISION.md
 
   - Plugin System: plugins.md
   - Glossary: glossary.md
 
   - API Reference: api_reference.md
-


### PR DESCRIPTION
### Motivation
- Remove duplicate top-level nav entries for `Technology Stack: technology_stack.md`, `Development Roadmap: development_roadmap.md`, and `Development Vision: DEVELOPMENT_VISION.md` so each page appears only once in the site navigation.

### Description
- Deleted the repeated top-level entries from `mkdocs.yml` and retained the canonical placements inside the `Project Overview` and `Development` grouped sections so each page is listed only once.

### Testing
- Ran a `python` occurrence check to confirm each target appears exactly once in `mkdocs.yml` and a link-resolution script against `docs/index.md` to ensure referenced files exist (both succeeded); attempted `mkdocs build` via `mkdocs` and `python -m mkdocs` failed because the `mkdocs` package is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b509680f4832692ce9cdeda8b0d99)