### PR TITLE
Apply constraint policy across all oligos and record per-oligo outcomes

### DIFF
--- a/src/genecoder/constraints/engine.py
+++ b/src/genecoder/constraints/engine.py
@@ -24,8 +24,15 @@ class ConstraintEngine:
         report = self.validate(repair_result.sequence_after)
         return report, repair_result
 
+    def validate_batch(self, sequences: list[str] | tuple[str, ...]) -> list[ConstraintReport]:
+        return [self.validate(sequence) for sequence in sequences]
 
-
+    def repair_batch(
+        self,
+        sequences: list[str] | tuple[str, ...],
+        strategy: RepairStrategy,
+    ) -> list[tuple[ConstraintReport, RepairResult]]:
+        return [self.repair(sequence, strategy) for sequence in sequences]
     def gate(self, sequence: str, *, stage: str) -> ConstraintReport:
         report = self.validate(sequence)
         if report.count > 0:

--- a/src/genecoder/constraints/repair_pipeline.py
+++ b/src/genecoder/constraints/repair_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Sequence
 
 from .engine import ConstraintEngine
 from .policy import ConstraintPolicy
@@ -85,3 +86,9 @@ class ConstraintRepairPipeline:
             residual_risk=after_report.pressure,
             stage=stage,
         )
+
+    def repair_batch(self, sequences: Sequence[str], *, stage: str = "encode") -> list[RepairPipelineResult]:
+        return [self.run(sequence, stage=stage) for sequence in sequences]
+
+    def validate_batch(self, sequences: Sequence[str]) -> list[ConstraintReport]:
+        return self.engine.validate_batch(list(sequences))

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -232,6 +232,67 @@ def _constraint_outcome_payload(result: object) -> dict[str, Any]:
     }
 
 
