### PR TITLE
Refactor channel CLI to use simulator/profile APIs and tighten legacy boundaries

### DIFF
--- a/docs/compatibility_shims.md
+++ b/docs/compatibility_shims.md
@@ -23,3 +23,6 @@ Legacy imports are routed through versioned adapters under `genecoder.compat.v1`
 - Shim modules may re-export compatibility APIs for downstream users during the deprecation window.
 - Removals are gated by release notes + migration callouts.
 - CI enforces no new `genecoder.api` / `genecoder.pipeline` imports outside approved compatibility tests.
+
+
+- `genecoder.channel_engine.legacy_adapter` is now treated as a compatibility-only implementation detail and must not be imported from interface packages (`genecoder.cli`, `genecoder.sdk`, `genecoder.dashboard`).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,3 +35,10 @@ an older plugin:
    invoke ``finalize_batch_statistics`` to generate aggregate metrics.
 4. Reuse ``apply_legacy_simulator`` for simple passthrough simulators that do not
    yet understand batches; it automatically produces ``SequenceBatch`` outputs.
+
+
+## Channel CLI legacy boundary
+
+`genecoder.cli.channel` now resolves profiles and mutation behavior from `genecoder.simulators.*` modules and the typed channel option adapter in `genecoder.simulators.channel_cli_adapter`.
+
+Legacy `channel_engine.legacy_adapter` usage is restricted to compatibility shims under `genecoder.compat.*` and deprecated top-level re-export modules. If you still use legacy flags such as `--indel-profile` with adapter-era aliases, the CLI emits migration warnings and maps them onto modern profile names (`illumina`, `nanopore`).

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -19,7 +19,12 @@ from genecoder.channel_config import ChannelConfig
 from genecoder.channels.base import BaseChannel
 from genecoder.synthesis import SynthesisConstraints, validate_sequence
 from genecoder.constraints import ConstraintEngine, ConstraintRepairPipeline, load_constraint_policy
-from genecoder.channel_engine.legacy_adapter import introduce_errors, ADAPTER_PROFILES, DEFAULT_ADAPTER_PROFILE, INDEL_PROFILES
+from genecoder.simulators.error_mutation import introduce_errors
+from genecoder.simulators.channel_cli_adapter import (
+    adapt_channel_options_to_simulators,
+    apply_run_indel_profile_compat,
+    validate_indel_profile,
+)
 from genecoder.metrics import metrics
 from genecoder.simulators.illumina import ILLUMINA_PROFILES
 from genecoder.simulators.nanopore import NANOPORE_PROFILES, DNARSIM_RATE_TABLES
@@ -807,95 +812,26 @@ def run_channel(args: argparse.Namespace) -> None:
     if opts.decay_rate is not None:
         simulators.append(("decay", {"deletion_prob": opts.decay_rate}))
 
-    updated: list[tuple[str, dict[str, object]]] = []
-    for name, params in simulators:
-        new_params = dict(params)
-        if name == "illumina" or name.startswith("nanopore"):
-            if opts.coverage is not None:
-                new_params.setdefault("coverage", opts.coverage)
-            if opts.quality_profile is not None:
-                new_params.setdefault("quality_profile", opts.quality_profile)
-        if name == "illumina":
-            if opts.illumina_profile:
-                new_params.setdefault("profile", opts.illumina_profile)
-            if opts.illumina_depth is not None:
-                new_params["coverage"] = opts.illumina_depth
-            if opts.illumina_quality is not None:
-                new_params["quality_profile"] = opts.illumina_quality
-            if opts.illumina_context is not None:
-                new_params["context_errors"] = opts.illumina_context
-            if opts.illumina_sub_rate is not None:
-                new_params["substitution_rate"] = opts.illumina_sub_rate
-            if opts.illumina_ins_rate is not None:
-                new_params["insertion_rate"] = opts.illumina_ins_rate
-            if opts.illumina_del_rate is not None:
-                new_params["deletion_rate"] = opts.illumina_del_rate
-        if name.startswith("nanopore"):
-            selected_profile = opts.nanopore_profile
-            profile_source = NANOPORE_PROFILES
-            if name == "nanopore_dnarsim":
-                selected_profile = opts.dnarsim_profile or opts.nanopore_profile
-                profile_source = DNARSIM_RATE_TABLES
+    try:
+        selection = adapt_channel_options_to_simulators(simulators, opts)
+    except ValueError as exc:
+        logger.error(str(exc))
+        raise SystemExit(1)
+    simulators = selection.simulators
+    for warning in selection.warnings:
+        logger.warning(warning)
 
