### PR TITLE
Unify plugin registration through runtime descriptor API

### DIFF
--- a/src/genecoder/builtin_plugins.py
+++ b/src/genecoder/builtin_plugins.py
@@ -5,14 +5,59 @@ from __future__ import annotations
 from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+from types import ModuleType
 
-from .plugin_manager import (
-    register_codec,
-    register_fec,
-    register_simulator,
-    register_visualizer,
-    _load_and_register,
+from .plugin_runtime.descriptors import (
+    PLUGIN_DESCRIPTOR_VERSION,
+    RegistrationCapabilities,
+    RuntimePluginDescriptor,
+    ValidationContract,
 )
+from .plugin_runtime.registry import register_plugin
+
+
+def _register_from_module(module: ModuleType, descriptor_kind: str, name_hint: str) -> None:
+    plugin_name = getattr(module, "PLUGIN_NAME", name_hint)
+    impl = getattr(module, "PLUGIN", None)
+    if impl is None:
+        register = getattr(module, "register", None)
+        if callable(register):
+            # Compatibility: allow old register(function) modules while built-ins migrate.
+            kind_map = {
+                "codec": lambda n, v: register_plugin(RuntimePluginDescriptor(api_version=PLUGIN_DESCRIPTOR_VERSION, name=n, kind="codec", implementation=v, capabilities=RegistrationCapabilities(deterministic=True), validation=ValidationContract(encode_input="bytes", encode_output="sequence", decode_input="sequence|batch", decode_output="bytes"))),
+                "fec": lambda n, v: register_plugin(RuntimePluginDescriptor(api_version=PLUGIN_DESCRIPTOR_VERSION, name=n, kind="fec", implementation=v)),
+                "simulator": lambda n, v: register_plugin(RuntimePluginDescriptor(api_version=PLUGIN_DESCRIPTOR_VERSION, name=n, kind="simulator", implementation=v)),
+                "visualizer": lambda n, v: register_plugin(RuntimePluginDescriptor(api_version=PLUGIN_DESCRIPTOR_VERSION, name=n, kind="visualizer", implementation=v)),
+            }
+            register(kind_map[descriptor_kind])
+            return
+        raise ValueError(f"Builtin module {module.__name__} does not expose a plugin implementation")
+
+    register_plugin(
+        RuntimePluginDescriptor(
+            api_version=PLUGIN_DESCRIPTOR_VERSION,
+            name=plugin_name,
+            kind=descriptor_kind,
+            implementation=impl,
+            capabilities=RegistrationCapabilities(deterministic=True),
+            validation=ValidationContract(
+                encode_input="bytes",
+                encode_output="sequence" if descriptor_kind == "codec" else "bytes",
+                decode_input="sequence|batch" if descriptor_kind == "codec" else "bytes",
+                decode_output="bytes",
+            ),
+            metadata={"builtin": True},
+        )
+    )
+
+
+def _load_and_register(items: list[str], kind: str) -> None:
+    for name in items:
+        try:
+            module = import_module(name)
+        except Exception:
+            continue
+        _register_from_module(module, kind, name.rsplit(".", 1)[-1])
 
 
 def register_builtin_plugins() -> None:
@@ -20,7 +65,7 @@ def register_builtin_plugins() -> None:
 
     try:
         module = import_module("plugins.reverse_codec")
-    except ModuleNotFoundError:  # pragma: no cover - fallback when a plugins.py module is present
+    except ModuleNotFoundError:  # pragma: no cover
         spec = spec_from_file_location(
             "plugins.reverse_codec",
             Path(__file__).resolve().parents[1] / "plugins" / "reverse_codec.py",
@@ -28,49 +73,33 @@ def register_builtin_plugins() -> None:
         assert spec and spec.loader
         module = module_from_spec(spec)
         spec.loader.exec_module(module)
-    register = getattr(module, "register", None)
-    if callable(register):
-        register(register_codec)
+    _register_from_module(module, "codec", "reverse")
 
-    _load_and_register(
-        [
-            "genecoder.chamaeleo_codec",
-            "genecoder.dnachisel_fixer",
-        ],
-        register_codec,
-        "builtin",
-    )
+    _load_and_register([
+        "genecoder.chamaeleo_codec",
+        "genecoder.dnachisel_fixer",
+    ], "codec")
 
-    _load_and_register(
-        [
-            "genecoder.reed_solomon_codec",
-            "genecoder.ldpc_codec",
-            "genecoder.fountain_codec",
-            "genecoder.bch_codec",
-            "genecoder.raptorq_codec",
-        ],
-        register_fec,
-        "builtin",
-    )
+    _load_and_register([
+        "genecoder.reed_solomon_codec",
+        "genecoder.ldpc_codec",
+        "genecoder.fountain_codec",
+        "genecoder.bch_codec",
+        "genecoder.raptorq_codec",
+    ], "fec")
 
-    _load_and_register(
-        [
-            "genecoder.error_simulation",
-            "genecoder.simulators.decay",
-            "genecoder.simulators.illumina",
-            "genecoder.insilicoseq_adapter",
-            "genecoder.simulators.nanopore",
-            "genecoder.d2sim_adapter",
-            "genecoder.dnarsim_adapter",
-            "genecoder.squigulator_adapter",
-            "genecoder.desp_adapter",
-        ],
-        register_simulator,
-        "builtin",
-    )
+    _load_and_register([
+        "genecoder.error_simulation",
+        "genecoder.simulators.decay",
+        "genecoder.simulators.illumina",
+        "genecoder.insilicoseq_adapter",
+        "genecoder.simulators.nanopore",
+        "genecoder.d2sim_adapter",
+        "genecoder.dnarsim_adapter",
+        "genecoder.squigulator_adapter",
+        "genecoder.desp_adapter",
+    ], "simulator")
 
-    _load_and_register(
-        ["genecoder.default_visualizer"],
-        register_visualizer,
-        "builtin",
-    )
+    _load_and_register([
+        "genecoder.default_visualizer",
+    ], "visualizer")

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 import base64
 import importlib
@@ -97,20 +97,6 @@ def install_registry_plugins(
 
 
 
-def _load_and_register(items: list[Any], registrar: Callable[..., object], kind: str, failures: list[str] | None = None) -> None:
-    for item in items:
-        name = getattr(item, "value", getattr(item, "__name__", str(item)))
-        try:
-            module = item if isinstance(item, ModuleType) else (item.load() if hasattr(item, "load") else importlib.import_module(name))
-        except Exception:
-            if failures is not None:
-                failures.append(f"{kind}:{name}")
-            continue
-        register = getattr(module, "register", None)
-        if callable(register):
-            register(registrar)
-
-
 def _collect_installed_plugins() -> tuple[dict[str, dict[str, Any]], list[str]]:
     discovery_mod.entry_points = entry_points
     catalog, failures, _ = collect_installed_plugins(PLUGIN_CATALOG)
@@ -154,6 +140,13 @@ def load_local_plugins() -> list[str]:
             except Exception:
                 failures.append(f"local:{module_name}")
                 continue
+            metadata = getattr(module, "PLUGIN_METADATA", None)
+            if metadata is not None:
+                try:
+                    _validate_plugin_metadata(metadata)
+                except Exception:
+                    failures.append(f"local:{module_name}")
+                    continue
             register = getattr(module, "register", None)
             if callable(register):
                 register(register_codec)
@@ -166,6 +159,14 @@ def load_local_plugins() -> list[str]:
             register_v = getattr(module, "register_visualizer", None)
             if callable(register_v):
                 register_v(register_visualizer)
+
+    metadata = getattr(plugins, "PLUGIN_METADATA", None)
+    if metadata is not None:
+        try:
+            _validate_plugin_metadata(metadata)
+        except Exception:
+            failures.append("local:plugins")
+            return failures
 
     register = getattr(plugins, "register", None)
     if callable(register):

--- a/src/genecoder/plugin_runtime/descriptors.py
+++ b/src/genecoder/plugin_runtime/descriptors.py
@@ -2,14 +2,45 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 
 class PluginLifecycleState(str, Enum):
     DISCOVERED = "discovered"
     VALIDATED = "validated"
+    DISABLED = "disabled"
     LOADED = "loaded"
+    ROLLED_BACK = "rolled_back"
     FAILED = "failed"
+
+
+PLUGIN_DESCRIPTOR_VERSION = "1.0"
+PluginKind = Literal["codec", "fec", "simulator", "visualizer", "package", "metadata"]
+
+
+@dataclass(slots=True, frozen=True)
+class RegistrationCapabilities:
+    deterministic: bool = True
+    supports_streaming: bool = False
+
+
+@dataclass(slots=True, frozen=True)
+class ValidationContract:
+    encode_input: str = "bytes"
+    encode_output: str = "bytes"
+    decode_input: str = "bytes"
+    decode_output: str = "bytes"
+
+
+@dataclass(slots=True)
+class RuntimePluginDescriptor:
+    api_version: str
+    name: str
+    kind: PluginKind
+    implementation: object
+    capabilities: RegistrationCapabilities = field(default_factory=RegistrationCapabilities)
+    validation: ValidationContract = field(default_factory=ValidationContract)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/src/genecoder/plugin_runtime/discovery.py
+++ b/src/genecoder/plugin_runtime/discovery.py
@@ -70,6 +70,9 @@ def _update_entry_point_metadata(entry_name: str, module: ModuleType) -> None:
 
 def _load_entry_point_module(entry_point: object, registrar: Callable[..., object], kind: str, entry_name: str) -> None:
     module = entry_point.load()
+    metadata = getattr(module, "PLUGIN_METADATA", None)
+    if metadata is not None:
+        validate_plugin_metadata(metadata)
     _update_entry_point_metadata(entry_name, module)
     register = getattr(module, "register", None)
     if callable(register):

--- a/src/genecoder/plugin_runtime/policy.py
+++ b/src/genecoder/plugin_runtime/policy.py
@@ -9,9 +9,15 @@ from typing import Any, Callable, Iterable, Mapping
 
 from genecoder import plugin_security
 
+from .descriptors import (
+    PLUGIN_DESCRIPTOR_VERSION,
+    PluginLifecycleState,
+    RuntimePluginDescriptor,
+)
+
 logger = logging.getLogger(__name__)
 
-VALID_INTERFACES = {"codec", "FEC", "simulator", "visualizer"}
+VALID_INTERFACES = {"codec", "FEC", "fec", "simulator", "visualizer"}
 ALLOWED_LICENSES = {
     "Apache-2.0",
     "BSD-2-Clause",
@@ -80,6 +86,39 @@ def validate_plugin_metadata(meta: object) -> dict[str, Any]:
         "interfaces": list(interfaces),
         "license": normalized,
     }
+
+
+def validate_runtime_descriptor(descriptor: RuntimePluginDescriptor) -> RuntimePluginDescriptor:
+    if descriptor.api_version != PLUGIN_DESCRIPTOR_VERSION:
+        raise ValueError(
+            f"Unsupported plugin registration API version {descriptor.api_version!r}; "
+            f"expected {PLUGIN_DESCRIPTOR_VERSION!r}"
+        )
+    if descriptor.kind not in VALID_INTERFACES:
+        raise ValueError(f"Unsupported plugin kind {descriptor.kind!r}")
+    if not descriptor.name or not descriptor.name.strip():
+        raise ValueError("Plugin descriptor name must be a non-empty string")
+    return descriptor
+
+
+ALLOWED_LIFECYCLE_TRANSITIONS: dict[PluginLifecycleState, tuple[PluginLifecycleState, ...]] = {
+    PluginLifecycleState.DISCOVERED: (PluginLifecycleState.VALIDATED, PluginLifecycleState.DISABLED, PluginLifecycleState.FAILED),
+    PluginLifecycleState.VALIDATED: (PluginLifecycleState.LOADED, PluginLifecycleState.DISABLED, PluginLifecycleState.FAILED),
+    PluginLifecycleState.LOADED: (PluginLifecycleState.VALIDATED, PluginLifecycleState.DISABLED, PluginLifecycleState.ROLLED_BACK, PluginLifecycleState.FAILED),
+    PluginLifecycleState.DISABLED: (PluginLifecycleState.VALIDATED, PluginLifecycleState.ROLLED_BACK, PluginLifecycleState.FAILED),
+    PluginLifecycleState.ROLLED_BACK: (PluginLifecycleState.VALIDATED, PluginLifecycleState.DISABLED, PluginLifecycleState.FAILED),
+    PluginLifecycleState.FAILED: (PluginLifecycleState.DISCOVERED,),
+}
+
+
+def enforce_lifecycle_transition(
+    current: PluginLifecycleState,
+    nxt: PluginLifecycleState,
+) -> PluginLifecycleState:
+    allowed = ALLOWED_LIFECYCLE_TRANSITIONS.get(current, ())
+    if nxt not in allowed:
+        raise ValueError(f"Invalid plugin lifecycle transition: {current.value} -> {nxt.value}")
+    return nxt
 
 
 def check_signature(impl: Callable[..., Any], base: Callable[..., Any], *, kind: str, method: str) -> None:

--- a/src/genecoder/plugin_runtime/registry.py
+++ b/src/genecoder/plugin_runtime/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping
 from typing import Any, Callable, cast
+import logging
 
 from genecoder.coding.stack import (
     CodecCapabilities,
@@ -12,11 +13,22 @@ from genecoder.coding.stack import (
 from genecoder.plugin_api import Codec, FEC, Simulator, Visualizer
 from genecoder.simulators import SIMULATOR_REGISTRY, register_simulator as _register_simulator
 
-from .policy import coerce_plugin
+from .descriptors import (
+    PLUGIN_DESCRIPTOR_VERSION,
+    PluginLifecycleState,
+    RegistrationCapabilities,
+    RuntimePluginDescriptor,
+    ValidationContract,
+)
+from .policy import coerce_plugin, enforce_lifecycle_transition, validate_runtime_descriptor
+
+logger = logging.getLogger(__name__)
 
 CODEC_REGISTRY: dict[str, PluginLayerDescriptor | dict[str, Callable[..., Any]]] = {}
 FEC_REGISTRY: dict[str, PluginLayerDescriptor | dict[str, Callable[..., Any]]] = {}
 VISUALIZER_REGISTRY: dict[str, Callable[..., Any]] = {}
+DEPRECATION_NOTICES: list[dict[str, str]] = []
+REGISTRATION_STATES: dict[str, PluginLifecycleState] = {}
 
 
 class RuntimeRegistry:
@@ -180,40 +192,128 @@ def register_lazy_placeholder(kind: str, name: str) -> None:
         _register_simulator(name, _LazySimulator(name, fallback))
 
 
+def _set_state(name: str, new_state: PluginLifecycleState) -> None:
+    current = REGISTRATION_STATES.get(name, PluginLifecycleState.DISCOVERED)
+    if current == new_state:
+        return
+    REGISTRATION_STATES[name] = enforce_lifecycle_transition(current, new_state)
+
+
+def _emit_legacy_notice(name: str, kind: str) -> None:
+    notice = {
+        "type": "deprecation",
+        "plugin": name,
+        "kind": kind,
+        "message": "Legacy registration entry point is deprecated.",
+        "migration_hint": "Return RuntimePluginDescriptor via register_plugin() or keep using register_* wrappers temporarily.",
+    }
+    DEPRECATION_NOTICES.append(notice)
+    logger.warning("%s", notice)
+
+
+def transition_plugin_state(name: str, new_state: PluginLifecycleState) -> PluginLifecycleState:
+    _set_state(name, new_state)
+    return REGISTRATION_STATES[name]
+
+
+def register_plugin(descriptor: RuntimePluginDescriptor) -> None:
+    validate_runtime_descriptor(descriptor)
+    _set_state(descriptor.name, PluginLifecycleState.VALIDATED)
+
+    if descriptor.kind == "codec":
+        inst = cast(Any, coerce_plugin(descriptor.implementation, Codec, ("encode", "decode"), "codec"))
+        CODEC_REGISTRY[descriptor.name] = PluginLayerDescriptor(
+            name=descriptor.name,
+            kind="codec",
+            encode_fn=inst.encode,
+            decode_fn=inst.decode,
+            capabilities=CodecCapabilities(supports_streaming=descriptor.capabilities.supports_streaming),
+            validation=ValidationMetadata(
+                encode_input=descriptor.validation.encode_input,
+                encode_output=descriptor.validation.encode_output,
+                decode_input=descriptor.validation.decode_input,
+                decode_output=descriptor.validation.decode_output,
+            ),
+        )
+    elif descriptor.kind == "fec":
+        inst = cast(Any, coerce_plugin(descriptor.implementation, FEC, ("encode", "decode"), "FEC"))
+        FEC_REGISTRY[descriptor.name] = PluginLayerDescriptor(
+            name=descriptor.name,
+            kind="fec",
+            encode_fn=inst.encode,
+            decode_fn=inst.decode,
+            capabilities=FECCapabilities(supports_streaming=descriptor.capabilities.supports_streaming),
+            validation=ValidationMetadata(
+                encode_input=descriptor.validation.encode_input,
+                encode_output=descriptor.validation.encode_output,
+                decode_input=descriptor.validation.decode_input,
+                decode_output=descriptor.validation.decode_output,
+            ),
+        )
+    elif descriptor.kind == "simulator":
+        inst = cast(Any, coerce_plugin(descriptor.implementation, Simulator, ("simulate",), "simulator"))
+        _register_simulator(descriptor.name, inst)
+    elif descriptor.kind == "visualizer":
+        inst = cast(Any, coerce_plugin(descriptor.implementation, Visualizer, ("visualize",), "visualizer"))
+        VISUALIZER_REGISTRY[descriptor.name] = inst.visualize
+    else:
+        raise ValueError(f"Unsupported runtime descriptor kind: {descriptor.kind}")
+
+    _set_state(descriptor.name, PluginLifecycleState.LOADED)
+
+
 def register_codec(name: str, codec: Codec | type[Codec]) -> None:
-    inst = cast(Any, coerce_plugin(codec, Codec, ("encode", "decode"), "codec"))
-    CODEC_REGISTRY[name] = PluginLayerDescriptor(
-        name=name,
-        kind="codec",
-        encode_fn=inst.encode,
-        decode_fn=inst.decode,
-        capabilities=CodecCapabilities(),
-        validation=ValidationMetadata(
-            encode_input="bytes",
-            encode_output="sequence",
-            decode_input="sequence|batch",
-            decode_output="bytes",
-        ),
+    _emit_legacy_notice(name, "codec")
+    register_plugin(
+        RuntimePluginDescriptor(
+            api_version=PLUGIN_DESCRIPTOR_VERSION,
+            name=name,
+            kind="codec",
+            implementation=codec,
+            capabilities=RegistrationCapabilities(deterministic=True),
+            validation=ValidationContract(
+                encode_input="bytes",
+                encode_output="sequence",
+                decode_input="sequence|batch",
+                decode_output="bytes",
+            ),
+        )
     )
 
 
 def register_fec(name: str, fec: FEC | type[FEC]) -> None:
-    inst = cast(Any, coerce_plugin(fec, FEC, ("encode", "decode"), "FEC"))
-    FEC_REGISTRY[name] = PluginLayerDescriptor(
-        name=name,
-        kind="fec",
-        encode_fn=inst.encode,
-        decode_fn=inst.decode,
-        capabilities=FECCapabilities(),
-        validation=ValidationMetadata(),
+    _emit_legacy_notice(name, "fec")
+    register_plugin(
+        RuntimePluginDescriptor(
+            api_version=PLUGIN_DESCRIPTOR_VERSION,
+            name=name,
+            kind="fec",
+            implementation=fec,
+            capabilities=RegistrationCapabilities(deterministic=True),
+            validation=ValidationContract(),
+        )
     )
 
 
 def register_simulator(name: str, channel: Simulator | type[Simulator]) -> None:
-    inst = cast(Any, coerce_plugin(channel, Simulator, ("simulate",), "simulator"))
-    _register_simulator(name, inst)
+    _emit_legacy_notice(name, "simulator")
+    register_plugin(
+        RuntimePluginDescriptor(
+            api_version=PLUGIN_DESCRIPTOR_VERSION,
+            name=name,
+            kind="simulator",
+            implementation=channel,
+        )
+    )
 
 
 def register_visualizer(name: str, visualizer: Visualizer | type[Visualizer]) -> None:
-    inst = cast(Any, coerce_plugin(visualizer, Visualizer, ("visualize",), "visualizer"))
-    VISUALIZER_REGISTRY[name] = inst.visualize
+    _emit_legacy_notice(name, "visualizer")
+    register_plugin(
+        RuntimePluginDescriptor(
+            api_version=PLUGIN_DESCRIPTOR_VERSION,
+            name=name,
+            kind="visualizer",
+            implementation=visualizer,
+        )
+    )

--- a/tests/test_plugin_lifecycle_conformance.py
+++ b/tests/test_plugin_lifecycle_conformance.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from genecoder.plugin_api import Codec
+from genecoder.plugin_runtime.descriptors import (
+    PLUGIN_DESCRIPTOR_VERSION,
+    PluginLifecycleState,
+    RegistrationCapabilities,
+    RuntimePluginDescriptor,
+    ValidationContract,
+)
+from genecoder.plugin_runtime.registry import (
+    CODEC_REGISTRY,
+    REGISTRATION_STATES,
+    register_plugin,
+    transition_plugin_state,
+)
+
+
+class CodecV1(Codec):
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
+        return data.decode("utf-8")[::-1]
+
+    def decode(self, encoded: str, /, **kwargs: object) -> bytes:
+        return encoded[::-1].encode("utf-8")
+
+
+class CodecV2(CodecV1):
+    def encode(self, data: bytes, /, **kwargs: object) -> str:
+        return f"v2:{super().encode(data, **kwargs)}"
+
+    def decode(self, encoded: str, /, **kwargs: object) -> bytes:
+        return super().decode(encoded.replace("v2:", "", 1), **kwargs)
+
+
+def _descriptor(name: str, impl: type[Codec]) -> RuntimePluginDescriptor:
+    return RuntimePluginDescriptor(
+        api_version=PLUGIN_DESCRIPTOR_VERSION,
+        name=name,
+        kind="codec",
+        implementation=impl,
+        capabilities=RegistrationCapabilities(deterministic=True),
+        validation=ValidationContract(
+            encode_input="bytes",
+            encode_output="sequence",
+            decode_input="sequence|batch",
+            decode_output="bytes",
+        ),
+    )
+
+
+def test_lifecycle_install_upgrade_disable_rollback_are_deterministic() -> None:
+    CODEC_REGISTRY.clear()
+    REGISTRATION_STATES.clear()
+
+    register_plugin(_descriptor("demo", CodecV1))
+    assert REGISTRATION_STATES["demo"] is PluginLifecycleState.LOADED
+    assert CODEC_REGISTRY["demo"]["decode"]("cba") == b"abc"
+
+    transition_plugin_state("demo", PluginLifecycleState.DISABLED)
+    assert REGISTRATION_STATES["demo"] is PluginLifecycleState.DISABLED
+
+    transition_plugin_state("demo", PluginLifecycleState.VALIDATED)
+    register_plugin(_descriptor("demo", CodecV2))
+    assert REGISTRATION_STATES["demo"] is PluginLifecycleState.LOADED
+    assert CODEC_REGISTRY["demo"]["encode"](b"abc") == "v2:cba"
+
+    transition_plugin_state("demo", PluginLifecycleState.ROLLED_BACK)
+    transition_plugin_state("demo", PluginLifecycleState.VALIDATED)
+    register_plugin(_descriptor("demo", CodecV1))
+
+    assert REGISTRATION_STATES["demo"] is PluginLifecycleState.LOADED
+    assert CODEC_REGISTRY["demo"]["encode"](b"abc") == "cba"


### PR DESCRIPTION
### Motivation

- Provide one authoritative registration path for codec/FEC/simulator/visualizer plugins with explicit API versioning and metadata so activation, validation and lifecycle are consistent.
- Enforce a standard descriptor/schema and validation contract to avoid duplicated registration logic spread across modules.
- Preserve backward compatibility for existing plugins while emitting structured deprecation notices and migration hints.

### Description

- Introduced `RuntimePluginDescriptor`, `RegistrationCapabilities`, `ValidationContract`, `PLUGIN_DESCRIPTOR_VERSION`, and expanded lifecycle states in `src/genecoder/plugin_runtime/descriptors.py` to model a single registration schema.
- Centralized runtime registration in `src/genecoder/plugin_runtime/registry.py` via `register_plugin(...)`, `transition_plugin_state(...)`, deterministic `REGISTRATION_STATES` tracking, and legacy adapter wrappers (`register_codec`, `register_fec`, `register_simulator`, `register_visualizer`) that emit structured deprecation notices.
- Added runtime descriptor validation and lifecycle transition rules in `src/genecoder/plugin_runtime/policy.py` and used them to validate descriptors before activation.
- Refactored built-in plugin loading in `src/genecoder/builtin_plugins.py` to register via the new descriptor API and added a compatibility adapter to accept legacy `register(...)` modules temporarily.
- Simplified `src/genecoder/plugin_manager.py` to orchestration only (install/discover/load order) and added metadata validation checks for local and entry-point activation paths in `plugin_runtime/discovery.py` and `plugin_manager.py`.
- Added conformance tests `tests/test_plugin_lifecycle_conformance.py` to verify deterministic lifecycle actions (install/upgrade/disable/rollback) and updated tests to pass against the unified flow.

### Testing

- Ran style checks with `ruff check src tests` and the linter passed with fixes applied.
- Executed targeted pytest suites including `pytest -q tests/test_plugin_lifecycle_conformance.py tests/test_builtin_plugin_loading.py tests/test_plugin_loading.py tests/test_plugin_manager.py tests/test_plugin_discovery.py` which completed successfully (all tests passed for those suites).
- Executed additional plugin/registration related tests with `pytest -q tests/test_plugin_interface_enforcement.py tests/test_plugin_class_registration.py tests/test_plugin_failures.py` and `pytest -q tests/test_plugin_manager_offline.py tests/test_plugin_metadata.py`, and all runs succeeded.
- All automated checks and the new conformance tests passed in CI-local runs (no failing tests observed; only expected deprecation warnings reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699737abbd848326b361faa496206679)