+def _apply_constraint_stage_to_batch(
+    batch: SequenceBatch,
+    *,
+    policy: ConstraintPolicy,
+    stage: str,
+) -> dict[str, Any]:
+    pipeline = ConstraintRepairPipeline(policy)
+    primaries = batch.primary_oligos() or batch.oligos
+    outcomes = pipeline.repair_batch([ol.sequence for ol in primaries], stage=stage)
+    by_oligo: dict[str, dict[str, Any]] = {}
+    for idx, (oligo, outcome) in enumerate(zip(primaries, outcomes), start=1):
+        if outcome.sequence != oligo.sequence:
+            oligo.sequence = outcome.sequence
+        key = str(
+            oligo.metadata.get("oligo_id")
+            or oligo.oligo_id
+            or oligo.metadata.get("oligo_index")
+            or idx
+        )
+        by_oligo[key] = {
+            "oligo_index": idx,
+            "violations_before": outcome.report_before.count,
+            "violations_after": outcome.report_after.count,
+            "pressure_before": outcome.report_before.pressure,
+            "pressure_after": outcome.report_after.pressure,
+            "repair_strategy": outcome.repair.strategy if outcome.repair is not None else None,
+            "repairs_applied": len(outcome.repair.changes) if outcome.repair is not None else 0,
+            "residual_risk": outcome.residual_risk,
+            "stage": outcome.stage,
+        }
+    return {
+        "stage": stage,
+        "violations": {
+            "before": sum(item.report_before.count for item in outcomes),
+            "after": sum(item.report_after.count for item in outcomes),
+            "pressure_before": (
+                sum(item.report_before.pressure for item in outcomes) / len(outcomes)
+                if outcomes
+                else 0.0
+            ),
+            "pressure_after": (
+                sum(item.report_after.pressure for item in outcomes) / len(outcomes)
+                if outcomes
+                else 0.0
+            ),
+        },
+        "repairs_applied": sum(len(item.repair.changes) if item.repair is not None else 0 for item in outcomes),
+        "repair_strategy": (
+            outcomes[0].repair.strategy
+            if outcomes and outcomes[0].repair is not None
+            else None
+        ),
+        "residual_risk": (
+            sum(item.residual_risk for item in outcomes) / len(outcomes)
+            if outcomes
+            else 0.0
+        ),
+        "by_oligo": by_oligo,
+    }
+
+
 def encode(
     codec: str,
     fec: str | None,
@@ -256,7 +317,7 @@ def encode(
         before_size = (
             len(current)
             if isinstance(current, (bytes, bytearray, str))
-            else len(current.primary_sequence())
+            else len(current.combined_sequence())
         )
         started_at = time.perf_counter()
         layer_out = layer.encode_block(current, context)
@@ -267,7 +328,7 @@ def encode(
         after_size = (
             len(current)
             if isinstance(current, (bytes, bytearray, str))
-            else len(current.primary_sequence())
+            else len(current.combined_sequence())
         )
         layer_metrics.append(
             build_layer_metric(
@@ -292,17 +353,25 @@ def encode(
 
     constraint_outcomes: list[dict[str, Any]] = []
     if constraint_policy is not None:
-        pipeline = ConstraintRepairPipeline(constraint_policy)
-        gate_result = pipeline.run(batch.primary_sequence(), stage="encode")
-        constraint_outcomes.append(_constraint_outcome_payload(gate_result))
-        if gate_result.sequence != batch.primary_sequence() and batch.oligos:
-            batch.oligos[0].sequence = gate_result.sequence
+        stage_outcome = _apply_constraint_stage_to_batch(
+            batch,
+            policy=constraint_policy,
+            stage="encode",
+        )
+        constraint_outcomes.append({k: v for k, v in stage_outcome.items() if k != "by_oligo"})
 
-    normalized_stack = normalize_stack_metrics(layer_metrics, batch.primary_sequence())
+    normalized_stack = normalize_stack_metrics(layer_metrics, "".join(ol.sequence for ol in batch.oligos))
     batch.metadata.setdefault("coding_stack", normalized_stack)
     if constraint_policy is not None:
         batch.metadata["constraint_policy"] = constraint_policy.to_dict()
-        batch.metadata["constraint_outcomes"] = constraint_outcomes
+        existing = batch.metadata.get("constraint_outcomes")
+        if isinstance(existing, Mapping):
+            merged = dict(existing)
+        else:
+            merged = {}
+        merged["by_oligo"] = stage_outcome.get("by_oligo", {})
+        merged["stages"] = constraint_outcomes
+        batch.metadata["constraint_outcomes"] = merged
 
     fec_info: Mapping[str, Any] | None = None
     if layer_info:
@@ -314,7 +383,7 @@ def encode(
             info_dict.update(dict(layer_info[fec]))
         if constraint_policy is not None:
             info_dict["constraint_policy"] = constraint_policy.to_dict()
-            info_dict["constraint_outcomes"] = list(constraint_outcomes)
+            info_dict["constraint_outcomes"] = dict(batch.metadata.get("constraint_outcomes", {}))
         info_dict.setdefault("batch_id", batch.batch_id)
         info_dict.setdefault("batch_metadata", dict(batch.metadata))
         fec_info = info_dict
@@ -494,8 +563,8 @@ def simulate(
             run_context=runtime_context,
         )
 
-        original_sequence = original_batch.primary_sequence()
-        mutated_sequence = mutated_batch.primary_sequence()
+        original_sequence = original_batch.combined_sequence()
+        mutated_sequence = mutated_batch.combined_sequence()
         subs, ins, dels = _count_errors(original_sequence, mutated_sequence)
 
         coverage = _estimate_coverage(mutated_batch)
@@ -598,13 +667,17 @@ def decode(
             "No survivor oligos available after filtering; "
             "adjust channel conditions or disable --filter-mutated."
         )
-    constraint_outcomes: list[dict[str, Any]] = []
+    constraint_outcomes: dict[str, Any] = {}
     if policy is not None:
-        pipeline = ConstraintRepairPipeline(policy)
-        gate = pipeline.run(batch.primary_sequence(), stage="pre_decode")
-        constraint_outcomes.append(_constraint_outcome_payload(gate))
-        if gate.sequence != batch.primary_sequence() and batch.oligos:
-            batch.oligos[0].sequence = gate.sequence
+        stage_outcome = _apply_constraint_stage_to_batch(
+            batch,
+            policy=policy,
+            stage="pre_decode",
+        )
+        constraint_outcomes = {
+            "by_oligo": stage_outcome.get("by_oligo", {}),
+            "stages": [{k: v for k, v in stage_outcome.items() if k != "by_oligo"}],
+        }
     context_meta: dict[str, Any] = {"batch_id": batch.batch_id, **batch.metadata}
     if fec_info:
         context_meta.update(dict(fec_info))
@@ -623,7 +696,7 @@ def decode(
         before_size = (
             len(current)
             if isinstance(current, (bytes, bytearray, str))
-            else len(current.primary_sequence())
+            else len(current.combined_sequence())
         )
         if not codec_decoded and layer.name == codec:
             layer_input: bytes | str | SequenceBatch = current
@@ -641,7 +714,7 @@ def decode(
         after_size = (
             len(current)
             if isinstance(current, (bytes, bytearray, str))
-            else len(current.primary_sequence())
+            else len(current.combined_sequence())
         )
         decode_metrics.append(
             build_layer_metric(
@@ -660,7 +733,7 @@ def decode(
     if isinstance(fec_info, dict):
         fec_info["coding_stack"] = normalize_stack_metrics(decode_metrics)
         if constraint_outcomes:
-            fec_info["constraint_outcomes"] = constraint_outcomes
+            fec_info["constraint_outcomes"] = dict(constraint_outcomes)
     return bytes(current)
 
 
@@ -679,13 +752,13 @@ def metrics(
     dropout_flags: Sequence[bool] | None = None,
     ecc_outcomes: Mapping[str, Sequence[bool | float]] | None = None,
     stack_metrics: Mapping[str, Any] | None = None,
-    constraint_outcomes: Sequence[Mapping[str, Any]] | None = None,
+    constraint_outcomes: Mapping[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Return quality metrics for ``dna`` and decode results."""
 
     batch = dna if isinstance(dna, SequenceBatch) else None
     if batch is not None:
-        base_sequence = batch.primary_sequence() or batch.combined_sequence()
+        base_sequence = batch.combined_sequence()
         primary_oligos = batch.primary_oligos() or batch.oligos
         sequences = [ol.sequence for ol in primary_oligos] or [base_sequence]
 
@@ -860,6 +933,22 @@ def metrics(
             if ratios:
                 ecc_map[str(name)] = ratios
 
+    if constraint_outcomes is None and batch is not None:
+        batch_outcomes = batch.metadata.get("constraint_outcomes")
+        if isinstance(batch_outcomes, Mapping):
+            constraint_outcomes = dict(batch_outcomes)
+
+    by_oligo_outcomes = (
+        dict(constraint_outcomes.get("by_oligo", {}))
+        if isinstance(constraint_outcomes, Mapping)
+        else {}
+    )
+    aggregate_before = 0
+    aggregate_after = 0
+    if by_oligo_outcomes:
+        aggregate_before = sum(int(item.get("violations_before", 0)) for item in by_oligo_outcomes.values() if isinstance(item, Mapping))
+        aggregate_after = sum(int(item.get("violations_after", 0)) for item in by_oligo_outcomes.values() if isinstance(item, Mapping))
+
     opportunities = max(0, sum(len(seq) for seq in sequences))
     result: Dict[str, Any] = {
         "gc_distribution": gc_dist,
@@ -871,7 +960,16 @@ def metrics(
         "decode_success_rate": success,
         "coverage": coverage,
         "constraint_violations": constraint_violations,
-        "constraint_outcomes": [dict(item) for item in (constraint_outcomes or ())],
+        "constraint_pressure": {
+            "aggregate": {
+                "before": aggregate_before,
+                "after": aggregate_after,
+                "violations": constraint_violations.get("count", 0),
+                "pressure": constraint_violations.get("pressure", 0.0),
+            },
+            "by_oligo": by_oligo_outcomes,
+        },
+        "constraint_outcomes": dict(constraint_outcomes) if isinstance(constraint_outcomes, Mapping) else {},
         "error_bases": opportunities,
         "substitution_rate": 0.0,
         "insertion_rate": 0.0,

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -103,6 +103,30 @@ def _render_oligo_section(metrics: dict[str, Any], html_lines: list[str]) -> Non
     html_lines.append("</ul>")
 
 
+
+
+def _render_constraint_section(metrics: dict[str, Any], html_lines: list[str]) -> None:
+    pressure = metrics.get("constraint_pressure")
+    if not isinstance(pressure, dict):
+        return
+    aggregate = pressure.get("aggregate") if isinstance(pressure.get("aggregate"), dict) else {}
+    by_oligo = pressure.get("by_oligo") if isinstance(pressure.get("by_oligo"), dict) else {}
+    if not aggregate and not by_oligo:
+        return
+    html_lines.append("<h2>Constraint Pressure</h2>")
+    html_lines.append("<ul>")
+    if aggregate:
+        before = aggregate.get("before", 0)
+        after = aggregate.get("after", 0)
+        current = aggregate.get("violations", 0)
+        level = aggregate.get("pressure", 0.0)
+        html_lines.append(
+            f"<li><strong>Aggregate:</strong> before {before}, after {after}, active {current}, pressure {float(level):.4f}</li>"
+        )
+    if by_oligo:
+        html_lines.append(f"<li><strong>Per-oligo entries:</strong> {len(by_oligo)}</li>")
+    html_lines.append("</ul>")
+
 def generate_html_report(manifest_path: str) -> str:
     """Return HTML summary for the manifest at ``manifest_path``."""
     run_schema = load_run_schema(manifest_path)
@@ -182,6 +206,7 @@ def generate_html_report(manifest_path: str) -> str:
         )
 
     _render_oligo_section(metrics, html_lines)
+    _render_constraint_section(metrics, html_lines)
 
     html_lines.extend(["</body>", "</html>"])
     return "\n".join(html_lines)

--- a/src/genecoder/results/collector.py
+++ b/src/genecoder/results/collector.py
@@ -104,7 +104,8 @@ class RunArtifactCollector:
             },
         }
         canonical["coding_stack"] = metrics.get("coding_stack", {})
-        canonical["constraint_outcomes"] = metrics.get("constraint_violations", {})
+        canonical["constraint_outcomes"] = metrics.get("constraint_outcomes", {})
+        canonical["constraint_pressure"] = metrics.get("constraint_pressure", {})
         canonical["decode_results"] = {
             "decode_success_rate": metrics.get("decode_success_rate"),
             "ecc_success_rates": metrics.get("ecc_success_rates", {}),

--- a/src/genecoder/results/schema.py
+++ b/src/genecoder/results/schema.py
@@ -5,14 +5,19 @@ import json
 from pathlib import Path
 from typing import IO, Any, Mapping
 
-RUN_SCHEMA_VERSION = "1.1"
-SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("1.0", "1.1")
+RUN_SCHEMA_VERSION = "1.2"
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("1.0", "1.1", "1.2")
 SCHEMA_DEPRECATIONS: dict[str, dict[str, str]] = {
     "1.0": {
         "deprecated_in": "1.1",
         "supported_until": "2.0",
         "notes": "Legacy metric mirroring remains available only through explicit migration commands.",
-    }
+    },
+    "1.1": {
+        "deprecated_in": "1.2",
+        "supported_until": "2.1",
+        "notes": "Constraint outcomes now include per-oligo entries under constraint_outcomes.by_oligo; migrate readers to handle nested shape.",
+    },
 }
 
 
@@ -108,6 +113,7 @@ def canonical_metrics_view(run_data: Mapping[str, Any]) -> dict[str, Any]:
             "coverage": simulate_metrics.get("coverage", metrics.get("coverage")),
             "coverage_distribution": metrics.get("coverage_distribution", []),
             "constraint_violations": metrics.get("constraint_violations"),
+            "constraint_pressure": metrics.get("constraint_pressure", {}),
             "oligo_metrics": metrics.get("oligo_metrics", {}),
             "dropout_count": simulate_metrics.get("dropout_count", metrics.get("dropout_count")),
             "dropout_fraction": simulate_metrics.get(
@@ -185,6 +191,7 @@ def translate_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
                     "gc_content": metrics.get("gc_content"),
                     "gc_variance": metrics.get("gc_variance"),
                     "max_homopolymer": metrics.get("max_homopolymer"),
+                    "constraint_pressure": metrics.get("constraint_pressure"),
                 },
             },
             "simulate": {

--- a/tests/test_constraint_policy.py
+++ b/tests/test_constraint_policy.py
@@ -40,3 +40,28 @@ def test_constraint_repair_pipeline_ecc_prefix_preserved() -> None:
 def test_constraint_policy_profile_strategy_resolution() -> None:
     policy = ConstraintPolicy(repair=RepairPolicy(enabled=True, profile="strict"))
     assert policy.strategy_name() == "deterministic"
+
+
+def test_constraint_engine_validate_batch() -> None:
+    policy = ConstraintPolicy(min_length=1, max_length=10, gc_min=0.4, gc_max=0.6, max_homopolymer=3)
+    engine = ConstraintEngine(policy.to_rule_set())
+    reports = engine.validate_batch(["ACGT", "GGGG"])
+    assert len(reports) == 2
+    assert reports[0].count == 0
+    assert reports[1].count >= 1
+
+
+def test_constraint_repair_pipeline_repair_batch() -> None:
+    policy = ConstraintPolicy(
+        min_length=1,
+        max_length=20,
+        gc_min=0.0,
+        gc_max=1.0,
+        max_homopolymer=2,
+        repair=RepairPolicy(enabled=True, profile="strict", strategy="deterministic"),
+    )
+    results = ConstraintRepairPipeline(policy).repair_batch(["AATTTT", "CCGG"], stage="encode")
+    assert len(results) == 2
+    assert results[0].sequence.startswith("AA")
+    assert results[0].report_after.count == 0
+    assert results[1].report_before.count == 0

--- a/tests/test_core_pipeline.py
+++ b/tests/test_core_pipeline.py
@@ -248,5 +248,7 @@ def test_encode_constraint_assumption_repair_deterministic() -> None:
     assert "AA" not in dna.primary_sequence()
     assert isinstance(fec_info, Mapping) or fec_info is None
     outcomes = dna.metadata.get("constraint_outcomes")
-    assert isinstance(outcomes, list) and outcomes
-    assert outcomes[0]["repairs_applied"] > 0
+    assert isinstance(outcomes, Mapping)
+    assert isinstance(outcomes.get("by_oligo"), Mapping) and outcomes["by_oligo"]
+    assert isinstance(outcomes.get("stages"), list) and outcomes["stages"]
+    assert outcomes["stages"][0]["repairs_applied"] > 0

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -21,6 +21,10 @@ def _make_manifest(path: Path) -> Path:
             "insertion_rate": 0.02,
             "deletion_rate": 0.03,
             "coverage": 42,
+            "constraint_pressure": {
+                "aggregate": {"before": 3, "after": 1, "violations": 1, "pressure": 0.01},
+                "by_oligo": {"ol-1": {"violations_before": 2, "violations_after": 0}},
+            },
         },
     }
     path.write_text(json.dumps(data))
@@ -39,6 +43,8 @@ def test_generate_html_report(tmp_path: Path) -> None:
     assert "Insertions:</strong> count 2; rate 2.0000%" in html
     assert "Deletions:</strong> count 3; rate 3.0000%" in html
     assert "Coverage:</strong> 42" in html
+    assert "Constraint Pressure" in html
+    assert "before 3, after 1" in html
 
 
 def test_cli_html_report_stdout(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Constraint handling previously operated on `primary_sequence()` (or mutated the first oligo) which prevented applying a single constraint policy consistently across all oligos. 
- The pipeline needs to preserve per-oligo repair/validation outcomes so downstream consumers and reports can show both aggregate and per-oligo constraint pressure. 
- The run schema must be updated to indicate the new nested metadata shape so tooling can migrate/read the new `constraint_outcomes.by_oligo` structure.

### Description
- Added batch APIs `validate_batch` and `repair_batch` to `ConstraintEngine` and `ConstraintRepairPipeline` to run validation/repair across multiple sequences with a shared policy via `validate_batch`/`repair_batch`. 
- Replaced `primary_sequence`-only mutation/inspection in `core.py` with per-oligo processing via a new helper `_apply_constraint_stage_to_batch`, and switched various size/error computations to use combined/all-oligo sequences where appropriate. 
- Emit stable per-oligo metadata under `SequenceBatch.metadata["constraint_outcomes"]["by_oligo"]` and expose aggregate + per-oligo summaries as `constraint_pressure` in metrics/manifest plumbing; the collector now includes both `constraint_outcomes` and `constraint_pressure` in canonical output. 
- Updated the HTML report to render constraint pressure (aggregate + per-oligo counts) and bumped run schema to `1.2` with deprecation/migration guidance noting the new `constraint_outcomes.by_oligo` shape; tests were adapted to check the new metadata shape and report output.

### Testing
- Ran the linter checks with `ruff` against modified modules using `ruff check ...` and all checks passed. 
- Executed targeted test suites with `pytest -q tests/test_constraint_policy.py tests/test_core_pipeline.py tests/test_html_report.py tests/test_results_schema.py` and the run completed with `28 passed, 1 skipped`. 
- Added unit tests for `validate_batch`/`repair_batch`, updated expectations in existing encode/decode tests for the new `constraint_outcomes` mapping, and added HTML report assertions for `constraint_pressure`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19811f7b4832682ef2d85a72519a0)