### PR TITLE
Add versioned run schema with translators and canonical visualizer loaders

### DIFF
--- a/src/genecoder/bundle_metrics.py
+++ b/src/genecoder/bundle_metrics.py
@@ -1,6 +1,7 @@
-import json
 from pathlib import Path
 from typing import Any, Iterable
+
+from .results.schema import canonical_to_legacy_metrics, load_run_schema
 
 
 def _extract_violation_count(value: object) -> int:
@@ -35,11 +36,12 @@ def parse_manifests(root: Path) -> Iterable[dict[str, Any]]:
     """
     for path in root.rglob("*.manifest.json"):
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            run_schema = load_run_schema(path)
+            data = canonical_to_legacy_metrics(run_schema)
         except Exception:
             continue
         if isinstance(data, dict):
-            yield data
+            yield {"metrics": data}
 
 
 def aggregate_metrics(root: Path) -> dict[str, Any]:

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -9,11 +9,12 @@ across multiple datasets.
 """
 
 from pathlib import Path
-import json
 import sys
 import math
 from typing import Any, Iterable, IO, cast
 from types import ModuleType
+
+from .results.schema import canonical_to_legacy_metrics, load_run_schema
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st
@@ -64,16 +65,8 @@ def _iterable(val: Iterable[str] | str | None) -> list[str]:
 
 def _load_metrics(src: str | Path | IO[str]) -> dict[str, Any]:
     try:
