### PR TITLE
Unify profile resolution through canonical registry service

### DIFF
--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -10,6 +10,7 @@ from .pipeline_runtime import run_pipeline
 from genecoder.results.schema import RUN_SCHEMA_VERSION, canonical_metrics_view
 from genecoder.html_report import generate_html_report
 from genecoder.runtime import make_run_context
+from genecoder.profiles.registry import canonicalize_profile_name
 
 
 @dataclass(frozen=True)
@@ -81,11 +82,15 @@ class RunPipelineUseCase:
             simulate_seed=request.seeds.simulate_seed if request.seeds else None,
             decode_seed=request.seeds.decode_seed if request.seeds else None,
         )
+        resolved_profile_name = (
+            canonicalize_profile_name(request.profile.name) if request.profile else None
+        )
+        resolved_channel_name = canonicalize_profile_name(request.channel)
 
         decoded, metrics, fec_info = run_pipeline(
             codec=request.codec,
             fec_backend=request.fec,
-            channel=request.channel,
+            channel=resolved_channel_name,
             input_path=request.input_path,
             output_path=request.output_path,
             filter_mutated=request.filter_mutated,
@@ -99,7 +104,7 @@ class RunPipelineUseCase:
             "run_id": Path(request.output_path).stem,
             "profiles": {
                 "encoding": request.codec,
-                "simulation": request.profile.name if request.profile else request.channel,
+                "simulation": resolved_profile_name if resolved_profile_name else resolved_channel_name,
                 "decode": request.codec,
             },
             "seeds": {
@@ -125,7 +130,7 @@ class RunPipelineUseCase:
                     },
                 },
                 "simulate": {
-                    "profile": request.profile.name if request.profile else request.channel,
+                    "profile": resolved_profile_name if resolved_profile_name else resolved_channel_name,
                     "metrics": {
                         "substitutions": metrics.get("substitutions"),
                         "insertions": metrics.get("insertions"),
@@ -159,10 +164,10 @@ class RunPipelineUseCase:
             "input_config": {
                 "codec": request.codec,
                 "fec": request.fec,
-                "channel": request.channel,
+                "channel": resolved_channel_name,
                 "channel_profile": (
                     {
-                        "name": request.profile.name,
+                        "name": resolved_profile_name or request.profile.name,
                         "parameters": dict(request.profile.parameters),
                     }
                     if request.profile
@@ -196,7 +201,7 @@ class RunPipelineUseCase:
         if request.artifacts.emit_manifest:
             manifest = generate_manifest(
                 request.input_path,
-                {"method": request.codec, "fec": request.fec, "channel": request.channel, "seeds": run_context.seed_provenance()},
+                {"method": request.codec, "fec": request.fec, "channel": resolved_channel_name, "seeds": run_context.seed_provenance()},
                 dashboard_metrics,
             )
             manifest_file = metrics_path.with_suffix(".manifest.json")

--- a/src/genecoder/app/ui_service.py
+++ b/src/genecoder/app/ui_service.py
@@ -9,7 +9,7 @@ from genecoder import plugins
 from genecoder.html_report import generate_html_report
 from genecoder.manifest import generate_manifest
 from genecoder.results.schema import compare_runs, load_run_schema, canonical_metrics_view
-from genecoder.simulators.profile_resolver import available_profiles
+from genecoder.profiles.registry import available_profiles
 
 from .pipeline_use_case import RunPipelineRequest, RunPipelineResponse, RunPipelineUseCase
 

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -55,7 +55,7 @@ from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.config.loader import validate_bundle_document
 from genecoder.synthesis import SynthesisConstraints
 from genecoder.constraints import load_constraint_policy
-from genecoder.simulators.profile_resolver import canonicalize_profile_name
+from genecoder.profiles.registry import canonicalize_profile_name
 
 
 @dataclass

--- a/src/genecoder/cli/channel.py
+++ b/src/genecoder/cli/channel.py
@@ -33,7 +33,7 @@ from genecoder.config.loader import (
     load_channel_workflow_config,
     load_mapping_file,
 )
-from genecoder.simulators.profile_resolver import PROFILE_ALIAS_TABLE, resolve_named_profiles
+from genecoder.profiles.registry import PROFILE_ALIAS_TABLE, resolve_channel_profile_alias, resolve_named_profiles
 from genecoder.simulators.batch_utils import (
     RESULT_COVERAGE_KEY,
     RESULT_DROPOUT_FLAG_KEY,
@@ -804,7 +804,7 @@ def run_channel(args: argparse.Namespace) -> None:
     opts.dnarsim_profile = resolved_profiles.dnarsim_profile
 
     if opts.profile:
-        target_sim, _ = PROFILE_ALIAS_TABLE[opts.profile.lower()]
+        target_sim, _ = resolve_channel_profile_alias(opts.profile)
         simulators = [(target_sim, {})]
     elif simulators is None:
         simulators = [(name, {}) for name in opts.simulators]
@@ -861,7 +861,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         dnarsim_profile=args.dnarsim_profile,
     )
     if args.profile is not None:
-        target_sim, _ = PROFILE_ALIAS_TABLE[args.profile.lower()]
+        target_sim, _ = resolve_channel_profile_alias(args.profile)
         simulators = [(target_sim, {})]
     if resolved_profiles.illumina_profile is not None:
         cfg.illumina_profile = resolved_profiles.illumina_profile

--- a/src/genecoder/config/loader.py
+++ b/src/genecoder/config/loader.py
@@ -5,12 +5,18 @@ import copy
 import json
 from pathlib import Path
 from typing import Any, Mapping, Sequence
-import warnings
 
 from genecoder.channel_config import ChannelConfig
 from genecoder.constraints import load_constraint_policy
+from genecoder.profiles.registry import (
+    LegacyProfilePolicy,
+    VersionedProfile,
+    policy_from_legacy_flag,
+    resolve_channel_profile_alias as _resolve_channel_profile_alias,
+    resolve_versioned_profile as _resolve_versioned_profile,
+    validate_profile_schema as _validate_profile_schema,
+)
 from genecoder.simulators.batch_utils import load_coverage_distribution
-from genecoder.simulators.profile_resolver import resolve_channel_profile_alias as _resolve_channel_profile_alias
 
 try:  # pragma: no cover - optional dependency
     from jsonschema import Draft202012Validator
@@ -28,14 +34,6 @@ PIPELINE_ALIASES: dict[str, str] = {
     "threads": "workers",
     "processes": "workers",
 }
-
-
-@dataclass(frozen=True)
-class VersionedProfile:
-    schema_version: int
-    kind: str
-    name: str
-    parameters: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -137,14 +135,7 @@ def load_mapping_file(path: str | Path) -> Mapping[str, Any]:
 
 
 def validate_profile_schema(profile: Mapping[str, Any], *, kind: str) -> VersionedProfile:
-    schema_version = int(profile.get("schema_version", 1))
-    if schema_version != 1:
-        raise ValueError(f"Unsupported {kind} profile schema_version: {schema_version}")
-    params = profile.get("parameters")
-    if not isinstance(params, Mapping):
-        raise ValueError(f"{kind} profile requires 'parameters' mapping")
-    name = str(profile.get("name") or kind)
-    return VersionedProfile(schema_version=schema_version, kind=kind, name=name, parameters=dict(params))
+    return _validate_profile_schema(profile, kind=kind)
 
 
 def resolve_profile(
@@ -153,45 +144,15 @@ def resolve_profile(
     kind: str,
     presets: Mapping[str, VersionedProfile],
     allow_legacy_dict: bool = False,
+    policy: LegacyProfilePolicy | None = None,
 ) -> VersionedProfile | None:
-    if value is None:
-        return None
-    if isinstance(value, Mapping):
-        if "parameters" not in value:
-            if not allow_legacy_dict:
-                raise ValueError(
-                    f"{kind} profile mappings must be versioned with schema_version/name/parameters"
-                )
-            warnings.warn(
-                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            value = {
-                "schema_version": 1,
-                "kind": kind,
-                "name": "custom",
-                "parameters": dict(value),
-            }
-        return validate_profile_schema(value, kind=kind)
-
-    path = Path(value)
-    if path.is_file():
-        loaded = dict(load_mapping_file(path))
-        if "parameters" not in loaded:
-            warnings.warn(
-                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            loaded = {
-                "schema_version": 1,
-                "kind": kind,
-                "name": path.stem,
-                "parameters": loaded,
-            }
-        return validate_profile_schema(loaded, kind=kind)
-    return presets.get(str(value).lower())
+    effective_policy = policy or policy_from_legacy_flag(allow_legacy_dict=allow_legacy_dict)
+    return _resolve_versioned_profile(
+        value,
+        kind=kind,
+        presets=presets,
+        policy=effective_policy,
+    )
 
 
 

--- a/src/genecoder/profiles/__init__.py
+++ b/src/genecoder/profiles/__init__.py
@@ -1,26 +1,29 @@
-from __future__ import annotations
-
-from typing import Mapping
-
-from genecoder.profiles.registry import (
+from .registry import (
+    LegacyProfilePolicy,
     PROFILE_ALIAS_TABLE,
     ResolvedChannelProfiles,
+    VersionedProfile,
     available_profile_help,
+    available_profiles,
     canonicalize_profile_name,
+    policy_from_legacy_flag,
     resolve_channel_profile_alias,
     resolve_named_profiles,
+    resolve_versioned_profile,
+    validate_profile_schema,
 )
 
 __all__ = [
+    "LegacyProfilePolicy",
     "PROFILE_ALIAS_TABLE",
     "ResolvedChannelProfiles",
+    "VersionedProfile",
     "available_profile_help",
     "available_profiles",
     "canonicalize_profile_name",
+    "policy_from_legacy_flag",
     "resolve_channel_profile_alias",
     "resolve_named_profiles",
+    "resolve_versioned_profile",
+    "validate_profile_schema",
 ]
-
-
-def available_profiles() -> Mapping[str, tuple[str, str]]:
-    return PROFILE_ALIAS_TABLE

--- a/src/genecoder/profiles/registry.py
+++ b/src/genecoder/profiles/registry.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping
+import warnings
+
+
+LegacyProfilePolicy = Literal["strict", "compat"]
+
+
+PROFILE_ALIAS_TABLE: dict[str, tuple[str, str]] = {
+    "miseq": ("illumina", "miseq"),
+    "hiseq": ("illumina", "hiseq"),
+    "novaseq": ("illumina", "novaseq"),
+    "nova": ("illumina", "novaseq"),
+    "minion": ("nanopore", "minion"),
+    "promethion": ("nanopore", "promethion"),
+    "r9": ("nanopore_dnarsim", "r9"),
+    "r10.3": ("nanopore_dnarsim", "r10.3"),
+    "r10.4": ("nanopore_dnarsim", "r10.4"),
+}
+
+
+@dataclass(frozen=True)
+class VersionedProfile:
+    schema_version: int
+    kind: str
+    name: str
+    parameters: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ResolvedChannelProfiles:
+    illumina_profile: str | None = None
+    nanopore_profile: str | None = None
+    dnarsim_profile: str | None = None
+
+
+def resolve_channel_profile_alias(alias: str) -> tuple[str, str]:
+    lowered = alias.lower()
+    if lowered not in PROFILE_ALIAS_TABLE:
+        raise ValueError(f"Unknown profile alias: {alias}")
+    return PROFILE_ALIAS_TABLE[lowered]
+
+
+def canonicalize_profile_name(name: str | None) -> str | None:
+    if not name:
+        return None
+    lowered = name.lower()
+    if lowered in PROFILE_ALIAS_TABLE:
+        return PROFILE_ALIAS_TABLE[lowered][1]
+    return name
+
+
+def resolve_named_profiles(
+    *,
+    profile: str | None = None,
+    illumina_profile: str | None = None,
+    nanopore_profile: str | None = None,
+    dnarsim_profile: str | None = None,
+) -> ResolvedChannelProfiles:
+    resolved_illumina = canonicalize_profile_name(illumina_profile)
+    resolved_nanopore = canonicalize_profile_name(nanopore_profile)
+    resolved_dnarsim = canonicalize_profile_name(dnarsim_profile)
+
+    if profile:
+        family, preset = resolve_channel_profile_alias(profile)
+        if family == "illumina":
+            resolved_illumina = preset
+        elif family == "nanopore_dnarsim":
+            resolved_dnarsim = preset
+        else:
+            resolved_nanopore = preset
+    return ResolvedChannelProfiles(
+        illumina_profile=resolved_illumina,
+        nanopore_profile=resolved_nanopore,
+        dnarsim_profile=resolved_dnarsim,
+    )
+
+
+def policy_from_legacy_flag(*, allow_legacy_dict: bool) -> LegacyProfilePolicy:
+    return "compat" if allow_legacy_dict else "strict"
+
+
+def validate_profile_schema(profile: Mapping[str, Any], *, kind: str) -> VersionedProfile:
+    schema_version = int(profile.get("schema_version", 1))
+    if schema_version != 1:
+        raise ValueError(f"Unsupported {kind} profile schema_version: {schema_version}")
+    params = profile.get("parameters")
+    if not isinstance(params, Mapping):
+        raise ValueError(f"{kind} profile requires 'parameters' mapping")
+    name = str(profile.get("name") or kind)
+    return VersionedProfile(schema_version=schema_version, kind=kind, name=name, parameters=dict(params))
+
+
+def resolve_versioned_profile(
+    value: str | Mapping[str, Any] | None,
+    *,
+    kind: str,
+    presets: Mapping[str, VersionedProfile],
+    policy: LegacyProfilePolicy = "strict",
+) -> VersionedProfile | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        if "parameters" not in value:
+            if policy == "strict":
+                raise ValueError(
+                    f"{kind} profile mappings must be versioned with schema_version/name/parameters"
+                )
+            warnings.warn(
+                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            value = {
+                "schema_version": 1,
+                "kind": kind,
+                "name": "custom",
+                "parameters": dict(value),
+            }
+        return validate_profile_schema(value, kind=kind)
+
+    path = Path(value)
+    if path.is_file():
+        from genecoder.config.loader import load_mapping_file
+
+        loaded = dict(load_mapping_file(path))
+        if "parameters" not in loaded:
+            if policy == "strict":
+                raise ValueError(
+                    f"{kind} profile mappings must be versioned with schema_version/name/parameters"
+                )
+            warnings.warn(
+                f"Raw dict-based {kind} profiles are deprecated; use a versioned profile object.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            loaded = {
+                "schema_version": 1,
+                "kind": kind,
+                "name": path.stem,
+                "parameters": loaded,
+            }
+        return validate_profile_schema(loaded, kind=kind)
+    return presets.get(str(value).lower())
+
+
+def available_profiles() -> Mapping[str, tuple[str, str]]:
+    return PROFILE_ALIAS_TABLE
+
+
+def available_profile_help() -> dict[str, str]:
+    from genecoder.simulators.illumina import ILLUMINA_PROFILES
+    from genecoder.simulators.nanopore import DNARSIM_RATE_TABLES, NANOPORE_PROFILES
+
+    return {
+        "illumina": ", ".join(sorted(ILLUMINA_PROFILES)),
+        "nanopore": ", ".join(sorted(NANOPORE_PROFILES)),
+        "dnarsim": ", ".join(sorted(DNARSIM_RATE_TABLES)),
+        "aliases": ", ".join(sorted(PROFILE_ALIAS_TABLE)),
+    }

--- a/src/genecoder/sdk/api.py
+++ b/src/genecoder/sdk/api.py
@@ -18,7 +18,7 @@ from ..app import (
 )
 
 
-from ..simulators.profile_resolver import canonicalize_profile_name
+from ..profiles.registry import canonicalize_profile_name
 SpecInput = "ExperimentRequest | Mapping[str, Any] | str | Path"
 
 

--- a/src/genecoder/simulation_engine/profiles.py
+++ b/src/genecoder/simulation_engine/profiles.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
-from genecoder.config.loader import (
+from genecoder.config.loader import load_mapping_file
+from genecoder.profiles.registry import (
+    LegacyProfilePolicy,
     VersionedProfile,
-    load_mapping_file,
-    resolve_profile as _resolve_profile
+    policy_from_legacy_flag,
+    resolve_versioned_profile,
 )
 
 
@@ -20,12 +22,14 @@ def normalize_profile(
     kind: str,
     presets: Mapping[str, VersionedProfile],
     allow_legacy_dict: bool = False,
+    policy: LegacyProfilePolicy | None = None,
 ) -> VersionedProfile | None:
-    return _resolve_profile(
+    effective_policy = policy or policy_from_legacy_flag(allow_legacy_dict=allow_legacy_dict)
+    return resolve_versioned_profile(
         value,
         kind=kind,
         presets=presets,
-        allow_legacy_dict=allow_legacy_dict,
+        policy=effective_policy,
     )
 
 
@@ -34,5 +38,6 @@ def resolve_profile(
     *,
     kind: str,
     presets: Mapping[str, VersionedProfile],
+    policy: LegacyProfilePolicy = "compat",
 ) -> VersionedProfile | None:
-    return _resolve_profile(value, kind=kind, presets=presets, allow_legacy_dict=True)
+    return resolve_versioned_profile(value, kind=kind, presets=presets, policy=policy)

--- a/tests/data/profile_resolution_golden.json
+++ b/tests/data/profile_resolution_golden.json
@@ -1,0 +1,29 @@
+[
+  {
+    "input": {"profile": "nova"},
+    "expected": {
+      "illumina_profile": "novaseq",
+      "nanopore_profile": null,
+      "dnarsim_profile": null,
+      "canonical_name": "novaseq"
+    }
+  },
+  {
+    "input": {"profile": "minion"},
+    "expected": {
+      "illumina_profile": null,
+      "nanopore_profile": "minion",
+      "dnarsim_profile": null,
+      "canonical_name": "minion"
+    }
+  },
+  {
+    "input": {"profile": "r10.4"},
+    "expected": {
+      "illumina_profile": null,
+      "nanopore_profile": null,
+      "dnarsim_profile": "r10.4",
+      "canonical_name": "r10.4"
+    }
+  }
+]

--- a/tests/test_profile_registry_golden.py
+++ b/tests/test_profile_registry_golden.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genecoder.app.pipeline_use_case import (
+    ArtifactOutputPolicy,
+    ChannelProfile,
+    RunPipelineRequest,
+    RunPipelineUseCase,
+)
+from genecoder.cli.bundle import _extract_channel_profile
+from genecoder.profiles.registry import resolve_named_profiles
+from genecoder.sdk.api import _request_from_mapping
+from genecoder.simulators.profile_resolver import resolve_named_profiles as resolve_named_profiles_wrapper
+
+
+FIXTURE_PATH = Path(__file__).parent / "data" / "profile_resolution_golden.json"
+
+
+def test_profile_resolution_golden_parity(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "genecoder.app.pipeline_use_case.run_pipeline",
+        lambda **_: (b"decoded", {"decode_success": True}, None),
+    )
+
+    use_case = RunPipelineUseCase()
+    fixtures = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    for idx, fixture in enumerate(fixtures):
+        profile_alias = fixture["input"]["profile"]
+        expected = fixture["expected"]
+
+        registry_resolved = resolve_named_profiles(profile=profile_alias)
+        wrapper_resolved = resolve_named_profiles_wrapper(profile=profile_alias)
+        assert registry_resolved == wrapper_resolved
+        assert registry_resolved.illumina_profile == expected["illumina_profile"]
+        assert registry_resolved.nanopore_profile == expected["nanopore_profile"]
+        assert registry_resolved.dnarsim_profile == expected["dnarsim_profile"]
+
+        assert _extract_channel_profile({"pipeline": {"profile": profile_alias}}) == expected["canonical_name"]
+
+        request = _request_from_mapping(
+            {
+                "codec": "huffman",
+                "input_path": "in.txt",
+                "output_path": "out.bin",
+                "profile": {"name": profile_alias, "parameters": {}},
+            }
+        )
+        assert request.profile is not None
+        assert request.profile.name == expected["canonical_name"]
+
+        output_file = tmp_path / f"out-{idx}.bin"
+        response = use_case.execute(
+            RunPipelineRequest(
+                codec="huffman",
+                input_path="in.txt",
+                output_path=str(output_file),
+                profile=ChannelProfile(name=profile_alias),
+                artifacts=ArtifactOutputPolicy(metrics_path=str(tmp_path / f"metrics-{idx}.json")),
+            )
+        )
+        assert response.run_schema["profiles"]["simulation"] == expected["canonical_name"]
+        assert response.run_schema["input_config"]["channel_profile"]["name"] == expected["canonical_name"]

--- a/tests/test_versioned_profiles.py
+++ b/tests/test_versioned_profiles.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import warnings
 
+import pytest
+
 from genecoder.simulation_engine.profiles import resolve_profile
 from genecoder.simulators.illumina.profiles import ILLUMINA_PROFILE_PRESETS
 
@@ -13,12 +15,35 @@ def test_resolve_illumina_preset_versioned_profile() -> None:
     assert resolved.kind == "illumina"
 
 
-def test_raw_dict_profile_is_deprecated() -> None:
+def test_raw_dict_profile_requires_explicit_compat_policy() -> None:
+    with pytest.raises(ValueError, match="must be versioned"):
+        resolve_profile(
+            {
+                "substitution_rate": 0.1,
+                "insertion_rate": 0.0,
+                "deletion_rate": 0.0,
+                "read_length": 100,
+                "coverage": 1.0,
+            },
+            kind="illumina",
+            presets=ILLUMINA_PROFILE_PRESETS,
+            policy="strict",
+        )
+
+
+def test_raw_dict_profile_is_deprecated_in_compat_policy() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", DeprecationWarning)
         resolve_profile(
-            {"substitution_rate": 0.1, "insertion_rate": 0.0, "deletion_rate": 0.0, "read_length": 100, "coverage": 1.0},
+            {
+                "substitution_rate": 0.1,
+                "insertion_rate": 0.0,
+                "deletion_rate": 0.0,
+                "read_length": 100,
+                "coverage": 1.0,
+            },
             kind="illumina",
             presets=ILLUMINA_PROFILE_PRESETS,
+            policy="compat",
         )
     assert any(item.category is DeprecationWarning for item in caught)


### PR DESCRIPTION
### Motivation
- Centralize and deduplicate profile resolution logic so alias expansion, versioned-schema normalization, and legacy-policy gating are implemented in one place. 
- Make legacy-dict handling deterministic and caller-visible via explicit policy modes (`strict` / `compat`).
- Ensure CLI, SDK, app, and simulator call paths all return identical canonical profile outputs for the same input specs. 

### Description
- Add a canonical registry service at `genecoder.profiles.registry` that owns `PROFILE_ALIAS_TABLE`, `canonicalize_profile_name`, `resolve_named_profiles`, `resolve_versioned_profile`, `validate_profile_schema`, and explicit legacy policy mapping (`policy_from_legacy_flag`).
- Provide a package export surface in `src/genecoder/profiles/__init__.py` and migrate simulator/loader wrappers to delegate to the registry via `resolve_versioned_profile` and `policy` parameters.
- Refactor `src/genecoder/config/loader.py` to delegate `resolve_profile` and `validate_profile_schema` to the registry while preserving the `allow_legacy_dict` compatibility flag via an explicit `policy` mapping.
- Replace duplicated logic in `src/genecoder/simulation_engine/profiles.py` and `src/genecoder/simulators/profile_resolver.py` with thin wrappers that call into the canonical registry.
- Route callers through the unified resolver: update CLI (`src/genecoder/cli/channel.py`, `src/genecoder/cli/bundle.py`), SDK (`src/genecoder/sdk/api.py`), and app (`src/genecoder/app/pipeline_use_case.py`, `src/genecoder/app/ui_service.py`) to use `canonicalize_profile_name`, `resolve_channel_profile_alias`, and `resolve_named_profiles` from the registry.
- Add golden fixture and parity test `tests/data/profile_resolution_golden.json` and `tests/test_profile_registry_golden.py` to assert identical resolution across registry, wrapper, CLI bundle extraction, SDK mapping, and `RunPipelineUseCase` output.
- Update `tests/test_versioned_profiles.py` to assert explicit `strict` vs `compat` behavior for legacy dict profiles.

### Testing
- Ran static checks with `ruff` over modified files and the checks passed.
- Ran unit tests `pytest -q tests/test_versioned_profiles.py tests/test_profile_contracts.py tests/test_profile_registry_golden.py` and they all passed (`5 passed`).
- Ran `pytest -q tests/test_ui_service_contract.py` which was skipped due to an optional dependency not present in this environment (`fastapi` not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a834b9083c8326be1e5cdcfa449736)