### PR TITLE
Unify runtime config loading and profile resolution

### DIFF
--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -52,6 +52,7 @@ from genecoder.core import metrics as gather_metrics
 from genecoder.manifest import generate_manifest
 from genecoder.plugin_manager import FEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.config.loader import validate_bundle_document
 from genecoder.synthesis import SynthesisConstraints
 from genecoder.constraints import load_constraint_policy
 
@@ -182,14 +183,10 @@ def _format_schema_error(error: ValidationError) -> str:
 
 def _validate_bundle_config(config: Mapping[str, object], config_path: Path) -> None:
     init_plugins()
-    schema = _augment_schema(_load_bundle_schema())
-    validator = Draft202012Validator(schema)
-    error = best_match(validator.iter_errors(config))
-    if error is None:
-        return
-
-    message = _format_schema_error(error)
-    raise ValueError(f"Invalid bundle config at {config_path} ({message})")
+    try:
+        validate_bundle_document(config)
+    except ValueError as exc:
+        raise ValueError(f"Invalid bundle config at {config_path} ({exc})") from exc
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -29,6 +29,12 @@ from genecoder.error_simulation import (
     INDEL_PROFILES,
 )
 from genecoder.runtime import make_run_context
+from genecoder.config.loader import (
+    PROFILE_ALIAS_TABLE,
+    load_channel_workflow_config,
+    load_mapping_file,
+    resolve_channel_profile_alias,
+)
 from genecoder.simulators.batch_utils import (
     RESULT_COVERAGE_KEY,
     RESULT_DROPOUT_FLAG_KEY,
@@ -38,7 +44,6 @@ from genecoder.simulators.batch_utils import (
     bool_to_str,
     clone_batch,
     finalize_batch_statistics,
-    load_coverage_distribution,
     mutation_counts,
 )
 from .options import ChannelOptions, build_channel_options, _parse_distribution
@@ -47,18 +52,8 @@ from .shared import add_single_io_args
 logger = logging.getLogger(__name__)
 
 
-PROFILE_MAP: dict[str, tuple[str, str]] = {
-    "miseq": ("illumina", "miseq"),
-    "hiseq": ("illumina", "hiseq"),
-    "novaseq": ("illumina", "novaseq"),
-    "nova": ("illumina", "nova"),
-    "minion": ("nanopore", "minion"),
-    "promethion": ("nanopore", "promethion"),
-    "r9": ("nanopore_dnarsim", "r9"),
-    "r10.3": ("nanopore_dnarsim", "r10.3"),
-    "r10.4": ("nanopore_dnarsim", "r10.4"),
-}
 
+PROFILE_MAP = PROFILE_ALIAS_TABLE
 
 def _normalize_stage_options(value: object) -> list[str]:
     """Return ``value`` as a list of command-line options."""
@@ -108,114 +103,34 @@ def _load_config(
     ChannelConfig,
     dict[str, Any],
 ]:
-    try:
-        import yaml
-    except Exception:  # pragma: no cover - optional dependency
-        from genecoder.plugin_manager import yaml as yaml_module
-        if yaml_module is None:
-            raise
-        yaml = yaml_module
-
-    with open(path, "r", encoding="utf-8") as f:
-        try:
-            data = yaml.safe_load(f) or {}
-        except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML path
-            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
-
-    if not isinstance(data, dict):
-        raise ValueError("Config file must map keys to values")
-
-    sim_section = data.get("simulators", [])
-    if not isinstance(sim_section, Sequence):
-        raise ValueError("'simulators' must be a list")
-
+    workflow = load_channel_workflow_config(path)
     simulators: list[tuple[str, Dict[str, Any]]] = []
-    for item in sim_section:
-        if isinstance(item, str):
-            simulators.append((item, {}))
-        elif isinstance(item, dict):
-            name = item.get("name")
-            if not isinstance(name, str):
-                raise ValueError("Simulator mapping must contain a string 'name'")
-            params = {k: v for k, v in item.items() if k != "name"}
-            simulators.append((name, params))
-        else:
-            raise ValueError("Each simulator must be a string or mapping")
-
-    synth_section = data.get("synthesis", data.get("constraints", {}))
-    if not isinstance(synth_section, dict):
-        raise ValueError("'synthesis' must be a mapping")
-
-    decay_section = data.get("decay")
-    if decay_section is not None and not isinstance(decay_section, dict):
-        raise ValueError("'decay' must be a mapping")
-
-    pipeline = data.get("pipeline", {})
-    if not isinstance(pipeline, dict):
-        raise ValueError("'pipeline' must be a mapping")
-
-    coverage_config = pipeline.get("coverage_distribution")
-    cfg = ChannelConfig(
-        parallel=bool(pipeline.get("parallel", False)),
-        workers=pipeline.get("workers"),
-        use_process_pool=bool(pipeline.get("use_process_pool", False)),
-        use_mpi=bool(pipeline.get("use_mpi", False)),
-        illumina_profile=pipeline.get("illumina_profile"),
-        nanopore_profile=pipeline.get("nanopore_profile"),
-        dropout_rate=(
-            float(pipeline["dropout_rate"]) if "dropout_rate" in pipeline else None
-        ),
-        coverage_distribution=load_coverage_distribution(coverage_config),
-        synthesis_loss=(
-            float(pipeline["synthesis_loss"]) if "synthesis_loss" in pipeline else None
-        ),
-    )
-
+    for stage in workflow.simulators:
+        params = dict(stage.parameters)
+        if stage.stage:
+            params["stage"] = stage.stage
+        if stage.options:
+            params["options"] = list(stage.options)
+        simulators.append((stage.name, params))
+    constraints = workflow.constraints.to_policy_dict()
+    cfg = workflow.pipeline.to_channel_config()
     extra = {
-        "input_file": data.get("input"),
-        "output_file": data.get("output"),
-        "sub_prob": float(data.get("sub_prob", 0.0) or 0.0),
-        "ins_prob": float(data.get("ins_prob", 0.0) or 0.0),
-        "del_prob": float(data.get("del_prob", 0.0) or 0.0),
-        "seed": data.get("seed"),
-        "batch_workers": data.get("batch_workers"),
+        "input_file": workflow.input_file,
+        "output_file": workflow.output_file,
+        "sub_prob": workflow.sub_prob,
+        "ins_prob": workflow.ins_prob,
+        "del_prob": workflow.del_prob,
+        "seed": workflow.seed,
+        "batch_workers": workflow.batch_workers,
     }
-    decay_section = data.get("decay")
-    if isinstance(decay_section, dict):
-        half_life = float(decay_section.get("half_life", 0.0) or 0.0)
-        variation = float(decay_section.get("variation", 0.0) or 0.0)
-        if half_life > 0.0:
-            decay_rate = 1.0 - 0.5 ** (1.0 / half_life)
-            decay_rate *= 1.0 + variation
-            extra["decay_rate"] = min(max(decay_rate, 0.0), 1.0)
-    if "decay_rate" in data:
-        extra["decay_rate"] = float(data["decay_rate"])
-
-    policy = load_constraint_policy(synth_section, fallback={"gc_min": 0.0, "gc_max": 1.0})
-
-    return simulators, policy.to_dict(), cfg, extra
+    if workflow.decay_rate is not None:
+        extra["decay_rate"] = workflow.decay_rate
+    return simulators, constraints, cfg, extra
 
 
 def _load_profile_file(path: str) -> Dict[str, Any]:
     """Return parameters from JSON or YAML ``path``."""
-    text = Path(path).read_text(encoding="utf-8")
-    try:
-        data: Any = json.loads(text)
-    except json.JSONDecodeError:
-        try:  # Optional at runtime
-            import yaml
-        except Exception:  # pragma: no cover - optional dependency
-            from genecoder.plugin_manager import yaml as yaml_module
-            if yaml_module is None:
-                raise
-            yaml = yaml_module
-        try:
-            data = yaml.safe_load(text)
-        except Exception as exc:  # pragma: no cover - invalid YAML path
-            raise ValueError(f"Invalid profile in {path}: {exc}") from exc
-    if not isinstance(data, dict):
-        raise ValueError("Profile file must map keys to values")
-    return data or {}
+    return dict(load_mapping_file(path))
 
 
 def _apply_simulators(
@@ -602,6 +517,7 @@ def process_channel(
             "del_prob": del_prob,
         },
         "constraint_policy": policy.to_dict(),
+        "constraints": policy.to_dict(),
         "metrics": {
             "length": total_len,
             "substitutions": sub_total,
@@ -879,7 +795,7 @@ def run_channel(args: argparse.Namespace) -> None:
     )
     simulators = opts.simulator_specs
     if opts.profile:
-        sim_name, prof = PROFILE_MAP[opts.profile]
+        sim_name, prof = resolve_channel_profile_alias(opts.profile)
         simulators = [(sim_name, {})]
         if sim_name == "illumina":
             opts.illumina_profile = prof
@@ -1005,7 +921,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         raise SystemExit(1)
 
     if args.profile is not None:
-        sim_name, preset = PROFILE_MAP[args.profile]
+        sim_name, preset = resolve_channel_profile_alias(args.profile)
         simulators = [(sim_name, {})]
         if sim_name == "illumina":
             cfg.illumina_profile = preset

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -12,13 +12,13 @@ from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES
 
 from genecoder.channel_config import ChannelConfig
+from genecoder.config.loader import load_mapping_file, validate_bundle_document
 from genecoder.core import encode, decode, inspect_coding_plan
 from genecoder.formats import SequenceBatch
 from genecoder.parallel import parallel_map
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
-    yaml as yaml_module,
     init_plugins,
 )
 from genecoder.simulators import SIMULATOR_REGISTRY, ChannelPipeline
@@ -92,21 +92,10 @@ def _is_truthy(value: object) -> bool:
 
 
 def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]]:
