### PR TITLE
Refactor plugin_manager into modular runtime components

### DIFF
--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1,659 +1,69 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, Any, Iterable, Mapping, cast
-from collections.abc import MutableMapping
 from types import ModuleType
+from typing import Any, Callable
 
+import base64
+import importlib
+import json
+import logging
 import os
-import sys
+import pkgutil
 import subprocess
 import urllib.request
-from urllib.parse import urlparse
-import tempfile
 from pathlib import Path
-import importlib
-import re
-import inspect
+
+from . import plugin_security
+from importlib.metadata import entry_points
+
+from .plugin_runtime import discovery as discovery_mod
+from .plugin_runtime import installer as installer_mod
+from .plugin_runtime.discovery import (
+    ENTRY_POINT_METADATA as _ENTRY_POINT_METADATA,
+    collect_installed_plugins,
+    load_entry_point_plugins as _load_entry_point_plugins,
+)
+from .plugin_runtime.descriptors import PluginDescriptor
+from .plugin_runtime.installer import (
+    PLUGIN_LOCK,
+    PipPluginInstaller,
+    fetch_catalog,
+    install_registry_plugins as _install_registry_plugins,
+    load_registry_mapping,
+    render_plugin_lock,
+)
+from .plugin_runtime.policy import (
+    validate_plugin_metadata as _validate_plugin_metadata,
+    validate_spec as _validate_spec,
+)
+from .plugin_runtime.registry import (
+    CODEC_REGISTRY,
+    FEC_REGISTRY,
+    VISUALIZER_REGISTRY,
+    register_codec,
+    register_fec,
+    register_simulator,
+    register_visualizer,
+)
+from .simulators import SIMULATOR_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_CATALOG: dict[str, dict[str, Any]] = {}
 
 yaml: ModuleType | None
-try:  # optional dependency
+try:
     import yaml as yaml_module
-except Exception:  # pragma: no cover - optional
+except Exception:
     yaml = None
 else:
     yaml = yaml_module
 
-
-from importlib.metadata import (
-    entry_points,
-    EntryPoints,
-    version as get_pkg_version,
-    PackageNotFoundError,
-)
-import logging
-import pkgutil
-
-from .simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
-from . import plugin_security
-from .plugin_api import Codec, FEC, Simulator, Visualizer
-import base64
-import json
-
-
-logger = logging.getLogger(__name__)
-
-CODEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-FEC_REGISTRY: Dict[str, Dict[str, Callable[..., Any]]] = {}
-VISUALIZER_REGISTRY: Dict[str, Callable[..., Any]] = {}
-
-PLUGIN_CATALOG: Dict[str, Dict[str, Any]] = {}
-
-_ENTRY_POINT_LOADERS: Dict[str, Dict[str, Callable[[], None]]] = {
-    "codec": {},
-    "FEC": {},
-    "simulator": {},
-    "visualizer": {},
-}
-
-_ENTRY_POINT_METADATA: Dict[str, Dict[str, Any]] = {}
-
-
-class _LazyMappingPlugin(MutableMapping[str, Callable[..., Any]]):
-    """Proxy mapping that imports entry point plugins on first access."""
-
-    __slots__ = ("_kind", "_name", "_registry", "_fallback", "_loading")
-
-    def __init__(
-        self,
-        kind: str,
-        name: str,
-        registry: Dict[str, Any],
-        fallback: Mapping[str, Callable[..., Any]] | None = None,
-    ) -> None:
-        self._kind = kind
-        self._name = name
-        self._registry = registry
-        self._fallback = fallback
-        self._loading = False
-
-    def _resolve(self) -> Mapping[str, Callable[..., Any]]:
-        value = self._registry.get(self._name)
-        if value is not self:
-            return cast(Mapping[str, Callable[..., Any]], value)
-        if self._loading:
-            raise RuntimeError(f"Recursive load for {self._kind} plugin {self._name}")
-        self._loading = True
-        try:
-            _load_pending_entry_point(self._kind, self._name)
-        except Exception:
-            if self._fallback is not None:
-                new_map = dict(self._fallback)
-                dict.__setitem__(self._registry, self._name, new_map)
-                return new_map
-            raise
-        finally:
-            self._loading = False
-        value = self._registry.get(self._name)
-        if value is self:
-            if self._fallback is not None:
-                new_map = dict(self._fallback)
-                dict.__setitem__(self._registry, self._name, new_map)
-                return new_map
-            raise KeyError(f"{self._kind} plugin {self._name} failed to register")
-        return cast(Mapping[str, Callable[..., Any]], value)
-
-    def __getitem__(self, key: str) -> Callable[..., Any]:
-        return self._resolve()[key]
-
-    def __setitem__(self, key: str, value: Callable[..., Any]) -> None:
-        mapping = dict(self._resolve())
-        mapping[key] = value
-        dict.__setitem__(self._registry, self._name, mapping)
-
-    def __delitem__(self, key: str) -> None:
-        mapping = dict(self._resolve())
-        del mapping[key]
-        dict.__setitem__(self._registry, self._name, mapping)
-
-    def __iter__(self):
-        return iter(self._resolve())
-
-    def __len__(self) -> int:
-        return len(self._resolve())
-
-    def __repr__(self) -> str:  # pragma: no cover - representation helper
-        if self._registry.get(self._name) is self:
-            return f"<Lazy{self._kind.title()}Plugin {self._name!r}>"
-        return repr(self._resolve())
-
-
-class _LazyVisualizer:
-    """Callable proxy that loads the underlying visualizer on demand."""
-
-    __slots__ = ("_name", "_fallback", "_loading")
-
-    def __init__(
-        self, name: str, fallback: Callable[..., object] | None = None
-    ) -> None:
-        self._name = name
-        self._fallback = fallback
-        self._loading = False
-
-    def _resolve(self) -> Callable[..., object]:
-        value = VISUALIZER_REGISTRY.get(self._name)
-        if value is not self:
-            return cast(Callable[..., object], value)
-        if self._loading:
-            raise RuntimeError(f"Recursive load for visualizer {self._name}")
-        self._loading = True
-        try:
-            _load_pending_entry_point("visualizer", self._name)
-        except Exception:
-            if self._fallback is not None:
-                VISUALIZER_REGISTRY[self._name] = self._fallback
-                return self._fallback
-            raise
-        finally:
-            self._loading = False
-        value = VISUALIZER_REGISTRY.get(self._name)
-        if value is self:
-            if self._fallback is not None:
-                VISUALIZER_REGISTRY[self._name] = self._fallback
-                return self._fallback
-            raise RuntimeError(f"Visualizer {self._name} failed to register")
-        return cast(Callable[..., object], value)
-
-    def __call__(self, *args: object, **kwargs: object) -> object:
-        return self._resolve()(*args, **kwargs)
-
-    def __getattr__(self, attr: str) -> object:
-        return getattr(self._resolve(), attr)
-
-    def __repr__(self) -> str:  # pragma: no cover - representation helper
-        if VISUALIZER_REGISTRY.get(self._name) is self:
-            return f"<LazyVisualizer {self._name!r}>"
-        return repr(self._resolve())
-
-
-class _LazySimulator(Simulator):
-    """Simulator proxy that loads entry point channels on demand."""
-
-    __slots__ = ("_name", "_fallback", "_loading")
-
-    def __init__(self, name: str, fallback: Simulator | None = None) -> None:
-        self._name = name
-        self._fallback = fallback
-        self._loading = False
-
-    def _resolve(self) -> Simulator:
-        channel = SIMULATOR_REGISTRY.get(self._name)
-        if channel is not self:
-            return cast(Simulator, channel)
-        if self._loading:
-            raise RuntimeError(f"Recursive load for simulator {self._name}")
-        self._loading = True
-        try:
-            _load_pending_entry_point("simulator", self._name)
-        except Exception:
-            if self._fallback is not None:
-                _register_simulator(self._name, self._fallback)
-                return self._fallback
-            raise
-        finally:
-            self._loading = False
-        channel = SIMULATOR_REGISTRY.get(self._name)
-        if channel is self:
-            if self._fallback is not None:
-                _register_simulator(self._name, self._fallback)
-                return self._fallback
-            raise RuntimeError(f"Simulator {self._name} failed to register")
-        return cast(Simulator, channel)
-
-    def simulate(self, sequence: str) -> str:
-        return self._resolve().simulate(sequence)
-
-    def with_profile(self, profile: str) -> Simulator:
-        return self._resolve().with_profile(profile)
-
-    def __getattr__(self, attr: str) -> object:
-        return getattr(self._resolve(), attr)
-
-    def __repr__(self) -> str:  # pragma: no cover - representation helper
-        if SIMULATOR_REGISTRY.get(self._name) is self:
-            return f"<LazySimulator {self._name!r}>"
-        return repr(self._resolve())
-
-
-def _load_pending_entry_point(kind: str, name: str) -> None:
-    loader = _ENTRY_POINT_LOADERS.get(kind, {}).pop(name, None)
-    if loader is None:
-        return
-    loader()
-
-
-def _entry_point_version(entry_point: object) -> str:
-    dist = getattr(entry_point, "dist", None)
-    version = getattr(dist, "version", None)
-    if version:
-        return str(version)
-    module_name = getattr(entry_point, "module", "")
-    if module_name:
-        root = module_name.split(".")[0]
-        try:
-            return get_pkg_version(root)
-        except PackageNotFoundError:
-            pass
-    value = getattr(entry_point, "value", "")
-    if value:
-        root = value.split(":", 1)[0].split(".")[0]
-        try:
-            return get_pkg_version(root)
-        except PackageNotFoundError:
-            pass
-    return ""
-
-
-def _record_entry_point_metadata(entry_name: str, kind: str, entry_point: object) -> None:
-    meta = _ENTRY_POINT_METADATA.setdefault(entry_name, {})
-    meta.setdefault("entry_name", entry_name)
-    meta.setdefault("metadata_name", meta.get("metadata_name") or entry_name)
-    version = meta.get("version")
-    if not version:
-        ep_version = _entry_point_version(entry_point)
-        if ep_version:
-            meta["version"] = ep_version
-    interfaces = meta.setdefault("interfaces", set())
-    interfaces.add(kind)
-    module_name = getattr(entry_point, "module", None)
-    if not module_name:
-        value = getattr(entry_point, "value", "")
-        module_name = value.split(":", 1)[0]
-    if module_name:
-        meta.setdefault("module", module_name)
-    meta.setdefault("entry_point", entry_point)
-
-
-def _update_entry_point_metadata(entry_name: str, module: ModuleType) -> None:
-    try:
-        meta = _validate_plugin_metadata(getattr(module, "PLUGIN_METADATA", None))
-    except Exception as exc:
-        cached = _ENTRY_POINT_METADATA.setdefault(entry_name, {})
-        cached["invalid"] = True
-        logger.warning("Incompatible plugin %s: %s", entry_name, exc)
-        cached = _ENTRY_POINT_METADATA.setdefault(entry_name, {})
-        cached["invalid_metadata"] = True
-        return
-    cached = _ENTRY_POINT_METADATA.setdefault(entry_name, {})
-    cached["entry_name"] = entry_name
-    cached["metadata_name"] = meta["name"]
-    cached["version"] = meta["version"]
-    cached["interfaces"] = set(meta["interfaces"])
-    cached["license"] = meta["license"]
-
-
-def _register_lazy_placeholder(kind: str, name: str) -> None:
-    if kind == "codec":
-        existing = CODEC_REGISTRY.get(name)
-        fallback = existing if isinstance(existing, Mapping) and not isinstance(existing, _LazyMappingPlugin) else None
-        CODEC_REGISTRY[name] = _LazyMappingPlugin("codec", name, CODEC_REGISTRY, fallback)
-    elif kind == "FEC":
-        existing = FEC_REGISTRY.get(name)
-        fallback = existing if isinstance(existing, Mapping) and not isinstance(existing, _LazyMappingPlugin) else None
-        FEC_REGISTRY[name] = _LazyMappingPlugin("FEC", name, FEC_REGISTRY, fallback)
-    elif kind == "visualizer":
-        existing = VISUALIZER_REGISTRY.get(name)
-        fallback = existing if callable(existing) and not isinstance(existing, _LazyVisualizer) else None
-        VISUALIZER_REGISTRY[name] = _LazyVisualizer(name, fallback)
-    elif kind == "simulator":
-        existing = SIMULATOR_REGISTRY.get(name)
-        fallback = existing if isinstance(existing, Simulator) and not isinstance(existing, _LazySimulator) else None
-        _register_simulator(name, _LazySimulator(name, fallback))
-
-
-def _load_entry_point_module(
-    entry_point: object,
-    registrar: Callable[..., object],
-    kind: str,
-    entry_name: str,
-) -> None:
-    try:
-        module = entry_point.load()
-    except Exception as exc:
-        logger.warning("Failed to import %s plugin %s: %s", kind, entry_name, exc)
-        raise
-    _update_entry_point_metadata(entry_name, module)
-    register = getattr(module, "register", None)
-    if not callable(register):
-        logger.warning("Entry point %s missing register()", entry_name)
-        return
-    try:
-        register(registrar)
-    except Exception as exc:
-        logger.warning("Failed to register %s plugin %s: %s", kind, entry_name, exc)
-        raise
-
-_VALID_INTERFACES = {"codec", "FEC", "simulator", "visualizer"}
-_ALLOWED_LICENSES = {
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "MIT",
-}
-
-# re-export for tests
 compute_checksum = plugin_security.compute_checksum
 
