### PR TITLE
Unify plugin management under plugin_runtime and slim plugin_manager facade

### DIFF
--- a/src/genecoder/cli/plugin.py
+++ b/src/genecoder/cli/plugin.py
@@ -2,44 +2,10 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
-import sys
-import tempfile
-from pathlib import Path
-import subprocess
 
-from pip._internal.exceptions import InstallationSubprocessError
-from pip._internal.utils.subprocess import call_subprocess
-
-import genecoder.plugin_manager as plugins
-from genecoder.plugin_checks import decode_signature, verify_package
+import genecoder.plugin_runtime as plugins
 
 logger = logging.getLogger(__name__)
-
-_ORIG_CHECK_CALL = subprocess.check_call
-
-
-def _run_pip(args: list[str], desc: str) -> None:
-    """Execute pip with output capture.
-
-    When ``subprocess.check_call`` has been monkeypatched (typically by tests),
-    the patched function is used instead of pip's internal helper. Otherwise
-    :func:`pip._internal.utils.subprocess.call_subprocess` is invoked with
-    ``stdout`` capture enabled so output is redirected to the logger.
-    """
-
-    try:
-        if subprocess.check_call is not _ORIG_CHECK_CALL:
-            subprocess.check_call([sys.executable, "-m", "pip", *args])
-        else:
-            call_subprocess(
-                [sys.executable, "-m", "pip", *args],
-                stdout_only=True,
-                command_desc=desc,
-            )
-    except InstallationSubprocessError as exc:
-        logger.error("%s failed: %s", desc, exc)
-        raise SystemExit(exc.exit_code)
 
 
 def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -71,7 +37,6 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
     reg_parser.set_defaults(func=_handle_install_registry)
 
 
-
 def _handle_list(args: argparse.Namespace) -> None:
     if not plugins.PLUGIN_CATALOG:
         logger.info("No plugin catalog available")
@@ -85,98 +50,12 @@ def _handle_list(args: argparse.Namespace) -> None:
         print(display)
 
 
-def download_plugin_bytes(name: str) -> tuple[str, bytes]:
-    """Return ``(filename, bytes)`` for plugin ``name`` after verification."""
-
-    meta = plugins.PLUGIN_CATALOG.get(name)
-    if not meta:
-        logger.error("Unknown plugin: %s", name)
-        raise SystemExit(1)
-
-    spec = meta.get("url") or name
-    version = meta.get("version")
-    if version and not meta.get("url"):
-        spec = f"{name}=={version}"
-    checksum = meta.get("checksum")
-    signature_b64 = meta.get("signature")
-    pubkey: bytes | None = None
-
-    key_path = os.getenv("GENECODER_PLUGIN_PUBLIC_KEY")
-    if signature_b64:
-        if not key_path:
-            logger.error("Missing public key for signed plugin %s", name)
-            raise SystemExit(1)
-        try:
-            pubkey = Path(key_path).read_bytes()
-        except Exception:
-            logger.warning("Failed to read public key %s", key_path)
-            pubkey = None
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        _run_pip(
-            ["download", "--no-deps", "-d", tmp_dir, spec],
-            "pip download",
-        )
-        files = list(Path(tmp_dir).iterdir())
-        if not files:
-            logger.error("No package downloaded for plugin %s", name)
-            raise SystemExit(1)
-        pkg_path = files[0]
-        pkg_bytes = pkg_path.read_bytes()
-
-        if signature_b64:
-            if pubkey is None:
-                logger.error("Missing public key for signed plugin %s", name)
-                raise SystemExit(1)
-            try:
-                sig_bytes = decode_signature(signature_b64)
-            except ValueError:
-                logger.error("Invalid signature for plugin %s", name)
-                raise SystemExit(1)
-        else:
-            sig_bytes = None
-
-        try:
-            verify_package(
-                pkg_bytes,
-                checksum=checksum,
-                signature=sig_bytes,
-                public_key=pubkey,
-                compute_fn=plugins.compute_checksum,
-            )
-        except ValueError as exc:
-            if str(exc) == "Checksum mismatch":
-                logger.error("Checksum mismatch for plugin %s", name)
-            else:
-                logger.error("Signature verification failed for plugin %s: %s", name, exc)
-            raise SystemExit(1)
-
-        return pkg_path.name, pkg_bytes
-
-
-def download_plugin(name: str) -> None:
-    """Download ``name`` from the catalog and install it via ``pip``."""
-
-    filename, pkg_bytes = download_plugin_bytes(name)
-    digest = plugins.compute_checksum(pkg_bytes)
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        pkg_path = Path(tmp_dir) / filename
-        pkg_path.write_bytes(pkg_bytes)
-
-        req_file = Path(tmp_dir) / "req.txt"
-        req_file.write_text(f"{pkg_path} --hash=sha256:{digest}\n")
-
-        _run_pip([
-            "install",
-            "--require-hashes",
-            "-r",
-            str(req_file),
-        ], "pip install")
-
-
 def _handle_install(args: argparse.Namespace) -> None:
-    download_plugin(args.name)
+    try:
+        plugins.install_catalog_plugin(args.name)
+    except KeyError:
+        logger.error("Unknown plugin: %s", args.name)
+        raise SystemExit(1)
 
 
 def _handle_install_registry(args: argparse.Namespace) -> None:
@@ -185,6 +64,3 @@ def _handle_install_registry(args: argparse.Namespace) -> None:
         raise SystemExit(1)
 
     plugins.install_registry_plugins(offline=args.offline)
-
-
-

--- a/src/genecoder/plugin_manager.py
+++ b/src/genecoder/plugin_manager.py
@@ -1,251 +1,71 @@
 from __future__ import annotations
 
-from types import ModuleType
-from typing import Any
-
-import base64
 import importlib
-import json
-import logging
-import os
 import subprocess
 import urllib.request
-from pathlib import Path
-
-from . import plugin_security
 from importlib.metadata import entry_points
 
+import genecoder.plugin_runtime as runtime
 from .plugin_runtime import discovery as discovery_mod
 from .plugin_runtime import installer as installer_mod
-from .plugin_runtime.discovery import (
-    ENTRY_POINT_METADATA as _ENTRY_POINT_METADATA,
-    collect_installed_plugins,
-    load_entry_point_plugins as _load_entry_point_plugins,
-    load_local_plugins as _load_local_plugins,
-)
-from .plugin_runtime.descriptors import PluginDescriptor
-from .plugin_runtime.installer import (
-    PLUGIN_LOCK,
-    PipPluginInstaller,
-    fetch_catalog,
-    install_registry_plugins as _install_registry_plugins,
-    load_registry_mapping,
-    render_plugin_lock,
-)
-from .plugin_runtime.policy import (
-    validate_plugin_metadata as _validate_plugin_metadata,
-    validate_spec as _validate_spec,
-)
-from .plugin_runtime.registry import (
-    CODEC_REGISTRY,
-    FEC_REGISTRY,
-    VISUALIZER_REGISTRY,
-    register_codec,
-    register_plugin,
-    register_fec,
-    register_simulator,
-    register_visualizer,
-)
-from .simulators import SIMULATOR_REGISTRY
+from .plugin_runtime.policy import validate_plugin_metadata as _validate_plugin_metadata
+from .plugin_runtime.policy import validate_spec as _validate_spec
 
-logger = logging.getLogger(__name__)
+CODEC_REGISTRY = runtime.CODEC_REGISTRY
+FEC_REGISTRY = runtime.FEC_REGISTRY
+VISUALIZER_REGISTRY = runtime.VISUALIZER_REGISTRY
+SIMULATOR_REGISTRY = runtime.SIMULATOR_REGISTRY
+PLUGIN_CATALOG = runtime.PLUGIN_CATALOG
+ENTRY_POINT_GROUPS = runtime.ENTRY_POINT_GROUPS
+_ENTRY_POINT_METADATA = runtime.ENTRY_POINT_METADATA
+compute_checksum = runtime.compute_checksum
+yaml = runtime.yaml
 
