### PR TITLE
Rebuild SDK pipeline API around typed run contracts

### DIFF
--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -418,3 +418,7 @@ A simple what-if loop is:
 
 This keeps a deterministic audit trail for how policy changes impact decode
 success and synthesis violations.
+
+## SDK API workflows
+
+See `examples/sdk_api_workflows.py` for end-to-end API usage patterns covering single run, sweep, compare, and bundle-style orchestration.

--- a/examples/sdk_api_workflows.py
+++ b/examples/sdk_api_workflows.py
@@ -1,0 +1,77 @@
+"""API-level workflow examples for GeneCoder SDK roadmap scenarios."""
+
+from genecoder.sdk import ExperimentRequest, run_experiment, sweep
+
+
+def single_run() -> None:
+    run_experiment(
+        ExperimentRequest(
+            codec="reverse",
+            input_path="input.bin",
+            output_path="single.decoded.bin",
+            channel="none",
+        )
+    )
+
+
+def sweep_run() -> None:
+    sweep(
+        [
+            {
+                "codec": "reverse",
+                "input_path": "input.bin",
+                "output_path": "sweep-a.bin",
+                "matrix": {"substitution_rate": [0.0, 0.01, 0.05]},
+            },
+            {
+                "codec": "reverse",
+                "input_path": "input.bin",
+                "output_path": "sweep-b.bin",
+                "matrix": {"coverage": [5, 10]},
+            },
+        ]
+    )
+
+
+def compare_runs() -> None:
+    baseline = run_experiment(
+        {
+            "codec": "reverse",
+            "input_path": "input.bin",
+            "output_path": "baseline.bin",
+        }
+    )
+    candidate = run_experiment(
+        {
+            "codec": "reverse",
+            "input_path": "input.bin",
+            "output_path": "candidate.bin",
+            "profile": {"name": "illumina", "parameters": {"substitution_rate": 0.01}},
+        }
+    )
+    print("baseline throughput", baseline.dashboard_metrics.get("throughput"))
+    print("candidate throughput", candidate.dashboard_metrics.get("throughput"))
+
+
+def bundle_workflow() -> None:
+    runs = sweep(
+        [
+            {
+                "codec": "reverse",
+                "input_path": "input_a.bin",
+                "output_path": "bundle/a.bin",
+                "artifacts": {"metrics_path": "bundle/a.run.json"},
+            },
+            {
+                "codec": "reverse",
+                "input_path": "input_b.bin",
+                "output_path": "bundle/b.bin",
+                "artifacts": {"metrics_path": "bundle/b.run.json"},
+            },
+        ]
+    )
+    print([run.artifact_paths["metrics"] for run in runs.runs])
+
+
+if __name__ == "__main__":
+    single_run()

--- a/src/genecoder/app/__init__.py
+++ b/src/genecoder/app/__init__.py
@@ -2,7 +2,16 @@
 
 from .analyze_use_case import AnalyzeRequest, AnalyzeResponse, AnalyzeUseCase
 from .encode_use_case import EncodeRequest, EncodeResponse, EncodeUseCase
