### PR TITLE
Refactor synthesis constraints into a rule-based validation and repair engine

### DIFF
--- a/src/genecoder/cli/encode.py
+++ b/src/genecoder/cli/encode.py
@@ -32,13 +32,14 @@ from genecoder.gc_constrained_encoder import (
 )
 from genecoder.gc_balancer import AdvancedGCBalancer
 from genecoder.hamming_codec import encode_data_with_hamming
-from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY
+from genecoder.plugin_manager import FEC_REGISTRY
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.formats import SequenceBatch
 from genecoder.huffman_coding import encode_huffman
 from genecoder.error_detection import PARITY_RULE_GC_EVEN_A_ODD_T
 from genecoder.utils import get_max_homopolymer_length, get_alphabet_maps
 from genecoder.constraint_fixer import encode as constraint_fix_encode
+from genecoder.synthesis import SynthesisConstraints
 from .common import run_tasks
 from typing import Callable, cast
 
@@ -389,29 +390,27 @@ def process_single_encode(
         auto_fix_metrics: dict[str, float] = {}
         if getattr(args, "auto_fix", True) and os.getenv("GENECODER_DISABLE_FIX") not in {"1", "true", "True"}:
             target_dna = raw_encoded_dna
-            if getattr(args, "fix_chisel", False) and "dnachisel_fixer" in CODEC_REGISTRY:
-                from genecoder.dnachisel_fixer import fix_sequence_dnachisel
-
-                target_dna = fix_sequence_dnachisel(
-                    target_dna,
-                    gc_min=args.gc_min,
-                    gc_max=args.gc_max,
-                    max_homopolymer=args.max_homopolymer,
-                )
-                fix_metrics = {
-                    "gc_content": calculate_gc_content(target_dna),
-                    "max_homopolymer": get_max_homopolymer_length(target_dna),
-                }
-            else:
+            strategy = "external_solver" if getattr(args, "fix_chisel", False) else "stochastic"
+            try:
                 target_dna, fix_metrics = constraint_fix_encode(
                     target_dna,
                     gc_min=args.gc_min,
                     gc_max=args.gc_max,
                     max_homopolymer=args.max_homopolymer,
+                    strategy=strategy,
+                )
+            except ImportError:
+                target_dna, fix_metrics = constraint_fix_encode(
+                    target_dna,
+                    gc_min=args.gc_min,
+                    gc_max=args.gc_max,
+                    max_homopolymer=args.max_homopolymer,
+                    strategy="stochastic",
                 )
             auto_fix_metrics = {
                 "fixed_gc": fix_metrics["gc_content"],
                 "fixed_max_homopolymer": fix_metrics["max_homopolymer"],
+                "constraint_repair_report": fix_metrics.get("repair_report", {}),
             }
 
             if args.fec == "triple_repeat":
@@ -500,6 +499,13 @@ def process_single_encode(
                     DEFAULT_MAX_HOMOPOLYMER,
                 )
 
+        constraint_engine = SynthesisConstraints(
+            min_length=1,
+            max_length=max(1, final_encoded_length_nucleotides),
+            max_homopolymer=args.max_homopolymer,
+            gc_min=args.gc_min,
+            gc_max=args.gc_max,
+        ).to_engine()
         metrics = {
             "original_size": original_size_bytes,
             "dna_length": final_encoded_length_nucleotides,
@@ -509,6 +515,7 @@ def process_single_encode(
             "final_max_homopolymer": final_hp,
             "gc_exceeds_default": gc_default_bad,
             "homopolymer_exceeds_default": hp_default_bad,
+            "constraint_report": constraint_engine.as_manifest_report(primary_sequence),
         }
         metrics.update(auto_fix_metrics)
 
@@ -839,4 +846,3 @@ def _handle_command(args: argparse.Namespace) -> None:
     if args.seed is not None:
         os.environ["GENECODER_SIM_SEED"] = str(args.seed)
     encode_files(args)
-

--- a/src/genecoder/constraint_fixer.py
+++ b/src/genecoder/constraint_fixer.py
@@ -1,27 +1,55 @@
-"""Utilities to modify DNA sequences to satisfy synthesis constraints.
-
-This module exposes small helpers for adjusting GC balance and disrupting
-excessive homopolymers.  The high-level :func:`fix` convenience function ties
-these helpers together and is designed for use directly from the main encoding
-pipeline or CLI, allowing sequences to be automatically corrected before they
-are passed along for synthesis.
-"""
+"""Utilities to repair DNA sequences to satisfy synthesis constraints."""
 
 from __future__ import annotations
 
 import random
+from dataclasses import dataclass
 
+from .constraints import (
+    ConstraintEngine,
+    ConstraintRuleSet,
+    DNAChiselSolverBackend,
+    DeterministicRepairStrategy,
+    ExternalSolverRepairStrategy,
+    GcRangeRule,
+    HomopolymerMaxRule,
+    StochasticRepairStrategy,
+)
 from .gc_constrained_encoder import calculate_gc_content
-from .utils import get_max_homopolymer_length
 from .random_utils import make_rng
+from .utils import get_max_homopolymer_length
 
 __all__ = [
     "adjust_gc_balance",
     "limit_homopolymers",
     "fix_sequence",
+    "fix_sequence_with_report",
     "fix",
     "encode",
 ]
+
+
+@dataclass
+class StrategyPlugin:
+    name: str
+
+    def build(self, *, rng: random.Random | None = None):
+        if self.name == "deterministic":
+            return DeterministicRepairStrategy()
+        if self.name == "stochastic":
+            return StochasticRepairStrategy(rng=rng)
+        if self.name == "external_solver":
+            return ExternalSolverRepairStrategy(solver_backend=DNAChiselSolverBackend())
+        raise ValueError(f"Unknown strategy '{self.name}'")
+
+
+def _rule_set(target_gc_min: float, target_gc_max: float, max_homopolymer: int) -> ConstraintRuleSet:
+    return ConstraintRuleSet(
+        rules=[
+            GcRangeRule(gc_min=target_gc_min, gc_max=target_gc_max),
+            HomopolymerMaxRule(max_homopolymer=max_homopolymer),
+        ]
+    )
 
 
 def adjust_gc_balance(
@@ -31,34 +59,15 @@ def adjust_gc_balance(
     *,
     rng: random.Random | None = None,
 ) -> str:
-    """Return ``sequence`` adjusted so its GC content falls within bounds."""
-    if target_gc_min > target_gc_max:
-        msg = "target_gc_min cannot exceed target_gc_max"
-        raise ValueError(msg)
-
-    if rng is None:
-        rng = make_rng()
-    seq = list(sequence.upper())
-    length = len(seq)
-    gc_count = sum(1 for b in seq if b in {"G", "C"})
-    gc = gc_count / length if length else 0.0
-    while gc < target_gc_min:
-        idxs = [i for i, b in enumerate(seq) if b in {"A", "T"}]
-        if not idxs:
-            break
-        i = rng.choice(idxs)
-        seq[i] = rng.choice(["G", "C"])
-        gc_count += 1
-        gc = gc_count / length
-    while gc > target_gc_max:
-        idxs = [i for i, b in enumerate(seq) if b in {"G", "C"}]
-        if not idxs:
-            break
-        i = rng.choice(idxs)
-        seq[i] = rng.choice(["A", "T"])
-        gc_count -= 1
-        gc = gc_count / length
-    return "".join(seq)
+    report = fix_sequence_with_report(
+        sequence,
+        target_gc_min=target_gc_min,
+        target_gc_max=target_gc_max,
+        max_homopolymer=max(1, len(sequence) + 1),
+        strategy="stochastic",
+        rng=rng,
+    )
+    return report[0]
 
 
 def limit_homopolymers(
@@ -67,33 +76,52 @@ def limit_homopolymers(
     *,
     rng: random.Random | None = None,
 ) -> str:
-    """Return ``sequence`` with runs longer than ``max_len`` disrupted."""
-    if max_len < 1:
-        msg = "max_len must be at least 1"
-        raise ValueError(msg)
+    report = fix_sequence_with_report(
+        sequence,
+        target_gc_min=0.0,
+        target_gc_max=1.0,
+        max_homopolymer=max_len,
+        strategy="stochastic",
+        rng=rng,
+    )
+    return report[0]
 
-    if rng is None:
-        rng = make_rng()
-    seq = list(sequence.upper())
-    i = 0
-    while i < len(seq):
-        run_char = seq[i]
-        run_end = i + 1
-        while run_end < len(seq) and seq[run_end] == run_char:
-            run_end += 1
-        run_len = run_end - i
-        if run_len > max_len:
-            insert_pos = i + max_len
-            replacement = {
-                "A": ["C", "G"],
-                "T": ["A", "C"],
-                "G": ["A", "T"],
-                "C": ["G", "T"],
-            }[run_char]
-            seq[insert_pos] = rng.choice(replacement)
-            run_end = insert_pos + 1
-        i = run_end
-    return "".join(seq)
+
+def fix_sequence_with_report(
+    sequence: str,
+    *,
+    target_gc_min: float,
+    target_gc_max: float,
+    max_homopolymer: int,
+    strategy: str = "stochastic",
+    rng: random.Random | None = None,
+) -> tuple[str, dict[str, object]]:
+    if target_gc_min > target_gc_max:
+        raise ValueError("target_gc_min cannot exceed target_gc_max")
+    if max_homopolymer < 1:
+        raise ValueError("max_homopolymer must be at least 1")
+
+    plugin = StrategyPlugin(strategy)
+    engine = ConstraintEngine(_rule_set(target_gc_min, target_gc_max, max_homopolymer))
+    repair_strategy = plugin.build(rng=rng or make_rng())
+    after_report, repair_result = engine.repair(sequence.upper(), repair_strategy)
+    payload = {
+        "strategy": repair_result.strategy,
+        "reason": repair_result.reason,
+        "changes": [
+            {
+                "start": change.start,
+                "end": change.end,
+                "before": change.before,
+                "after": change.after,
+                "reason": change.reason,
+            }
+            for change in repair_result.changes
+        ],
+        "metadata": repair_result.metadata,
+        "remaining_violations": [v.rule_id for v in after_report.violations],
+    }
+    return repair_result.sequence_after, payload
 
 
 def fix_sequence(
@@ -104,24 +132,15 @@ def fix_sequence(
     max_homopolymer: int,
     rng: random.Random | None = None,
 ) -> str:
-    """Return ``sequence`` adjusted for GC content and homopolymers."""
-    if target_gc_min > target_gc_max:
-        msg = "target_gc_min cannot exceed target_gc_max"
-        raise ValueError(msg)
-    if max_homopolymer < 1:
-        msg = "max_homopolymer must be at least 1"
-        raise ValueError(msg)
-
-    if rng is None:
-        rng = make_rng()
-
-    seq = adjust_gc_balance(sequence, target_gc_min, target_gc_max, rng=rng)
-    seq = limit_homopolymers(seq, max_homopolymer, rng=rng)
-    # Breaking up long homopolymers can skew the GC ratio slightly. Run a final
-    # pass of GC balancing to ensure the sequence ends within the requested
-    # bounds.
-    seq = adjust_gc_balance(seq, target_gc_min, target_gc_max, rng=rng)
-    return seq
+    fixed, _report = fix_sequence_with_report(
+        sequence,
+        target_gc_min=target_gc_min,
+        target_gc_max=target_gc_max,
+        max_homopolymer=max_homopolymer,
+        strategy="stochastic",
+        rng=rng,
+    )
+    return fixed
 
 
 def fix(
@@ -132,12 +151,6 @@ def fix(
     max_homopolymer: int,
     rng: random.Random | None = None,
 ) -> str:
-    """Return ``sequence`` fixed for GC content and homopolymer limits.
-
-    This convenience wrapper uses shorter parameter names to integrate
-    smoothly with the main encoding pipeline.
-    """
-
     return fix_sequence(
         sequence,
         target_gc_min=gc_min,
@@ -154,17 +167,19 @@ def encode(
     gc_max: float,
     max_homopolymer: int,
     rng: random.Random | None = None,
-) -> tuple[str, dict[str, float]]:
-    """Return a fixed sequence along with GC and homopolymer metrics."""
-    fixed = fix_sequence(
+    strategy: str = "stochastic",
+) -> tuple[str, dict[str, object]]:
+    fixed, repair_report = fix_sequence_with_report(
         sequence,
         target_gc_min=gc_min,
         target_gc_max=gc_max,
         max_homopolymer=max_homopolymer,
+        strategy=strategy,
         rng=rng,
     )
-    metrics = {
+    metrics: dict[str, object] = {
         "gc_content": calculate_gc_content(fixed),
         "max_homopolymer": get_max_homopolymer_length(fixed),
+        "repair_report": repair_report,
     }
     return fixed, metrics

--- a/src/genecoder/constraints/__init__.py
+++ b/src/genecoder/constraints/__init__.py
@@ -1,0 +1,33 @@
+from .engine import ConstraintEngine
+from .report import ConstraintReport, ConstraintViolation, RepairResult
+from .rules import (
+    ConstraintRuleSet,
+    GcRangeRule,
+    HomopolymerMaxRule,
+    LengthRule,
+    MotifAllowRule,
+    MotifDenyRule,
+)
+from .solvers import DNAChiselSolverBackend
+from .strategies import (
+    DeterministicRepairStrategy,
+    ExternalSolverRepairStrategy,
+    StochasticRepairStrategy,
+)
+
+__all__ = [
+    "ConstraintEngine",
+    "ConstraintReport",
+    "ConstraintViolation",
+    "RepairResult",
+    "ConstraintRuleSet",
+    "GcRangeRule",
+    "HomopolymerMaxRule",
+    "LengthRule",
+    "MotifAllowRule",
+    "MotifDenyRule",
+    "DeterministicRepairStrategy",
+    "StochasticRepairStrategy",
+    "ExternalSolverRepairStrategy",
+    "DNAChiselSolverBackend",
+]

--- a/src/genecoder/constraints/engine.py
+++ b/src/genecoder/constraints/engine.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from .report import ConstraintReport, RepairResult
+from .rules import ConstraintRuleSet
+from .strategies import RepairStrategy
+
+
+@dataclass
+class ConstraintEngine:
+    rules: ConstraintRuleSet
+
+    def validate(self, sequence: str) -> ConstraintReport:
+        return ConstraintReport(sequence=sequence, violations=self.rules.validate(sequence))
+
+    def repair(self, sequence: str, strategy: RepairStrategy) -> tuple[ConstraintReport, RepairResult]:
+        repair_result = strategy.repair(sequence, self.rules)
+        report = self.validate(repair_result.sequence_after)
+        return report, repair_result
+
+    def as_manifest_report(self, sequence: str) -> dict[str, object]:
+        report = self.validate(sequence)
+        counts = Counter(v.rule_id for v in report.violations)
+        return {
+            "count": report.count,
+            "pressure": report.pressure,
+            "type_counts": dict(counts),
+            "violations": [
+                {
+                    "type": violation.rule_id,
+                    "message": violation.message,
+                    "severity": violation.severity,
+                    "location": (
+                        {"start": violation.location.start, "end": violation.location.end}
+                        if violation.location
+                        else None
+                    ),
+                    "details": violation.details,
+                }
+                for violation in report.violations
+            ],
+            "limits": self.rules.limits(),
+        }

--- a/src/genecoder/constraints/report.py
+++ b/src/genecoder/constraints/report.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Literal
+
+Severity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class ViolationLocation:
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ConstraintViolation:
+    rule_id: str
+    message: str
+    severity: Severity = "error"
+    location: ViolationLocation | None = None
+    details: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RepairChange:
+    start: int
+    end: int
+    before: str
+    after: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RepairResult:
+    strategy: str
+    sequence_before: str
+    sequence_after: str
+    changes: list[RepairChange]
+    reason: str
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConstraintReport:
+    sequence: str
+    violations: list[ConstraintViolation]
+
+    @property
+    def count(self) -> int:
+        return len(self.violations)
+
+    @property
+    def pressure(self) -> float:
+        if not self.sequence:
+            return float(self.count)
+        return self.count / len(self.sequence)
+
+
+def build_diff_changes(before: str, after: str, *, reason: str) -> list[RepairChange]:
+    matcher = SequenceMatcher(a=before, b=after)
+    changes: list[RepairChange] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        changes.append(
+            RepairChange(
+                start=i1,
+                end=i2,
+                before=before[i1:i2],
+                after=after[j1:j2],
+                reason=reason,
+            )
+        )
+    return changes

--- a/src/genecoder/constraints/rules.py
+++ b/src/genecoder/constraints/rules.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from genecoder.gc_constrained_encoder import calculate_gc_content
+from genecoder.utils import get_max_homopolymer_length
+
+from .report import ConstraintViolation, ViolationLocation
+
+
+class ConstraintRule:
+    rule_id: str
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class GcRangeRule(ConstraintRule):
+    gc_min: float
+    gc_max: float
+    rule_id: str = "gc_range"
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        if not sequence:
+            return []
+        gc = calculate_gc_content(sequence)
+        if self.gc_min <= gc <= self.gc_max:
+            return []
+        status = "below" if gc < self.gc_min else "above"
+        return [
+            ConstraintViolation(
+                rule_id=self.rule_id,
+                message=f"GC content {gc:.3f} is {status} allowed range [{self.gc_min:.3f}, {self.gc_max:.3f}]",
+                details={"gc_content": gc, "gc_min": self.gc_min, "gc_max": self.gc_max},
+            )
+        ]
+
+
+@dataclass(frozen=True)
+class HomopolymerMaxRule(ConstraintRule):
+    max_homopolymer: int
+    rule_id: str = "homopolymer_max"
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        run = get_max_homopolymer_length(sequence)
+        if run <= self.max_homopolymer:
+            return []
+        return [
+            ConstraintViolation(
+                rule_id=self.rule_id,
+                message=f"Maximum homopolymer run {run} exceeds {self.max_homopolymer}",
+                details={"max_observed": run, "max_allowed": self.max_homopolymer},
+            )
+        ]
+
+
+@dataclass(frozen=True)
+class LengthRule(ConstraintRule):
+    min_length: int
+    max_length: int
+    rule_id: str = "length"
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        length = len(sequence)
+        if self.min_length <= length <= self.max_length:
+            return []
+        status = "short" if length < self.min_length else "long"
+        return [
+            ConstraintViolation(
+                rule_id=self.rule_id,
+                message=f"Sequence length {length} is too {status}; allowed [{self.min_length}, {self.max_length}]",
+                details={"length": length, "min_length": self.min_length, "max_length": self.max_length},
+            )
+        ]
+
+
+@dataclass(frozen=True)
+class MotifDenyRule(ConstraintRule):
+    motifs: tuple[str, ...]
+    rule_id: str = "motif_deny"
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        seq = sequence.upper()
+        violations: list[ConstraintViolation] = []
+        for motif in self.motifs:
+            needle = motif.upper()
+            start = seq.find(needle)
+            while start != -1:
+                violations.append(
+                    ConstraintViolation(
+                        rule_id=self.rule_id,
+                        message=f"Denied motif '{needle}' found",
+                        location=ViolationLocation(start=start, end=start + len(needle)),
+                        details={"motif": needle},
+                    )
+                )
+                start = seq.find(needle, start + 1)
+        return violations
+
+
+@dataclass(frozen=True)
+class MotifAllowRule(ConstraintRule):
+    motifs: tuple[str, ...]
+    rule_id: str = "motif_allow"
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        if not self.motifs:
+            return []
+        seq = sequence.upper()
+        if any(motif.upper() in seq for motif in self.motifs):
+            return []
+        return [
+            ConstraintViolation(
+                rule_id=self.rule_id,
+                message="Sequence does not contain any required motifs",
+                details={"required_motifs": list(self.motifs)},
+            )
+        ]
+
+
+@dataclass
+class ConstraintRuleSet:
+    rules: list[ConstraintRule] = field(default_factory=list)
+
+    def validate(self, sequence: str) -> list[ConstraintViolation]:
+        violations: list[ConstraintViolation] = []
+        for rule in self.rules:
+            violations.extend(rule.validate(sequence))
+        return violations
+
+    def limits(self) -> dict[str, float | int | list[str]]:
+        details: dict[str, float | int | list[str]] = {}
+        for rule in self.rules:
+            if isinstance(rule, GcRangeRule):
+                details["gc_min"] = rule.gc_min
+                details["gc_max"] = rule.gc_max
+            elif isinstance(rule, HomopolymerMaxRule):
+                details["max_homopolymer"] = rule.max_homopolymer
+            elif isinstance(rule, LengthRule):
+                details["min_length"] = rule.min_length
+                details["max_length"] = rule.max_length
+            elif isinstance(rule, MotifDenyRule):
+                details["deny_motifs"] = list(rule.motifs)
+            elif isinstance(rule, MotifAllowRule):
+                details["allow_motifs"] = list(rule.motifs)
+        return details

--- a/src/genecoder/constraints/solvers.py
+++ b/src/genecoder/constraints/solvers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .report import RepairResult, build_diff_changes
+from .rules import ConstraintRuleSet, GcRangeRule, HomopolymerMaxRule, MotifDenyRule
+
+try:  # optional dependency
+    from dnachisel import AvoidPattern, DnaOptimizationProblem, EnforceGCContent
+except Exception:  # pragma: no cover
+    AvoidPattern = None
+    DnaOptimizationProblem = None
+    EnforceGCContent = None
+
+
+@dataclass
+class DNAChiselSolverBackend:
+    name: str = "dnachisel"
+
+    def solve(self, sequence: str, rules: ConstraintRuleSet, *, strategy_name: str) -> RepairResult:
+        if DnaOptimizationProblem is None:
+            raise ImportError("dnachisel is required for DNAChiselSolverBackend")
+
+        constraints = []
+        for rule in rules.rules:
+            if isinstance(rule, GcRangeRule):
+                constraints.append(EnforceGCContent(mini=rule.gc_min, maxi=rule.gc_max))
+            elif isinstance(rule, HomopolymerMaxRule):
+                for base in "ATGC":
+                    constraints.append(AvoidPattern(base * (rule.max_homopolymer + 1)))
+            elif isinstance(rule, MotifDenyRule):
+                for motif in rule.motifs:
+                    constraints.append(AvoidPattern(motif))
+
+        before = sequence.upper()
+        problem = DnaOptimizationProblem(sequence=before, constraints=constraints, logger=None)
+        problem.resolve_constraints()
+        after = str(problem.sequence)
+        changes = build_diff_changes(before, after, reason="dnachisel_solver")
+        return RepairResult(
+            strategy=strategy_name,
+            sequence_before=before,
+            sequence_after=after,
+            changes=changes,
+            reason="Solved constraints via DNAChisel backend",
+            metadata={"backend": self.name},
+        )

--- a/src/genecoder/constraints/strategies.py
+++ b/src/genecoder/constraints/strategies.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Protocol
+
+from genecoder.random_utils import make_rng
+
+from .report import RepairResult, build_diff_changes
+from .rules import ConstraintRuleSet, GcRangeRule, HomopolymerMaxRule
+
+
+class RepairStrategy(Protocol):
+    name: str
+
+    def repair(self, sequence: str, rules: ConstraintRuleSet) -> RepairResult:
+        ...
+
+
+@dataclass
+class DeterministicRepairStrategy:
+    name: str = "deterministic"
+
+    def repair(self, sequence: str, rules: ConstraintRuleSet) -> RepairResult:
+        seq = sequence.upper()
+        before = seq
+        for rule in rules.rules:
+            if isinstance(rule, HomopolymerMaxRule):
+                seq = _limit_homopolymers(seq, rule.max_homopolymer)
+            elif isinstance(rule, GcRangeRule):
+                seq = _adjust_gc(seq, rule.gc_min, rule.gc_max, rng=random.Random(0))
+        changes = build_diff_changes(before, seq, reason="deterministic_rule_pass")
+        return RepairResult(
+            strategy=self.name,
+            sequence_before=before,
+            sequence_after=seq,
+            changes=changes,
+            reason="Applied deterministic constraint repair",
+        )
+
+
+@dataclass
+class StochasticRepairStrategy:
+    rng: random.Random | None = None
+    name: str = "stochastic"
+
+    def repair(self, sequence: str, rules: ConstraintRuleSet) -> RepairResult:
+        seq = sequence.upper()
+        before = seq
+        rng = self.rng or make_rng()
+        for rule in rules.rules:
+            if isinstance(rule, GcRangeRule):
+                seq = _adjust_gc(seq, rule.gc_min, rule.gc_max, rng=rng)
+            elif isinstance(rule, HomopolymerMaxRule):
+                seq = _limit_homopolymers(seq, rule.max_homopolymer, rng=rng)
+        changes = build_diff_changes(before, seq, reason="stochastic_rule_pass")
+        return RepairResult(
+            strategy=self.name,
+            sequence_before=before,
+            sequence_after=seq,
+            changes=changes,
+            reason="Applied stochastic constraint repair",
+        )
+
+
+@dataclass
+class ExternalSolverRepairStrategy:
+    solver_backend: "SolverBackend"
+    name: str = "external_solver"
+
+    def repair(self, sequence: str, rules: ConstraintRuleSet) -> RepairResult:
+        return self.solver_backend.solve(sequence, rules, strategy_name=self.name)
+
+
+class SolverBackend(Protocol):
+    def solve(self, sequence: str, rules: ConstraintRuleSet, *, strategy_name: str) -> RepairResult:
+        ...
+
+
+def _adjust_gc(sequence: str, gc_min: float, gc_max: float, *, rng: random.Random) -> str:
+    if gc_min > gc_max:
+        raise ValueError("gc_min cannot exceed gc_max")
+    seq = list(sequence)
+    length = len(seq)
+    if length == 0:
+        return ""
+    gc_count = sum(1 for b in seq if b in {"G", "C"})
+    gc = gc_count / length
+    while gc < gc_min:
+        idxs = [i for i, b in enumerate(seq) if b in {"A", "T"}]
+        if not idxs:
+            break
+        i = rng.choice(idxs)
+        seq[i] = rng.choice(["G", "C"])
+        gc_count += 1
+        gc = gc_count / length
+    while gc > gc_max:
+        idxs = [i for i, b in enumerate(seq) if b in {"G", "C"}]
+        if not idxs:
+            break
+        i = rng.choice(idxs)
+        seq[i] = rng.choice(["A", "T"])
+        gc_count -= 1
+        gc = gc_count / length
+    return "".join(seq)
+
+
+def _limit_homopolymers(sequence: str, max_len: int, *, rng: random.Random | None = None) -> str:
+    if max_len < 1:
+        raise ValueError("max_len must be at least 1")
+    effective_rng = rng or random.Random(0)
+    seq = list(sequence)
+    i = 0
+    while i < len(seq):
+        run_char = seq[i]
+        run_end = i + 1
+        while run_end < len(seq) and seq[run_end] == run_char:
+            run_end += 1
+        run_len = run_end - i
+        if run_len > max_len:
+            insert_pos = i + max_len
+            replacement = {
+                "A": ["C", "G"],
+                "T": ["A", "C"],
+                "G": ["A", "T"],
+                "C": ["G", "T"],
+            }[run_char]
+            seq[insert_pos] = effective_rng.choice(replacement)
+            run_end = insert_pos + 1
+        i = run_end
+    return "".join(seq)

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -524,16 +524,10 @@ def metrics(
     success = 1.0 if decoded == original_data else 0.0
     constraint_violations: Dict[str, Any]
     try:
-        from .synthesis import SynthesisConstraints, validate_sequence
+        from .synthesis import SynthesisConstraints
 
         constraint_limits = constraints if constraints is not None else SynthesisConstraints()
-        constraint_limits_info = {
-            "min_length": constraint_limits.min_length,
-            "max_length": constraint_limits.max_length,
-            "max_homopolymer": constraint_limits.max_homopolymer,
-            "gc_min": constraint_limits.gc_min,
-            "gc_max": constraint_limits.gc_max,
-        }
+        engine = constraint_limits.to_engine()
         violation_records: list[dict[str, Any]] = []
         type_counts: Counter[str] = Counter()
 
@@ -561,55 +555,48 @@ def metrics(
                 target_oligos.append((idx, sequence, info))
 
         for idx, sequence, info in target_oligos:
-            try:
-                is_valid = validate_sequence(sequence, constraint_limits)
-            except Exception:
+            report = engine.validate(sequence)
+            if report.count == 0:
                 continue
-            if is_valid:
-                continue
+            for violation in report.violations:
+                violation_type = violation.rule_id
+                if violation.rule_id == "gc_range":
+                    gc_value = float(violation.details.get("gc_content", 0.0))
+                    gc_min = float(violation.details.get("gc_min", 0.0))
+                    gc_max = float(violation.details.get("gc_max", 1.0))
+                    if gc_value < gc_min:
+                        violation_type = "gc_low"
+                    elif gc_value > gc_max:
+                        violation_type = "gc_high"
+                type_counts[violation_type] += 1
+                record: dict[str, Any] = {
+                    "sequence_id": info.get("sequence_id", f"oligo-{idx}"),
+                    "index": idx,
+                    "length": len(sequence),
+                    "type": violation_type,
+                    "constraint": violation.rule_id,
+                    "message": violation.message,
+                    "severity": violation.severity,
+                    "details": violation.details,
+                }
+                if violation.location is not None:
+                    record["location"] = {
+                        "start": violation.location.start,
+                        "end": violation.location.end,
+                    }
+                if info.get("oligo_id"):
+                    record["oligo_id"] = info["oligo_id"]
+                if info.get("oligo_index") is not None:
+                    record["oligo_index"] = info["oligo_index"]
+                violation_records.append(record)
 
-            reasons: list[str] = []
-            length = len(sequence)
-            if length < constraint_limits.min_length:
-                reasons.append("length_short")
-            elif length > constraint_limits.max_length:
-                reasons.append("length_long")
-
-            homopolymer = get_max_homopolymer_length(sequence)
-            if homopolymer > constraint_limits.max_homopolymer:
-                reasons.append("homopolymer")
-
-            gc_fraction = calculate_gc_content(sequence) if sequence else 0.0
-            if gc_fraction < constraint_limits.gc_min:
-                reasons.append("gc_low")
-            elif gc_fraction > constraint_limits.gc_max:
-                reasons.append("gc_high")
-
-            if not reasons:
-                reasons.append("unknown")
-
-            for name in reasons:
-                type_counts[name] += 1
-
-            record: dict[str, Any] = {
-                "sequence_id": info.get("sequence_id", f"oligo-{idx}"),
-                "index": idx,
-                "length": length,
-                "type": reasons[0],
-            }
-            if len(reasons) > 1:
-                record["types"] = reasons
-            if info.get("oligo_id"):
-                record["oligo_id"] = info["oligo_id"]
-            if info.get("oligo_index") is not None:
-                record["oligo_index"] = info["oligo_index"]
-            violation_records.append(record)
-
+        opportunities = max(1, sum(len(sequence) for _, sequence, _ in target_oligos))
         constraint_violations = {
             "count": len(violation_records),
+            "pressure": len(violation_records) / opportunities,
             "violations": violation_records,
             "type_counts": dict(type_counts),
-            "limits": constraint_limits_info,
+            "limits": engine.rules.limits(),
         }
     except Exception:  # pragma: no cover - optional dependency
         constraint_violations = {

--- a/src/genecoder/dnachisel_fixer.py
+++ b/src/genecoder/dnachisel_fixer.py
@@ -1,18 +1,12 @@
-"""Constraint fixer powered by DNA Chisel."""
+"""Constraint fixer backed by the pluggable solver engine."""
 # ruff: noqa: ANN401
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
-try:  # optional dependency
-    from dnachisel import DnaOptimizationProblem, EnforceGCContent, AvoidPattern
-except Exception:  # pragma: no cover - optional dependency missing
-    DnaOptimizationProblem = None
-    EnforceGCContent = None
-    AvoidPattern = None
-
 from .api import Codec
+from .constraint_fixer import fix_sequence_with_report
 
 __all__ = ["fix_sequence_dnachisel", "register"]
 
@@ -24,33 +18,23 @@ def fix_sequence_dnachisel(
     gc_max: float,
     max_homopolymer: int,
 ) -> str:
-    """Return ``sequence`` fixed for GC and homopolymers using DNA Chisel."""
-    if DnaOptimizationProblem is None:
-        raise ImportError("dnachisel is required for fix_sequence_dnachisel")
-    constraints = [EnforceGCContent(mini=gc_min, maxi=gc_max)]
-    if max_homopolymer >= 1:
-        for base in "ATGC":
-            constraints.append(AvoidPattern(base * (max_homopolymer + 1)))
-    problem = DnaOptimizationProblem(
-        sequence=sequence.upper(),
-        constraints=constraints,
-        logger=None,
+    fixed, _report = fix_sequence_with_report(
+        sequence,
+        target_gc_min=gc_min,
+        target_gc_max=gc_max,
+        max_homopolymer=max_homopolymer,
+        strategy="external_solver",
     )
-    problem.resolve_constraints()
-    return str(problem.sequence)
+    return fixed
 
 
 class _DummyCodec(Codec):
-    """Minimal codec used only for plugin registration."""
-
-    def encode(self, data: bytes, /, **kwargs: Any) -> str:  # pragma: no cover - unused
+    def encode(self, data: bytes, /, **kwargs: Any) -> str:  # pragma: no cover
         return ""
 
-    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:  # pragma: no cover - unused
+    def decode(self, encoded: str, /, **kwargs: Any) -> bytes:  # pragma: no cover
         return b""
 
 
 def register(register_codec: Callable[[str, type[Codec]], None]) -> None:
-    """Register this module's dummy codec with ``register_codec``."""
-
     register_codec("dnachisel_fixer", _DummyCodec)

--- a/src/genecoder/synthesis.py
+++ b/src/genecoder/synthesis.py
@@ -4,18 +4,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .utils import get_max_homopolymer_length
+from .constraints import (
+    ConstraintEngine,
+    ConstraintRuleSet,
+    GcRangeRule,
+    HomopolymerMaxRule,
+    LengthRule,
+    MotifAllowRule,
+    MotifDenyRule,
+)
 
 
 @dataclass
 class SynthesisConstraints:
-    """Simple synthesis constraints."""
+    """Synthesis constraints represented as a reusable rule set."""
 
     min_length: int = 25
     max_length: int = 300
     max_homopolymer: int = 3
     gc_min: float = 0.45
     gc_max: float = 0.55
+    deny_motifs: tuple[str, ...] = ()
+    allow_motifs: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.min_length <= 0:
@@ -31,20 +41,24 @@ class SynthesisConstraints:
         if self.gc_min > self.gc_max:
             raise ValueError("gc_min cannot be greater than gc_max")
 
+    def to_rule_set(self) -> ConstraintRuleSet:
+        rules = [
+            LengthRule(min_length=self.min_length, max_length=self.max_length),
+            HomopolymerMaxRule(max_homopolymer=self.max_homopolymer),
+            GcRangeRule(gc_min=self.gc_min, gc_max=self.gc_max),
+        ]
+        if self.deny_motifs:
+            rules.append(MotifDenyRule(motifs=tuple(self.deny_motifs)))
+        if self.allow_motifs:
+            rules.append(MotifAllowRule(motifs=tuple(self.allow_motifs)))
+        return ConstraintRuleSet(rules=rules)
+
+    def to_engine(self) -> ConstraintEngine:
+        return ConstraintEngine(self.to_rule_set())
+
 
 def validate_sequence(seq: str, constraints: SynthesisConstraints | None = None) -> bool:
-    """Return ``True`` if ``seq`` satisfies ``constraints``."""
-
     if constraints is None:
         constraints = SynthesisConstraints()
-
-    length = len(seq)
-    if length < constraints.min_length or length > constraints.max_length:
-        return False
-    if get_max_homopolymer_length(seq) > constraints.max_homopolymer:
-        return False
-    seq_upper = seq.upper()
-    gc_content = (seq_upper.count("G") + seq_upper.count("C")) / length if length else 0.0
-    if gc_content < constraints.gc_min or gc_content > constraints.gc_max:
-        return False
-    return True
+    report = constraints.to_engine().validate(seq)
+    return report.count == 0

--- a/tests/test_constraint_fixer.py
+++ b/tests/test_constraint_fixer.py
@@ -2,7 +2,13 @@ import random
 
 import pytest
 
-from genecoder.constraint_fixer import adjust_gc_balance, limit_homopolymers, fix_sequence
+from genecoder.constraint_fixer import (
+    adjust_gc_balance,
+    encode,
+    fix_sequence,
+    fix_sequence_with_report,
+    limit_homopolymers,
+)
 from genecoder.gc_constrained_encoder import calculate_gc_content
 from genecoder.random_utils import reset_rng
 from genecoder.utils import get_max_homopolymer_length
@@ -125,3 +131,34 @@ def test_fix_sequence_invalid_parameters() -> None:
     with pytest.raises(ValueError):
         fix_sequence("AT", target_gc_min=0.4, target_gc_max=0.6, max_homopolymer=0)
 
+
+
+def test_encode_reports_repair_diff_metadata() -> None:
+    seq = "A" * 12
+    fixed, metrics = encode(
+        seq,
+        gc_min=0.4,
+        gc_max=0.6,
+        max_homopolymer=3,
+        rng=random.Random(0),
+    )
+    assert fixed != seq
+    repair = metrics.get("repair_report")
+    assert isinstance(repair, dict)
+    assert repair.get("strategy") == "stochastic"
+    changes = repair.get("changes")
+    assert isinstance(changes, list)
+    assert changes
+
+
+def test_fix_sequence_with_report_deterministic_strategy() -> None:
+    fixed, report = fix_sequence_with_report(
+        "AAAAAA",
+        target_gc_min=0.4,
+        target_gc_max=0.6,
+        max_homopolymer=2,
+        strategy="deterministic",
+    )
+    assert 0.4 <= calculate_gc_content(fixed) <= 0.6
+    assert get_max_homopolymer_length(fixed) <= 2
+    assert report["strategy"] == "deterministic"


### PR DESCRIPTION
### Motivation
- Centralize synthesis constraint logic into a reusable rule engine so validation and repair share a single canonical model.  
- Make repair strategies pluggable and auditable by requiring repair plugins to report diffs and rationale.  
- Treat DNAChisel as an optional solver backend rather than a standalone fixer and normalize its outputs.  
- Surface normalized constraint metrics (including a `pressure` signal) in manifests for easier preset comparison.

### Description
- Added a new `genecoder.constraints` package with rule definitions (`GcRangeRule`, `HomopolymerMaxRule`, `LengthRule`, `MotifAllowRule`, `MotifDenyRule`), an engine (`ConstraintEngine`), solvers (`DNAChiselSolverBackend`) and repair strategies (`deterministic`, `stochastic`, `external_solver`), plus a structured report model (`ConstraintViolation`, `RepairResult`, `RepairChange`).  
- Refactored `SynthesisConstraints` to produce a `ConstraintRuleSet` and `ConstraintEngine` via `to_rule_set()` / `to_engine()` and updated `validate_sequence` to use the engine.  
- Reworked `constraint_fixer.py` into a strategy-driven API, added `fix_sequence_with_report` that returns before/after sequence and a repair payload containing per-change diffs and metadata, and retained convenience functions (`fix`, `encode`, `adjust_gc_balance`, `limit_homopolymers`) atop the new engine.  
- Converted `dnachisel_fixer` to call the shared repair pipeline using the `external_solver` strategy (DNA Chisel is optional), and changed the CLI encode flow to select a strategy (with fallback) and include `constraint_report` and `constraint_repair_report` in encoding metrics/manifest.  
- Routed encode-time constraint aggregation in `core.gather_metrics` through the new engine and produce normalized violation payloads (including `pressure`, `type_counts`, per-violation details and optional `location`).

### Testing
- Ran style checks with `ruff check` on changed modules; all checks passed.  
- Executed the focused test set with `pytest -q tests/test_constraint_fixer.py tests/test_synthesis.py tests/test_dnachisel_fixer.py tests/test_core_pipeline.py::test_metrics_constraint_violations_per_oligo`; result: all tests passed in this run (27 passed, 2 skipped for optional dependencies in the environment).  
- Also ran `pytest` locally on the modified tests and observed the new repair-report tests passing; DNAChisel-related tests are skipped when `dnachisel` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb35395b8832684639a3e98874575)