### PR TITLE
Unify pipeline orchestration path across CLI and SDK

### DIFF
--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -95,7 +95,7 @@ class RunPipelineUseCase:
         metrics_path = Path(request.artifacts.metrics_path or str(request.output_path) + ".json")
         run_schema: dict[str, Any] = {
             "schema_version": RUN_SCHEMA_VERSION,
-            "source_format": "sdk_pipeline",
+            "source_format": "pipeline_use_case",
             "run_id": Path(request.output_path).stem,
             "profiles": {
                 "encoding": request.codec,
@@ -108,6 +108,41 @@ class RunPipelineUseCase:
                 "simulate": run_context.simulate_seed,
                 "decode": run_context.decode_seed,
                 "provenance": run_context.seed_provenance(),
+            },
+            "runtime": {
+                "total_seconds": None,
+                "encode_seconds": None,
+                "simulate_seconds": None,
+                "decode_seconds": None,
+            },
+            "stages": {
+                "encode": {
+                    "parameters": {"codec": request.codec, "fec": request.fec},
+                    "metrics": {
+                        "gc_content": metrics.get("gc_content"),
+                        "gc_variance": metrics.get("gc_variance"),
+                        "max_homopolymer": metrics.get("max_homopolymer"),
+                    },
+                },
+                "simulate": {
+                    "profile": request.profile.name if request.profile else request.channel,
+                    "metrics": {
+                        "substitutions": metrics.get("substitutions"),
+                        "insertions": metrics.get("insertions"),
+                        "deletions": metrics.get("deletions"),
+                        "coverage": metrics.get("coverage"),
+                        "dropout_count": metrics.get("dropout_count"),
+                        "dropout_fraction": metrics.get("dropout_fraction"),
+                    },
+                },
+                "decode": {
+                    "parameters": {"codec": request.codec, "fec": request.fec},
+                    "metrics": {
+                        "decode_success": metrics.get("decode_success"),
+                        "decode_success_rate": metrics.get("decode_success_rate"),
+                        "ecc_success_rates": metrics.get("ecc_success_rates", {}),
+                    },
+                },
             },
             "sweep": dict(request.matrix.axes) if request.matrix else {},
             "constraints": (

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+import warnings
 from collections import Counter
 from pathlib import Path
 from dataclasses import dataclass
@@ -46,6 +47,19 @@ __all__ = [
     "compile_coding_stack",
     "inspect_coding_plan",
 ]
+
+ORCHESTRATION_DEPRECATION_GATE = "v0.18.0"
+
+
+def _warn_orchestration_deprecation(name: str) -> None:
+    warnings.warn(
+        (
+            f"genecoder.core.{name} is a compatibility facade and will be removed in "
+            f"{ORCHESTRATION_DEPRECATION_GATE}; use genecoder.app.RunPipelineUseCase instead."
+        ),
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 @dataclass(slots=True)
@@ -461,6 +475,8 @@ def run_canonical_pipeline(
     run_context: RunContext | None = None,
 ) -> CanonicalRuntimeResult:
     """Execute the canonical internal runtime route: encode → simulate → decode."""
+
+    _warn_orchestration_deprecation("run_canonical_pipeline")
 
     init_plugins()
     runtime_context = run_context or make_run_context()
@@ -1036,6 +1052,7 @@ def run_pipeline(
 
     The decoded bytes are written to ``output_path`` and also returned.
     """
+    _warn_orchestration_deprecation("run_pipeline")
     original_data = Path(input_path).read_bytes()
     result = run_canonical_pipeline(codec, fec, channel, original_data)
     Path(output_path).write_bytes(result.decoded)

--- a/src/genecoder/sdk/api.py
+++ b/src/genecoder/sdk/api.py
@@ -13,7 +13,7 @@ from ..app import (
     ConstraintProfile,
     RunPipelineRequest,
     RunPipelineResponse,
-    RunPipelineUseCase,
+    UIService,
     SeedProfile,
 )
 
@@ -163,7 +163,7 @@ def run_experiment(spec: SpecInput) -> ExperimentResult:
     """Run one experiment from dataclass, mapping, or YAML file path."""
 
     normalized = _normalize_request(spec)
-    response = RunPipelineUseCase().execute(
+    response = UIService().run_pipeline(
         RunPipelineRequest(
             codec=normalized.codec,
             fec=normalized.fec_backend,

--- a/tests/test_runtime_contract_cli_sdk.py
+++ b/tests/test_runtime_contract_cli_sdk.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from genecoder.cli import pipeline as pipeline_cli
+from genecoder.sdk import run_experiment
+
+
+def _schema_shape(value):  # noqa: ANN001
+    if isinstance(value, dict):
+        return {key: _schema_shape(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_schema_shape(item) for item in value]
+    return type(value).__name__
+
+
+def test_cli_and_sdk_emit_same_run_schema_structure_for_seeded_profile_request(tmp_path: Path) -> None:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"runtime-contract")
+
+    output = tmp_path / "decoded.bin"
+
+    cli_args = argparse.Namespace(
+        seed=17,
+        metrics_path=None,
+        launch_dashboard=False,
+        config=None,
+        codec="reverse",
+        fec=None,
+        channel="simple",
+        sub_rate=0.0,
+        ins_rate=0.0,
+        del_rate=0.0,
+        explain_coding_stack=False,
+        mpi_workers=None,
+        input=str(source),
+        output=str(output),
+        emit_manifest_report=False,
+    )
+    pipeline_cli._handle_command(cli_args)
+    cli_schema = json.loads(Path(str(output) + ".json").read_text(encoding="utf-8"))
+
+    sdk_result = run_experiment(
+        {
+            "codec": "reverse",
+            "input_path": str(source),
+            "output_path": str(output),
+            "channel": "simple",
+            "profile": {
+                "name": "simple",
+                "parameters": {"substitution_prob": 0.0},
+            },
+            "seeds": {"global_seed": 17},
+        }
+    )
+
+    assert _schema_shape(cli_schema) == _schema_shape(dict(sdk_result.canonical_run))


### PR DESCRIPTION
### Motivation
- Consolidate pipeline orchestration so CLI and SDK use a single application use-case entrypoint and emit a consistent canonical run-schema for downstream consumers.
- Preserve compatibility by keeping `genecoder.core` helpers as a thin facade while signaling migration with deprecation notices.

### Description
- Switch SDK experiment execution to call `UIService().run_pipeline(...)` so SDK and CLI route through the same `RunPipelineUseCase` path (`src/genecoder/sdk/api.py`).
- Extend `RunPipelineUseCase` run-schema emission to include canonical `runtime` and `stages` sections and set `source_format` to `pipeline_use_case` for schema consumers (`src/genecoder/app/pipeline_use_case.py`).
- Add a deprecation gate constant `ORCHESTRATION_DEPRECATION_GATE` and emit `DeprecationWarning` for old direct orchestration functions `run_canonical_pipeline` and `run_pipeline` in `genecoder.core` to mark them as compatibility facades (`src/genecoder/core.py`).
- Add a runtime contract test `tests/test_runtime_contract_cli_sdk.py` that runs both CLI and SDK flows for the same seeded/profile request and asserts the emitted run-schema structures have the same shape.

### Testing
- Ran `ruff check src/genecoder/app/pipeline_use_case.py src/genecoder/core.py src/genecoder/sdk/api.py tests/test_runtime_contract_cli_sdk.py` which passed.
- Ran `pytest -q tests/test_runtime_contract_cli_sdk.py tests/test_cli_pipeline_adapter.py tests/test_sdk_api_compatibility.py` and the selected tests passed (all passed; deprecation warnings were observed but tests succeeded).
- Ran a targeted `pytest -q tests/test_combined_fec_pipeline.py -k "not slow"` which executed (skipped tests requiring optional dependency) and reported expected outcome.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82ee184e88326b25803ebaac527d1)