-    """Parse pipeline settings from a YAML ``path``."""
+    """Parse pipeline settings from a YAML/JSON ``path``."""
 
-    if yaml_module is None:  # pragma: no cover - optional dependency
-        import yaml as yaml_fallback
-    else:
-        yaml_fallback = yaml_module
-
-    with open(path, "r", encoding="utf-8") as f:
-        try:
-            data = yaml_fallback.safe_load(f) or {}
-        except Exception as exc:  # pragma: no cover - invalid YAML path
-            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
-
-    if not isinstance(data, dict):
-        raise ValueError("Config file must map keys to values")
+    data = dict(load_mapping_file(path))
+    validate_bundle_document({"encode": {"input_files": ["placeholder"], "method": "base4_direct"}, "simulate": data})
 
     codec = data.get("codec")
     if not isinstance(codec, str):

--- a/src/genecoder/config/__init__.py
+++ b/src/genecoder/config/__init__.py
@@ -1,0 +1,27 @@
+"""Shared configuration ingestion helpers."""
+
+from .loader import (
+    ChannelWorkflowConfig,
+    ConstraintConfig,
+    PipelineRunSettings,
+    SimulatorStageConfig,
+    VersionedProfile,
+    load_channel_workflow_config,
+    load_mapping_file,
+    resolve_channel_profile_alias,
+    resolve_profile,
+    validate_bundle_document,
+)
+
+__all__ = [
+    "VersionedProfile",
+    "SimulatorStageConfig",
+    "ConstraintConfig",
+    "PipelineRunSettings",
+    "ChannelWorkflowConfig",
+    "load_mapping_file",
+    "resolve_profile",
+    "resolve_channel_profile_alias",
+    "validate_bundle_document",
+    "load_channel_workflow_config",
+]