-PLUGIN_CATALOG: dict[str, dict[str, Any]] = {}
-
-yaml: ModuleType | None
-try:
-    import yaml as yaml_module
-except Exception:
-    yaml = None
-else:
-    yaml = yaml_module
-
-compute_checksum = plugin_security.compute_checksum
+register_plugin = runtime.register_plugin
+register_codec = runtime.register_codec
+register_fec = runtime.register_fec
+register_simulator = runtime.register_simulator
+register_visualizer = runtime.register_visualizer
+install_catalog_plugin = runtime.install_catalog_plugin
+generate_plugin_lock = runtime.generate_plugin_lock
+_collect_installed_plugins = runtime._collect_installed_plugins
+load_registry_mapping = runtime.load_registry_mapping
+_verify_catalog_signature = runtime._verify_catalog_signature
 
 
-class _CompatInstaller(PipPluginInstaller):
-    pass
-
-
-def install_registry_plugins(
-    url: str | os.PathLike[str] | None = None,
-    *,
-    offline: bool | None = None,
-    allow_network: bool | None = None,
-) -> None:
-    global yaml
-    yaml_module = yaml
-    if yaml_module is None:
-        try:
-            import yaml as yaml_module_real
-        except Exception:
-            logger.warning("YAML support unavailable; skipping registry %s", url)
-            return
-        yaml = yaml_module_real
-        yaml_module = yaml_module_real
-
+def _sync_runtime_hooks() -> None:
+    discovery_mod.entry_points = entry_points
     installer_mod.subprocess = subprocess
     installer_mod.urllib.request = urllib.request
-    descriptors = _install_registry_plugins(
-        url,
-        offline=offline,
-        allow_network=allow_network,
-        yaml_module=yaml_module,
-        installer=_CompatInstaller(),
-    )
-    PLUGIN_LOCK.clear()
-    PLUGIN_LOCK.extend(d.as_lock_entry() for d in sorted(descriptors, key=lambda d: (d.name, d.version, d.source)))
 
 
-
-def _collect_installed_plugins() -> tuple[dict[str, dict[str, Any]], list[str]]:
-    discovery_mod.entry_points = entry_points
-    catalog, failures, _ = collect_installed_plugins(PLUGIN_CATALOG)
-    return catalog, failures
-
-
-def load_builtin_plugins() -> None:
-    CODEC_REGISTRY.clear()
-    FEC_REGISTRY.clear()
-    VISUALIZER_REGISTRY.clear()
-    SIMULATOR_REGISTRY.clear()
-    builtin = importlib.import_module("genecoder.builtin_plugins")
-    if hasattr(builtin, "register_builtin_plugins"):
-        builtin.register_builtin_plugins()
+def install_registry_plugins(url=None, *, offline=None, allow_network=None) -> None:
+    _sync_runtime_hooks()
+    runtime.install_registry_plugins(url, offline=offline, allow_network=allow_network)
 
 
 def load_entry_point_plugins() -> list[str]:
-    offline = bool(os.getenv("GENECODER_OFFLINE"))
-    groups = {
-        "genecoder.plugins": (register_codec, "codec"),
-        "genecoder.fec": (register_fec, "FEC"),
-        "genecoder.simulators": (register_simulator, "simulator"),
-        "genecoder.visualizers": (register_visualizer, "visualizer"),
-    }
-    discovery_mod.entry_points = entry_points
-    failures, _ = _load_entry_point_plugins(offline=offline, registrars=groups)
-    return failures
-
-
-def load_local_plugins() -> list[str]:
-    return _load_local_plugins(
-        registrars={
-            "codec": register_codec,
-            "fec": register_fec,
-            "simulator": register_simulator,
-            "visualizer": register_visualizer,
-        }
-    )
-
-
-def _verify_catalog_signature(data: bytes, signature_b64: str, *, padding_scheme: str | None = None) -> bool:
-    key_path = os.getenv("GENECODER_CATALOG_PUBLIC_KEY")
-    if not key_path:
-        return False
-    try:
-        public_key = Path(key_path).read_bytes()
-        signature = base64.b64decode(signature_b64, validate=True)
-    except Exception:
-        return False
-    try:
-        compute_checksum(data, signature=signature, public_key=public_key, padding_scheme=padding_scheme or "pkcs1")
-    except Exception:
-        return False
-    return True
+    _sync_runtime_hooks()
+    return runtime.load_entry_point_plugins()
 
 
 def load_plugin_catalog(url: str | None = None) -> None:
-    if url is None:
-        url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
-    catalog: dict[str, dict[str, Any]] = {}
-    offline = bool(os.getenv("GENECODER_OFFLINE"))
-    allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
-    network_ok = allow_network and not offline
-
-    if url:
-        raw = b""
-        if (url.startswith("http://") or url.startswith("https://")) and not network_ok:
-            logger.info("Network access disabled; skipped remote catalog %s", url)
-        else:
-            try:
-                raw = fetch_catalog(url, allow_network=network_ok)
-            except Exception as exc:
-                logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
-
-        if raw:
-            try:
-                data = json.loads(raw.decode("utf-8"))
-            except Exception:
-                if yaml is None:
-                    data = {}
-                else:
-                    try:
-                        data = yaml.safe_load(raw) or {}
-                    except Exception:
-                        data = {}
-            if isinstance(data, dict):
-                signature = data.get("signature")
-                scheme = data.get("signature_scheme") or data.get("scheme")
-                if signature and not _verify_catalog_signature(raw, signature, padding_scheme=scheme):
-                    logger.warning("Invalid catalog signature for %s", url)
-                else:
-                    plugins_data = data.get("plugins", data.get("entries", {}))
-                    if isinstance(plugins_data, list):
-                        for entry in plugins_data:
-                            if isinstance(entry, dict) and "name" in entry:
-                                catalog[str(entry["name"])] = {k: v for k, v in entry.items() if k != "name"}
-                    elif isinstance(plugins_data, dict):
-                        for name, meta in plugins_data.items():
-                            if isinstance(meta, dict):
-                                catalog[str(name)] = dict(meta)
-
-    discovered, failures = _collect_installed_plugins()
-    for name, meta in discovered.items():
-        catalog.setdefault(name, meta)
-
-    PLUGIN_CATALOG.clear()
-    PLUGIN_CATALOG.update(catalog)
-    if failures:
-        logger.warning("Failed to load plugin metadata: %s", ", ".join(failures))
-
-
-def generate_plugin_lock() -> str:
-    descriptors: list[PluginDescriptor] = []
-    for item in PLUGIN_LOCK:
-        descriptors.append(
-            PluginDescriptor(
-                name=item.get("name", ""),
-                kind="package",
-                source=item.get("source", ""),
-                version=item.get("version", ""),
-                checksum=item.get("checksum") or None,
-                signature=item.get("signature") or None,
-            )
-        )
-    return render_plugin_lock(descriptors)
+    _sync_runtime_hooks()
+    runtime.load_plugin_catalog(url)
 
 
 def load_plugins() -> None:
-    load_builtin_plugins()
-    failures = load_entry_point_plugins()
-    failures.extend(load_local_plugins())
-    load_plugin_catalog()
-    if failures:
-        logger.warning("Failed to import plugins: %s", ", ".join(failures))
-
-
-_initialized = False
+    _sync_runtime_hooks()
+    runtime.load_plugins()
 
 
 def init_plugins() -> None:
-    global _initialized
-    if _initialized:
-        return
-    try:
-        load_plugins()
-    except Exception as exc:
-        logger.warning("Failed to load plugins: %s", exc)
-    _initialized = True
+    _sync_runtime_hooks()
+    runtime.init_plugins()
+
+
+def __getattr__(name: str):
+    return getattr(runtime, name)
 
 
 __all__ = [
@@ -254,18 +74,29 @@ __all__ = [
     "VISUALIZER_REGISTRY",
     "SIMULATOR_REGISTRY",
     "PLUGIN_CATALOG",
+    "ENTRY_POINT_GROUPS",
     "register_plugin",
     "register_codec",
     "register_fec",
     "register_simulator",
     "register_visualizer",
     "install_registry_plugins",
+    "install_catalog_plugin",
     "load_plugins",
     "load_entry_point_plugins",
+    "load_plugin_catalog",
     "init_plugins",
+    "generate_plugin_lock",
     "_validate_spec",
     "_validate_plugin_metadata",
     "_collect_installed_plugins",
     "_ENTRY_POINT_METADATA",
     "load_registry_mapping",
+    "compute_checksum",
+    "_verify_catalog_signature",
+    "yaml",
+    "entry_points",
+    "subprocess",
+    "urllib",
+    "importlib",
 ]

--- a/src/genecoder/plugin_runtime/__init__.py
+++ b/src/genecoder/plugin_runtime/__init__.py
@@ -1,1 +1,260 @@
-"""Internal plugin runtime components."""
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import logging
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from genecoder import plugin_security
+
+from .discovery import ENTRY_POINT_METADATA, collect_installed_plugins, load_entry_point_plugins as _load_entry_point_plugins, load_local_plugins as _load_local_plugins
+from .entry_points import ENTRY_POINT_GROUPS, entry_point_registrars
+from .installer import PLUGIN_LOCK, PipPluginInstaller, fetch_catalog, install_plugin_spec, install_registry_plugins as _install_registry_plugins, load_registry_mapping, render_plugin_lock
+from .registry import CODEC_REGISTRY, FEC_REGISTRY, VISUALIZER_REGISTRY, register_codec, register_fec, register_plugin, register_simulator, register_visualizer
+from genecoder.simulators import SIMULATOR_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_CATALOG: dict[str, dict[str, Any]] = {}
+
+_initialized = False
+
+yaml: ModuleType | None
+try:
+    import yaml as yaml_module
+except Exception:
+    yaml = None
+else:
+    yaml = yaml_module
+
+compute_checksum = plugin_security.compute_checksum
+
+
+def _yaml_module_or_none() -> ModuleType | None:
+    global yaml
+    if yaml is not None:
+        return yaml
+    try:
+        import yaml as yaml_module_real
+    except Exception:
+        return None
+    yaml = yaml_module_real
+    return yaml_module_real
+
+
+def install_registry_plugins(
+    url: str | os.PathLike[str] | None = None,
+    *,
+    offline: bool | None = None,
+    allow_network: bool | None = None,
+) -> None:
+    yaml_module = _yaml_module_or_none()
+    if yaml_module is None:
+        logger.warning("YAML support unavailable; skipping registry %s", url)
+        return
+    descriptors = _install_registry_plugins(
+        url,
+        offline=offline,
+        allow_network=allow_network,
+        yaml_module=yaml_module,
+        installer=PipPluginInstaller(),
+    )
+    PLUGIN_LOCK.clear()
+    PLUGIN_LOCK.extend(d.as_lock_entry() for d in sorted(descriptors, key=lambda d: (d.name, d.version, d.source)))
+
+
+def install_catalog_plugin(name: str) -> None:
+    meta = PLUGIN_CATALOG.get(name)
+    if not meta:
+        raise KeyError(name)
+    spec = str(meta.get("url") or name)
+    version = meta.get("version")
+    if version and not meta.get("url"):
+        spec = f"{name}=={version}"
+    offline = bool(os.getenv("GENECODER_OFFLINE"))
+    allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
+    network_ok = allow_network and not offline
+    install_plugin_spec(
+        spec,
+        checksum=meta.get("checksum"),
+        signature=meta.get("signature"),
+        allow_network=network_ok,
+        installer=PipPluginInstaller(),
+    )
+
+
+def _collect_installed_plugins() -> tuple[dict[str, dict[str, Any]], list[str]]:
+    catalog, failures, _ = collect_installed_plugins(PLUGIN_CATALOG)
+    return catalog, failures
+
+
+def load_builtin_plugins() -> None:
+    CODEC_REGISTRY.clear()
+    FEC_REGISTRY.clear()
+    VISUALIZER_REGISTRY.clear()
+    SIMULATOR_REGISTRY.clear()
+    builtin = importlib.import_module("genecoder.builtin_plugins")
+    if hasattr(builtin, "register_builtin_plugins"):
+        builtin.register_builtin_plugins()
+
+
+def load_entry_point_plugins() -> list[str]:
+    failures, _ = _load_entry_point_plugins(
+        offline=bool(os.getenv("GENECODER_OFFLINE")),
+        registrars=entry_point_registrars(
+            register_codec=register_codec,
+            register_fec=register_fec,
+            register_simulator=register_simulator,
+            register_visualizer=register_visualizer,
+        ),
+    )
+    return failures
+
+
+def load_local_plugins() -> list[str]:
+    return _load_local_plugins(
+        registrars={
+            "codec": register_codec,
+            "fec": register_fec,
+            "simulator": register_simulator,
+            "visualizer": register_visualizer,
+        }
+    )
+
+
+def _verify_catalog_signature(data: bytes, signature_b64: str, *, padding_scheme: str | None = None) -> bool:
+    key_path = os.getenv("GENECODER_CATALOG_PUBLIC_KEY")
+    if not key_path:
+        return False
+    try:
+        public_key = Path(key_path).read_bytes()
+        signature = base64.b64decode(signature_b64, validate=True)
+    except Exception:
+        return False
+    try:
+        compute_checksum(data, signature=signature, public_key=public_key, padding_scheme=padding_scheme or "pkcs1")
+    except Exception:
+        return False
+    return True
+
+
+def load_plugin_catalog(url: str | None = None) -> None:
+    if url is None:
+        url = os.getenv("GENECODER_PLUGIN_CATALOG_URL")
+    catalog: dict[str, dict[str, Any]] = {}
+    offline = bool(os.getenv("GENECODER_OFFLINE"))
+    allow_network = bool(os.getenv("GENECODER_ALLOW_NETWORK"))
+    network_ok = allow_network and not offline
+
+    if url:
+        raw = b""
+        if (url.startswith("http://") or url.startswith("https://")) and not network_ok:
+            logger.info("offline: skipped remote catalog %s", url)
+        else:
+            try:
+                raw = fetch_catalog(url, allow_network=network_ok)
+            except Exception as exc:
+                logger.warning("Failed to fetch plugin catalog %s: %s", url, exc)
+
+        if raw:
+            try:
+                data = json.loads(raw.decode("utf-8"))
+            except Exception:
+                yaml_module = _yaml_module_or_none()
+                if yaml_module is None:
+                    data = {}
+                else:
+                    try:
+                        data = yaml_module.safe_load(raw) or {}
+                    except Exception:
+                        data = {}
+            if isinstance(data, dict):
+                signature = data.get("signature")
+                scheme = data.get("signature_scheme") or data.get("scheme")
+                if signature and not _verify_catalog_signature(raw, str(signature), padding_scheme=str(scheme) if scheme else None):
+                    logger.warning("Invalid catalog signature for %s", url)
+                else:
+                    plugins_data = data.get("plugins", data.get("entries", {}))
+                    if isinstance(plugins_data, list):
+                        for entry in plugins_data:
+                            if isinstance(entry, dict) and "name" in entry:
+                                catalog[str(entry["name"])] = {k: v for k, v in entry.items() if k != "name"}
+                    elif isinstance(plugins_data, dict):
+                        for pname, meta in plugins_data.items():
+                            if isinstance(meta, dict):
+                                catalog[str(pname)] = dict(meta)
+
+    discovered, failures = _collect_installed_plugins()
+    for pname, meta in discovered.items():
+        catalog.setdefault(pname, meta)
+
+    PLUGIN_CATALOG.clear()
+    PLUGIN_CATALOG.update(catalog)
+    if failures:
+        logger.warning("Failed to load plugin metadata: %s", ", ".join(failures))
+
+
+def generate_plugin_lock() -> str:
+    from .descriptors import PluginDescriptor
+
+    descriptors = [
+        PluginDescriptor(
+            name=item.get("name", ""),
+            kind="package",
+            source=item.get("source", ""),
+            version=item.get("version", ""),
+            checksum=item.get("checksum") or None,
+            signature=item.get("signature") or None,
+        )
+        for item in PLUGIN_LOCK
+    ]
+    return render_plugin_lock(descriptors)
+
+
+def load_plugins() -> None:
+    load_builtin_plugins()
+    failures = load_entry_point_plugins()
+    failures.extend(load_local_plugins())
+    load_plugin_catalog()
+    if failures:
+        logger.warning("Failed to import plugins: %s", ", ".join(failures))
+
+
+def init_plugins() -> None:
+    global _initialized
+    if _initialized:
+        return
+    try:
+        load_plugins()
+    except Exception as exc:
+        logger.warning("Failed to load plugins: %s", exc)
+    _initialized = True
+
+
+__all__ = [
+    "CODEC_REGISTRY",
+    "FEC_REGISTRY",
+    "VISUALIZER_REGISTRY",
+    "SIMULATOR_REGISTRY",
+    "PLUGIN_CATALOG",
+    "ENTRY_POINT_METADATA",
+    "ENTRY_POINT_GROUPS",
+    "register_plugin",
+    "register_codec",
+    "register_fec",
+    "register_simulator",
+    "register_visualizer",
+    "install_registry_plugins",
+    "install_catalog_plugin",
+    "load_plugins",
+    "load_entry_point_plugins",
+    "init_plugins",
+    "generate_plugin_lock",
+    "load_plugin_catalog",
+    "load_registry_mapping",
+    "compute_checksum",
+]

--- a/src/genecoder/plugin_runtime/discovery.py
+++ b/src/genecoder/plugin_runtime/discovery.py
@@ -10,6 +10,7 @@ from types import ModuleType
 from typing import Any, Callable, cast
 
 from .descriptors import PluginDescriptor, PluginLifecycleState
+from .entry_points import ENTRY_POINT_GROUPS
 from .policy import validate_plugin_metadata
 from .registry import RUNTIME_REGISTRY, register_lazy_placeholder
 
@@ -178,12 +179,7 @@ def collect_installed_plugins(existing_catalog: dict[str, dict[str, Any]]) -> tu
     descriptors: list[PluginDescriptor] = []
     offline = bool(os.getenv("GENECODER_OFFLINE"))
 
-    groups = {
-        "genecoder.plugins": "codec",
-        "genecoder.fec": "FEC",
-        "genecoder.simulators": "simulator",
-        "genecoder.visualizers": "visualizer",
-    }
+    groups = ENTRY_POINT_GROUPS
     for group, kind in groups.items():
         try:
             entries = entry_points(group=group)

--- a/src/genecoder/plugin_runtime/entry_points.py
+++ b/src/genecoder/plugin_runtime/entry_points.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+ENTRY_POINT_GROUPS: dict[str, str] = {
+    "genecoder.plugins": "codec",
+    "genecoder.fec": "FEC",
+    "genecoder.simulators": "simulator",
+    "genecoder.visualizers": "visualizer",
+}
+
+
+def entry_point_registrars(
+    *,
+    register_codec: Callable[..., Any],
+    register_fec: Callable[..., Any],
+    register_simulator: Callable[..., Any],
+    register_visualizer: Callable[..., Any],
+) -> dict[str, tuple[Callable[..., Any], str]]:
+    return {
+        "genecoder.plugins": (register_codec, ENTRY_POINT_GROUPS["genecoder.plugins"]),
+        "genecoder.fec": (register_fec, ENTRY_POINT_GROUPS["genecoder.fec"]),
+        "genecoder.simulators": (register_simulator, ENTRY_POINT_GROUPS["genecoder.simulators"]),
+        "genecoder.visualizers": (register_visualizer, ENTRY_POINT_GROUPS["genecoder.visualizers"]),
+    }

--- a/tests/test_cli_plugin_registry.py
+++ b/tests/test_cli_plugin_registry.py
@@ -1,5 +1,5 @@
 from tests.test_cli import run_cli_command
-import genecoder.plugin_manager as plugins
+import genecoder.plugin_runtime as plugins
 
 
 def test_install_registry_requires_flag(monkeypatch):

--- a/tests/test_plugin_runtime_unified_paths.py
+++ b/tests/test_plugin_runtime_unified_paths.py
@@ -1,0 +1,53 @@
+import argparse
+
+import pytest
+
+import genecoder.plugin_runtime as runtime
+from genecoder.cli import plugin as plugin_cli
+
+
+def test_registry_install_offline_uses_installer_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, bool]] = []
+
+    def fake_install(url, *, offline, allow_network, yaml_module, installer):
+        calls.append((str(url), bool(offline)))
+        assert allow_network is True
+        return []
+
+    monkeypatch.setattr(runtime, "yaml", object())
+    monkeypatch.setattr(runtime, "_install_registry_plugins", fake_install)
+    runtime.install_registry_plugins("https://example.com/plugins.yaml", offline=True, allow_network=True)
+    assert calls == [("https://example.com/plugins.yaml", True)]
+
+
+def test_catalog_plugin_install_uses_unified_spec_installer(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime.PLUGIN_CATALOG.clear()
+    runtime.PLUGIN_CATALOG["demo"] = {
+        "url": "https://example.com/demo.whl",
+        "checksum": "abc",
+        "signature": "sig",
+    }
+    calls: list[tuple[str, str | None, str | None, bool]] = []
+
+    def fake_install(spec: str, *, checksum, signature, allow_network, installer):
+        calls.append((spec, checksum, signature, allow_network))
+        return spec
+
+    monkeypatch.setattr(runtime, "install_plugin_spec", fake_install)
+    monkeypatch.setenv("GENECODER_ALLOW_NETWORK", "1")
+    runtime.install_catalog_plugin("demo")
+
+    assert calls == [("https://example.com/demo.whl", "abc", "sig", True)]
+
+
+def test_cli_plugin_registry_delegates_to_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[bool] = []
+
+    monkeypatch.setattr(runtime, "install_registry_plugins", lambda **kwargs: called.append(kwargs["offline"]))
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    plugin_cli.register_subcommand(sub)
+    args = parser.parse_args(["plugin", "install-registry", "--allow-registry", "--offline"])
+    args.func(args)
+
+    assert called == [True]


### PR DESCRIPTION
### Motivation
- Centralize plugin lifecycle responsibilities (discovery, catalog/registry installs, signature/checksum validation, lock rendering, and registration) into a single runtime owner to remove duplicated code paths. 
- Make the top-level `plugin_manager` a thin compatibility facade so callers and tests can continue to patch the expected module-level hooks while real logic lives in the runtime. 
- Ensure CLI plugin commands and registry/catalog install flows use the same secure installer pathway so offline, checksum, and signature verification are unified. 

### Description
- Promoted `src/genecoder/plugin_runtime/` as the runtime owner and implemented unified APIs in `plugin_runtime/__init__.py`, including `install_catalog_plugin()`, catalog loading with signature verification, lock rendering, and orchestration for entry-point/local discovery and loading. 
- Centralized entry-point group metadata into `src/genecoder/plugin_runtime/entry_points.py` and switched discovery to use that mapping. 
- Consolidated registry/catalog installation logic to reuse the single installer path (`install_plugin_spec` / `_install_registry_plugins`) and removed duplicated fallback branches. 
- Reduced `src/genecoder/plugin_manager.py` to a thin facade that delegates to `plugin_runtime` while preserving test-friendly hooks (`entry_points`, `urllib`, `subprocess` sync). 
- Updated CLI plugin commands (`src/genecoder/cli/plugin.py`) to call `plugin_runtime` APIs directly and removed duplicated pip/download/signature code from the CLI layer. 
- Added regression tests `tests/test_plugin_runtime_unified_paths.py` and updated `tests/test_cli_plugin_registry.py` to exercise unified offline/installer and CLI delegation paths. 

### Testing
- Ran the linter on modified modules with `python -m ruff check ...` which completed without errors. 
- Ran the plugin-related test suite with `python -m pytest tests/test_cli_plugin_registry.py tests/test_plugin_runtime_unified_paths.py tests/test_plugin_manager.py tests/test_plugin_registry_offline.py tests/test_plugin_metadata.py tests/test_plugin_error_handling.py -q` and all tests passed (`15 passed`, 2 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a7811abc83268a2cae467c1c0772)