### PR TITLE
docs: add Product Strategy to MkDocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Reproducibility Guide: reproducibility.md
   - Project Overview:
       - Vision & Core Concept: vision.md
+      - Product Strategy: product_strategy.md
       - Implemented Features: features.md
       - Technology Stack: technology_stack.md
   - Migration Guide: migration.md


### PR DESCRIPTION
### Motivation
- Make the canonical `product_strategy.md` document discoverable from the main site navigation under a clear section so strategy and roadmap content is easier to find.
- Ensure the homepage link and nav route both resolve to the same page and that the addition does not create duplicate placements in the navigation.

### Description
- Updated `mkdocs.yml` to add `- Product Strategy: product_strategy.md` under the `Project Overview` nav section and made no other nav changes.
- The change is nav-only and does not modify content files other than updating the navigation order.

### Testing
- Ran `python -m pip install mkdocs mkdocs-material "mkdocstrings[python]"` which completed successfully to provision build tools.
- Ran `mkdocs build --strict` which failed due to a pre-existing `mkdocstrings` import error (`No module named 'web'`) unrelated to the nav change.
- Built a temporary site with a minimal config using `mkdocs build -f /tmp/mkdocs-nav-check.yml -d /tmp/gc-site` which succeeded and produced a `search_index.json` containing `product_strategy` entries and a generated route `product_strategy/`.
- Verified `docs/index.md` contains the link `[Product Strategy](product_strategy.md)` and `mkdocs.yml` references `product_strategy.md` exactly once (no duplicate nav placement).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5410d81c8326b380a82a7499b293)