-from .pipeline_use_case import RunPipelineRequest, RunPipelineResponse, RunPipelineUseCase
+from .pipeline_use_case import (
+    ArtifactOutputPolicy,
+    BatchSweepMatrix,
+    ChannelProfile,
+    ConstraintProfile,
+    RunPipelineRequest,
+    RunPipelineResponse,
+    RunPipelineUseCase,
+    SeedProfile,
+)
 
 __all__ = [
     "AnalyzeRequest",
@@ -11,6 +20,11 @@ __all__ = [
     "EncodeRequest",
     "EncodeResponse",
     "EncodeUseCase",
+    "ArtifactOutputPolicy",
+    "BatchSweepMatrix",
+    "ChannelProfile",
+    "ConstraintProfile",
+    "SeedProfile",
     "RunPipelineRequest",
     "RunPipelineResponse",
     "RunPipelineUseCase",

--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -1,11 +1,50 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import json
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from genecoder.manifest import generate_manifest
 from genecoder.pipeline import run_pipeline
+from genecoder.results.schema import RUN_SCHEMA_VERSION, canonical_metrics_view
+from genecoder.html_report import generate_html_report
+
+
+@dataclass(frozen=True)
+class ChannelProfile:
+    name: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SeedProfile:
+    global_seed: int | None = None
+    encode_seed: int | None = None
+    simulate_seed: int | None = None
+    decode_seed: int | None = None
+
+
+@dataclass(frozen=True)
+class BatchSweepMatrix:
+    axes: Mapping[str, tuple[Any, ...]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConstraintProfile:
+    min_length: int | None = None
+    max_length: int | None = None
+    gc_min: float | None = None
+    gc_max: float | None = None
+    max_homopolymer: int | None = None
+
+
+@dataclass(frozen=True)
+class ArtifactOutputPolicy:
+    metrics_path: str | None = None
+    emit_manifest: bool = True
+    emit_html_report: bool = False
 
 
 @dataclass(frozen=True)
@@ -15,52 +54,113 @@ class RunPipelineRequest:
     output_path: str
     fec: str | None = None
     channel: str | None = None
+    filter_mutated: bool = False
+    profile: ChannelProfile | None = None
+    seeds: SeedProfile | None = None
+    matrix: BatchSweepMatrix | None = None
+    constraints: ConstraintProfile | None = None
+    artifacts: ArtifactOutputPolicy = field(default_factory=ArtifactOutputPolicy)
 
 
 @dataclass(frozen=True)
 class RunPipelineResponse:
     decoded: bytes
-    metrics: dict[str, Any]
-    fec_info: dict[str, Any] | None
+    dashboard_metrics: Mapping[str, Any]
+    run_schema: Mapping[str, Any]
+    fec_info: Mapping[str, Any] | None
     metrics_path: str
-    manifest_path: str
+    manifest_path: str | None
+    html_report_path: str | None
 
 
 class RunPipelineUseCase:
     def execute(self, request: RunPipelineRequest) -> RunPipelineResponse:
+        if request.seeds and request.seeds.global_seed is not None:
+            os.environ["GENECODER_SIM_SEED"] = str(request.seeds.global_seed)
+
         decoded, metrics, fec_info = run_pipeline(
             codec=request.codec,
             fec_backend=request.fec,
             channel=request.channel,
             input_path=request.input_path,
             output_path=request.output_path,
+            filter_mutated=request.filter_mutated,
         )
-        artifact = {
+
+        metrics_path = Path(request.artifacts.metrics_path or str(request.output_path) + ".json")
+        run_schema: dict[str, Any] = {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "source_format": "sdk_pipeline",
+            "run_id": Path(request.output_path).stem,
+            "profiles": {
+                "encoding": request.codec,
+                "simulation": request.profile.name if request.profile else request.channel,
+                "decode": request.codec,
+            },
+            "seeds": {
+                "global": request.seeds.global_seed if request.seeds else None,
+                "encode": request.seeds.encode_seed if request.seeds else None,
+                "simulate": request.seeds.simulate_seed if request.seeds else None,
+                "decode": request.seeds.decode_seed if request.seeds else None,
+            },
+            "sweep": dict(request.matrix.axes) if request.matrix else {},
+            "constraints": (
+                {
+                    "min_length": request.constraints.min_length,
+                    "max_length": request.constraints.max_length,
+                    "gc_min": request.constraints.gc_min,
+                    "gc_max": request.constraints.gc_max,
+                    "max_homopolymer": request.constraints.max_homopolymer,
+                }
+                if request.constraints
+                else {}
+            ),
             "input_config": {
                 "codec": request.codec,
                 "fec": request.fec,
                 "channel": request.channel,
+                "channel_profile": (
+                    {
+                        "name": request.profile.name,
+                        "parameters": dict(request.profile.parameters),
+                    }
+                    if request.profile
+                    else None
+                ),
             },
             "outcome": {
-                "metrics": metrics,
-                "fec_info": fec_info,
+                "metrics": dict(metrics),
+                "fec_info": dict(fec_info) if isinstance(fec_info, Mapping) else fec_info,
             },
-            "metrics": metrics,
         }
-        metrics_path = Path(str(request.output_path) + ".json")
-        metrics_path.write_text(__import__("json").dumps(artifact, indent=2), encoding="utf-8")
+        dashboard_metrics = canonical_metrics_view(run_schema)
+        run_schema["dashboard_metrics"] = dashboard_metrics
 
-        manifest = generate_manifest(
-            request.input_path,
-            {"method": request.codec, "fec": request.fec, "channel": request.channel},
-            metrics,
-        )
-        manifest_path = metrics_path.with_suffix(".manifest.json")
-        manifest_path.write_text(__import__("json").dumps(manifest, indent=2), encoding="utf-8")
+        metrics_path.write_text(json.dumps(run_schema, indent=2), encoding="utf-8")
+
+        manifest_path: str | None = None
+        if request.artifacts.emit_manifest:
+            manifest = generate_manifest(
+                request.input_path,
+                {"method": request.codec, "fec": request.fec, "channel": request.channel},
+                dashboard_metrics,
+            )
+            manifest_file = metrics_path.with_suffix(".manifest.json")
+            manifest_file.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+            manifest_path = str(manifest_file)
+
+        html_report_path: str | None = None
+        if request.artifacts.emit_html_report and manifest_path:
+            report_path = metrics_path.with_suffix(".html")
+            report_path.write_text(generate_html_report(manifest_path), encoding="utf-8")
+            html_report_path = str(report_path)
+
         return RunPipelineResponse(
             decoded=decoded,
-            metrics=metrics,
-            fec_info=dict(fec_info) if isinstance(fec_info, dict) else None,
+            dashboard_metrics=dashboard_metrics,
+            run_schema=run_schema,
+            fec_info=dict(fec_info) if isinstance(fec_info, Mapping) else None,
             metrics_path=str(metrics_path),
-            manifest_path=str(manifest_path),
+            manifest_path=manifest_path,
+            html_report_path=html_report_path,
         )

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -15,8 +15,6 @@ from genecoder.simulators.nanopore import NANOPORE_PROFILES
 from genecoder.channel_config import ChannelConfig
 from genecoder.core import encode, decode, inspect_coding_plan
 from genecoder.formats import SequenceBatch
-from genecoder.html_report import generate_html_report
-from genecoder.manifest import generate_manifest
 from genecoder.parallel import parallel_map
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
@@ -37,7 +35,6 @@ from genecoder.simulators.batch_utils import (
 )
 from genecoder.metrics import metrics as aggregate_metrics, set_metrics_path
 from genecoder.synthesis import SynthesisConstraints
-from genecoder.results.schema import canonical_metrics_view
 from genecoder.results.collector import (
     DecodeStageEvent,
     EncodeStageEvent,
@@ -45,6 +42,13 @@ from genecoder.results.collector import (
     SimulateStageEvent,
 )
 from genecoder.constraints import load_constraint_policy
+from genecoder.app import (
+    ArtifactOutputPolicy,
+    ChannelProfile,
+    RunPipelineRequest,
+    RunPipelineUseCase,
+    SeedProfile,
+)
 
 RUN_PROFILE_VERSION = "2026.02"
 
@@ -637,22 +641,23 @@ def _handle_command(args: argparse.Namespace) -> None:
         logger.info("Coding planner: %s", json.dumps(explanation, indent=2, sort_keys=True))
 
     def _execute() -> Dict[str, Any]:
-        return _run_with_params(
-            codec, fec, channel, channel_params, args.input, args.output
+        response = RunPipelineUseCase().execute(
+            RunPipelineRequest(
+                codec=codec,
+                fec=fec,
+                channel=channel,
+                input_path=args.input,
+                output_path=args.output,
+                profile=(ChannelProfile(name=channel, parameters=channel_params) if channel and channel != "none" else None),
+                seeds=SeedProfile(global_seed=args.seed),
+                artifacts=ArtifactOutputPolicy(
+                    metrics_path=(str(metrics_override) if metrics_override else None),
+                    emit_manifest=True,
+                    emit_html_report=bool(args.emit_manifest_report),
+                ),
+            )
         )
-
-    if args.mpi_workers:
-        artifact = parallel_map(
-            lambda _: _execute(),
-            [None],
-            workers=args.mpi_workers,
-            use_mpi=True,
-        )[0]
-    else:
-        artifact = _execute()
-
-    metrics_path = Path(str(args.output) + ".json")
-    if isinstance(artifact, dict):
+        artifact = dict(response.run_schema)
         artifact.setdefault("schema_provenance", {}).update(
             {
                 "seed": args.seed,
@@ -660,34 +665,28 @@ def _handle_command(args: argparse.Namespace) -> None:
                 "command_lineage": ["genecli pipeline", "encode", "simulate", "decode"],
             }
         )
-        canonical_metrics = canonical_metrics_view(artifact)
-        runtime = artifact.get("input_config", {}).get("channel_runtime", {}) if isinstance(artifact.get("input_config"), dict) else {}
-        if isinstance(runtime, dict):
-            canonical_metrics.setdefault("dropout_count", runtime.get("dropout_count"))
-            canonical_metrics.setdefault("dropout_fraction", runtime.get("dropout_fraction"))
-        artifact["dashboard_metrics"] = canonical_metrics
-        artifact["metrics"] = dict(canonical_metrics)
-    metrics_path.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+        return artifact
+
+    if args.mpi_workers:
+        parallel_map(
+            lambda _: _execute(),
+            [None],
+            workers=args.mpi_workers,
+            use_mpi=True,
+        )[0]
+    else:
+        _execute()
+
+    metrics_path = Path(str(metrics_override) if metrics_override else str(args.output) + ".json")
     logger.info("Run artifact written to %s", metrics_path)
 
-    manifest_params: Dict[str, Any] = {"method": codec}
-    if fec:
-        manifest_params["fec"] = fec
-    if channel and channel != "none":
-        manifest_params["channel"] = channel
-        if channel_params:
-            manifest_params["channel_parameters"] = channel_params
-
-    manifest_metrics = artifact.get("dashboard_metrics", {}) if isinstance(artifact, dict) else {}
-    manifest = generate_manifest(args.input, manifest_params, manifest_metrics if isinstance(manifest_metrics, dict) else {})
     manifest_path = metrics_path.with_suffix(".manifest.json")
-    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
-    logger.info("Manifest written to %s", manifest_path)
+    if manifest_path.exists():
+        logger.info("Manifest written to %s", manifest_path)
 
     if args.emit_manifest_report:
         html_report_path = metrics_path.with_suffix(".html")
-        html = generate_html_report(str(manifest_path))
-        html_report_path.write_text(html, encoding="utf-8")
-        logger.info("HTML report written to %s", html_report_path)
+        if html_report_path.exists():
+            logger.info("HTML report written to %s", html_report_path)
 
     _launch_dashboard_if_requested()

--- a/src/genecoder/sdk/__init__.py
+++ b/src/genecoder/sdk/__init__.py
@@ -1,12 +1,15 @@
 from .api import (
+    ExperimentRequest,
     ExperimentResult,
-    ExperimentSpec,
     SweepResult,
     run_experiment,
     sweep,
 )
 
+ExperimentSpec = ExperimentRequest
+
 __all__ = [
+    "ExperimentRequest",
     "ExperimentSpec",
     "ExperimentResult",
     "SweepResult",

--- a/src/genecoder/sdk/api.py
+++ b/src/genecoder/sdk/api.py
@@ -6,14 +6,23 @@ from typing import Any, Iterable, Mapping
 
 import yaml
 
-from ..app import RunPipelineRequest, RunPipelineUseCase
+from ..app import (
+    ArtifactOutputPolicy,
+    BatchSweepMatrix,
+    ChannelProfile,
+    ConstraintProfile,
+    RunPipelineRequest,
+    RunPipelineResponse,
+    RunPipelineUseCase,
+    SeedProfile,
+)
 
-SpecInput = "ExperimentSpec | Mapping[str, Any] | str | Path"
+SpecInput = "ExperimentRequest | Mapping[str, Any] | str | Path"
 
 
 @dataclass(frozen=True)
-class ExperimentSpec:
-    """SDK specification for a single encode/simulate/decode experiment."""
+class ExperimentRequest:
+    """Stable SDK request contract for one pipeline run."""
 
     codec: str
     input_path: str
@@ -21,16 +30,30 @@ class ExperimentSpec:
     fec_backend: str | None = None
     channel: str | None = None
     filter_mutated: bool = False
+    profile: ChannelProfile | None = None
+    seeds: SeedProfile | None = None
+    matrix: BatchSweepMatrix | None = None
+    constraints: ConstraintProfile | None = None
+    artifacts: ArtifactOutputPolicy = ArtifactOutputPolicy()
 
 
 @dataclass(frozen=True)
 class ExperimentResult:
-    """Immutable normalized result of a single experiment."""
+    """Immutable SDK result payload containing run schema and artifact paths."""
 
-    spec: ExperimentSpec
+    request: ExperimentRequest
     decoded: bytes
+    canonical_run: Mapping[str, Any]
+    dashboard_metrics: Mapping[str, Any]
+    artifact_paths: Mapping[str, str | None]
     metrics: Mapping[str, Any]
     fec_info: Mapping[str, Any] | None
+
+    @property
+    def spec(self) -> ExperimentRequest:
+        """Backwards-compatible alias for older SDK integrations."""
+
+        return self.request
 
 
 @dataclass(frozen=True)
@@ -47,30 +70,97 @@ def _load_yaml_spec(path: Path) -> Mapping[str, Any]:
     return loaded
 
 
-def _spec_from_mapping(raw: Mapping[str, Any]) -> ExperimentSpec:
-    return ExperimentSpec(
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _request_from_mapping(raw: Mapping[str, Any]) -> ExperimentRequest:
+    profile_raw = _as_mapping(raw.get("profile"))
+    seeds_raw = _as_mapping(raw.get("seeds"))
+    matrix_raw = _as_mapping(raw.get("matrix"))
+    constraints_raw = _as_mapping(raw.get("constraints"))
+    artifacts_raw = _as_mapping(raw.get("artifacts"))
+
+    return ExperimentRequest(
         codec=str(raw["codec"]),
         input_path=str(raw["input_path"]),
         output_path=str(raw["output_path"]),
         fec_backend=(None if raw.get("fec_backend") in (None, "") else str(raw["fec_backend"])),
         channel=(None if raw.get("channel") in (None, "") else str(raw["channel"])),
         filter_mutated=bool(raw.get("filter_mutated", False)),
+        profile=(
+            ChannelProfile(
+                name=str(profile_raw.get("name")),
+                parameters={str(k): v for k, v in _as_mapping(profile_raw.get("parameters")).items()},
+            )
+            if profile_raw
+            else None
+        ),
+        seeds=(
+            SeedProfile(
+                global_seed=seeds_raw.get("global_seed"),
+                encode_seed=seeds_raw.get("encode_seed"),
+                simulate_seed=seeds_raw.get("simulate_seed"),
+                decode_seed=seeds_raw.get("decode_seed"),
+            )
+            if seeds_raw
+            else None
+        ),
+        matrix=(
+            BatchSweepMatrix(
+                axes={str(k): tuple(v) if isinstance(v, (list, tuple)) else (v,) for k, v in matrix_raw.items()}
+            )
+            if matrix_raw
+            else None
+        ),
+        constraints=(
+            ConstraintProfile(
+                min_length=constraints_raw.get("min_length"),
+                max_length=constraints_raw.get("max_length"),
+                gc_min=constraints_raw.get("gc_min"),
+                gc_max=constraints_raw.get("gc_max"),
+                max_homopolymer=constraints_raw.get("max_homopolymer"),
+            )
+            if constraints_raw
+            else None
+        ),
+        artifacts=ArtifactOutputPolicy(
+            metrics_path=(str(artifacts_raw["metrics_path"]) if artifacts_raw.get("metrics_path") else None),
+            emit_manifest=bool(artifacts_raw.get("emit_manifest", True)),
+            emit_html_report=bool(artifacts_raw.get("emit_html_report", False)),
+        ),
     )
 
 
-def _normalize_spec(spec: ExperimentSpec | Mapping[str, Any] | str | Path) -> ExperimentSpec:
-    if isinstance(spec, ExperimentSpec):
+def _normalize_request(spec: SpecInput) -> ExperimentRequest:
+    if isinstance(spec, ExperimentRequest):
         return spec
     if isinstance(spec, Mapping):
-        return _spec_from_mapping(spec)
+        return _request_from_mapping(spec)
     path = Path(spec)
-    return _spec_from_mapping(_load_yaml_spec(path))
+    return _request_from_mapping(_load_yaml_spec(path))
 
 
-def run_experiment(spec: ExperimentSpec | Mapping[str, Any] | str | Path) -> ExperimentResult:
+def _to_result(request: ExperimentRequest, response: RunPipelineResponse) -> ExperimentResult:
+    return ExperimentResult(
+        request=request,
+        decoded=response.decoded,
+        canonical_run=dict(response.run_schema),
+        dashboard_metrics=dict(response.dashboard_metrics),
+        artifact_paths={
+            "metrics": response.metrics_path,
+            "manifest": response.manifest_path,
+            "html_report": response.html_report_path,
+        },
+        metrics=dict(response.dashboard_metrics),
+        fec_info=(dict(response.fec_info) if isinstance(response.fec_info, Mapping) else response.fec_info),
+    )
+
+
+def run_experiment(spec: SpecInput) -> ExperimentResult:
     """Run one experiment from dataclass, mapping, or YAML file path."""
 
-    normalized = _normalize_spec(spec)
+    normalized = _normalize_request(spec)
     response = RunPipelineUseCase().execute(
         RunPipelineRequest(
             codec=normalized.codec,
@@ -78,24 +168,25 @@ def run_experiment(spec: ExperimentSpec | Mapping[str, Any] | str | Path) -> Exp
             channel=normalized.channel,
             input_path=normalized.input_path,
             output_path=normalized.output_path,
+            filter_mutated=normalized.filter_mutated,
+            profile=normalized.profile,
+            seeds=normalized.seeds,
+            matrix=normalized.matrix,
+            constraints=normalized.constraints,
+            artifacts=normalized.artifacts,
         )
     )
-    return ExperimentResult(
-        spec=normalized,
-        decoded=response.decoded,
-        metrics=dict(response.metrics),
-        fec_info=(dict(response.fec_info) if isinstance(response.fec_info, Mapping) else response.fec_info),
-    )
+    return _to_result(normalized, response)
 
 
-def sweep(specs: Iterable[ExperimentSpec | Mapping[str, Any] | str | Path]) -> SweepResult:
+def sweep(specs: Iterable[SpecInput]) -> SweepResult:
     """Run a collection of experiments and return immutable results."""
 
     return SweepResult(tuple(run_experiment(spec) for spec in specs))
 
 
 __all__ = [
-    "ExperimentSpec",
+    "ExperimentRequest",
     "ExperimentResult",
     "SweepResult",
     "run_experiment",

--- a/tests/test_cli_pipeline_adapter.py
+++ b/tests/test_cli_pipeline_adapter.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from genecoder.cli import pipeline as pipeline_cli
+
+
+def test_pipeline_cli_uses_pipeline_use_case(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"adapter")
+
+    class StubResponse:
+        decoded = b"adapter"
+        run_schema = {"schema_version": "1.1", "outcome": {"metrics": {}}, "dashboard_metrics": {}}
+
+    called = {"count": 0}
+
+    class StubUseCase:
+        def execute(self, request):  # noqa: ANN001
+            called["count"] += 1
+            metrics_path = Path(str(request.output_path) + ".json")
+            metrics_path.write_text("{}", encoding="utf-8")
+            metrics_path.with_suffix(".manifest.json").write_text("{}", encoding="utf-8")
+            return StubResponse()
+
+    monkeypatch.setattr(pipeline_cli, "RunPipelineUseCase", StubUseCase)
+
+    args = argparse.Namespace(
+        seed=None,
+        metrics_path=None,
+        launch_dashboard=False,
+        config=None,
+        codec="reverse",
+        fec=None,
+        channel="none",
+        sub_rate=None,
+        ins_rate=None,
+        del_rate=None,
+        explain_coding_stack=False,
+        mpi_workers=None,
+        input=str(source),
+        output=str(tmp_path / "decoded.bin"),
+        emit_manifest_report=False,
+    )
+
+    pipeline_cli._handle_command(args)
+
+    assert called["count"] == 1

--- a/tests/test_sdk_api_compatibility.py
+++ b/tests/test_sdk_api_compatibility.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import yaml
+
+from genecoder.sdk import ExperimentRequest, ExperimentSpec, run_experiment
+
+
+EXPECTED_REQUEST_FIELDS = {
+    "codec",
+    "input_path",
+    "output_path",
+    "fec_backend",
+    "channel",
+    "filter_mutated",
+    "profile",
+    "seeds",
+    "matrix",
+    "constraints",
+    "artifacts",
+}
+
+
+def test_experiment_spec_alias_is_preserved() -> None:
+    assert ExperimentSpec is ExperimentRequest
+
+
+def test_experiment_request_field_surface_is_stable() -> None:
+    assert {item.name for item in fields(ExperimentRequest)} == EXPECTED_REQUEST_FIELDS
+
+
+def test_run_experiment_accepts_extended_yaml_contract(tmp_path: Path) -> None:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"compat")
+
+    config = tmp_path / "request.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "codec": "reverse",
+                "input_path": str(source),
+                "output_path": str(tmp_path / "decoded.bin"),
+                "profile": {"name": "illumina", "parameters": {"substitution_rate": 0.01}},
+                "seeds": {"global_seed": 9},
+                "matrix": {"coverage": [5, 10]},
+                "constraints": {"gc_min": 0.4, "gc_max": 0.6},
+                "artifacts": {"emit_manifest": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_experiment(config)
+
+    assert result.decoded == source.read_bytes()
+    assert "schema_version" in result.canonical_run
+    assert result.artifact_paths["metrics"]


### PR DESCRIPTION
### Motivation
- Provide a stable, typed SDK surface that models pipeline orchestration (profiles, seeds, sweep matrices, constraints, artifact policies) instead of mirroring CLI arguments.
- Ensure CLI and SDK call the same orchestration logic so the CLI becomes an adapter and SDK users get canonical, immutable run outputs.
- Preserve backwards compatibility for existing integrations and enforce minor-release API stability with automated compatibility tests.

### Description
- Introduced typed request/result models: `ExperimentRequest`, `ExperimentResult`, `SweepResult`, plus supporting types `ChannelProfile`, `SeedProfile`, `BatchSweepMatrix`, `ConstraintProfile`, and `ArtifactOutputPolicy` (see `src/genecoder/sdk/api.py` and `src/genecoder/app/pipeline_use_case.py`).
- Reworked the application use-case to return an immutable `RunPipelineResponse` containing `run_schema`, `dashboard_metrics`, artifact paths, and `fec_info` and to accept typed `RunPipelineRequest` (see `src/genecoder/app/pipeline_use_case.py`).
- Updated SDK functions `run_experiment`/`sweep` to normalize YAML/mapping inputs into `ExperimentRequest` and delegate to `RunPipelineUseCase` (see `src/genecoder/sdk/api.py` and `src/genecoder/sdk/__init__.py`).
- Made CLI pipeline command delegate to `RunPipelineUseCase` so CLI only adapts arguments into `RunPipelineRequest` and logs artifact paths instead of owning pipeline logic (see `src/genecoder/cli/pipeline.py`).
- Preserved compatibility: `ExperimentSpec` alias maps to `ExperimentRequest` and `ExperimentResult` exposes a `spec` property for older call sites (see `src/genecoder/sdk/__init__.py` and `src/genecoder/sdk/api.py`).
- Added API workflow examples and documentation pointer (`examples/sdk_api_workflows.py`, `docs/pipeline_examples.md`) and compatibility tests to lock the request surface and verify CLI uses the use-case (`tests/test_sdk_api_compatibility.py`, `tests/test_cli_pipeline_adapter.py`).

### Testing
- Ran linting: `ruff check src/genecoder/sdk/api.py src/genecoder/app/pipeline_use_case.py src/genecoder/cli/pipeline.py tests/test_sdk_api_compatibility.py tests/test_cli_pipeline_adapter.py examples/sdk_api_workflows.py` and fixed reported issues (all checks passed). ✅
- Executed tests: `pytest -q tests/test_sdk.py tests/test_sdk_api_compatibility.py tests/test_cli_pipeline_adapter.py` and observed all tests passing (`7 passed` for the targeted suite). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699740357e448326b81ab2e27eff3789)