### PR TITLE
Add ConstraintPolicy subsystem, repair pipeline, and integrate structured constraint reports

### DIFF
--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -400,3 +400,21 @@ comparison = pd.DataFrame(
 )
 comparison
 ```
+
+## Constraint policy files and reproducible what-if analysis
+
+GeneCoder now supports a portable `ConstraintPolicy` object that can be shared
+across CLI, API, and GUI surfaces. A policy can be stored in YAML/JSON and fed
+into channel or pipeline configs to keep constraints reproducible across runs.
+
+Example policy: `examples/constraint_policy.yaml`.
+
+A simple what-if loop is:
+
+1. Run a baseline with `repair.enabled: false`.
+2. Re-run with `repair.enabled: true` and the same seed.
+3. Compare `constraint_report_pre` and `constraint_report_post` in per-oligo
+   metadata plus the `constraint_policy` block in output manifests.
+
+This keeps a deterministic audit trail for how policy changes impact decode
+success and synthesis violations.

--- a/examples/constraint_policy.yaml
+++ b/examples/constraint_policy.yaml
@@ -1,0 +1,12 @@
+min_length: 80
+max_length: 180
+gc_min: 0.45
+gc_max: 0.55
+max_homopolymer: 3
+restriction_site_bans:
+  - GAATTC  # EcoRI
+  - AAGCTT  # HindIII
+repair:
+  enabled: true
+  strategy: deterministic
+  ecc_protected_prefix: 16

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -53,6 +53,7 @@ from genecoder.manifest import generate_manifest
 from genecoder.plugin_manager import FEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.synthesis import SynthesisConstraints
+from genecoder.constraints import load_constraint_policy
 
 
 @dataclass
@@ -432,46 +433,21 @@ def _derive_constraints(
 ) -> SynthesisConstraints | None:
     """Return synthesis constraints from encoding and simulation configs."""
 
-    params: dict[str, float | int] = {}
-
-    def _apply_int(key: str, raw: object, *, prefer_min: bool = False) -> None:
-        val = _parse_int(raw)
-        if val is None:
-            return
-        if prefer_min and key in params:
-            try:
-                params[key] = min(int(params[key]), val)
-            except Exception:
-                params[key] = val
-        else:
-            params[key] = val
-
-    def _apply_float(key: str, raw: object) -> None:
-        val = _parse_float(raw)
-        if val is not None:
-            params[key] = val
-
+    params: dict[str, object] = {}
     if isinstance(sim_cfg, Mapping):
-        synth_cfg = sim_cfg.get("synthesis") if isinstance(sim_cfg, Mapping) else None
+        synth_cfg = sim_cfg.get("synthesis")
         if isinstance(synth_cfg, Mapping):
-            _apply_int("min_length", synth_cfg.get("min_length"))
-            _apply_int("max_length", synth_cfg.get("max_length"))
-            _apply_int("max_homopolymer", synth_cfg.get("max_homopolymer"))
-            _apply_float("gc_min", synth_cfg.get("gc_min"))
-            _apply_float("gc_max", synth_cfg.get("gc_max"))
-
+            params.update(dict(synth_cfg))
     if isinstance(enc_cfg, Mapping):
-        _apply_int("min_length", enc_cfg.get("min_length"))
-        _apply_int("max_length", enc_cfg.get("max_length"))
-        _apply_int("max_homopolymer", enc_cfg.get("max_homopolymer"), prefer_min=True)
-        _apply_float("gc_min", enc_cfg.get("gc_min"))
-        _apply_float("gc_max", enc_cfg.get("gc_max"))
+        for key in ("min_length", "max_length", "max_homopolymer", "gc_min", "gc_max"):
+            if key in enc_cfg:
+                params[key] = enc_cfg[key]
 
     if not params:
         return None
-
     try:
-        return SynthesisConstraints(**params)
+        policy = load_constraint_policy(params)
+        return SynthesisConstraints.from_policy(policy)
     except Exception:
         logger.warning("Ignoring invalid synthesis constraints in bundle config")
         return None

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -18,6 +18,7 @@ from genecoder.channel_engine import ChannelPipeline
 from genecoder.channel_config import ChannelConfig
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
+from genecoder.constraints import ConstraintEngine, ConstraintRepairPipeline, load_constraint_policy
 from genecoder.error_simulation import introduce_errors
 from genecoder.metrics import metrics
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
@@ -189,19 +190,9 @@ def _load_config(
     if "decay_rate" in data:
         extra["decay_rate"] = float(data["decay_rate"])
 
-    constraints: dict[str, float | int] = {}
-    for key, value in synth_section.items():
-        if key in {"min_length", "max_length", "max_homopolymer"}:
-            constraints[key] = int(value)
-        elif key in {"gc_min", "gc_max"}:
-            constraints[key] = float(value)
-        else:
-            constraints[key] = value
-    if constraints:
-        constraints.setdefault("gc_min", 0.0)
-        constraints.setdefault("gc_max", 1.0)
+    policy = load_constraint_policy(synth_section, fallback={"gc_min": 0.0, "gc_max": 1.0})
 
-    return simulators, constraints, cfg, extra
+    return simulators, policy.to_dict(), cfg, extra
 
 
 def _load_profile_file(path: str) -> Dict[str, Any]:
@@ -483,19 +474,10 @@ def process_channel(
         logger.error("No FASTA records found in %s", input_file)
         raise SystemExit(1)
 
-    synth: SynthesisConstraints | None
-    normalized_constraints = dict(constraints)
-    if normalized_constraints:
-        normalized_constraints.setdefault("gc_min", 0.0)
-        normalized_constraints.setdefault("gc_max", 1.0)
-
-    if normalized_constraints:
-        try:
-            synth = SynthesisConstraints(**normalized_constraints)
-        except ValueError:
-            synth = SynthesisConstraints()
-    else:
-        synth = None
+    policy = load_constraint_policy(constraints if constraints else None, fallback={"gc_min": 0.0, "gc_max": 1.0})
+    synth = SynthesisConstraints.from_policy(policy)
+    constraint_engine = ConstraintEngine(policy.to_rule_set())
+    repair_pipeline = ConstraintRepairPipeline(policy)
 
     cfg = config or ChannelConfig()
     stage_metadata: list[dict[str, Any]] = []
@@ -524,9 +506,29 @@ def process_channel(
             dropout_count += 1
         if synth_fail:
             synth_failures += 1
+        pre_report = constraint_engine.validate(original.sequence)
+        processed.metadata["constraint_report_pre"] = {
+            "count": pre_report.count,
+            "score": pre_report.score,
+            "violations": [v.rule_id for v in pre_report.violations],
+        }
         if dropout or synth_fail:
             continue
-        if synth is not None and not validate_sequence(processed.sequence, synth):
+        repaired = repair_pipeline.run(processed.sequence)
+        if repaired.repair is not None:
+            processed.sequence = repaired.sequence
+            processed.metadata["constraint_repair"] = {
+                "strategy": repaired.repair.strategy,
+                "changes": len(repaired.repair.changes),
+                "reason": repaired.repair.reason,
+            }
+        post_report = constraint_engine.validate(processed.sequence)
+        processed.metadata["constraint_report_post"] = {
+            "count": post_report.count,
+            "score": post_report.score,
+            "violations": [v.rule_id for v in post_report.violations],
+        }
+        if not validate_sequence(processed.sequence, synth):
             raise ValueError("Sequence violates synthesis constraints")
         totals_json = processed.metadata.get(RESULT_MUTATION_TOTALS_KEY)
         totals = None
@@ -605,7 +607,7 @@ def process_channel(
             "ins_prob": ins_prob,
             "del_prob": del_prob,
         },
-        "constraints": constraints,
+        "constraint_policy": policy.to_dict(),
         "metrics": {
             "length": total_len,
             "substitutions": sub_total,

--- a/src/genecoder/cli/options.py
+++ b/src/genecoder/cli/options.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import List, Dict, Sequence
 
 from genecoder.options import EncodingOptions, DecodingOptions
+from genecoder.constraints import load_constraint_policy
 
 
 @dataclass
@@ -223,11 +224,15 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
     from .channel import _load_config  # Local import to avoid heavy deps at import time
 
     simulators = list(args.simulators)
-    constraints = {
-        "min_length": args.min_length,
-        "max_length": args.max_length,
-        "max_homopolymer": args.max_homopolymer,
-    }
+    constraints = load_constraint_policy(
+        {
+            "min_length": args.min_length,
+            "max_length": args.max_length,
+            "max_homopolymer": args.max_homopolymer,
+            "gc_min": 0.0,
+            "gc_max": 1.0,
+        }
+    ).to_dict()
 
     sim_specs: list[tuple[str, dict[str, object]]] | None = None
     dropout_rate = getattr(args, "dropout_rate", None)
@@ -241,7 +246,7 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         if cfg_sim:
             sim_specs = cfg_sim
             simulators = [name for name, _ in cfg_sim]
-        constraints.update(cfg_con)
+        constraints = load_constraint_policy(cfg_con, fallback=constraints).to_dict()
         if not args.parallel and cfg_pipeline.parallel:
             args.parallel = True
         if args.threads is None and args.processes is None:
@@ -273,9 +278,6 @@ def build_channel_options(args: argparse.Namespace) -> ChannelOptions:
         raise ValueError("batch_workers must be greater than 0")
     if coverage_distribution is not None:
         coverage_distribution = dict(coverage_distribution)
-    if constraints:
-        constraints.setdefault("gc_min", 0.0)
-        constraints.setdefault("gc_max", 1.0)
     return ChannelOptions(
         simulators=simulators,
         constraints=constraints,

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -37,6 +37,7 @@ from genecoder.simulators.batch_utils import (
 )
 from genecoder.metrics import metrics as aggregate_metrics, set_metrics_path
 from genecoder.synthesis import SynthesisConstraints
+from genecoder.constraints import load_constraint_policy
 
 
 logger = logging.getLogger(__name__)
@@ -133,26 +134,11 @@ def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]
 def _build_constraints_from_channel(channel_params: Mapping[str, Any]) -> SynthesisConstraints | None:
     """Return synthesis constraints defined in ``channel_params`` when present."""
 
-    constraint_fields = {
-        "min_length": _parse_int,
-        "max_length": _parse_int,
-        "max_homopolymer": _parse_int,
-        "gc_min": _parse_float,
-        "gc_max": _parse_float,
-    }
-    values: dict[str, float | int] = {}
-    for key, parser in constraint_fields.items():
-        if key not in channel_params:
-            continue
-        parsed = parser(channel_params.get(key))
-        if parsed is not None:
-            values[key] = parsed
-
-    if not values:
+    if not channel_params:
         return None
-
     try:
-        return SynthesisConstraints(**values)
+        policy = load_constraint_policy(channel_params)
+        return SynthesisConstraints.from_policy(policy)
     except Exception:
         logger.warning("Ignoring invalid synthesis constraints in channel config")
         return None

--- a/src/genecoder/constraints/__init__.py
+++ b/src/genecoder/constraints/__init__.py
@@ -1,5 +1,7 @@
 from .engine import ConstraintEngine
 from .report import ConstraintReport, ConstraintViolation, RepairResult
+from .policy import ConstraintPolicy, RepairPolicy, load_constraint_policy
+from .repair_pipeline import ConstraintRepairPipeline, RepairPipelineResult
 from .rules import (
     ConstraintRuleSet,
     GcRangeRule,
@@ -20,6 +22,11 @@ __all__ = [
     "ConstraintReport",
     "ConstraintViolation",
     "RepairResult",
+    "ConstraintPolicy",
+    "RepairPolicy",
+    "load_constraint_policy",
+    "ConstraintRepairPipeline",
+    "RepairPipelineResult",
     "ConstraintRuleSet",
     "GcRangeRule",
     "HomopolymerMaxRule",

--- a/src/genecoder/constraints/engine.py
+++ b/src/genecoder/constraints/engine.py
@@ -13,7 +13,11 @@ class ConstraintEngine:
     rules: ConstraintRuleSet
 
     def validate(self, sequence: str) -> ConstraintReport:
-        return ConstraintReport(sequence=sequence, violations=self.rules.validate(sequence))
+        return ConstraintReport(
+            sequence=sequence,
+            violations=self.rules.validate(sequence),
+            score=self.rules.score(sequence),
+        )
 
     def repair(self, sequence: str, strategy: RepairStrategy) -> tuple[ConstraintReport, RepairResult]:
         repair_result = strategy.repair(sequence, self.rules)

--- a/src/genecoder/constraints/policy.py
+++ b/src/genecoder/constraints/policy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+from .rules import (
+    ConstraintRuleSet,
+    GcRangeRule,
+    HomopolymerMaxRule,
+    LengthRule,
+    MotifAllowRule,
+    MotifDenyRule,
+)
+
+
+@dataclass(frozen=True)
+class RepairPolicy:
+    enabled: bool = False
+    strategy: str = "stochastic"
+    ecc_protected_prefix: int = 0
+
+
+@dataclass(frozen=True)
+class ConstraintPolicy:
+    min_length: int = 25
+    max_length: int = 300
+    gc_min: float = 0.45
+    gc_max: float = 0.55
+    max_homopolymer: int = 3
+    restriction_site_bans: tuple[str, ...] = ()
+    required_motifs: tuple[str, ...] = ()
+    repair: RepairPolicy = field(default_factory=RepairPolicy)
+
+    def validate(self) -> None:
+        if self.min_length <= 0 or self.max_length <= 0:
+            raise ValueError("length window must be positive")
+        if self.min_length > self.max_length:
+            raise ValueError("min_length cannot exceed max_length")
+        if not 0 <= self.gc_min <= 1 or not 0 <= self.gc_max <= 1:
+            raise ValueError("gc_min/gc_max must be between 0 and 1")
+        if self.gc_min > self.gc_max:
+            raise ValueError("gc_min cannot exceed gc_max")
+        if self.max_homopolymer < 1:
+            raise ValueError("max_homopolymer must be >=1")
+        if self.repair.ecc_protected_prefix < 0:
+            raise ValueError("ecc_protected_prefix must be >=0")
+
+    def to_rule_set(self) -> ConstraintRuleSet:
+        rules = [
+            LengthRule(min_length=self.min_length, max_length=self.max_length),
+            GcRangeRule(gc_min=self.gc_min, gc_max=self.gc_max),
+            HomopolymerMaxRule(max_homopolymer=self.max_homopolymer),
+        ]
+        if self.restriction_site_bans:
+            rules.append(MotifDenyRule(motifs=self.restriction_site_bans, rule_id="restriction_site_ban"))
+        if self.required_motifs:
+            rules.append(MotifAllowRule(motifs=self.required_motifs, rule_id="required_motif"))
+        return ConstraintRuleSet(rules=rules)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "min_length": self.min_length,
+            "max_length": self.max_length,
+            "gc_min": self.gc_min,
+            "gc_max": self.gc_max,
+            "max_homopolymer": self.max_homopolymer,
+            "restriction_site_bans": list(self.restriction_site_bans),
+            "required_motifs": list(self.required_motifs),
+            "repair": {
+                "enabled": self.repair.enabled,
+                "strategy": self.repair.strategy,
+                "ecc_protected_prefix": self.repair.ecc_protected_prefix,
+            },
+        }
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "ConstraintPolicy":
+        src = dict(data or {})
+        repair_raw = src.get("repair") if isinstance(src.get("repair"), Mapping) else {}
+        policy = cls(
+            min_length=int(src.get("min_length", 25)),
+            max_length=int(src.get("max_length", 300)),
+            gc_min=float(src.get("gc_min", 0.45)),
+            gc_max=float(src.get("gc_max", 0.55)),
+            max_homopolymer=int(src.get("max_homopolymer", 3)),
+            restriction_site_bans=tuple(str(x) for x in src.get("restriction_site_bans", src.get("deny_motifs", [])) or ()),
+            required_motifs=tuple(str(x) for x in src.get("required_motifs", src.get("allow_motifs", [])) or ()),
+            repair=RepairPolicy(
+                enabled=bool(repair_raw.get("enabled", False)),
+                strategy=str(repair_raw.get("strategy", "stochastic")),
+                ecc_protected_prefix=int(repair_raw.get("ecc_protected_prefix", 0)),
+            ),
+        )
+        policy.validate()
+        return policy
+
+
+def load_constraint_policy(source: str | Path | Mapping[str, Any] | None, *, fallback: Mapping[str, Any] | None = None) -> ConstraintPolicy:
+    if source is None:
+        merged = dict(fallback or {})
+        return ConstraintPolicy.from_mapping(merged)
+    if isinstance(source, Mapping):
+        merged = dict(fallback or {})
+        merged.update(dict(source))
+        return ConstraintPolicy.from_mapping(merged)
+
+    path = Path(source)
+    text = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        import yaml
+
+        payload = yaml.safe_load(text)
+    if not isinstance(payload, Mapping):
+        raise ValueError("Constraint policy file must contain a mapping")
+    merged = dict(fallback or {})
+    merged.update(dict(payload))
+    return ConstraintPolicy.from_mapping(merged)

--- a/src/genecoder/constraints/repair_pipeline.py
+++ b/src/genecoder/constraints/repair_pipeline.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .engine import ConstraintEngine
+from .policy import ConstraintPolicy
+from .report import RepairResult
+from .strategies import DeterministicRepairStrategy, StochasticRepairStrategy
+
+
+@dataclass
+class RepairPipelineResult:
+    sequence: str
+    repair: RepairResult | None
+
+
+class ConstraintRepairPipeline:
+    def __init__(self, policy: ConstraintPolicy):
+        self.policy = policy
+        self.engine = ConstraintEngine(policy.to_rule_set())
+
+    def run(self, sequence: str) -> RepairPipelineResult:
+        if not self.policy.repair.enabled:
+            return RepairPipelineResult(sequence=sequence, repair=None)
+        prefix = max(0, self.policy.repair.ecc_protected_prefix)
+        protected = sequence[:prefix]
+        mutable = sequence[prefix:]
+        strategy_name = self.policy.repair.strategy
+        if strategy_name == "deterministic":
+            strategy = DeterministicRepairStrategy()
+        else:
+            strategy = StochasticRepairStrategy()
+        _report, repair = self.engine.repair(mutable, strategy)
+        repaired = protected + repair.sequence_after
+        return RepairPipelineResult(sequence=repaired, repair=repair)

--- a/src/genecoder/constraints/report.py
+++ b/src/genecoder/constraints/report.py
@@ -45,6 +45,7 @@ class RepairResult:
 class ConstraintReport:
     sequence: str
     violations: list[ConstraintViolation]
+    score: float = 0.0
 
     @property
     def count(self) -> int:

--- a/src/genecoder/constraints/rules.py
+++ b/src/genecoder/constraints/rules.py
@@ -14,6 +14,13 @@ class ConstraintRule:
     def validate(self, sequence: str) -> list[ConstraintViolation]:
         raise NotImplementedError
 
+    def score(self, sequence: str) -> float:
+        violations = self.validate(sequence)
+        return float(len(violations))
+
+    def repair(self, sequence: str) -> str | None:
+        return None
+
 
 @dataclass(frozen=True)
 class GcRangeRule(ConstraintRule):
@@ -128,6 +135,9 @@ class ConstraintRuleSet:
         for rule in self.rules:
             violations.extend(rule.validate(sequence))
         return violations
+
+    def score(self, sequence: str) -> float:
+        return sum(rule.score(sequence) for rule in self.rules)
 
     def limits(self) -> dict[str, float | int | list[str]]:
         details: dict[str, float | int | list[str]] = {}

--- a/src/genecoder/synthesis.py
+++ b/src/genecoder/synthesis.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from .constraints import (
     ConstraintEngine,
+    ConstraintPolicy,
     ConstraintRuleSet,
     GcRangeRule,
     HomopolymerMaxRule,
@@ -40,6 +41,30 @@ class SynthesisConstraints:
             raise ValueError("gc_max must be between 0.0 and 1.0")
         if self.gc_min > self.gc_max:
             raise ValueError("gc_min cannot be greater than gc_max")
+
+
+    def to_policy(self) -> ConstraintPolicy:
+        return ConstraintPolicy(
+            min_length=self.min_length,
+            max_length=self.max_length,
+            gc_min=self.gc_min,
+            gc_max=self.gc_max,
+            max_homopolymer=self.max_homopolymer,
+            restriction_site_bans=tuple(self.deny_motifs),
+            required_motifs=tuple(self.allow_motifs),
+        )
+
+    @classmethod
+    def from_policy(cls, policy: ConstraintPolicy) -> "SynthesisConstraints":
+        return cls(
+            min_length=policy.min_length,
+            max_length=policy.max_length,
+            max_homopolymer=policy.max_homopolymer,
+            gc_min=policy.gc_min,
+            gc_max=policy.gc_max,
+            deny_motifs=tuple(policy.restriction_site_bans),
+            allow_motifs=tuple(policy.required_motifs),
+        )
 
     def to_rule_set(self) -> ConstraintRuleSet:
         rules = [

--- a/tests/test_constraint_policy.py
+++ b/tests/test_constraint_policy.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from genecoder.constraints import ConstraintEngine, ConstraintPolicy, ConstraintRepairPipeline, RepairPolicy, load_constraint_policy
+
+
+def test_constraint_policy_roundtrip() -> None:
+    policy = ConstraintPolicy(
+        min_length=10,
+        max_length=20,
+        gc_min=0.2,
+        gc_max=0.8,
+        max_homopolymer=4,
+        restriction_site_bans=("GAATTC",),
+    )
+    clone = load_constraint_policy(policy.to_dict())
+    assert clone.to_dict()["restriction_site_bans"] == ["GAATTC"]
+
+
+def test_constraint_engine_reports_score() -> None:
+    policy = ConstraintPolicy(min_length=5, max_length=10, gc_min=0.5, gc_max=0.6, max_homopolymer=2)
+    report = ConstraintEngine(policy.to_rule_set()).validate("AAAA")
+    assert report.count >= 1
+    assert report.score >= 1
+
+
+def test_constraint_repair_pipeline_ecc_prefix_preserved() -> None:
+    policy = ConstraintPolicy(
+        min_length=1,
+        max_length=20,
+        gc_min=0.4,
+        gc_max=1.0,
+        max_homopolymer=2,
+        repair=RepairPolicy(enabled=True, strategy="deterministic", ecc_protected_prefix=2),
+    )
+    seq = "AATTTT"
+    fixed = ConstraintRepairPipeline(policy).run(seq)
+    assert fixed.sequence.startswith("AA")


### PR DESCRIPTION
### Motivation

- Provide a single, serializable constraint model that can be shared across CLI/API/GUI and stored in manifests for reproducible what‑if analyses.
- Centralize scattered synthesis constraint parsing and validation into one policy loader to reduce duplication and mismatch across CLI/module code paths.
- Enable structured pre/post evaluation of constraints around channel simulation and optional ECC‑aware repair while preserving repair provenance.

### Description

- Added a `ConstraintPolicy`/`RepairPolicy` model with `to_dict`/`from_mapping` and `load_constraint_policy` file/Mapping loader in `src/genecoder/constraints/policy.py` and exported helpers via the constraints package.  This supports GC range, homopolymer cap, length windows, restriction‑site bans, required motifs, and repair options.
- Extended the constraint rule API in `rules.py` with `score` and an optional `repair` hook, added `ConstraintRuleSet.score`, and propagated a `score` field into `ConstraintReport` and `ConstraintEngine.validate` to give numeric policy stress metrics.
- Implemented an ECC‑aware `ConstraintRepairPipeline` in `src/genecoder/constraints/repair_pipeline.py` that preserves a protected prefix (e.g., ECC region), applies deterministic/stochastic strategies, and returns repair provenance (`RepairResult`).
- Integrated policy loading and structured constraint evaluation in the channel flow (`src/genecoder/cli/channel.py`) to produce per‑oligo `constraint_report_pre` and `constraint_report_post` metadata and optional `constraint_repair` provenance, and to record `constraint_policy` in manifests.
- Replaced ad‑hoc parsing of synthesis constraints in CLI modules with the shared `load_constraint_policy` usage in `src/genecoder/cli/options.py`, `src/genecoder/cli/pipeline.py`, and `src/genecoder/cli/bundle.py` and added `SynthesisConstraints.from_policy`/`to_policy` adapters in `src/genecoder/synthesis.py`.
- Added an example policy file `examples/constraint_policy.yaml`, a docs snippet describing policy-driven what‑if analysis in `docs/pipeline_examples.md`, and unit tests exercising policy roundtrip, scoring, and ECC‑prefix‑preserving repair in `tests/test_constraint_policy.py`.

### Testing

- Ran the linter: `python -m ruff check src/genecoder/constraints src/genecoder/cli/channel.py src/genecoder/cli/options.py src/genecoder/cli/pipeline.py src/genecoder/cli/bundle.py src/genecoder/synthesis.py tests/test_constraint_policy.py` and all checks passed.
- Ran focused unit tests: `python -m pytest tests/test_constraint_policy.py tests/test_gc_constraint_failures.py tests/test_cli_simulator_fallback.py -q` and the tests passed.
- Ran integration suites: `python -m pytest tests/test_cli_pipeline.py tests/test_bundle_cli_integration.py -q` and `python -m pytest tests/test_channel_run.py tests/test_cli.py -q` and the targeted test runs completed successfully (with the usual skipped tests for optional deps noted by the harness).
- All automated checks invoked during development on the modified modules succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cf9c91988326a43cced3bb5a5eaa)