-            if selected_profile:
-                prof = profile_source.get(selected_profile)
-                if prof is None:
-                    label = "DNArSim" if name == "nanopore_dnarsim" else "Nanopore"
-                    logger.error("Unknown %s profile: %s", label, selected_profile)
-                    raise SystemExit(1)
-                for k, v in prof.items():
-                    new_params.setdefault(k, v)
-                if name == "nanopore_dnarsim":
-                    new_params.setdefault("profile", selected_profile)
+    if opts.nanopore_profile_file:
+        file_params = _load_profile_file(opts.nanopore_profile_file)
+        with_file: list[tuple[str, dict[str, object]]] = []
+        for name, params in simulators:
+            new_params = dict(params)
+            if name.startswith("nanopore"):
+                for key, value in file_params.items():
+                    new_params.setdefault(key, value)
+            with_file.append((name, new_params))
+        simulators = with_file
 
-            if opts.nanopore_profile_file:
-                file_params = _load_profile_file(opts.nanopore_profile_file)
-                for k, v in file_params.items():
-                    new_params.setdefault(k, v)
-            if opts.nanopore_depth is not None:
-                new_params["coverage"] = opts.nanopore_depth
-            if opts.nanopore_quality is not None:
-                new_params["quality_profile"] = opts.nanopore_quality
-            if opts.nanopore_context is not None:
-                new_params["context_errors"] = opts.nanopore_context
-            if opts.nanopore_sub_rate is not None:
-                new_params["substitution_rate"] = opts.nanopore_sub_rate
-            if opts.nanopore_ins_rate is not None:
-                new_params["insertion_rate"] = opts.nanopore_ins_rate
-            if opts.nanopore_del_rate is not None:
-                new_params["deletion_rate"] = opts.nanopore_del_rate
-            if name == "nanopore_dnarsim":
-                for unsupported in ("insertion_profile", "deletion_profile"):
-                    new_params.pop(unsupported, None)
-        if name == "indel":
-            indel_profile = opts.indel_profile
-            if indel_profile is None and not any(
-                rate is not None
-                for rate in (opts.sub_rate, opts.ins_rate, opts.del_rate)
-            ):
-                indel_profile = DEFAULT_ADAPTER_PROFILE
-            if indel_profile is not None:
-                if indel_profile not in INDEL_PROFILES and indel_profile not in ADAPTER_PROFILES:
-                    logger.error("Unknown indel profile: %s", indel_profile)
-                    raise SystemExit(1)
-                new_params.setdefault("profile", indel_profile)
-            if opts.sub_rate is not None:
-                new_params["substitution_prob"] = opts.sub_rate
-            if opts.ins_rate is not None:
-                new_params["insertion_prob"] = opts.ins_rate
-            if opts.del_rate is not None:
-                new_params["deletion_prob"] = opts.del_rate
-        if name == "simple" and opts.sub_rate is not None:
-            new_params["substitution_prob"] = opts.sub_rate
-        if name == "illumina_builtin":
-            if opts.sub_rate is not None:
-                new_params["error_rate"] = opts.sub_rate
-            if opts.illumina_depth is not None:
-                new_params["coverage_depth"] = opts.illumina_depth
-            if opts.illumina_quality is not None:
-                new_params["quality_distribution"] = opts.illumina_quality
-        updated.append((name, new_params))
-    simulators = updated
 
     process_channel(
         args.input_file,
@@ -942,21 +878,18 @@ def _handle_run(args: argparse.Namespace) -> None:
             if name == "nanopore_dnarsim":
                 params.setdefault("profile", args.dnarsim_profile)
     if args.indel_profile is not None:
-        if args.indel_profile not in INDEL_PROFILES and args.indel_profile not in ADAPTER_PROFILES:
+        try:
+            validate_indel_profile(args.indel_profile)
+        except ValueError:
             logger.error("Unknown indel profile: %s", args.indel_profile)
             raise SystemExit(1)
-        for name, params in simulators:
-            if name == "indel":
-                params.setdefault("profile", args.indel_profile)
-    else:
-        for name, params in simulators:
-            if name == "indel" and "profile" not in params:
-                if any(
-                    key in params
-                    for key in ("substitution_prob", "insertion_prob", "deletion_prob", "error_rate")
-                ):
-                    continue
-                params.setdefault("profile", DEFAULT_ADAPTER_PROFILE)
+
+    simulators, compat_warnings = apply_run_indel_profile_compat(
+        simulators,
+        indel_profile=args.indel_profile,
+    )
+    for warning in compat_warnings:
+        logger.warning(warning)
     if args.nanopore_profile_file is not None:
         prof = _load_profile_file(args.nanopore_profile_file)
         for name, params in simulators:

--- a/src/genecoder/compat/channel_cli.py
+++ b/src/genecoder/compat/channel_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Final
+
+MODERN_INDEL_PROFILES: Final[dict[str, dict[str, float]]] = {
+    "illumina": {
+        "substitution_prob": 0.002,
+        "insertion_prob": 0.0001,
+        "deletion_prob": 0.0001,
+    },
+    "nanopore": {
+        "substitution_prob": 0.01,
+        "insertion_prob": 0.02,
+        "deletion_prob": 0.02,
+    },
+}
+
+LEGACY_INDEL_PROFILE_ALIASES: Final[dict[str, str]] = {
+    "illumina_adapter": "illumina",
+    "nanopore_adapter": "nanopore",
+}
+
+LEGACY_INDEL_PROFILE_NAMES: Final[set[str]] = set(LEGACY_INDEL_PROFILE_ALIASES)
+LEGACY_DEFAULT_INDEL_PROFILE: Final[str] = "illumina_adapter"
+
+
+def resolve_indel_profile(
+    *,
+    requested_profile: str | None,
+    has_explicit_rates: bool,
+) -> tuple[str | None, list[str]]:
+    warnings: list[str] = []
+    profile = requested_profile
+    if profile is None and not has_explicit_rates:
+        profile = LEGACY_DEFAULT_INDEL_PROFILE
+        warnings.append(
+            "Using legacy implicit indel default profile; migrate to --simulator indel --indel-profile illumina."
+        )
+    if profile is None:
+        return None, warnings
+
+    lowered = profile.lower()
+    if lowered in LEGACY_INDEL_PROFILE_ALIASES:
+        warnings.append(
+            f"Legacy indel profile '{profile}' is deprecated; using '{LEGACY_INDEL_PROFILE_ALIASES[lowered]}' instead."
+        )
+        return LEGACY_INDEL_PROFILE_ALIASES[lowered], warnings
+    if lowered in MODERN_INDEL_PROFILES:
+        if requested_profile is not None:
+            warnings.append(
+                "--indel-profile is a compatibility flag and may be removed; prefer simulator config in workflow YAML."
+            )
+        return lowered, warnings
+    raise ValueError(f"Unknown indel profile: {profile}")
+

--- a/src/genecoder/simulators/channel_cli_adapter.py
+++ b/src/genecoder/simulators/channel_cli_adapter.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from genecoder.compat.channel_cli import (
+    LEGACY_INDEL_PROFILE_NAMES,
+    MODERN_INDEL_PROFILES,
+    resolve_indel_profile,
+)
+from genecoder.simulators.nanopore import DNARSIM_RATE_TABLES, NANOPORE_PROFILES
+
+
+@dataclass(frozen=True)
+class ChannelSimulatorSelection:
+    simulators: list[tuple[str, dict[str, object]]]
+    warnings: list[str]
+
+
+def _is_rate_set(*values: float | None) -> bool:
+    return any(value is not None for value in values)
+
+
+def adapt_channel_options_to_simulators(
+    simulators: Sequence[tuple[str, dict[str, object]]],
+    opts: object,
+) -> ChannelSimulatorSelection:
+    warnings: list[str] = []
+    updated: list[tuple[str, dict[str, object]]] = []
+    for name, params in simulators:
+        new_params = dict(params)
+        if name == "illumina" or name.startswith("nanopore"):
+            if opts.coverage is not None:
+                new_params.setdefault("coverage", opts.coverage)
+            if opts.quality_profile is not None:
+                new_params.setdefault("quality_profile", opts.quality_profile)
+        if name == "illumina":
+            if opts.illumina_profile:
+                new_params.setdefault("profile", opts.illumina_profile)
+            if opts.illumina_depth is not None:
+                new_params["coverage"] = opts.illumina_depth
+            if opts.illumina_quality is not None:
+                new_params["quality_profile"] = opts.illumina_quality
+            if opts.illumina_context is not None:
+                new_params["context_errors"] = opts.illumina_context
+            if opts.illumina_sub_rate is not None:
+                new_params["substitution_rate"] = opts.illumina_sub_rate
+            if opts.illumina_ins_rate is not None:
+                new_params["insertion_rate"] = opts.illumina_ins_rate
+            if opts.illumina_del_rate is not None:
+                new_params["deletion_rate"] = opts.illumina_del_rate
+        if name.startswith("nanopore"):
+            selected_profile = opts.nanopore_profile
+            profile_source = NANOPORE_PROFILES
+            if name == "nanopore_dnarsim":
+                selected_profile = opts.dnarsim_profile or opts.nanopore_profile
+                profile_source = DNARSIM_RATE_TABLES
+            if selected_profile:
+                prof = profile_source.get(selected_profile)
+                if prof is None:
+                    label = "DNArSim" if name == "nanopore_dnarsim" else "Nanopore"
+                    raise ValueError(f"Unknown {label} profile: {selected_profile}")
+                for key, value in prof.items():
+                    new_params.setdefault(key, value)
+                if name == "nanopore_dnarsim":
+                    new_params.setdefault("profile", selected_profile)
+            if opts.nanopore_depth is not None:
+                new_params["coverage"] = opts.nanopore_depth
+            if opts.nanopore_quality is not None:
+                new_params["quality_profile"] = opts.nanopore_quality
+            if opts.nanopore_context is not None:
+                new_params["context_errors"] = opts.nanopore_context
+            if opts.nanopore_sub_rate is not None:
+                new_params["substitution_rate"] = opts.nanopore_sub_rate
+            if opts.nanopore_ins_rate is not None:
+                new_params["insertion_rate"] = opts.nanopore_ins_rate
+            if opts.nanopore_del_rate is not None:
+                new_params["deletion_rate"] = opts.nanopore_del_rate
+            if name == "nanopore_dnarsim":
+                for unsupported in ("insertion_profile", "deletion_profile"):
+                    new_params.pop(unsupported, None)
+        if name == "indel":
+            profile_name, compat_warnings = resolve_indel_profile(
+                requested_profile=opts.indel_profile,
+                has_explicit_rates=_is_rate_set(opts.sub_rate, opts.ins_rate, opts.del_rate),
+            )
+            warnings.extend(compat_warnings)
+            if profile_name is not None:
+                new_params.setdefault("profile", profile_name)
+            if opts.sub_rate is not None:
+                new_params["substitution_prob"] = opts.sub_rate
+            if opts.ins_rate is not None:
+                new_params["insertion_prob"] = opts.ins_rate
+            if opts.del_rate is not None:
+                new_params["deletion_prob"] = opts.del_rate
+        if name == "simple" and opts.sub_rate is not None:
+            new_params["substitution_prob"] = opts.sub_rate
+        if name == "illumina_builtin":
+            if opts.sub_rate is not None:
+                new_params["error_rate"] = opts.sub_rate
+            if opts.illumina_depth is not None:
+                new_params["coverage_depth"] = opts.illumina_depth
+            if opts.illumina_quality is not None:
+                new_params["quality_distribution"] = opts.illumina_quality
+        updated.append((name, new_params))
+    return ChannelSimulatorSelection(simulators=updated, warnings=warnings)
+
+
+def apply_run_indel_profile_compat(
+    simulators: Sequence[tuple[str, dict[str, object]]],
+    *,
+    indel_profile: str | None,
+) -> tuple[list[tuple[str, dict[str, object]]], list[str]]:
+    profile_name, warnings = resolve_indel_profile(
+        requested_profile=indel_profile,
+        has_explicit_rates=False,
+    )
+    resolved: list[tuple[str, dict[str, object]]] = []
+    for name, params in simulators:
+        updated = dict(params)
+        if name == "indel" and profile_name is not None and "profile" not in updated:
+            if not any(
+                key in updated
+                for key in ("substitution_prob", "insertion_prob", "deletion_prob", "error_rate")
+            ):
+                updated["profile"] = profile_name
+        resolved.append((name, updated))
+    return resolved, warnings
+
+
+def validate_indel_profile(profile: str) -> None:
+    lowered = profile.lower()
+    if lowered in MODERN_INDEL_PROFILES or lowered in LEGACY_INDEL_PROFILE_NAMES:
+        return
+    raise ValueError(f"Unknown indel profile: {profile}")

--- a/src/genecoder/simulators/error_mutation.py
+++ b/src/genecoder/simulators/error_mutation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import random
+
+from .mutation_primitives import NUCLEOTIDES, random_substitution
+
+
+def introduce_errors(
+    sequence: str,
+    *,
+    substitution_prob: float = 0.0,
+    insertion_prob: float = 0.0,
+    deletion_prob: float = 0.0,
+    rng: random.Random,
+) -> str:
+    mutated: list[str] = []
+    for nt in sequence:
+        if nt.upper() not in NUCLEOTIDES:
+            mutated.append(nt)
+            continue
+        if rng.random() < deletion_prob:
+            continue
+        if rng.random() < substitution_prob:
+            nt = random_substitution(nt, rng)
+        mutated.append(nt)
+        if rng.random() < insertion_prob:
+            mutated.append(rng.choice(NUCLEOTIDES))
+    return "".join(mutated)

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 SRC_ROOT = Path("src/genecoder")
 
+LEGACY_CHANNEL_ADAPTER_MODULE = "genecoder.channel_engine.legacy_adapter"
+
 LEGACY_MODULES = {
     "genecoder.pipeline",
     "genecoder.api",
@@ -93,6 +95,16 @@ def test_only_compat_adapters_can_import_legacy_modules() -> None:
             continue
         if module not in APPROVED_LEGACY_IMPORTERS:
             violations.append(f"{module} imports {bad}")
+    assert not violations, "\n".join(violations)
+
+
+def test_interface_packages_do_not_import_channel_legacy_adapter() -> None:
+    violations: list[str] = []
+    for module, imports in _all_imports().items():
+        if not _is_interface_module(module):
+            continue
+        if LEGACY_CHANNEL_ADAPTER_MODULE in imports:
+            violations.append(f"{module} imports {LEGACY_CHANNEL_ADAPTER_MODULE}")
     assert not violations, "\n".join(violations)
 
 

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -319,7 +319,8 @@ def test_cli_indel_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     output_fasta = tmp_path / "out_indel_profile.fasta"
     called: list[tuple[float, float, float]] = []
 
-    from genecoder.error_simulation import Channel as IndelChannel, INDEL_PROFILES
+    from genecoder.error_simulation import Channel as IndelChannel
+    from genecoder.compat.channel_cli import MODERN_INDEL_PROFILES
 
     def fake_simulate(self: IndelChannel, seq: str) -> str:
         called.append((self.substitution_prob, self.insertion_prob, self.deletion_prob))
@@ -351,7 +352,7 @@ def test_cli_indel_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
         env=env,
     )
     assert result.returncode == 0, result.stderr
-    prof = INDEL_PROFILES["illumina"]
+    prof = MODERN_INDEL_PROFILES["illumina"]
     assert called == [(
         prof["substitution_prob"],
         prof["insertion_prob"],
@@ -367,10 +368,7 @@ def test_cli_indel_default_adapter(
     output_fasta = tmp_path / "out_indel_default.fasta"
     observed_profiles: list[str | None] = []
 
-    from genecoder.error_simulation import (
-        Channel as IndelChannel,
-        DEFAULT_ADAPTER_PROFILE,
-    )
+    from genecoder.error_simulation import Channel as IndelChannel
 
     def fake_init(
         self: IndelChannel,
@@ -412,7 +410,7 @@ def test_cli_indel_default_adapter(
     )
     assert result.returncode == 0, result.stderr
     adapter_profiles = [p for p in observed_profiles if p is not None]
-    assert adapter_profiles[-1:] == [DEFAULT_ADAPTER_PROFILE]
+    assert adapter_profiles[-1:] == ["illumina"]
 
 
 def test_channel_cli_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Stop direct imports of the legacy channel adapter from interface code so the CLI routes to modern simulator/profile APIs and keeps legacy behavior confined to compatibility shims. 
- Provide a typed adapter that maps CLI options to the simulator/profile model to centralize and type-check migration behavior. 
- Enforce architecture boundaries with tests so interface packages do not import `genecoder.channel_engine.legacy_adapter`.

### Description

- Replaced direct legacy imports in the channel CLI by importing `introduce_errors` from `genecoder.simulators.error_mutation` and by routing CLI option → simulator mapping through the new adapter API `genecoder.simulators.channel_cli_adapter` (functions: `adapt_channel_options_to_simulators`, `apply_run_indel_profile_compat`, `validate_indel_profile`).
- Introduced `src/genecoder/simulators/error_mutation.py` as the non-legacy mutation helper used by CLI probability simulation paths.
- Added `src/genecoder/simulators/channel_cli_adapter.py` implementing a typed adapter that maps `ChannelOptions`-like objects to modern simulator parameters and surfaces compatibility warnings for legacy flags.
- Added `src/genecoder/compat/channel_cli.py` containing compatibility-only indel profile aliases and resolution logic; legacy name translation and deprecation warnings are kept here rather than in interface code.
- Updated `src/genecoder/cli/channel.py` to call the simulator adapter and to emit migration warnings when legacy flags are used, and to validate indel profile names via the new adapter.
- Strengthened architecture-boundary tests by adding an explicit test that interface packages do not import `genecoder.channel_engine.legacy_adapter` (`tests/test_architecture_boundaries.py`) and adjusted `tests/test_cli_channel.py` to assert the new modern-profile mapping behavior.
- Updated docs (`docs/migration.md`, `docs/compatibility_shims.md`) to document the new CLI/simulator boundary and migration guidance.

### Testing

- Ran the targeted test suite: `pytest -q tests/test_architecture_boundaries.py tests/test_cli_channel.py`, and all tests passed (`24 passed`).
- Ran static checks: `ruff check src/genecoder/cli/channel.py src/genecoder/simulators/channel_cli_adapter.py src/genecoder/simulators/error_mutation.py src/genecoder/compat/channel_cli.py tests/test_architecture_boundaries.py tests/test_cli_channel.py`, and linter checks passed.
- No regressions observed in the exercised tests; compatibility warnings are emitted as expected by the new adapter logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8309a97e8832690396ea250215ade)