-        if hasattr(src, "read"):
-            data = json.load(src)
-        else:
-            with open(src, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        if isinstance(data, dict):
-            metrics = data.get("metrics")
-            if isinstance(metrics, dict):
-                return metrics
-            return data
+        run_schema = load_run_schema(src)
+        return canonical_to_legacy_metrics(run_schema)
     except Exception:  # pragma: no cover - surfaced in UI
         pass
     return {}

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """Simple HTML summary generation for manifest metrics."""
 
 from html import escape
-import json
 from typing import Any
 
 from .bool_parsing import parse_bool_like
+from .results.schema import canonical_to_legacy_metrics, load_run_schema
 
 __all__ = ["generate_html_report"]
 
@@ -105,10 +105,8 @@ def _render_oligo_section(metrics: dict[str, Any], html_lines: list[str]) -> Non
 
 def generate_html_report(manifest_path: str) -> str:
     """Return HTML summary for the manifest at ``manifest_path``."""
-    with open(manifest_path, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-
-    metrics = data.get("metrics", data)
+    run_schema = load_run_schema(manifest_path)
+    metrics = canonical_to_legacy_metrics(run_schema)
     html_lines: list[str] = ["<html>", "<body>", "<h1>GeneCoder Summary Report</h1>"]
 
     gc_content = metrics.get("gc_content")

--- a/src/genecoder/results/__init__.py
+++ b/src/genecoder/results/__init__.py
@@ -1,0 +1,21 @@
+from .schema import (
+    RUN_SCHEMA_VERSION,
+    canonical_to_legacy_metrics,
+    compare_runs,
+    load_run_schema,
+    migrate_run_schema,
+    translate_bundle_metrics,
+    translate_decode_summary,
+    translate_manifest,
+)
+
+__all__ = [
+    "RUN_SCHEMA_VERSION",
+    "canonical_to_legacy_metrics",
+    "compare_runs",
+    "load_run_schema",
+    "migrate_run_schema",
+    "translate_bundle_metrics",
+    "translate_decode_summary",
+    "translate_manifest",
+]

--- a/src/genecoder/results/schema.py
+++ b/src/genecoder/results/schema.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import IO, Any, Mapping
+
+RUN_SCHEMA_VERSION = "1.0"
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _coerce_success(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value) > 0
+    return None
+
+
+def _decode_success_rate(metrics: Mapping[str, Any]) -> float | None:
+    explicit = _as_float(metrics.get("decode_success_rate"))
+    if explicit is not None:
+        return explicit
+    ecc = metrics.get("ecc_success_rates")
+    if not isinstance(ecc, Mapping) or not ecc:
+        return None
+    values: list[float] = []
+    for value in ecc.values():
+        as_float = _as_float(value)
+        if as_float is not None:
+            values.append(as_float)
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _normalize_runtime(runtime: Mapping[str, Any] | None) -> dict[str, float | None]:
+    if not isinstance(runtime, Mapping):
+        return {
+            "total_seconds": None,
+            "encode_seconds": None,
+            "simulate_seconds": None,
+            "decode_seconds": None,
+        }
+    return {
+        "total_seconds": _as_float(runtime.get("total_seconds")),
+        "encode_seconds": _as_float(runtime.get("encode_seconds")),
+        "simulate_seconds": _as_float(runtime.get("simulate_seconds")),
+        "decode_seconds": _as_float(runtime.get("decode_seconds")),
+    }
+
+
+def translate_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    metrics = manifest.get("metrics") if isinstance(manifest.get("metrics"), Mapping) else manifest
+    metrics = dict(metrics) if isinstance(metrics, Mapping) else {}
+    encoding_params = manifest.get("encoding_parameters")
+    if not isinstance(encoding_params, Mapping):
+        encoding_params = {}
+    channel = metrics.get("channel")
+    if not isinstance(channel, Mapping):
+        channel = {}
+
+    decode_success_rate = _decode_success_rate(metrics)
+    decode_success = _coerce_success(metrics.get("decode_success"))
+    if decode_success is None and decode_success_rate is not None:
+        decode_success = decode_success_rate >= 1.0
+
+    return {
+        "schema_version": RUN_SCHEMA_VERSION,
+        "source_format": "manifest",
+        "run_id": str(manifest.get("file") or manifest.get("run_id") or "run"),
+        "profiles": {
+            "encoding": encoding_params.get("method"),
+            "simulation": channel.get("name"),
+            "decode": metrics.get("decoder") or metrics.get("decode_method"),
+        },
+        "seeds": {
+            "global": metrics.get("seed"),
+            "encode": metrics.get("encode_seed"),
+            "simulate": metrics.get("simulate_seed") or metrics.get("sequence_batch", {}).get("seed") if isinstance(metrics.get("sequence_batch"), Mapping) else None,
+            "decode": metrics.get("decode_seed"),
+        },
+        "runtime": _normalize_runtime(metrics.get("runtime") if isinstance(metrics.get("runtime"), Mapping) else None),
+        "stages": {
+            "encode": {
+                "parameters": dict(encoding_params),
+                "metrics": {
+                    "original_size": metrics.get("original_size"),
+                    "dna_length": metrics.get("dna_length"),
+                    "bits_per_nt": metrics.get("bits_per_nt"),
+                    "gc_content": metrics.get("gc_content"),
+                    "gc_variance": metrics.get("gc_variance"),
+                    "max_homopolymer": metrics.get("max_homopolymer"),
+                },
+            },
+            "simulate": {
+                "profile": channel.get("name"),
+                "metrics": {
+                    "dropout_count": metrics.get("dropout_count") or (channel.get("dropout", {}).get("count") if isinstance(channel.get("dropout"), Mapping) else None),
+                    "dropout_fraction": metrics.get("dropout_fraction") or (channel.get("dropout", {}).get("fraction") if isinstance(channel.get("dropout"), Mapping) else None),
+                    "coverage": metrics.get("coverage"),
+                    "substitutions": metrics.get("substitutions"),
+                    "insertions": metrics.get("insertions"),
+                    "deletions": metrics.get("deletions"),
+                },
+            },
+            "decode": {
+                "metrics": {
+                    "decode_success": decode_success,
+                    "decode_success_rate": decode_success_rate,
+                    "ber": metrics.get("ber"),
+                    "throughput": metrics.get("throughput"),
+                    "ecc_success_rates": metrics.get("ecc_success_rates"),
+                }
+            },
+        },
+        "outcome": {
+            "ber": _as_float(metrics.get("ber")),
+            "throughput": _as_float(metrics.get("throughput")),
+            "dropout_rate": _as_float(metrics.get("dropout_fraction"))
+            or _as_float(metrics.get("dropout_rate"))
+            or _as_float(channel.get("dropout", {}).get("fraction") if isinstance(channel.get("dropout"), Mapping) else None),
+            "gc_stress": _as_float(metrics.get("gc_variance")),
+            "homopolymer_stress": _as_float(metrics.get("max_homopolymer")),
+            "decode_success": decode_success,
+            "decode_success_rate": decode_success_rate,
+            "metrics": dict(metrics),
+        },
+    }
+
+
+def translate_bundle_metrics(bundle_metrics: Mapping[str, Any], *, run_id: str = "bundle") -> dict[str, Any]:
+    data = dict(bundle_metrics)
+    throughput = _as_float(data.get("throughput"))
+    if throughput is None:
+        total_nt = _as_float(data.get("total_dna_length")) or 0.0
+        total_cov = _as_float(data.get("total_coverage")) or 0.0
+        throughput = total_nt if total_cov <= 0 else total_nt / total_cov
+
+    return {
+        "schema_version": RUN_SCHEMA_VERSION,
+        "source_format": "bundle_metrics",
+        "run_id": run_id,
+        "profiles": {"encoding": None, "simulation": None, "decode": None},
+        "seeds": {"global": None, "encode": None, "simulate": None, "decode": None},
+        "runtime": _normalize_runtime(None),
+        "stages": {
+            "encode": {"metrics": {"files": data.get("files"), "total_original_size": data.get("total_original_size"), "total_dna_length": data.get("total_dna_length"), "avg_bits_per_nt": data.get("avg_bits_per_nt")}},
+            "simulate": {"metrics": {"total_substitutions": data.get("total_substitutions"), "total_insertions": data.get("total_insertions"), "total_deletions": data.get("total_deletions"), "total_coverage": data.get("total_coverage"), "total_constraint_violations": data.get("total_constraint_violations")}},
+            "decode": {"metrics": {}},
+        },
+        "outcome": {
+            "ber": _as_float(data.get("ber")),
+            "throughput": throughput,
+            "dropout_rate": _as_float(data.get("dropout_rate")),
+            "gc_stress": _as_float(data.get("gc_stress")),
+            "homopolymer_stress": _as_float(data.get("homopolymer_stress")),
+            "decode_success": _coerce_success(data.get("decode_success")),
+            "decode_success_rate": _as_float(data.get("decode_success_rate")),
+            "metrics": data,
+        },
+    }
+
+
+def translate_decode_summary(summary: Mapping[str, Any], *, run_id: str = "decode") -> dict[str, Any]:
+    data = dict(summary)
+    decode_success_rate = _as_float(data.get("decode_success_rate"))
+    decode_success = _coerce_success(data.get("decode_success"))
+    if decode_success is None and decode_success_rate is not None:
+        decode_success = decode_success_rate >= 1.0
+
+    return {
+        "schema_version": RUN_SCHEMA_VERSION,
+        "source_format": "decode_summary",
+        "run_id": run_id,
+        "profiles": {
+            "encoding": data.get("encoding_profile"),
+            "simulation": data.get("simulation_profile"),
+            "decode": data.get("decode_profile") or data.get("decoder"),
+        },
+        "seeds": {
+            "global": data.get("seed"),
+            "encode": data.get("encode_seed"),
+            "simulate": data.get("simulate_seed"),
+            "decode": data.get("decode_seed"),
+        },
+        "runtime": _normalize_runtime(data.get("runtime") if isinstance(data.get("runtime"), Mapping) else None),
+        "stages": {
+            "encode": {"metrics": {}},
+            "simulate": {"metrics": {"dropout_count": data.get("dropout_count"), "dropout_fraction": data.get("dropout_fraction")}},
+            "decode": {"metrics": dict(data)},
+        },
+        "outcome": {
+            "ber": _as_float(data.get("ber")),
+            "throughput": _as_float(data.get("throughput")),
+            "dropout_rate": _as_float(data.get("dropout_fraction")) or _as_float(data.get("dropout_rate")),
+            "gc_stress": _as_float(data.get("gc_stress")) or _as_float(data.get("gc_variance")),
+            "homopolymer_stress": _as_float(data.get("homopolymer_stress")) or _as_float(data.get("max_homopolymer")),
+            "decode_success": decode_success,
+            "decode_success_rate": decode_success_rate,
+            "metrics": dict(data),
+        },
+    }
+
+
+def migrate_run_schema(run_data: Mapping[str, Any], target_version: str = RUN_SCHEMA_VERSION) -> dict[str, Any]:
+    data = copy.deepcopy(dict(run_data))
+    current = data.get("schema_version")
+    if current == target_version:
+        return data
+
+    if current in {None, "", 1, "1", "1.0"}:
+        # v1 migration is mostly shape normalization.
+        if "outcome" not in data or not isinstance(data.get("outcome"), Mapping):
+            data = translate_manifest(data)
+        data["schema_version"] = RUN_SCHEMA_VERSION
+        return data
+
+    # Unknown future version: keep payload but mark requested target.
+    data["schema_version"] = target_version
+    return data
+
+
+def load_run_schema(src: str | Path | IO[str] | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(src, Mapping):
+        raw: dict[str, Any] = dict(src)
+    elif hasattr(src, "read"):
+        raw = json.load(src)
+    else:
+        with open(src, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+
+    if not isinstance(raw, Mapping):
+        return translate_manifest({})
+    data = dict(raw)
+
+    if data.get("schema_version"):
+        return migrate_run_schema(data)
+    if isinstance(data.get("metrics"), Mapping) or "encoding_parameters" in data:
+        return translate_manifest(data)
+    if "total_original_size" in data and "files" in data:
+        return translate_bundle_metrics(data)
+    return translate_decode_summary(data)
+
+
+def canonical_to_legacy_metrics(run_data: Mapping[str, Any]) -> dict[str, Any]:
+    run = migrate_run_schema(run_data)
+    outcome = run.get("outcome") if isinstance(run.get("outcome"), Mapping) else {}
+    embedded_metrics = outcome.get("metrics") if isinstance(outcome, Mapping) and isinstance(outcome.get("metrics"), Mapping) else {}
+    metrics: dict[str, Any] = dict(embedded_metrics)
+
+    if "decode_success_rate" not in metrics and isinstance(outcome, Mapping):
+        metrics["decode_success_rate"] = outcome.get("decode_success_rate")
+    if "decode_success" not in metrics and isinstance(outcome, Mapping):
+        metrics["decode_success"] = outcome.get("decode_success")
+    if "throughput" not in metrics and isinstance(outcome, Mapping):
+        metrics["throughput"] = outcome.get("throughput")
+    if "ber" not in metrics and isinstance(outcome, Mapping):
+        metrics["ber"] = outcome.get("ber")
+    if "dropout_fraction" not in metrics and isinstance(outcome, Mapping):
+        metrics["dropout_fraction"] = outcome.get("dropout_rate")
+    if "gc_variance" not in metrics and isinstance(outcome, Mapping):
+        metrics["gc_variance"] = outcome.get("gc_stress")
+    if "max_homopolymer" not in metrics and isinstance(outcome, Mapping):
+        metrics["max_homopolymer"] = outcome.get("homopolymer_stress")
+
+    return metrics
+
+
+def _comparison_slice(run_data: Mapping[str, Any]) -> dict[str, float | bool | None]:
+    outcome = run_data.get("outcome") if isinstance(run_data.get("outcome"), Mapping) else {}
+    return {
+        "ber": _as_float(outcome.get("ber")) if isinstance(outcome, Mapping) else None,
+        "throughput": _as_float(outcome.get("throughput")) if isinstance(outcome, Mapping) else None,
+        "dropout_rate": _as_float(outcome.get("dropout_rate")) if isinstance(outcome, Mapping) else None,
+        "gc_stress": _as_float(outcome.get("gc_stress")) if isinstance(outcome, Mapping) else None,
+        "homopolymer_stress": _as_float(outcome.get("homopolymer_stress")) if isinstance(outcome, Mapping) else None,
+        "decode_success": _coerce_success(outcome.get("decode_success")) if isinstance(outcome, Mapping) else None,
+    }
+
+
+def _metric_delta(base: float | None, candidate: float | None) -> dict[str, float | None]:
+    if base is None or candidate is None:
+        return {"base": base, "candidate": candidate, "absolute": None, "relative": None}
+    absolute = candidate - base
+    relative = None if base == 0 else absolute / base
+    return {"base": base, "candidate": candidate, "absolute": absolute, "relative": relative}
+
+
+def compare_runs(run_a: Mapping[str, Any], run_b: Mapping[str, Any], *other_runs: Mapping[str, Any]) -> dict[str, Any]:
+    baseline = migrate_run_schema(run_a)
+    candidates = [migrate_run_schema(run_b)] + [migrate_run_schema(item) for item in other_runs]
+
+    baseline_metrics = _comparison_slice(baseline)
+    comparisons: list[dict[str, Any]] = []
+    for candidate in candidates:
+        candidate_metrics = _comparison_slice(candidate)
+        comparisons.append(
+            {
+                "run_id": candidate.get("run_id"),
+                "metrics": {
+                    "ber": _metric_delta(baseline_metrics["ber"], candidate_metrics["ber"]),
+                    "throughput": _metric_delta(baseline_metrics["throughput"], candidate_metrics["throughput"]),
+                    "dropout_rate": _metric_delta(baseline_metrics["dropout_rate"], candidate_metrics["dropout_rate"]),
+                    "gc_stress": _metric_delta(baseline_metrics["gc_stress"], candidate_metrics["gc_stress"]),
+                    "homopolymer_stress": _metric_delta(baseline_metrics["homopolymer_stress"], candidate_metrics["homopolymer_stress"]),
+                    "decode_success": {
+                        "base": baseline_metrics["decode_success"],
+                        "candidate": candidate_metrics["decode_success"],
+                        "changed": baseline_metrics["decode_success"] != candidate_metrics["decode_success"],
+                    },
+                },
+            }
+        )
+
+    return {
+        "schema_version": RUN_SCHEMA_VERSION,
+        "baseline_run_id": baseline.get("run_id"),
+        "comparisons": comparisons,
+    }

--- a/tests/test_results_schema.py
+++ b/tests/test_results_schema.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from genecoder.results.schema import (
+    RUN_SCHEMA_VERSION,
+    canonical_to_legacy_metrics,
+    compare_runs,
+    load_run_schema,
+    migrate_run_schema,
+    translate_bundle_metrics,
+    translate_decode_summary,
+    translate_manifest,
+)
+
+
+def test_translate_manifest_to_canonical() -> None:
+    run = translate_manifest(
+        {
+            "file": "sample.bin",
+            "encoding_parameters": {"method": "base4_direct"},
+            "metrics": {
+                "decode_success_rate": 0.9,
+                "gc_variance": 0.01,
+                "max_homopolymer": 4,
+                "dropout_fraction": 0.1,
+                "ber": 0.02,
+                "throughput": 12.5,
+            },
+        }
+    )
+    assert run["schema_version"] == RUN_SCHEMA_VERSION
+    assert run["profiles"]["encoding"] == "base4_direct"
+    assert run["outcome"]["decode_success_rate"] == 0.9
+
+
+def test_backward_compatibility_loader_for_manifest() -> None:
+    run = load_run_schema(
+        {
+            "file": "sample.bin",
+            "encoding_parameters": {"method": "base4_direct"},
+            "metrics": {"substitutions": 2},
+        }
+    )
+    metrics = canonical_to_legacy_metrics(run)
+    assert metrics["substitutions"] == 2
+
+
+def test_translate_bundle_and_decode_summary() -> None:
+    bundle = translate_bundle_metrics({"files": 2, "total_original_size": 10, "total_dna_length": 20})
+    decode = translate_decode_summary({"decode_success": True, "ber": 0.01, "throughput": 3.0})
+    assert bundle["source_format"] == "bundle_metrics"
+    assert decode["source_format"] == "decode_summary"
+
+
+def test_compare_runs_returns_structured_deltas() -> None:
+    baseline = translate_decode_summary({"decode_success": True, "ber": 0.01, "throughput": 3.0, "dropout_rate": 0.1, "gc_stress": 0.02, "homopolymer_stress": 5}, run_id="a")
+    candidate = translate_decode_summary({"decode_success": False, "ber": 0.02, "throughput": 2.0, "dropout_rate": 0.3, "gc_stress": 0.03, "homopolymer_stress": 6}, run_id="b")
+
+    result = compare_runs(baseline, candidate)
+    assert result["baseline_run_id"] == "a"
+    metric_delta = result["comparisons"][0]["metrics"]["ber"]
+    assert metric_delta["absolute"] == 0.01
+    assert result["comparisons"][0]["metrics"]["decode_success"]["changed"] is True
+
+
+def test_migrate_legacy_payload() -> None:
+    migrated = migrate_run_schema({"metrics": {"substitutions": 1}})
+    assert migrated["schema_version"] == RUN_SCHEMA_VERSION

--- a/web/helix-ui/src/Dashboard.jsx
+++ b/web/helix-ui/src/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import HeatmapLoader from './HeatmapLoader.jsx';
+import { toLegacyMetrics, toRunSchema } from './runSchema.js';
 
 export default function Dashboard() {
   const [sequence, setSequence] = useState('ACGT');
@@ -20,7 +21,7 @@ export default function Dashboard() {
       body: JSON.stringify({ dna_sequence: sequence }),
     });
     const json = await resp.json();
-    setData(json);
+    setData(toRunSchema(json));
   };
 
   const decodeDeepdna = async () => {
@@ -52,19 +53,20 @@ export default function Dashboard() {
       <button onClick={decodeDeepdna}>DeepDNA Decode</button>
       {data && (
         <div>
-          <p>GC Mean: {(data.gc_content * 100).toFixed(2)}%</p>
-          <p>GC Variance: {data.gc_variance.toFixed(4)}</p>
-          <p>Max Homopolymer: {data.max_homopolymer}</p>
-          <p>Error Rate: {(data.error_rate * 100).toFixed(2)}%</p>
-          <img src={`data:image/png;base64,${data.plot}`} style={{ maxWidth: '100%' }} />
-          {data.oligo_metrics && data.oligo_metrics.gc_percentages?.length > 0 && (
+          {(() => { const metrics = toLegacyMetrics(data); return (<>
+          <p>GC Mean: {typeof metrics.gc_content === 'number' ? (metrics.gc_content * 100).toFixed(2) : 'n/a'}%</p>
+          <p>GC Variance: {typeof metrics.gc_variance === 'number' ? metrics.gc_variance.toFixed(4) : 'n/a'}</p>
+          <p>Max Homopolymer: {metrics.max_homopolymer ?? 'n/a'}</p>
+          <p>Error Rate: {typeof metrics.error_rate === 'number' ? (metrics.error_rate * 100).toFixed(2) : 'n/a'}%</p>
+          {metrics.plot && <img src={`data:image/png;base64,${metrics.plot}`} style={{ maxWidth: '100%' }} />}
+          {metrics.oligo_metrics && metrics.oligo_metrics.gc_percentages?.length > 0 && (
             <div>
               <h3>Per-oligo metrics</h3>
               <ul>
-                {data.oligo_metrics.gc_percentages.map((gcVal, idx) => {
-                  const hp = data.oligo_metrics.max_homopolymers?.[idx];
-                  const drop = data.oligo_metrics.dropout_flags?.[idx];
-                  const ecc = data.oligo_metrics.ecc_success || {};
+                {metrics.oligo_metrics.gc_percentages.map((gcVal, idx) => {
+                  const hp = metrics.oligo_metrics.max_homopolymers?.[idx];
+                  const drop = metrics.oligo_metrics.dropout_flags?.[idx];
+                  const ecc = metrics.oligo_metrics.ecc_success || {};
                   const eccSummary = Object.entries(ecc)
                     .map(([name, values]) => {
                       const v = Array.isArray(values) ? values[idx] : undefined;
@@ -89,6 +91,7 @@ export default function Dashboard() {
               </ul>
             </div>
           )}
+          </>); })()}
           <HeatmapLoader sequence={sequence} />
           {deepdna && (
             <div>

--- a/web/helix-ui/src/MetricsCharts.jsx
+++ b/web/helix-ui/src/MetricsCharts.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { toRunSchema } from './runSchema.js';
 
 export default function MetricsCharts() {
   const [data, setData] = useState(null);
@@ -7,7 +8,7 @@ export default function MetricsCharts() {
   useEffect(() => {
     fetch('/bundle-metrics')
       .then((r) => r.json())
-      .then(setData);
+      .then((json) => setData(toRunSchema(json, "bundle")));
   }, []);
 
   useEffect(() => {
@@ -18,7 +19,8 @@ export default function MetricsCharts() {
     canvasRef.current.width = width;
     canvasRef.current.height = height;
     ctx.clearRect(0, 0, width, height);
-    const vals = [data.total_original_size, data.total_dna_length];
+    const metrics = data.outcome?.metrics || {};
+    const vals = [metrics.total_original_size || 0, metrics.total_dna_length || 0];
     const labels = ['Bytes', 'Bases'];
     const maxVal = Math.max(...vals, 1);
     const barWidth = width / vals.length;
@@ -40,8 +42,8 @@ export default function MetricsCharts() {
     <div style={{ padding: 20 }}>
       <h2>Bundle Metrics</h2>
       <canvas ref={canvasRef} />
-      <p>Files: {data.files}</p>
-      <p>Avg bits/nt: {data.avg_bits_per_nt.toFixed(2)}</p>
+      <p>Files: {data.outcome?.metrics?.files ?? 0}</p>
+      <p>Avg bits/nt: {Number(data.outcome?.metrics?.avg_bits_per_nt ?? 0).toFixed(2)}</p>
     </div>
   );
 }

--- a/web/helix-ui/src/runSchema.js
+++ b/web/helix-ui/src/runSchema.js
@@ -1,0 +1,88 @@
+export const RUN_SCHEMA_VERSION = '1.0';
+
+const toNumber = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+};
+
+const asBoolean = (value) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value > 0;
+  return null;
+};
+
+const decodeSuccessRate = (metrics) => {
+  if (toNumber(metrics.decode_success_rate) !== null) return toNumber(metrics.decode_success_rate);
+  const ecc = metrics.ecc_success_rates;
+  if (!ecc || typeof ecc !== 'object') return null;
+  const vals = Object.values(ecc).map(toNumber).filter((v) => v !== null);
+  if (!vals.length) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+};
+
+export function toRunSchema(input, runId = 'run') {
+  if (input?.schema_version && input?.outcome) return input;
+
+  if (input && typeof input === 'object' && input.files !== undefined && input.total_original_size !== undefined) {
+    return {
+      schema_version: RUN_SCHEMA_VERSION,
+      run_id: runId,
+      source_format: 'bundle_metrics',
+      stages: {},
+      profiles: {},
+      seeds: {},
+      runtime: {},
+      outcome: {
+        throughput: toNumber(input.throughput),
+        ber: toNumber(input.ber),
+        dropout_rate: toNumber(input.dropout_rate),
+        gc_stress: toNumber(input.gc_stress),
+        homopolymer_stress: toNumber(input.homopolymer_stress),
+        decode_success: asBoolean(input.decode_success),
+        decode_success_rate: toNumber(input.decode_success_rate),
+        metrics: input,
+      },
+    };
+  }
+
+  const metrics = (input && input.metrics && typeof input.metrics === 'object') ? input.metrics : (input || {});
+  const successRate = decodeSuccessRate(metrics);
+  const decodeSuccess = asBoolean(metrics.decode_success) ?? (successRate !== null ? successRate >= 1 : null);
+
+  return {
+    schema_version: RUN_SCHEMA_VERSION,
+    run_id: input?.file || runId,
+    source_format: 'manifest',
+    stages: {},
+    profiles: {
+      encoding: input?.encoding_parameters?.method || null,
+      simulation: metrics?.channel?.name || null,
+      decode: metrics?.decode_method || metrics?.decoder || null,
+    },
+    seeds: {},
+    runtime: {},
+    outcome: {
+      ber: toNumber(metrics.ber),
+      throughput: toNumber(metrics.throughput),
+      dropout_rate: toNumber(metrics.dropout_fraction ?? metrics.dropout_rate),
+      gc_stress: toNumber(metrics.gc_variance),
+      homopolymer_stress: toNumber(metrics.max_homopolymer),
+      decode_success: decodeSuccess,
+      decode_success_rate: successRate,
+      metrics,
+    },
+  };
+}
+
+export function toLegacyMetrics(input) {
+  const run = toRunSchema(input);
+  const metrics = { ...(run.outcome?.metrics || {}) };
+  if (metrics.decode_success_rate === undefined) metrics.decode_success_rate = run.outcome?.decode_success_rate;
+  if (metrics.decode_success === undefined) metrics.decode_success = run.outcome?.decode_success;
+  if (metrics.ber === undefined) metrics.ber = run.outcome?.ber;
+  if (metrics.throughput === undefined) metrics.throughput = run.outcome?.throughput;
+  if (metrics.dropout_fraction === undefined) metrics.dropout_fraction = run.outcome?.dropout_rate;
+  if (metrics.gc_variance === undefined) metrics.gc_variance = run.outcome?.gc_stress;
+  if (metrics.max_homopolymer === undefined) metrics.max_homopolymer = run.outcome?.homopolymer_stress;
+  return metrics;
+}


### PR DESCRIPTION
### Motivation

- Provide a single, versioned canonical representation for run results (encode / simulate / decode) so visualizers and tooling can consume a stable shape.  
- Preserve backward compatibility by adding translators for existing manifest/bundle/decode outputs so archived runs remain analyzable.  
- Centralize comparison logic for run-to-run deltas (BER, throughput, dropout, GC/homopolymer stress, decode success).  

### Description

- Added a new canonical schema module at `src/genecoder/results/schema.py` that defines `RUN_SCHEMA_VERSION` and implements `translate_manifest`, `translate_bundle_metrics`, `translate_decode_summary`, `load_run_schema`, `migrate_run_schema`, `canonical_to_legacy_metrics`, and `compare_runs`.  
- Exported the schema APIs via `src/genecoder/results/__init__.py` for easy consumption across the codebase.  
- Refactored Python visualizers and aggregation to use the canonical loader/compatibility projection: `src/genecoder/dashboard_streamlit.py`, `src/genecoder/html_report.py`, and `src/genecoder/bundle_metrics.py` now call `load_run_schema` / `canonical_to_legacy_metrics` so they accept legacy payloads and canonical payloads uniformly.  
- Normalized frontend data loading by adding `web/helix-ui/src/runSchema.js` and adapting `web/helix-ui/src/Dashboard.jsx` and `web/helix-ui/src/MetricsCharts.jsx` to call `toRunSchema`/`toLegacyMetrics` so UI components always render from the canonical shape.  
- Added unit tests covering translation, migration, compatibility loading, and comparisons in `tests/test_results_schema.py` while keeping legacy readers intact.  

### Testing

- Ran static checks with `ruff` on the modified files; the check passed.  
- Ran focused Python tests with `pytest` on schema + related modules using `pytest tests/test_results_schema.py tests/test_html_report.py tests/test_cli_stats.py tests/test_web_bundle_metrics.py tests/test_dashboard_streamlit.py`, resulting in the test suite passing (9 passed, 2 skipped in this run).  
- Ran frontend tests and build in `web/helix-ui` using `npm --prefix web/helix-ui test` and `npm --prefix web/helix-ui run build`; the JS unit tests passed and the production build completed successfully.  
- Attempted a Playwright screenshot to validate the live UI but Chromium launch crashed in this environment (segfault), so no screenshot was produced; this does not affect the automated unit/test results above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb63dce448326850dfcbe30871a1f)