--- a/src/genecoder/config/loader.py
+++ b/src/genecoder/config/loader.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import copy
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+import warnings
+
+from genecoder.channel_config import ChannelConfig
+from genecoder.constraints import load_constraint_policy
+from genecoder.simulators.batch_utils import load_coverage_distribution
+
+try:  # pragma: no cover - optional dependency
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import best_match
+except Exception:  # pragma: no cover - optional dependency
+    Draft202012Validator = None  # type: ignore[assignment]
+    best_match = None  # type: ignore[assignment]
+
+PROFILE_ALIAS_TABLE: dict[str, tuple[str, str]] = {
+    "miseq": ("illumina", "miseq"),
+    "hiseq": ("illumina", "hiseq"),
+    "novaseq": ("illumina", "novaseq"),
+    "nova": ("illumina", "nova"),
+    "minion": ("nanopore", "minion"),
+    "promethion": ("nanopore", "promethion"),
+    "r9": ("nanopore_dnarsim", "r9"),
+    "r10.3": ("nanopore_dnarsim", "r10.3"),
+    "r10.4": ("nanopore_dnarsim", "r10.4"),
+}
+
+CONSTRAINT_ALIASES: dict[str, str] = {
+    "homopolymer_max": "max_homopolymer",
+}
+
+PIPELINE_ALIASES: dict[str, str] = {
+    "threads": "workers",
+    "processes": "workers",
+}
+
+
+@dataclass(frozen=True)
+class VersionedProfile:
+    schema_version: int
+    kind: str
+    name: str
+    parameters: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SimulatorStageConfig:
+    name: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    stage: str | None = None
+    options: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ConstraintConfig:
+    min_length: int | None = None
+    max_length: int | None = None
+    max_homopolymer: int | None = None
+    gc_min: float = 0.0
+    gc_max: float = 1.0
+
+    def to_policy_dict(self) -> dict[str, float | int]:
+        raw: dict[str, float | int] = {"gc_min": self.gc_min, "gc_max": self.gc_max}
+        if self.min_length is not None:
+            raw["min_length"] = self.min_length
+        if self.max_length is not None:
+            raw["max_length"] = self.max_length
+        if self.max_homopolymer is not None:
+            raw["max_homopolymer"] = self.max_homopolymer
+        return load_constraint_policy(raw, fallback={"gc_min": 0.0, "gc_max": 1.0}).to_dict()
+
+
+@dataclass(frozen=True)
+class PipelineRunSettings:
+    parallel: bool = False
+    workers: int | None = None
+    use_process_pool: bool = False
+    use_mpi: bool = False
+    illumina_profile: str | None = None
+    nanopore_profile: str | None = None
+    dropout_rate: float | None = None
+    coverage_distribution: Mapping[str, float] | None = None
+    synthesis_loss: float | None = None
+
+    def to_channel_config(self) -> ChannelConfig:
+        return ChannelConfig(
+            parallel=self.parallel,
+            workers=self.workers,
+            use_process_pool=self.use_process_pool,
+            use_mpi=self.use_mpi,
+            illumina_profile=self.illumina_profile,
+            nanopore_profile=self.nanopore_profile,
+            dropout_rate=self.dropout_rate,
+            coverage_distribution=(
+                dict(self.coverage_distribution) if self.coverage_distribution else None
+            ),
+            synthesis_loss=self.synthesis_loss,
+        )
+
+
+@dataclass(frozen=True)
+class ChannelWorkflowConfig:
+    simulators: tuple[SimulatorStageConfig, ...]
+    constraints: ConstraintConfig
+    pipeline: PipelineRunSettings
+    input_file: str | None = None
+    output_file: str | None = None
+    sub_prob: float = 0.0
+    ins_prob: float = 0.0
+    del_prob: float = 0.0
+    seed: int | None = None
+    batch_workers: int | None = None
+    decay_rate: float | None = None
+
+
+def _load_yaml_module() -> object:
+    try:
+        import yaml
+
+        return yaml
+    except Exception:  # pragma: no cover
+        from genecoder.plugin_manager import yaml as yaml_module
+
+        if yaml_module is None:
+            raise
+        return yaml_module
+
+
+def load_mapping_file(path: str | Path) -> Mapping[str, Any]:
+    text = Path(path).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        yaml_mod = _load_yaml_module()
+        try:
+            data = yaml_mod.safe_load(text)
+        except Exception as exc:  # pragma: no cover
+            raise ValueError(f"Invalid config in {path}: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("Config file must map keys to values")
+    return dict(data)
+
+
+def validate_profile_schema(profile: Mapping[str, Any], *, kind: str) -> VersionedProfile:
+    schema_version = int(profile.get("schema_version", 1))
+    if schema_version != 1:
+        raise ValueError(f"Unsupported {kind} profile schema_version: {schema_version}")
+    params = profile.get("parameters")
+    if not isinstance(params, Mapping):
+        raise ValueError(f"{kind} profile requires 'parameters' mapping")
+    name = str(profile.get("name") or kind)
+    return VersionedProfile(schema_version=schema_version, kind=kind, name=name, parameters=dict(params))
+
+
+def resolve_profile(
+    value: str | Mapping[str, Any] | None,
+    *,
+    kind: str,
+    presets: Mapping[str, VersionedProfile],
+    allow_legacy_dict: bool = False,
+) -> VersionedProfile | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        if "parameters" not in value:
+            if not allow_legacy_dict:
+                raise ValueError(
+                    f"{kind} profile mappings must be versioned with schema_version/name/parameters"
+                )
+            warnings.warn(
+                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            value = {
+                "schema_version": 1,
+                "kind": kind,
+                "name": "custom",
+                "parameters": dict(value),
+            }
+        return validate_profile_schema(value, kind=kind)
+
+    path = Path(value)
+    if path.is_file():
+        loaded = dict(load_mapping_file(path))
+        if "parameters" not in loaded:
+            warnings.warn(
+                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            loaded = {
+                "schema_version": 1,
+                "kind": kind,
+                "name": path.stem,
+                "parameters": loaded,
+            }
+        return validate_profile_schema(loaded, kind=kind)
+    return presets.get(str(value).lower())
+
+
+def resolve_channel_profile_alias(alias: str) -> tuple[str, str]:
+    lowered = alias.lower()
+    if lowered not in PROFILE_ALIAS_TABLE:
+        raise ValueError(f"Unknown profile alias: {alias}")
+    return PROFILE_ALIAS_TABLE[lowered]
+
+
+def _schema_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "configs" / "schema" / "bundle.schema.json"
+
+
+def _augment_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    schema = copy.deepcopy(schema)
+    defs = schema.setdefault("$defs", {})
+    # legacy field aliases still accepted at config boundary
+    synth = defs.get("synthesisConstraints")
+    if isinstance(synth, dict):
+        props = synth.setdefault("properties", {})
+        if isinstance(props, dict):
+            props.setdefault("homopolymer_max", props.get("max_homopolymer", {"type": ["integer", "null"]}))
+    pipe = defs.get("pipeline")
+    if isinstance(pipe, dict):
+        props = pipe.setdefault("properties", {})
+        if isinstance(props, dict):
+            props.setdefault("threads", props.get("workers", {"type": ["integer", "null"]}))
+            props.setdefault("processes", props.get("workers", {"type": ["integer", "null"]}))
+    return schema
+
+
+def validate_bundle_document(config: Mapping[str, Any]) -> None:
+    if Draft202012Validator is None or best_match is None:
+        return
+    schema = _augment_schema(json.loads(_schema_path().read_text(encoding="utf-8")))
+    validator = Draft202012Validator(schema)
+    error = best_match(validator.iter_errors(config))
+    if error:
+        path = ".".join(str(p) for p in error.path)
+        loc = path or "<root>"
+        raise ValueError(f"Schema validation failed at {loc}: {error.message}")
+
+
+def _normalize_constraints(raw: Mapping[str, Any]) -> ConstraintConfig:
+    normalized = dict(raw)
+    for old, new in CONSTRAINT_ALIASES.items():
+        if old in normalized and new not in normalized:
+            normalized[new] = normalized[old]
+    return ConstraintConfig(
+        min_length=int(normalized["min_length"]) if normalized.get("min_length") is not None else None,
+        max_length=int(normalized["max_length"]) if normalized.get("max_length") is not None else None,
+        max_homopolymer=(
+            int(normalized["max_homopolymer"]) if normalized.get("max_homopolymer") is not None else None
+        ),
+        gc_min=float(normalized.get("gc_min", 0.0)),
+        gc_max=float(normalized.get("gc_max", 1.0)),
+    )
+
+
+def _normalize_pipeline(raw: Mapping[str, Any]) -> PipelineRunSettings:
+    normalized = dict(raw)
+    for old, new in PIPELINE_ALIASES.items():
+        if old in normalized and new not in normalized:
+            normalized[new] = normalized[old]
+    return PipelineRunSettings(
+        parallel=bool(normalized.get("parallel", False)),
+        workers=int(normalized["workers"]) if normalized.get("workers") is not None else None,
+        use_process_pool=bool(normalized.get("use_process_pool", False)),
+        use_mpi=bool(normalized.get("use_mpi", False)),
+        illumina_profile=(str(normalized["illumina_profile"]) if normalized.get("illumina_profile") else None),
+        nanopore_profile=(str(normalized["nanopore_profile"]) if normalized.get("nanopore_profile") else None),
+        dropout_rate=(float(normalized["dropout_rate"]) if normalized.get("dropout_rate") is not None else None),
+        coverage_distribution=load_coverage_distribution(normalized.get("coverage_distribution")),
+        synthesis_loss=(float(normalized["synthesis_loss"]) if normalized.get("synthesis_loss") is not None else None),
+    )
+
+
+def _normalize_stage_options(value: object) -> tuple[str, ...]:
+    if value in (None, ""):
+        return ()
+    if isinstance(value, str):
+        return tuple(chunk for chunk in value.split() if chunk)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return tuple(str(opt) for opt in value if str(opt))
+    return (str(value),)
+
+
+def _normalize_simulators(items: Sequence[Any]) -> tuple[SimulatorStageConfig, ...]:
+    stages: list[SimulatorStageConfig] = []
+    for item in items:
+        if isinstance(item, str):
+            stages.append(SimulatorStageConfig(name=item))
+            continue
+        if not isinstance(item, Mapping):
+            raise ValueError("Each simulator must be a string or mapping")
+        name = item.get("name")
+        if not isinstance(name, str):
+            raise ValueError("Simulator mapping must contain a string 'name'")
+        params = dict(item)
+        params.pop("name", None)
+        stage = str(params.pop("stage", params.pop("stage_name", "")) or "") or None
+        options_raw = None
+        for key in ("options", "stage_options", "flags", "cli_options"):
+            if key in params:
+                options_raw = params.pop(key)
+                break
+        stages.append(
+            SimulatorStageConfig(
+                name=name,
+                parameters=params,
+                stage=stage,
+                options=_normalize_stage_options(options_raw),
+            )
+        )
+    return tuple(stages)
+
+
+def load_channel_workflow_config(path: str | Path) -> ChannelWorkflowConfig:
+    data = load_mapping_file(path)
+    # Validate against simulate contract from bundle schema.
+    validate_bundle_document({"encode": {"input_files": ["placeholder"], "method": "base4_direct"}, "simulate": data})
+
+    sims_raw = data.get("simulators", [])
+    if not isinstance(sims_raw, Sequence) or isinstance(sims_raw, (str, bytes, bytearray)):
+        raise ValueError("'simulators' must be a list")
+    simulators = _normalize_simulators(sims_raw)
+
+    synth_section = data.get("synthesis", data.get("constraints", {}))
+    if not isinstance(synth_section, Mapping):
+        raise ValueError("'synthesis' must be a mapping")
+    constraints = _normalize_constraints(synth_section)
+
+    pipeline_raw = data.get("pipeline", {})
+    if not isinstance(pipeline_raw, Mapping):
+        raise ValueError("'pipeline' must be a mapping")
+    pipeline = _normalize_pipeline(pipeline_raw)
+
+    decay_rate: float | None = None
+    decay_section = data.get("decay")
+    if decay_section is not None:
+        if not isinstance(decay_section, Mapping):
+            raise ValueError("'decay' must be a mapping")
+        half_life = float(decay_section.get("half_life", 0.0) or 0.0)
+        variation = float(decay_section.get("variation", 0.0) or 0.0)
+        if half_life > 0.0:
+            decay_rate = 1.0 - 0.5 ** (1.0 / half_life)
+            decay_rate = min(max(decay_rate * (1.0 + variation), 0.0), 1.0)
+
+    if data.get("decay_rate") is not None:
+        decay_rate = float(data["decay_rate"])
+
+    return ChannelWorkflowConfig(
+        simulators=simulators,
+        constraints=constraints,
+        pipeline=pipeline,
+        input_file=(str(data["input"]) if data.get("input") is not None else None),
+        output_file=(str(data["output"]) if data.get("output") is not None else None),
+        sub_prob=float(data.get("sub_prob", 0.0) or 0.0),
+        ins_prob=float(data.get("ins_prob", 0.0) or 0.0),
+        del_prob=float(data.get("del_prob", 0.0) or 0.0),
+        seed=(int(data["seed"]) if data.get("seed") is not None else None),
+        batch_workers=(int(data["batch_workers"]) if data.get("batch_workers") is not None else None),
+        decay_rate=decay_rate,
+    )

--- a/src/genecoder/simulation_engine/profiles.py
+++ b/src/genecoder/simulation_engine/profiles.py
@@ -1,48 +1,17 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-import json
 from pathlib import Path
 from typing import Any, Mapping
-import warnings
 
-
-@dataclass(frozen=True)
-class VersionedProfile:
-    schema_version: int
-    kind: str
-    name: str
-    parameters: Mapping[str, Any]
-
-
-def validate_profile_schema(profile: Mapping[str, Any], *, kind: str) -> VersionedProfile:
-    schema_version = int(profile.get("schema_version", 1))
-    if schema_version != 1:
-        raise ValueError(f"Unsupported {kind} profile schema_version: {schema_version}")
-    name = str(profile.get("name") or kind)
-    params = profile.get("parameters")
-    if not isinstance(params, Mapping):
-        raise ValueError(f"{kind} profile requires 'parameters' mapping")
-    return VersionedProfile(schema_version=schema_version, kind=kind, name=name, parameters=dict(params))
+from genecoder.config.loader import (
+    VersionedProfile,
+    load_mapping_file,
+    resolve_profile as _resolve_profile
+)
 
 
 def _load_mapping(path: str | Path) -> Mapping[str, Any]:
-    text = Path(path).read_text(encoding="utf-8")
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        try:
-            import yaml
-        except Exception:
-            from genecoder.plugin_manager import yaml as yaml_module
-
-            if yaml_module is None:
-                raise
-            yaml = yaml_module
-        data = yaml.safe_load(text) or {}
-    if not isinstance(data, Mapping):
-        raise ValueError("Profile file must map keys to values")
-    return data
+    return load_mapping_file(path)
 
 
 def normalize_profile(
@@ -52,26 +21,12 @@ def normalize_profile(
     presets: Mapping[str, VersionedProfile],
     allow_legacy_dict: bool = False,
 ) -> VersionedProfile | None:
-    if value is None:
-        return None
-    if isinstance(value, Mapping):
-        if "parameters" not in value:
-            if not allow_legacy_dict:
-                raise ValueError(
-                    f"{kind} profile mappings must be versioned with schema_version/name/parameters"
-                )
-            warnings.warn(
-                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            value = {"schema_version": 1, "kind": kind, "name": "custom", "parameters": dict(value)}
-        return validate_profile_schema(value, kind=kind)
-
-    path = Path(value)
-    if path.is_file():
-        return validate_profile_schema(_load_mapping(path), kind=kind)
-    return presets.get(str(value).lower())
+    return _resolve_profile(
+        value,
+        kind=kind,
+        presets=presets,
+        allow_legacy_dict=allow_legacy_dict,
+    )
 
 
 def resolve_profile(
@@ -80,4 +35,4 @@ def resolve_profile(
     kind: str,
     presets: Mapping[str, VersionedProfile],
 ) -> VersionedProfile | None:
-    return normalize_profile(value, kind=kind, presets=presets, allow_legacy_dict=True)
+    return _resolve_profile(value, kind=kind, presets=presets, allow_legacy_dict=True)

--- a/src/genecoder/simulators/illumina/profiles.py
+++ b/src/genecoder/simulators/illumina/profiles.py
@@ -7,7 +7,8 @@ from typing import Any, Mapping, Sequence
 import json
 import warnings
 
-from ...simulation_engine.profiles import VersionedProfile, normalize_profile as _normalize_profile
+from ...config.loader import VersionedProfile, load_mapping_file
+from ...simulation_engine.profiles import normalize_profile as _normalize_profile
 
 
 __all__ = [
@@ -87,22 +88,7 @@ def _validate_profile(data: Mapping[str, Any]) -> IlluminaProfile:
 
 
 def _load_profile_file(path: str | Path) -> Mapping[str, Any]:
-    text = Path(path).read_text(encoding="utf-8")
-    try:
-        data: Any = json.loads(text)
-    except json.JSONDecodeError:
-        try:
-            import yaml
-        except Exception:
-            from genecoder.plugin_manager import yaml as yaml_module
-
-            if yaml_module is None:
-                raise
-            yaml = yaml_module
-        data = yaml.safe_load(text) or {}
-    if not isinstance(data, Mapping):
-        raise ValueError("Profile file must map keys to values")
-    return data
+    return load_mapping_file(path)
 
 
 _BASE_PRESETS: dict[str, dict[str, float | int]] = {


### PR DESCRIPTION
### Motivation

- Consolidate YAML/JSON config parsing, profile resolution and schema validation into a single shared loader so all entrypoints enforce the same contract and avoid duplicate ad-hoc normalization.
- Provide typed canonical objects for channel profiles, constraints and pipeline run settings to simplify callers and make defaults/aliases explicit.

### Description

- Add a new shared config ingestion module `src/genecoder/config/loader.py` and export it via `src/genecoder/config/__init__.py`, providing `ChannelWorkflowConfig`, `SimulatorStageConfig`, `ConstraintConfig`, `PipelineRunSettings`, `VersionedProfile`, `load_channel_workflow_config`, `load_mapping_file`, `resolve_profile` and `resolve_channel_profile_alias`.
- Move channel workflow parsing from `cli/channel.py` into `load_channel_workflow_config` and refactor `_load_config` to return typed simulators, constraint policy and `ChannelConfig` built from `PipelineRunSettings`.
- Delegate profile file loading and normalization to the shared loader by updating `src/genecoder/simulation_engine/profiles.py` and `src/genecoder/simulators/illumina/profiles.py` to use `load_mapping_file`/`resolve_profile`.
- Wire `configs/schema/bundle.schema.json` into runtime validation via `validate_bundle_document` and call it from `cli/bundle.py` and `cli/pipeline.py` so bundle/pipeline configs are validated at load time.
- Preserve legacy aliases and compatibility by mapping old fields (`homopolymer_max`, `threads`, `processes`) in the loader and keeping manifest compatibility by emitting both `constraint_policy` and `constraints`; replace ad-hoc `PROFILE_MAP` with `resolve_channel_profile_alias`.

### Testing

- Ran static checks with `ruff` on the modified modules and the check succeeded.
- Executed focused unit tests with `PYTHONPATH=src python -m pytest` including `tests/test_versioned_profiles.py`, `tests/test_cli_channel.py`, `tests/test_bundle.py::test_bundle_run` and pipeline/profile related tests; the final validated run reported 23 passed (with warnings) for the exercised test subset.
- Exercised bundle schema validation by loading `configs/schema/bundle.schema.json` at runtime via the new loader and confirmed failure cases produce clear schema errors during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19d85008c83269023a81bcd239673)