-_SAFE_PKG_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-_SAFE_URL_RE = re.compile(r"^(?:https?|file)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$")
 
-
-def _validate_spec(spec: str) -> None:
-    """Raise ``ValueError`` if *spec* is not a safe package name or URL."""
-
-    if not spec or re.search(r"[\s;&|`$<>]", spec):
-        raise ValueError("Unsafe plugin spec")
-    if _SAFE_PKG_RE.fullmatch(spec) or _SAFE_URL_RE.fullmatch(spec):
-        return
-    raise ValueError("Unsafe plugin spec")
-
-
-def _validate_registry_license(entry: Mapping[str, Any], *, spec: str) -> str:
-    license_value = entry.get("license")
-    if not isinstance(license_value, str) or not license_value.strip():
-        message = f"Missing license for plugin entry {spec}"
-        logger.error(message)
-        raise ValueError(message)
-    normalized = license_value.strip()
-    if normalized not in _ALLOWED_LICENSES:
-        allowed = ", ".join(sorted(_ALLOWED_LICENSES))
-        message = (
-            f"Disallowed license {normalized!r} for plugin entry {spec}. "
-            f"Allowed licenses: {allowed}"
-        )
-        logger.error(message)
-        raise ValueError(message)
-    return normalized
-
-
-def _check_signature(
-    impl: Callable[..., Any], base: Callable[..., Any], *, kind: str, method: str
-) -> None:
-    """Validate that ``impl`` can accept the parameters of ``base``."""
-
-    base_sig = inspect.signature(base)
-    params = list(base_sig.parameters.values())
-    if params and params[0].name == "self":
-        params = params[1:]
-    base_sig = base_sig.replace(parameters=params)
-
-    impl_sig = inspect.signature(impl)
-
-    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
-        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in impl_sig.parameters.values()):
-            raise TypeError(f"{kind} {method} must accept **kwargs")
-
-    dummy_args = [
-        object()
-        for p in params
-        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-    ]
-    dummy_kwargs = {
-        p.name: object()
-        for p in params
-        if p.kind == inspect.Parameter.KEYWORD_ONLY
-    }
-    try:
-        impl_sig.bind(*dummy_args, **dummy_kwargs)
-    except TypeError as exc:
-        raise TypeError(f"{kind} {method} has incompatible signature: {exc}") from exc
-
-
-def _coerce_plugin(
-    obj: object, expected: type[object], methods: Iterable[str], kind: str
-) -> object:
-    """Return ``obj`` as an instance of ``expected`` ensuring required methods."""
-    if isinstance(obj, type):
-        if not issubclass(obj, expected):
-            raise TypeError(f"{kind} must subclass {expected.__name__}")
-        instance: object = obj()
-    else:
-        if not isinstance(obj, expected):
-            raise TypeError(f"{kind} must subclass {expected.__name__}")
-        instance = obj
-    for method in methods:
-        if not callable(getattr(instance, method, None)):
-            raise TypeError(f"{kind} missing required method {method}")
-        _check_signature(
-            getattr(instance, method), getattr(expected, method), kind=kind, method=method
-        )
-    return instance
-
-
-def register_codec(name: str, codec: Codec | type[Codec]) -> None:
-    """Register a codec implementation under ``name``.
-
-    If multiple plugins register the same ``name`` the last registration wins.
-    Plugins are discovered in the order built-in, entry-point and then local
-    modules, allowing user supplied plugins to override bundled ones.
-    """
-
-    inst = cast(Any, _coerce_plugin(codec, Codec, ("encode", "decode"), "codec"))
-    CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
-
-
-def register_fec(name: str, fec: FEC | type[FEC]) -> None:
-    """Register a FEC backend under ``name``.
-
-    Later registrations override earlier ones; discovery follows the same
-    built-in, entry-point then local order as codecs.
-    """
-
-    inst = cast(Any, _coerce_plugin(fec, FEC, ("encode", "decode"), "FEC"))
-    FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
-
-
-def register_simulator(name: str, channel: Simulator | type[Simulator]) -> None:
-    """Register a read simulator under ``name``.
-
-    Later registrations with the same ``name`` replace earlier ones.  The
-    discovery order mirrors codecs and FEC backends.
-    """
-
-    inst = cast(Any, _coerce_plugin(channel, Simulator, ("simulate",), "simulator"))
-    _register_simulator(name, inst)
-
-
-def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
-    """Register a visualizer under ``name``.
-
-    As with other plugin types, later registrations win and discovery order is
-    built-in first followed by entry-point and local plugins.
-    """
-
-    inst = cast(Any, _coerce_plugin(visualizer, Visualizer, ("visualize",), "visualizer"))
-    VISUALIZER_REGISTRY[name] = inst.visualize
-
-
-
-def _read_local(path_str: str) -> bytes:
-    path = urlparse(path_str).path if path_str.startswith("file://") else path_str
-    return Path(path).read_bytes()
-
-
-def _parse_simple_yaml(text: str) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
-    current_list: list[Dict[str, Any]] | None = None
-    current_item: Dict[str, Any] | None = None
-    for raw_line in text.splitlines():
-        stripped = raw_line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if stripped.endswith(":") and not stripped.startswith("- "):
-            key = stripped[:-1].strip()
-            current_item = None
-            current_list = []
-            result[key] = current_list
-            continue
-        if stripped.startswith("- "):
-            if current_list is None:
-                continue
-            current_item = {}
-            current_list.append(current_item)
-            remainder = stripped[2:].strip()
-            if remainder:
-                if ":" in remainder:
-                    k, v = remainder.split(":", 1)
-                    current_item[k.strip()] = v.strip()
-            continue
-        if current_item is not None and ":" in stripped:
-            key, value = stripped.split(":", 1)
-            current_item[key.strip()] = value.strip()
-    return result
-
-
-def _load_registry_mapping(raw: bytes | str, yaml_module: ModuleType | None) -> Dict[str, Any]:
-    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
-    if yaml_module is not None:
-        try:
-            data = yaml_module.safe_load(text)
-        except Exception as exc:
-            raise ValueError("Invalid plugin registry YAML") from exc
-        if isinstance(data, dict) and data:
-            return data
-        # fall back to minimal parser if PyYAML returns an empty result
-    try:
-        data = json.loads(text)
-    except Exception:
-        data = _parse_simple_yaml(text)
-    if not isinstance(data, dict):
-        raise ValueError("Invalid plugin registry YAML")
-    return data
-
-
-def _fetch_catalog(url: str, *, allow_network: bool) -> bytes:
-    if url.startswith("http://") or url.startswith("https://"):
-        if not allow_network:
-            msg = (
-                "Network access is disabled. Set GENECODER_ALLOW_NETWORK=1 to enable "
-                "downloads from the plugin registry specified by GENECODER_PLUGIN_REGISTRY_URL."
-            )
-            logger.error(msg)
-            raise RuntimeError(msg)
-        with urllib.request.urlopen(url, timeout=30) as response:
-            return cast(bytes, response.read())
-    return _read_local(url)
-
-
-def _install_plugin_spec(
-    spec: str,
-    *,
-    checksum: str | None = None,
-    sig_b64: str | None = None,
-    version_req: str | None = None,
-    package: str | None = None,
-    allow_network: bool,
-) -> None:
-    install_target = spec
-    pkg_path = None
-    if checksum or sig_b64:
-        try:
-            path = urlparse(spec).path if spec.startswith("file://") else spec
-            if Path(path).exists():
-                pkg_bytes = _read_local(spec)
-            else:
-                if not allow_network:
-                    msg = (
-                        "Network access is disabled. Set GENECODER_ALLOW_NETWORK=1 to enable "
-                        "downloads from the plugin registry specified by GENECODER_PLUGIN_REGISTRY_URL."
-                    )
-                    logger.error(msg)
-                    raise RuntimeError(msg)
-                with urllib.request.urlopen(spec, timeout=30) as resp:
-                    pkg_bytes = resp.read()
-        except Exception as exc:  # pragma: no cover - download error path
-            if isinstance(exc, RuntimeError):
-                raise
-            logger.warning("Failed to download plugin %s: %s", spec, exc)
-            raise
-
-        signature = None
-        public_key = None
-        if sig_b64:
-            try:
-                signature = base64.b64decode(str(sig_b64), validate=True)
-            except Exception:
-                logger.error("Invalid signature for plugin %s", spec)
-                raise ValueError("Invalid signature")
-
-            key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
-            if not key_path:
-                logger.error("Invalid signature for plugin %s", spec)
-                raise ValueError("Invalid signature")
-            try:
-                public_key = Path(key_path).read_bytes()
-            except Exception:
-                logger.error("Invalid signature for plugin %s", spec)
-                raise ValueError("Invalid signature")
-
-        try:
-            digest = plugin_security.compute_checksum(
-                pkg_bytes, signature=signature, public_key=public_key
-            )
-        except Exception:
-            logger.error("Invalid signature for plugin %s", spec)
-            raise ValueError("Invalid signature")
-
-        if checksum:
-            try:
-                expected = plugin_security.decode_checksum(str(checksum))
-            except ValueError:
-                logger.error("Invalid checksum for plugin %s", spec)
-                raise ValueError("Invalid checksum")
-            if digest != expected:
-                logger.error("Checksum mismatch for plugin %s", spec)
-                raise ValueError("Checksum mismatch")
-
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        pkg_path = tmp.name
-        tmp.write(pkg_bytes)
-        tmp.close()
-        install_target = pkg_path
-
-    if not allow_network and not (spec.startswith("file://") or Path(spec).exists()):
-        msg = (
-            "Network access is disabled. Set GENECODER_ALLOW_NETWORK=1 to enable "
-            "downloads from the plugin registry specified by GENECODER_PLUGIN_REGISTRY_URL."
-        )
-        logger.error(msg)
-        raise RuntimeError(msg)
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", install_target])
-        if version_req:
-            pkg_name = str(package or spec).split("==")[0]
-            if _SAFE_PKG_RE.fullmatch(pkg_name):
-                try:
-                    installed_version = get_pkg_version(pkg_name)
-                except PackageNotFoundError:
-                    logger.error("Version mismatch for plugin %s", pkg_name)
-                    raise ValueError("Version mismatch")
-                if installed_version != str(version_req):
-                    logger.error(
-                        "Version mismatch for plugin %s (expected %s, got %s)",
-                        pkg_name,
-                        version_req,
-                        installed_version,
-                    )
-                    raise ValueError("Version mismatch")
-    except Exception as exc:  # pragma: no cover - install error path
-        if isinstance(exc, ValueError):
-            raise
-        logger.warning("Failed to install plugin %s from registry: %s", spec, exc)
-    finally:
-        if pkg_path is not None:
-            try:
-                os.unlink(pkg_path)
-            except Exception:
-                pass
+class _CompatInstaller(PipPluginInstaller):
+    pass
 
 
 def install_registry_plugins(
@@ -662,367 +72,75 @@ def install_registry_plugins(
     offline: bool | None = None,
     allow_network: bool | None = None,
 ) -> None:
-    """Install plugin packages listed in a YAML registry at ``url``.
-
-    The ``url`` argument may be an HTTP(S) address, a ``file://`` URL or a plain
-    filesystem path. Network access is disabled by default; set the
-    ``GENECODER_ALLOW_NETWORK`` environment variable or pass ``allow_network=True``
-    to enable downloads from the registry specified by
-    ``GENECODER_PLUGIN_REGISTRY_URL``. When *offline* is ``True`` or the
-    ``GENECODER_OFFLINE`` environment variable is set, network access remains
-    disabled regardless of ``allow_network``.
-    """
-
-    if isinstance(url, os.PathLike):
-        url = os.fspath(url)
-
-    if offline is None:
-        offline = bool(os.getenv("GENECODER_OFFLINE"))
-    if allow_network is None:
-        allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
-
-    if url is None:
-        url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
-    if not url:
-        return
-
-    network_ok = allow_network and not offline
-
+    global yaml
     yaml_module = yaml
     if yaml_module is None:
-        try:  # lazy import for environments where PyYAML may be installed later
+        try:
             import yaml as yaml_module_real
-        except Exception:  # pragma: no cover - optional
+        except Exception:
             logger.warning("YAML support unavailable; skipping registry %s", url)
             return
-        else:
-            yaml_module = yaml_module_real
-            globals()["yaml"] = yaml_module
-    if yaml_module is None:  # for type checkers
-        logger.warning("YAML support unavailable; skipping registry %s", url)
-        return
+        yaml = yaml_module_real
+        yaml_module = yaml_module_real
 
-    try:
-        raw = _fetch_catalog(url, allow_network=network_ok)
-    except Exception as exc:
-        if isinstance(exc, RuntimeError):
-            raise
-        logger.warning("Failed to fetch plugin registry %s: %s", url, exc)
-        return
-
-    try:
-        data = _load_registry_mapping(raw, yaml_module)
-    except ValueError as exc:
-        logger.warning("Failed to parse plugin registry %s: %s", url, exc)
-        raise
-
-    for entry in data.get("packages", []):
-        spec = ""
-        checksum = None
-        sig_b64: str | None = None
-        version_req: str | None = None
-        package = None
-        if isinstance(entry, dict):
-            spec = str(entry.get("spec") or entry.get("package") or entry.get("url") or "")
-            checksum = entry.get("checksum")
-            sig_b64 = entry.get("signature")
-            version_req = entry.get("version")
-            package = entry.get("package")
-        else:
-            spec = str(entry)
-
-        if not spec:
-            logger.warning("Missing spec for plugin entry %s", entry)
-            continue
-
-        if isinstance(entry, dict):
-            _validate_registry_license(entry, spec=spec)
-        else:
-            message = f"Missing license for plugin entry {spec}"
-            logger.error(message)
-            raise ValueError(message)
-
-        _validate_spec(spec)
-
-        if checksum is None and sig_b64 is None:
-            raise ValueError("Checksum or signature required")
-
-        _install_plugin_spec(
-            spec,
-            checksum=checksum,
-            sig_b64=sig_b64,
-            version_req=version_req,
-            package=package,
-            allow_network=network_ok,
-        )
+    installer_mod.subprocess = subprocess
+    installer_mod.urllib.request = urllib.request
+    descriptors = _install_registry_plugins(
+        url,
+        offline=offline,
+        allow_network=allow_network,
+        yaml_module=yaml_module,
+        installer=_CompatInstaller(),
+    )
+    PLUGIN_LOCK.clear()
+    PLUGIN_LOCK.extend(d.as_lock_entry() for d in sorted(descriptors, key=lambda d: (d.name, d.version, d.source)))
 
 
 
-
-
-
-
-def _load_and_register(
-    items: Iterable[Any],
-    registrar: Callable[..., Any],
-    kind: str,
-    failures: list[str] | None = None,
-) -> None:
-    """Load ``items`` and call ``register`` on each."""
-
+def _load_and_register(items: list[Any], registrar: Callable[..., object], kind: str, failures: list[str] | None = None) -> None:
     for item in items:
         name = getattr(item, "value", getattr(item, "__name__", str(item)))
         try:
-            module = (
-                item
-                if isinstance(item, ModuleType)
-                else (
-                    item.load()
-                    if hasattr(item, "load")
-                    else importlib.import_module(name)
-                )
-            )
-        except Exception:  # pragma: no cover - error path
+            module = item if isinstance(item, ModuleType) else (item.load() if hasattr(item, "load") else importlib.import_module(name))
+        except Exception:
             if failures is not None:
                 failures.append(f"{kind}:{name}")
-            else:
-                logger.warning("Failed to import %s plugin %s", kind, name)
             continue
         register = getattr(module, "register", None)
         if callable(register):
             register(registrar)
 
 
-def _validate_plugin_metadata(meta: object) -> Dict[str, Any]:
-    """Validate plugin metadata structure."""
-
-    if not isinstance(meta, dict):
-        raise TypeError("PLUGIN_METADATA must be a dict")
-    name = meta.get("name")
-    version = meta.get("version")
-    interfaces = meta.get("interfaces")
-    license_value = meta.get("license")
-    if not isinstance(name, str) or not name:
-        raise ValueError("PLUGIN_METADATA.name is required and must be a non-empty string")
-    if not isinstance(version, str) or not version:
-        raise ValueError("PLUGIN_METADATA.version is required and must be a non-empty string")
-    if not isinstance(interfaces, (list, tuple)) or not interfaces:
-        raise ValueError("PLUGIN_METADATA.interfaces is required and must be a non-empty list")
-    if any(i not in _VALID_INTERFACES for i in interfaces):
-        raise ValueError("PLUGIN_METADATA.interfaces contains an unknown interface")
-    if not isinstance(license_value, str) or not license_value.strip():
-        raise ValueError(
-            "PLUGIN_METADATA.license is required and must be a non-empty SPDX identifier"
-        )
-    normalized = license_value.strip()
-    if normalized not in _ALLOWED_LICENSES:
-        allowed = ", ".join(sorted(_ALLOWED_LICENSES))
-        raise ValueError(
-            f"PLUGIN_METADATA.license {normalized!r} is not allowed. Allowed licenses: {allowed}"
-        )
-    return {
-        "name": name,
-        "version": version,
-        "interfaces": list(interfaces),
-        "license": normalized,
-    }
-
-
-def _collect_installed_plugins() -> tuple[Dict[str, Dict[str, Any]], list[str]]:
-    """Discover installed plugins via entry points and local modules."""
-
-    _ENTRY_POINT_METADATA.clear()
-    catalog: Dict[str, Dict[str, Any]] = {}
-    failures: list[str] = []
-
-    groups = {
-        "genecoder.plugins": "codec",
-        "genecoder.fec": "FEC",
-        "genecoder.simulators": "simulator",
-        "genecoder.visualizers": "visualizer",
-    }
-    for group, kind in groups.items():
-        try:
-            entries = entry_points(group=group)
-        except TypeError:
-            eps = entry_points()
-            if hasattr(eps, "select"):
-                entries = eps.select(group=group)
-            elif isinstance(eps, dict):
-                entries = eps.get(group, EntryPoints())
-            else:  # pragma: no cover - legacy path
-                entries = [ep for ep in eps if getattr(ep, "group", None) == group]
-        for ep in entries:
-            entry_name = str(getattr(ep, "value", getattr(ep, "name", "")))
-            if entry_name:
-                _record_entry_point_metadata(entry_name, kind, ep)
-
-    for entry_name, cached in list(_ENTRY_POINT_METADATA.items()):
-        if cached.get("invalid_metadata"):
-            continue
-        if cached.get("metadata_name") and cached.get("metadata_name") != cached.get("entry_name"):
-            continue
-        module_name = cached.get("module")
-        entry_point = cached.get("entry_point")
-        if not module_name and entry_point is None:
-            continue
-        module = sys.modules.get(str(module_name)) if module_name else None
-        if module is None and entry_point is not None:
-            try:
-                module = cast(ModuleType, entry_point.load())
-            except Exception as exc:
-                failures.append(f"entry_point:{entry_name}")
-                logger.warning("Failed to import entry point metadata for %s: %s", entry_name, exc)
-                continue
-        if module is not None:
-            _update_entry_point_metadata(entry_name, module)
-
-    for cached in _ENTRY_POINT_METADATA.values():
-        if cached.get("invalid"):
-            continue
-        entry_name = str(cached.get("entry_name") or "")
-        plugin_name = str(cached.get("metadata_name") or entry_name)
-        if cached.get("invalid_metadata") or not plugin_name:
-            continue
-        interfaces_raw = cached.get("interfaces") or set()
-        interfaces = {str(interface) for interface in interfaces_raw}
-        version = str(cached.get("version") or "")
-        license_value = str(cached.get("license") or "")
-        existing = catalog.get(plugin_name)
-        if existing:
-            combined = set(existing.get("interfaces", [])) | interfaces
-            existing["interfaces"] = sorted(combined)
-            if not existing.get("version") and version:
-                existing["version"] = version
-            if not existing.get("license") and license_value:
-                existing["license"] = license_value
-        else:
-            catalog[plugin_name] = {
-                "version": version,
-                "interfaces": sorted(interfaces) if interfaces else [],
-                "license": license_value,
-            }
-
-    def _handle_module(module: ModuleType, src: str) -> None:
-        try:
-            meta = _validate_plugin_metadata(getattr(module, "PLUGIN_METADATA", None))
-        except Exception as exc:  # pragma: no cover - invalid metadata
-            failures.append(src)
-            logger.warning("Incompatible plugin %s: %s", src, exc)
-            return
-        name = meta["name"]
-        if name in catalog or name in PLUGIN_CATALOG:
-            failures.append(src)
-            logger.warning("Duplicate plugin name %s from %s", name, src)
-            return
-        catalog[name] = {
-            "version": meta["version"],
-            "interfaces": meta["interfaces"],
-            "license": meta["license"],
-        }
-
-    # discover local plugins in a ``plugins`` package
-    try:
-        import plugins as local_pkg
-    except ModuleNotFoundError:
-        local_pkg = None
-
-    modules: list[ModuleType] = []
-    if local_pkg is not None:
-        modules.append(local_pkg)
-        if hasattr(local_pkg, "__path__"):
-            for _, module_name, _ in pkgutil.iter_modules(local_pkg.__path__):
-                try:
-                    modules.append(importlib.import_module(f"plugins.{module_name}"))
-                except Exception as exc:  # pragma: no cover - import failure path
-                    src = f"local:{module_name}"
-                    failures.append(src)
-                    logger.warning("Failed to import %s: %s", src, exc)
-    for mod in modules:
-        _handle_module(mod, getattr(mod, "__name__", "local"))
-
+def _collect_installed_plugins() -> tuple[dict[str, dict[str, Any]], list[str]]:
+    discovery_mod.entry_points = entry_points
+    catalog, failures, _ = collect_installed_plugins(PLUGIN_CATALOG)
     return catalog, failures
 
 
 def load_builtin_plugins() -> None:
-    """Load built-in plugins and clear existing registries."""
-
     CODEC_REGISTRY.clear()
     FEC_REGISTRY.clear()
     VISUALIZER_REGISTRY.clear()
     SIMULATOR_REGISTRY.clear()
-
     builtin = importlib.import_module("genecoder.builtin_plugins")
     if hasattr(builtin, "register_builtin_plugins"):
         builtin.register_builtin_plugins()
 
 
-
-
 def load_entry_point_plugins() -> list[str]:
-    """Load plugins registered via Python entry points."""
-
-    failures: list[str] = []
-    for loaders in _ENTRY_POINT_LOADERS.values():
-        loaders.clear()
     offline = bool(os.getenv("GENECODER_OFFLINE"))
-
-    groups: dict[str, tuple[Callable[..., Any], str]] = {
+    groups = {
         "genecoder.plugins": (register_codec, "codec"),
         "genecoder.fec": (register_fec, "FEC"),
         "genecoder.simulators": (register_simulator, "simulator"),
         "genecoder.visualizers": (register_visualizer, "visualizer"),
     }
-
-    for group, (registrar, kind) in groups.items():
-        try:
-            entries = entry_points(group=group)
-        except TypeError:
-            eps = entry_points()
-            if hasattr(eps, "select"):
-                entries = eps.select(group=group)
-            elif isinstance(eps, dict):
-                entries = eps.get(group, EntryPoints())
-            else:
-                entries = [ep for ep in eps if getattr(ep, "group", None) == group]
-
-        seen: set[str] = set()
-        for ep in entries:
-            entry_name = str(getattr(ep, "name", ""))
-            entry_value = str(getattr(ep, "value", entry_name))
-            entry_key = entry_name or entry_value
-            if not entry_key:
-                failures.append(f"{kind}:unknown")
-                continue
-            seen.add(entry_key)
-            _record_entry_point_metadata(entry_key, kind, ep)
-            if offline:
-                _ENTRY_POINT_LOADERS[kind][entry_key] = (
-                    lambda entry=ep, reg=registrar, k=kind, name=entry_value: _load_entry_point_module(
-                        entry, reg, k, name
-                    )
-                )
-                _register_lazy_placeholder(kind, entry_key)
-                continue
-            try:
-                _load_entry_point_module(ep, registrar, kind, entry_value)
-            except (ImportError, ModuleNotFoundError) as exc:
-                failures.append(f"{kind}:{entry_value}")
-                logger.warning("Failed to import %s:%s", kind, entry_value)
-                logger.debug("Entry point import error for %s:%s: %s", kind, entry_value, exc)
-
-        # prune metadata for removed entry points of this kind
-        for meta in _ENTRY_POINT_METADATA.values():
-            interfaces = meta.get("interfaces")
-            if isinstance(interfaces, set) and kind in interfaces and meta.get("entry_name") not in seen:
-                interfaces.discard(kind)
-
+    discovery_mod.entry_points = entry_points
+    failures, _ = _load_entry_point_plugins(offline=offline, registrars=groups)
     return failures
 
 
 def load_local_plugins() -> list[str]:
-    """Load plugins from a local ``plugins`` package if present."""
-
     failures: list[str] = []
     try:
         import plugins
@@ -1033,7 +151,7 @@ def load_local_plugins() -> list[str]:
         for _, module_name, _ in pkgutil.iter_modules(plugins.__path__):
             try:
                 module = importlib.import_module(f"plugins.{module_name}")
-            except Exception:  # pragma: no cover - error path
+            except Exception:
                 failures.append(f"local:{module_name}")
                 continue
             register = getattr(module, "register", None)
@@ -1061,19 +179,30 @@ def load_local_plugins() -> list[str]:
     register_v = getattr(plugins, "register_visualizer", None)
     if callable(register_v):
         register_v(register_visualizer)
-
     return failures
 
 
-_initialized = False
+
+def _verify_catalog_signature(data: bytes, signature_b64: str, *, padding_scheme: str | None = None) -> bool:
+    key_path = os.getenv("GENECODER_CATALOG_PUBLIC_KEY")
+    if not key_path:
+        return False
+    try:
+        public_key = Path(key_path).read_bytes()
+        signature = base64.b64decode(signature_b64, validate=True)
+    except Exception:
+        return False
+    try:
+        compute_checksum(data, signature=signature, public_key=public_key, padding_scheme=padding_scheme or "pkcs1")
+    except Exception:
+        return False
+    return True
 
 
 def load_plugin_catalog(url: str | None = None) -> None:
-    """Populate :data:`PLUGIN_CATALOG` from ``url`` or the environment."""
-
     if url is None:
         url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
-    catalog: Dict[str, Dict[str, Any]] = {}
+    catalog: dict[str, dict[str, Any]] = {}
     offline = bool(os.getenv("GENECODER_OFFLINE"))
     allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
     network_ok = allow_network and not offline
@@ -1084,7 +213,7 @@ def load_plugin_catalog(url: str | None = None) -> None:
             logger.info("Network access disabled; skipped remote catalog %s", url)
         else:
             try:
-                raw = _fetch_catalog(url, allow_network=network_ok)
+                raw = fetch_catalog(url, allow_network=network_ok)
             except Exception as exc:
                 logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
 
@@ -1092,15 +221,12 @@ def load_plugin_catalog(url: str | None = None) -> None:
             try:
                 data = json.loads(raw.decode("utf-8"))
             except Exception:
-                yaml_module = yaml
-                if yaml_module is None:
-                    logger.warning("Failed to parse plugin catalog %s", url)
+                if yaml is None:
                     data = {}
                 else:
                     try:
-                        data = yaml_module.safe_load(raw) or {}
-                    except Exception as exc:
-                        logger.warning("Failed to parse plugin catalog %s: %s", url, exc)
+                        data = yaml.safe_load(raw) or {}
+                    except Exception:
                         data = {}
             if isinstance(data, dict):
                 signature = data.get("signature")
@@ -1112,14 +238,11 @@ def load_plugin_catalog(url: str | None = None) -> None:
                     if isinstance(plugins_data, list):
                         for entry in plugins_data:
                             if isinstance(entry, dict) and "name" in entry:
-                                meta = {k: v for k, v in entry.items() if k != "name"}
-                                catalog[str(entry["name"])] = meta
+                                catalog[str(entry["name"])] = {k: v for k, v in entry.items() if k != "name"}
                     elif isinstance(plugins_data, dict):
                         for name, meta in plugins_data.items():
                             if isinstance(meta, dict):
                                 catalog[str(name)] = dict(meta)
-                    else:
-                        logger.warning("Invalid plugin catalog format from %s", url)
 
     discovered, failures = _collect_installed_plugins()
     for name, meta in discovered.items():
@@ -1131,9 +254,23 @@ def load_plugin_catalog(url: str | None = None) -> None:
         logger.warning("Failed to load plugin metadata: %s", ", ".join(failures))
 
 
-def load_plugins() -> None:
-    """Load built-in, entry point and local plugins and fetch catalog entries."""
+def generate_plugin_lock() -> str:
+    descriptors: list[PluginDescriptor] = []
+    for item in PLUGIN_LOCK:
+        descriptors.append(
+            PluginDescriptor(
+                name=item.get("name", ""),
+                kind="package",
+                source=item.get("source", ""),
+                version=item.get("version", ""),
+                checksum=item.get("checksum") or None,
+                signature=item.get("signature") or None,
+            )
+        )
+    return render_plugin_lock(descriptors)
 
+
+def load_plugins() -> None:
     load_builtin_plugins()
     failures = load_entry_point_plugins()
     failures.extend(load_local_plugins())
@@ -1142,49 +279,37 @@ def load_plugins() -> None:
         logger.warning("Failed to import plugins: %s", ", ".join(failures))
 
 
-def init_plugins() -> None:
-    """Initialize plugins once with error handling."""
+_initialized = False
 
+
+def init_plugins() -> None:
     global _initialized
     if _initialized:
         return
     try:
         load_plugins()
-    except Exception as exc:  # pragma: no cover - unexpected error path
+    except Exception as exc:
         logger.warning("Failed to load plugins: %s", exc)
     _initialized = True
 
 
-def _verify_catalog_signature(
-    data: bytes, signature_b64: str, *, padding_scheme: str | None = None
-) -> bool:
-    """Return ``True`` if ``signature_b64`` verifies ``data`` using the public key.
-
-    The key path is read from the ``GENECODER_CATALOG_PUBLIC_KEY`` environment
-    variable. ``False`` is returned on any failure.
-    """
-
-    key_path = os.getenv("GENECODER_CATALOG_PUBLIC_KEY")
-    if not key_path:
-        return False
-
-    try:
-        public_key = Path(key_path).read_bytes()
-    except Exception:
-        return False
-
-    try:
-        signature = base64.b64decode(signature_b64, validate=True)
-    except Exception:
-        return False
-
-    try:
-        compute_checksum(
-            data,
-            signature=signature,
-            public_key=public_key,
-            padding_scheme=padding_scheme or "pkcs1",
-        )
-    except Exception:
-        return False
-    return True
+__all__ = [
+    "CODEC_REGISTRY",
+    "FEC_REGISTRY",
+    "VISUALIZER_REGISTRY",
+    "SIMULATOR_REGISTRY",
+    "PLUGIN_CATALOG",
+    "register_codec",
+    "register_fec",
+    "register_simulator",
+    "register_visualizer",
+    "install_registry_plugins",
+    "load_plugins",
+    "load_entry_point_plugins",
+    "init_plugins",
+    "_validate_spec",
+    "_validate_plugin_metadata",
+    "_collect_installed_plugins",
+    "_ENTRY_POINT_METADATA",
+    "load_registry_mapping",
+]

--- a/src/genecoder/plugin_runtime/__init__.py
+++ b/src/genecoder/plugin_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Internal plugin runtime components."""

--- a/src/genecoder/plugin_runtime/descriptors.py
+++ b/src/genecoder/plugin_runtime/descriptors.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class PluginLifecycleState(str, Enum):
+    DISCOVERED = "discovered"
+    VALIDATED = "validated"
+    LOADED = "loaded"
+    FAILED = "failed"
+
+
+@dataclass(slots=True)
+class PluginDescriptor:
+    name: str
+    kind: str
+    source: str
+    version: str = ""
+    license: str = ""
+    checksum: str | None = None
+    signature: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    state: PluginLifecycleState = PluginLifecycleState.DISCOVERED
+    error: str | None = None
+
+    def as_lock_entry(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "source": self.source,
+            "checksum": self.checksum or "",
+            "signature": self.signature or "",
+        }

--- a/src/genecoder/plugin_runtime/discovery.py
+++ b/src/genecoder/plugin_runtime/discovery.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import pkgutil
+import sys
+from importlib.metadata import EntryPoints, PackageNotFoundError, entry_points, version as get_pkg_version
+from types import ModuleType
+from typing import Any, Callable, cast
+
+from .descriptors import PluginDescriptor, PluginLifecycleState
+from .policy import validate_plugin_metadata
+from .registry import RUNTIME_REGISTRY, register_lazy_placeholder
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_METADATA: dict[str, dict[str, Any]] = {}
+
+
+def _entry_point_version(entry_point: object) -> str:
+    dist = getattr(entry_point, "dist", None)
+    version = getattr(dist, "version", None)
+    if version:
+        return str(version)
+    module_name = getattr(entry_point, "module", "")
+    for root in [module_name.split(".")[0], getattr(entry_point, "value", "").split(":", 1)[0].split(".")[0]]:
+        if root:
+            try:
+                return get_pkg_version(root)
+            except PackageNotFoundError:
+                pass
+    return ""
+
+
+def _record_entry_point_metadata(entry_name: str, kind: str, entry_point: object) -> None:
+    meta = ENTRY_POINT_METADATA.setdefault(entry_name, {})
+    meta.setdefault("entry_name", entry_name)
+    meta.setdefault("metadata_name", meta.get("metadata_name") or entry_name)
+    if not meta.get("version"):
+        version = _entry_point_version(entry_point)
+        if version:
+            meta["version"] = version
+    interfaces = meta.setdefault("interfaces", set())
+    interfaces.add(kind)
+    module_name = getattr(entry_point, "module", None) or str(getattr(entry_point, "value", "")).split(":", 1)[0]
+    if module_name:
+        meta.setdefault("module", module_name)
+    meta.setdefault("entry_point", entry_point)
+
+
+def _update_entry_point_metadata(entry_name: str, module: ModuleType) -> None:
+    try:
+        meta = validate_plugin_metadata(getattr(module, "PLUGIN_METADATA", None))
+    except Exception as exc:
+        cached = ENTRY_POINT_METADATA.setdefault(entry_name, {})
+        cached["invalid"] = True
+        cached["invalid_metadata"] = True
+        logger.warning("Incompatible plugin %s: %s", entry_name, exc)
+        return
+    cached = ENTRY_POINT_METADATA.setdefault(entry_name, {})
+    cached.update({
+        "entry_name": entry_name,
+        "metadata_name": meta["name"],
+        "version": meta["version"],
+        "interfaces": set(meta["interfaces"]),
+        "license": meta["license"],
+    })
+
+
+def _load_entry_point_module(entry_point: object, registrar: Callable[..., object], kind: str, entry_name: str) -> None:
+    module = entry_point.load()
+    _update_entry_point_metadata(entry_name, module)
+    register = getattr(module, "register", None)
+    if callable(register):
+        register(registrar)
+
+
+def load_entry_point_plugins(*, offline: bool, registrars: dict[str, tuple[Callable[..., Any], str]]) -> tuple[list[str], list[PluginDescriptor]]:
+    failures: list[str] = []
+    descriptors: list[PluginDescriptor] = []
+    for loaders in RUNTIME_REGISTRY.entry_point_loaders.values():
+        loaders.clear()
+
+    for group, (registrar, kind) in registrars.items():
+        try:
+            entries = entry_points(group=group)
+        except TypeError:
+            eps = entry_points()
+            if hasattr(eps, "select"):
+                entries = eps.select(group=group)
+            elif isinstance(eps, dict):
+                entries = eps.get(group, EntryPoints())
+            else:
+                entries = [ep for ep in eps if getattr(ep, "group", None) == group]
+
+        seen: set[str] = set()
+        for ep in entries:
+            entry_name = str(getattr(ep, "name", ""))
+            entry_value = str(getattr(ep, "value", entry_name))
+            entry_key = entry_name or entry_value
+            if not entry_key:
+                failures.append(f"{kind}:unknown")
+                continue
+            seen.add(entry_key)
+            _record_entry_point_metadata(entry_key, kind, ep)
+            descriptor = PluginDescriptor(name=entry_key, kind=kind, source=f"entry_point:{group}", version=_entry_point_version(ep))
+            descriptors.append(descriptor)
+
+            if offline:
+                RUNTIME_REGISTRY.entry_point_loaders[kind][entry_key] = (
+                    lambda entry=ep, reg=registrar, k=kind, name=entry_value: _load_entry_point_module(entry, reg, k, name)
+                )
+                register_lazy_placeholder(kind, entry_key)
+                descriptor.state = PluginLifecycleState.DISCOVERED
+                continue
+            try:
+                _load_entry_point_module(ep, registrar, kind, entry_value)
+                descriptor.state = PluginLifecycleState.LOADED
+            except (ImportError, ModuleNotFoundError):
+                descriptor.state = PluginLifecycleState.FAILED
+                failures.append(f"{kind}:{entry_value}")
+
+        for meta in ENTRY_POINT_METADATA.values():
+            interfaces = meta.get("interfaces")
+            if isinstance(interfaces, set) and kind in interfaces and meta.get("entry_name") not in seen:
+                interfaces.discard(kind)
+
+    return failures, descriptors
+
+
+def collect_installed_plugins(existing_catalog: dict[str, dict[str, Any]]) -> tuple[dict[str, dict[str, Any]], list[str], list[PluginDescriptor]]:
+    ENTRY_POINT_METADATA.clear()
+    catalog: dict[str, dict[str, Any]] = {}
+    failures: list[str] = []
+    descriptors: list[PluginDescriptor] = []
+    offline = bool(os.getenv("GENECODER_OFFLINE"))
+
+    groups = {
+        "genecoder.plugins": "codec",
+        "genecoder.fec": "FEC",
+        "genecoder.simulators": "simulator",
+        "genecoder.visualizers": "visualizer",
+    }
+    for group, kind in groups.items():
+        try:
+            entries = entry_points(group=group)
+        except TypeError:
+            eps = entry_points()
+            if hasattr(eps, "select"):
+                entries = eps.select(group=group)
+            elif isinstance(eps, dict):
+                entries = eps.get(group, EntryPoints())
+            else:
+                entries = [ep for ep in eps if getattr(ep, "group", None) == group]
+        for ep in entries:
+            entry_name = str(getattr(ep, "value", getattr(ep, "name", "")))
+            if entry_name:
+                _record_entry_point_metadata(entry_name, kind, ep)
+
+    for entry_name, cached in list(ENTRY_POINT_METADATA.items()):
+        if cached.get("invalid_metadata"):
+            continue
+        if cached.get("metadata_name") and cached.get("metadata_name") != cached.get("entry_name"):
+            continue
+        module_name = cached.get("module")
+        entry_point = cached.get("entry_point")
+        module = sys.modules.get(str(module_name)) if module_name else None
+        if module is None and entry_point is not None and not offline:
+            try:
+                module = cast(ModuleType, entry_point.load())
+            except Exception as exc:
+                failures.append(f"entry_point:{entry_name}")
+                logger.warning("Failed to import entry point metadata for %s: %s", entry_name, exc)
+                continue
+        if module is not None:
+            _update_entry_point_metadata(entry_name, module)
+
+    for cached in ENTRY_POINT_METADATA.values():
+        if cached.get("invalid"):
+            continue
+        entry_name = str(cached.get("entry_name") or "")
+        plugin_name = str(cached.get("metadata_name") or entry_name)
+        if cached.get("invalid_metadata") or not plugin_name:
+            continue
+        interfaces = {str(i) for i in (cached.get("interfaces") or set())}
+        version = str(cached.get("version") or "")
+        license_value = str(cached.get("license") or "")
+        catalog[plugin_name] = {"version": version, "interfaces": sorted(interfaces), "license": license_value}
+        descriptors.append(PluginDescriptor(name=plugin_name, kind="metadata", source="entry_point", version=version, license=license_value, state=PluginLifecycleState.VALIDATED))
+
+    try:
+        import plugins as local_pkg
+    except ModuleNotFoundError:
+        local_pkg = None
+
+    modules: list[ModuleType] = []
+    if local_pkg is not None:
+        modules.append(local_pkg)
+        if hasattr(local_pkg, "__path__"):
+            for _, module_name, _ in pkgutil.iter_modules(local_pkg.__path__):
+                try:
+                    modules.append(importlib.import_module(f"plugins.{module_name}"))
+                except Exception as exc:
+                    src = f"local:{module_name}"
+                    failures.append(src)
+                    logger.warning("Failed to import %s: %s", src, exc)
+    for mod in modules:
+        src = getattr(mod, "__name__", "local")
+        try:
+            meta = validate_plugin_metadata(getattr(mod, "PLUGIN_METADATA", None))
+        except Exception as exc:
+            failures.append(src)
+            logger.warning("Incompatible plugin %s: %s", src, exc)
+            continue
+        name = meta["name"]
+        if name in catalog or name in existing_catalog:
+            failures.append(src)
+            logger.warning("Duplicate plugin name %s from %s", name, src)
+            continue
+        catalog[name] = {"version": meta["version"], "interfaces": meta["interfaces"], "license": meta["license"]}
+        descriptors.append(PluginDescriptor(name=name, kind="metadata", source=src, version=meta["version"], license=meta["license"], state=PluginLifecycleState.VALIDATED))
+    return catalog, failures, descriptors

--- a/src/genecoder/plugin_runtime/installer.py
+++ b/src/genecoder/plugin_runtime/installer.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping, Protocol, cast
+from urllib.parse import urlparse
+
+from genecoder import plugin_security
+
+from .descriptors import PluginDescriptor, PluginLifecycleState
+from .policy import validate_registry_license, validate_spec
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_LOCK: list[dict[str, str]] = []
+
+
+class PluginInstaller(Protocol):
+    def install(self, target: str) -> None: ...
+
+
+class PipPluginInstaller:
+    def install(self, target: str) -> None:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", target])
+
+
+def _read_local(path_str: str) -> bytes:
+    path = urlparse(path_str).path if path_str.startswith("file://") else path_str
+    return Path(path).read_bytes()
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    current_list: list[dict[str, Any]] | None = None
+    current_item: dict[str, Any] | None = None
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.endswith(":") and not stripped.startswith("- "):
+            key = stripped[:-1].strip()
+            current_item = None
+            current_list = []
+            result[key] = current_list
+            continue
+        if stripped.startswith("- "):
+            if current_list is None:
+                continue
+            current_item = {}
+            current_list.append(current_item)
+            remainder = stripped[2:].strip()
+            if remainder and ":" in remainder:
+                k, v = remainder.split(":", 1)
+                current_item[k.strip()] = v.strip()
+            continue
+        if current_item is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current_item[key.strip()] = value.strip()
+    return result
+
+
+def load_registry_mapping(raw: bytes | str, yaml_module: ModuleType | None) -> dict[str, Any]:
+    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+    if yaml_module is not None:
+        try:
+            data = yaml_module.safe_load(text)
+        except Exception as exc:
+            raise ValueError("Invalid plugin registry YAML") from exc
+        if isinstance(data, dict) and data:
+            return data
+    try:
+        data = json.loads(text)
+    except Exception:
+        data = _parse_simple_yaml(text)
+    if not isinstance(data, dict):
+        raise ValueError("Invalid plugin registry YAML")
+    return data
+
+
+def fetch_catalog(url: str, *, allow_network: bool) -> bytes:
+    if url.startswith("http://") or url.startswith("https://"):
+        if not allow_network:
+            msg = (
+                "Network access is disabled. Set GENECODER_ALLOW_NETWORK=1 to enable "
+                "downloads from the plugin registry specified by GENECODER_PLUGIN_REGISTRY_URL."
+            )
+            raise RuntimeError(msg)
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return cast(bytes, response.read())
+    return _read_local(url)
+
+
+def _download_plugin_bytes(spec: str, *, allow_network: bool) -> bytes:
+    path = urlparse(spec).path if spec.startswith("file://") else spec
+    if Path(path).exists():
+        return _read_local(spec)
+    if not allow_network:
+        raise RuntimeError(
+            "Network access is disabled. Set GENECODER_ALLOW_NETWORK=1 to enable "
+            "downloads from the plugin registry specified by GENECODER_PLUGIN_REGISTRY_URL."
+        )
+    with urllib.request.urlopen(spec, timeout=30) as resp:
+        return resp.read()
+
+
+def _verify_payload(payload: bytes, *, checksum: str | None, signature: str | None) -> None:
+    sig_bytes = None
+    public_key = None
+    if signature:
+        import base64
+
+        try:
+            sig_bytes = base64.b64decode(str(signature), validate=True)
+            key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
+            if not key_path:
+                raise ValueError
+            public_key = Path(key_path).read_bytes()
+        except Exception as exc:
+            raise ValueError("Invalid signature") from exc
+    digest = plugin_security.compute_checksum(payload, signature=sig_bytes, public_key=public_key)
+    if checksum:
+        expected = plugin_security.decode_checksum(str(checksum))
+        if expected != digest:
+            raise ValueError("Checksum mismatch")
+
+
+def install_plugin_spec(
+    spec: str,
+    *,
+    checksum: str | None,
+    signature: str | None,
+    allow_network: bool,
+    installer: PluginInstaller,
+) -> str:
+    target = spec
+    tmp_path: str | None = None
+    try:
+        if checksum or signature:
+            payload = _download_plugin_bytes(spec, allow_network=allow_network)
+            _verify_payload(payload, checksum=checksum, signature=signature)
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            tmp_path = tmp.name
+            tmp.write(payload)
+            tmp.close()
+            target = tmp_path
+        installer.install(target)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+    return target
+
+
+def render_plugin_lock(descriptors: list[PluginDescriptor]) -> str:
+    entries = sorted((d.as_lock_entry() for d in descriptors), key=lambda item: (item["name"], item["version"], item["source"]))
+    return json.dumps({"plugins": entries}, indent=2, sort_keys=True)
+
+
+def install_registry_plugins(
+    url: str | os.PathLike[str] | None,
+    *,
+    offline: bool | None,
+    allow_network: bool | None,
+    yaml_module: ModuleType | None,
+    installer: PluginInstaller | None = None,
+) -> list[PluginDescriptor]:
+    if isinstance(url, os.PathLike):
+        url = os.fspath(url)
+    if offline is None:
+        offline = bool(os.getenv("GENECODER_OFFLINE"))
+    if allow_network is None:
+        allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
+    if url is None:
+        url = os.getenv("GENECODER_PLUGIN_REGISTRY_URL")
+    if not url:
+        return []
+
+    network_ok = allow_network and not offline
+    raw = fetch_catalog(url, allow_network=network_ok)
+    data = load_registry_mapping(raw, yaml_module)
+    impl = installer or PipPluginInstaller()
+    descriptors: list[PluginDescriptor] = []
+
+    for entry in data.get("packages", []):
+        spec = ""
+        checksum = None
+        signature = None
+        version = ""
+        name = ""
+        if isinstance(entry, Mapping):
+            spec = str(entry.get("spec") or entry.get("package") or entry.get("url") or "")
+            checksum = cast(str | None, entry.get("checksum"))
+            signature = cast(str | None, entry.get("signature"))
+            version = str(entry.get("version") or "")
+            name = str(entry.get("package") or spec)
+        else:
+            spec = str(entry)
+            name = spec
+        if not spec:
+            continue
+        if isinstance(entry, Mapping):
+            validate_registry_license(entry, spec=spec)
+        else:
+            raise ValueError(f"Missing license for plugin entry {spec}")
+        validate_spec(spec)
+        if checksum is None and signature is None:
+            raise ValueError("Checksum or signature required")
+
+        descriptor = PluginDescriptor(name=name, kind="package", source=spec, version=version, checksum=checksum, signature=signature)
+        descriptors.append(descriptor)
+        try:
+            install_plugin_spec(spec, checksum=checksum, signature=signature, allow_network=network_ok, installer=impl)
+            descriptor.state = PluginLifecycleState.LOADED
+        except Exception as exc:
+            descriptor.state = PluginLifecycleState.FAILED
+            descriptor.error = str(exc)
+            raise
+    return descriptors

--- a/src/genecoder/plugin_runtime/policy.py
+++ b/src/genecoder/plugin_runtime/policy.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from genecoder import plugin_security
+
+logger = logging.getLogger(__name__)
+
+VALID_INTERFACES = {"codec", "FEC", "simulator", "visualizer"}
+ALLOWED_LICENSES = {
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "MIT",
+}
+
+SAFE_PKG_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+SAFE_URL_RE = re.compile(r"^(?:https?|file)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$")
+
+
+def validate_spec(spec: str) -> None:
+    if not spec or re.search(r"[\s;&|`$<>]", spec):
+        raise ValueError("Unsafe plugin spec")
+    if SAFE_PKG_RE.fullmatch(spec) or SAFE_URL_RE.fullmatch(spec):
+        return
+    raise ValueError("Unsafe plugin spec")
+
+
+def validate_registry_license(entry: Mapping[str, Any], *, spec: str) -> str:
+    license_value = entry.get("license")
+    if not isinstance(license_value, str) or not license_value.strip():
+        message = f"Missing license for plugin entry {spec}"
+        logger.error(message)
+        raise ValueError(message)
+    normalized = license_value.strip()
+    if normalized not in ALLOWED_LICENSES:
+        allowed = ", ".join(sorted(ALLOWED_LICENSES))
+        message = (
+            f"Disallowed license {normalized!r} for plugin entry {spec}. "
+            f"Allowed licenses: {allowed}"
+        )
+        logger.error(message)
+        raise ValueError(message)
+    return normalized
+
+
+def validate_plugin_metadata(meta: object) -> dict[str, Any]:
+    if not isinstance(meta, dict):
+        raise TypeError("PLUGIN_METADATA must be a dict")
+    name = meta.get("name")
+    version = meta.get("version")
+    interfaces = meta.get("interfaces")
+    license_value = meta.get("license")
+    if not isinstance(name, str) or not name:
+        raise ValueError("PLUGIN_METADATA.name is required and must be a non-empty string")
+    if not isinstance(version, str) or not version:
+        raise ValueError("PLUGIN_METADATA.version is required and must be a non-empty string")
+    if not isinstance(interfaces, (list, tuple)) or not interfaces:
+        raise ValueError("PLUGIN_METADATA.interfaces is required and must be a non-empty list")
+    if any(i not in VALID_INTERFACES for i in interfaces):
+        raise ValueError("PLUGIN_METADATA.interfaces contains an unknown interface")
+    if not isinstance(license_value, str) or not license_value.strip():
+        raise ValueError(
+            "PLUGIN_METADATA.license is required and must be a non-empty SPDX identifier"
+        )
+    normalized = license_value.strip()
+    if normalized not in ALLOWED_LICENSES:
+        allowed = ", ".join(sorted(ALLOWED_LICENSES))
+        raise ValueError(
+            f"PLUGIN_METADATA.license {normalized!r} is not allowed. Allowed licenses: {allowed}"
+        )
+    return {
+        "name": name,
+        "version": version,
+        "interfaces": list(interfaces),
+        "license": normalized,
+    }
+
+
+def check_signature(impl: Callable[..., Any], base: Callable[..., Any], *, kind: str, method: str) -> None:
+    params = list(inspect.signature(base).parameters.values())
+    if params and params[0].name == "self":
+        params = params[1:]
+    impl_sig = inspect.signature(impl)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in impl_sig.parameters.values()):
+            raise TypeError(f"{kind} {method} must accept **kwargs")
+    args = [object() for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)]
+    kwargs = {p.name: object() for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY}
+    try:
+        impl_sig.bind(*args, **kwargs)
+    except TypeError as exc:
+        raise TypeError(f"{kind} {method} has incompatible signature: {exc}") from exc
+
+
+def coerce_plugin(obj: object, expected: type[object], methods: Iterable[str], kind: str) -> object:
+    if isinstance(obj, type):
+        if not issubclass(obj, expected):
+            raise TypeError(f"{kind} must subclass {expected.__name__}")
+        instance: object = obj()
+    else:
+        if not isinstance(obj, expected):
+            raise TypeError(f"{kind} must subclass {expected.__name__}")
+        instance = obj
+    for method in methods:
+        method_impl = getattr(instance, method, None)
+        if not callable(method_impl):
+            raise TypeError(f"{kind} missing required method {method}")
+        check_signature(method_impl, getattr(expected, method), kind=kind, method=method)
+    return instance
+
+
+def decode_and_verify_checksum(
+    payload: bytes,
+    *,
+    checksum: str | None = None,
+    signature_b64: str | None = None,
+    public_key_env_var: str = "GENECODER_PLUGIN_PUBLIC_KEY",
+) -> bytes:
+    signature = None
+    public_key = None
+    if signature_b64:
+        import base64
+
+        try:
+            signature = base64.b64decode(str(signature_b64), validate=True)
+            public_key = Path(os.environ[public_key_env_var]).read_bytes()
+        except Exception as exc:
+            raise ValueError("Invalid signature") from exc
+    digest = plugin_security.compute_checksum(payload, signature=signature, public_key=public_key)
+    if checksum:
+        expected = plugin_security.decode_checksum(str(checksum))
+        if digest != expected:
+            raise ValueError("Checksum mismatch")
+    return digest

--- a/src/genecoder/plugin_runtime/registry.py
+++ b/src/genecoder/plugin_runtime/registry.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Callable, cast
+
+from genecoder.plugin_api import Codec, FEC, Simulator, Visualizer
+from genecoder.simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
+
+from .policy import coerce_plugin
+
+CODEC_REGISTRY: dict[str, dict[str, Callable[..., Any]]] = {}
+FEC_REGISTRY: dict[str, dict[str, Callable[..., Any]]] = {}
+VISUALIZER_REGISTRY: dict[str, Callable[..., Any]] = {}
+
+
+class RuntimeRegistry:
+    def __init__(self) -> None:
+        self.entry_point_loaders: dict[str, dict[str, Callable[[], None]]] = {
+            "codec": {},
+            "FEC": {},
+            "simulator": {},
+            "visualizer": {},
+        }
+
+    def load_pending(self, kind: str, name: str) -> None:
+        loader = self.entry_point_loaders.get(kind, {}).pop(name, None)
+        if loader:
+            loader()
+
+
+RUNTIME_REGISTRY = RuntimeRegistry()
+
+
+class _LazyMappingPlugin(MutableMapping[str, Callable[..., Any]]):
+    __slots__ = ("_kind", "_name", "_registry", "_fallback", "_loading")
+
+    def __init__(self, kind: str, name: str, registry: dict[str, Any], fallback: Mapping[str, Callable[..., Any]] | None = None) -> None:
+        self._kind = kind
+        self._name = name
+        self._registry = registry
+        self._fallback = fallback
+        self._loading = False
+
+    def _resolve(self) -> Mapping[str, Callable[..., Any]]:
+        value = self._registry.get(self._name)
+        if value is not self:
+            return cast(Mapping[str, Callable[..., Any]], value)
+        if self._loading:
+            raise RuntimeError(f"Recursive load for {self._kind} plugin {self._name}")
+        self._loading = True
+        try:
+            RUNTIME_REGISTRY.load_pending(self._kind, self._name)
+        except Exception:
+            if self._fallback is not None:
+                new_map = dict(self._fallback)
+                dict.__setitem__(self._registry, self._name, new_map)
+                return new_map
+            raise
+        finally:
+            self._loading = False
+        value = self._registry.get(self._name)
+        if value is self:
+            if self._fallback is not None:
+                new_map = dict(self._fallback)
+                dict.__setitem__(self._registry, self._name, new_map)
+                return new_map
+            raise KeyError(f"{self._kind} plugin {self._name} failed to register")
+        return cast(Mapping[str, Callable[..., Any]], value)
+
+    def __getitem__(self, key: str) -> Callable[..., Any]:
+        return self._resolve()[key]
+
+    def __setitem__(self, key: str, value: Callable[..., Any]) -> None:
+        m = dict(self._resolve())
+        m[key] = value
+        dict.__setitem__(self._registry, self._name, m)
+
+    def __delitem__(self, key: str) -> None:
+        m = dict(self._resolve())
+        del m[key]
+        dict.__setitem__(self._registry, self._name, m)
+
+    def __iter__(self):
+        return iter(self._resolve())
+
+    def __len__(self) -> int:
+        return len(self._resolve())
+
+
+class _LazyVisualizer:
+    __slots__ = ("_name", "_fallback", "_loading")
+
+    def __init__(self, name: str, fallback: Callable[..., object] | None = None) -> None:
+        self._name = name
+        self._fallback = fallback
+        self._loading = False
+
+    def _resolve(self) -> Callable[..., object]:
+        value = VISUALIZER_REGISTRY.get(self._name)
+        if value is not self:
+            return cast(Callable[..., object], value)
+        if self._loading:
+            raise RuntimeError(f"Recursive load for visualizer {self._name}")
+        self._loading = True
+        try:
+            RUNTIME_REGISTRY.load_pending("visualizer", self._name)
+        except Exception:
+            if self._fallback is not None:
+                VISUALIZER_REGISTRY[self._name] = self._fallback
+                return self._fallback
+            raise
+        finally:
+            self._loading = False
+        value = VISUALIZER_REGISTRY.get(self._name)
+        if value is self and self._fallback is not None:
+            VISUALIZER_REGISTRY[self._name] = self._fallback
+            return self._fallback
+        return cast(Callable[..., object], value)
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self._resolve()(*args, **kwargs)
+
+
+class _LazySimulator(Simulator):
+    __slots__ = ("_name", "_fallback", "_loading")
+
+    def __init__(self, name: str, fallback: Simulator | None = None) -> None:
+        self._name = name
+        self._fallback = fallback
+        self._loading = False
+
+    def _resolve(self) -> Simulator:
+        channel = SIMULATOR_REGISTRY.get(self._name)
+        if channel is not self:
+            return cast(Simulator, channel)
+        if self._loading:
+            raise RuntimeError(f"Recursive load for simulator {self._name}")
+        self._loading = True
+        try:
+            RUNTIME_REGISTRY.load_pending("simulator", self._name)
+        except Exception:
+            if self._fallback is not None:
+                _register_simulator(self._name, self._fallback)
+                return self._fallback
+            raise
+        finally:
+            self._loading = False
+        channel = SIMULATOR_REGISTRY.get(self._name)
+        if channel is self and self._fallback is not None:
+            _register_simulator(self._name, self._fallback)
+            return self._fallback
+        return cast(Simulator, channel)
+
+    def simulate(self, sequence: str) -> str:
+        return self._resolve().simulate(sequence)
+
+
+def register_lazy_placeholder(kind: str, name: str) -> None:
+    if kind == "codec":
+        existing = CODEC_REGISTRY.get(name)
+        fallback = existing if isinstance(existing, Mapping) and not isinstance(existing, _LazyMappingPlugin) else None
+        CODEC_REGISTRY[name] = _LazyMappingPlugin("codec", name, CODEC_REGISTRY, fallback)
+    elif kind == "FEC":
+        existing = FEC_REGISTRY.get(name)
+        fallback = existing if isinstance(existing, Mapping) and not isinstance(existing, _LazyMappingPlugin) else None
+        FEC_REGISTRY[name] = _LazyMappingPlugin("FEC", name, FEC_REGISTRY, fallback)
+    elif kind == "visualizer":
+        existing = VISUALIZER_REGISTRY.get(name)
+        fallback = existing if callable(existing) and not isinstance(existing, _LazyVisualizer) else None
+        VISUALIZER_REGISTRY[name] = _LazyVisualizer(name, fallback)
+    elif kind == "simulator":
+        existing = SIMULATOR_REGISTRY.get(name)
+        fallback = existing if isinstance(existing, Simulator) and not isinstance(existing, _LazySimulator) else None
+        _register_simulator(name, _LazySimulator(name, fallback))
+
+
+def register_codec(name: str, codec: Codec | type[Codec]) -> None:
+    inst = cast(Any, coerce_plugin(codec, Codec, ("encode", "decode"), "codec"))
+    CODEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
+
+
+def register_fec(name: str, fec: FEC | type[FEC]) -> None:
+    inst = cast(Any, coerce_plugin(fec, FEC, ("encode", "decode"), "FEC"))
+    FEC_REGISTRY[name] = {"encode": inst.encode, "decode": inst.decode}
+
+
+def register_simulator(name: str, channel: Simulator | type[Simulator]) -> None:
+    inst = cast(Any, coerce_plugin(channel, Simulator, ("simulate",), "simulator"))
+    _register_simulator(name, inst)
+
+
+def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
+    inst = cast(Any, coerce_plugin(visualizer, Visualizer, ("visualize",), "visualizer"))
+    VISUALIZER_REGISTRY[name] = inst.visualize

--- a/tests/test_plugin_lock.py
+++ b/tests/test_plugin_lock.py
@@ -1,0 +1,37 @@
+import json
+
+import genecoder.plugin_manager as plugins
+from genecoder.plugin_runtime.installer import PLUGIN_LOCK
+
+
+def test_generate_plugin_lock_is_deterministic() -> None:
+    PLUGIN_LOCK.clear()
+    PLUGIN_LOCK.extend(
+        [
+            {
+                "name": "zeta",
+                "version": "2.0",
+                "source": "https://example.com/zeta.whl",
+                "checksum": "aa",
+                "signature": "sig-z",
+            },
+            {
+                "name": "alpha",
+                "version": "1.0",
+                "source": "https://example.com/alpha.whl",
+                "checksum": "bb",
+                "signature": "sig-a",
+            },
+        ]
+    )
+
+    rendered = plugins.generate_plugin_lock()
+    payload = json.loads(rendered)
+    assert [entry["name"] for entry in payload["plugins"]] == ["alpha", "zeta"]
+    assert payload["plugins"][0].keys() == {
+        "name",
+        "version",
+        "source",
+        "checksum",
+        "signature",
+    }


### PR DESCRIPTION
### Motivation
- Reduce the huge single-file `plugin_manager.py` by separating discovery, policy, installation and runtime registry concerns for better maintainability and testability.
- Provide an explicit, shared plugin descriptor model with lifecycle states so all plugin types (codec, FEC, simulator, visualizer) can be tracked consistently through discovery, validation and load attempts.
- Move network/package-install side effects behind an installer interface so core runtime code remains side-effect free and easier to mock during tests.
- Produce deterministic plugin lock output to support reproducible environments and simpler triage of plugin installation issues.

### Description
- Split the original `plugin_manager.py` into focused internal modules under `src/genecoder/plugin_runtime/`: `discovery.py`, `policy.py`, `installer.py`, `registry.py`, and `descriptors.py`, and added a thin compatibility layer in `plugin_manager.py` that preserves old API signatures while routing to the new components.
- Added `PluginDescriptor` and `PluginLifecycleState` to standardize metadata and lifecycle tracking, and implemented `as_lock_entry()` for lock serialization.
- Implemented `PluginInstaller` protocol and a `PipPluginInstaller` default in `installer.py`, plus `install_registry_plugins` plumbing that returns descriptors and populates a deterministic `PLUGIN_LOCK` (and `generate_plugin_lock()`/`render_plugin_lock()` helpers).
- Moved policy and validation logic (spec safety, SPDX license allowlist, PLUGIN_METADATA validation, signature/checksum verification and interface signature checks) into `policy.py`, and moved runtime registries and lazy adapters to `registry.py` to centralize coercion/registration logic.

### Testing
- Ran linter checks with `ruff check src tests` and fixed reported issues, resulting in no lint errors.
- Ran the plugin-focused test suite with `pytest` (plugin-related tests referenced in the repo), including the newly added `tests/test_plugin_lock.py`, and observed `58 passed, 3 skipped` with warnings in this environment.
- Verified `tests/test_plugin_lock.py` asserts deterministic lock ordering and shape and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cba53bf3083269f2308c2e3cb36c0)