### PR TITLE
Add capability matrix metadata and CI-backed roadmap/strategy sync

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,22 +1,22 @@
 name: Deploy Docs
 
 on:
-    push:
-      branches: [ main ]
-      paths:
-        - 'docs/**'
-        - 'mkdocs.yml'
-        - 'README.md'
-        - 'src/**'
-        - 'web/**'
-    pull_request:
-      branches: [ main ]
-      paths:
-        - 'docs/**'
-        - 'mkdocs.yml'
-        - 'README.md'
-        - 'src/**'
-        - 'web/**'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'src/**'
+      - 'web/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'src/**'
+      - 'web/**'
   workflow_dispatch: {}
 
 concurrency:
@@ -47,6 +47,8 @@ jobs:
         run: pip install pre-commit
       - name: Check Markdown links
         run: pre-commit run markdown-link-check --files README.md $(git ls-files "docs/**/*.md")
+      - name: Check capability matrix/doc consistency
+        run: python scripts/check_capability_docs_sync.py
       - name: Build docs
         run: mkdocs build --strict
       - name: Upload PDF
@@ -58,6 +60,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: site
+
   deploy:
     needs: build
     runs-on: self-hosted

--- a/docs/DEVELOPMENT_VISION.md
+++ b/docs/DEVELOPMENT_VISION.md
@@ -10,4 +10,4 @@ GeneCoder aims to provide an end-to-end simulation and research platform for DNA
 The full original document is preserved in `archived/DEVELOPMENT_VISION.md`.
 You can also download the PDF version from the [project's releases page](https://github.com/d0tTino/GeneCoder/releases).
 
-Execution planning, milestones, and KPI-linked delivery checkpoints are tracked in [roadmap_execution.md](roadmap_execution.md).
+Execution planning summaries are tracked in [roadmap_execution.md](roadmap_execution.md), while canonical phase-gate criteria are maintained only in [development_roadmap.md](development_roadmap.md).

--- a/docs/capabilities.yaml
+++ b/docs/capabilities.yaml
@@ -1,0 +1,176 @@
+version: 1
+last_updated: "2026-03-04"
+
+capabilities:
+  - id: cli_bundle_presets
+    name: CLI bundle presets for end-to-end pipelines
+    status: implemented
+    phase: 1
+    owner_modules:
+      - src/genecoder/cli/bundle.py
+      - src/genecoder/pipeline.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_cli_bundle.py
+      - type: doc
+        path: docs/mvp_checklist.md
+
+  - id: illumina_simulation_profiles
+    name: Illumina simulation with profile-resolved errors
+    status: implemented
+    phase: 1
+    owner_modules:
+      - src/genecoder/simulators/illumina/simulator.py
+      - src/genecoder/simulators/illumina/profiles.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_illumina_coverage_quality.py
+      - type: doc
+        path: docs/channel_profiles.md
+
+  - id: nanopore_simulation_profiles
+    name: Nanopore simulation with context-aware profile controls
+    status: implemented
+    phase: 1
+    owner_modules:
+      - src/genecoder/simulators/nanopore.py
+      - src/genecoder/simulators/nanopore_profiles.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_nanopore_context_profile.py
+      - type: doc
+        path: docs/channel_profiles.md
+
+  - id: deterministic_reproducibility_governance
+    name: Deterministic seed/profile reproducibility governance
+    status: partial
+    phase: 2
+    owner_modules:
+      - src/genecoder/pipeline.py
+      - src/genecoder/cli/main.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_simulator_seed_reproducibility.py
+      - type: doc
+        path: docs/reproducibility.md
+
+  - id: benchmark_depth_and_parity
+    name: Standardized benchmark depth and parity validation
+    status: partial
+    phase: 3
+    owner_modules:
+      - benchmarks/throughput.py
+      - benchmarks/error_rate.py
+    validation_artifacts:
+      - type: benchmark
+        path: benchmarks/throughput.py
+      - type: benchmark
+        path: benchmarks/error_rate.py
+      - type: doc
+        path: docs/performance.md
+
+  - id: plugin_registry_policy_automation
+    name: Plugin registry policy/security automation
+    status: partial
+    phase: 4
+    owner_modules:
+      - src/genecoder/plugin_manager.py
+      - configs/registry.yaml
+    validation_artifacts:
+      - type: test
+        path: tests/test_plugin_spec_validation.py
+      - type: test
+        path: tests/test_plugin_security.py
+      - type: doc
+        path: docs/plugins.md
+
+strategy_sections:
+  product_strategy_current_capabilities:
+    include_ids:
+      - cli_bundle_presets
+      - illumina_simulation_profiles
+      - nanopore_simulation_profiles
+  product_strategy_priority_gaps:
+    include_ids:
+      - deterministic_reproducibility_governance
+      - benchmark_depth_and_parity
+      - plugin_registry_policy_automation
+  vision_capability_status:
+    include_ids:
+      - cli_bundle_presets
+      - illumina_simulation_profiles
+      - nanopore_simulation_profiles
+      - deterministic_reproducibility_governance
+      - benchmark_depth_and_parity
+      - plugin_registry_policy_automation
+
+phase_gates:
+  - gate: "Phase 1 -> Phase 2"
+    canonical_source: docs/development_roadmap.md
+    measurable_checks:
+      - metric: Weekly usage (oligos_per_week)
+        threshold: ">= 1,000 simulated oligos/week for 4 consecutive ISO weeks"
+        tests_or_checks:
+          - genecli stats
+          - /metrics endpoint export
+        docs_links:
+          - docs/metrics.md
+        evidence_artifacts:
+          - ~/.genecoder/metrics.json
+
+  - gate: "Phase 2 -> Phase 3"
+    canonical_source: docs/development_roadmap.md
+    measurable_checks:
+      - metric: Reproducibility pass rate
+        threshold: "100% deterministic seed/profile checks for 2 consecutive weeks"
+        tests_or_checks:
+          - tests/test_simulator_seed_reproducibility.py
+          - tests/test_illumina_coverage_quality.py
+          - tests/test_nanopore_context_profile.py
+        docs_links:
+          - docs/reproducibility.md
+        evidence_artifacts:
+          - CI pytest logs
+      - metric: Throughput median floor
+        threshold: ">= 2.0 MB/s Base-4 encode throughput"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/throughput.py
+        docs_links:
+          - docs/performance.md
+        evidence_artifacts:
+          - benchmark stdout artifact
+
+  - gate: "Phase 3 -> Phase 4"
+    canonical_source: docs/development_roadmap.md
+    measurable_checks:
+      - metric: BER baseline quality
+        threshold: "<= 0.01 BER on documented baseline profile/seed"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/error_rate.py
+        docs_links:
+          - docs/performance.md
+        evidence_artifacts:
+          - benchmark stdout artifact
+      - metric: Suite category health
+        threshold: "Green CI across CLI/API, pipeline/simulation, plugins/security categories"
+        tests_or_checks:
+          - pytest tests/test_cli*.py tests/test_web_api*.py
+          - pytest tests/test_pipeline*.py tests/test_simulator*.py
+          - pytest tests/test_plugin*.py tests/test_security*.py
+        docs_links:
+          - docs/development_roadmap.md
+        evidence_artifacts:
+          - CI pytest summaries
+
+  - gate: "Phase 4 release gate"
+    canonical_source: docs/development_roadmap.md
+    measurable_checks:
+      - metric: Plugin policy compliance
+        threshold: "100% pass on plugin spec/security checks before registry publication"
+        tests_or_checks:
+          - pytest tests/test_plugin_spec_validation.py tests/test_plugin_security.py
+          - registry schema validation for configs/registry.yaml
+        docs_links:
+          - docs/plugins.md
+        evidence_artifacts:
+          - CI logs and registry validation output

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -21,6 +21,7 @@ above their phase targets.
 > **Source of truth for phase gates:** This document is the canonical
 > definition of phase numbering, phase names, KPI thresholds, and gate evidence.
 > Any other roadmap/strategy document must align to this framework.
+> Capability status metadata that strategy/vision docs must reflect is maintained in `docs/capabilities.yaml` and checked in CI via `scripts/check_capability_docs_sync.py`.
 
 Roadmap phases advance only when KPI thresholds, validation checks, and evidence
 artifacts all satisfy the quarter/phase definitions in the table above.

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -26,6 +26,24 @@ Implemented codec and FEC modules include Base-4 direct, Huffman-4, and GC-balan
 
 Operational outputs include FASTA and manifest artifacts, metrics exports, and dashboard-compatible run summaries. The CLI supports both single runs and sweep workflows, and `src/genecoder/cli/channel.py` exposes channel/profile command surfaces for simulation setup and execution. The current UI/reporting stack enables KPI tracking (decode success, runtime, profile behavior) across preset pipelines.
 
+<!-- capabilities:strategy-status:start -->
+### Capability status snapshot (generated from `docs/capabilities.yaml`)
+
+| Capability | Status | Phase | Owner modules | Validation artifacts |
+| --- | --- | --- | --- | --- |
+| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_cli_bundle.py`, `docs/mvp_checklist.md` |
+| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/simulator.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
+| Nanopore simulation with context-aware profile controls | `implemented` | 1 | `src/genecoder/simulators/nanopore.py`<br>`src/genecoder/simulators/nanopore_profiles.py` | `tests/test_nanopore_context_profile.py`, `docs/channel_profiles.md` |
+
+### Priority gap status snapshot (generated from `docs/capabilities.yaml`)
+
+| Capability | Status | Phase | Owner modules | Validation artifacts |
+| --- | --- | --- | --- | --- |
+| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/main.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
+| Standardized benchmark depth and parity validation | `partial` | 3 | `benchmarks/throughput.py`<br>`benchmarks/error_rate.py` | `benchmarks/throughput.py`, `benchmarks/error_rate.py`, `docs/performance.md` |
+| Plugin registry policy/security automation | `partial` | 4 | `src/genecoder/plugin_manager.py`<br>`configs/registry.yaml` | `tests/test_plugin_spec_validation.py`, `tests/test_plugin_security.py`, `docs/plugins.md` |
+<!-- capabilities:strategy-status:end -->
+
 ### Operational baseline (completed)
 
 - Illumina and Nanopore simulator profiles are available in current bundle presets and tested reproducibility flows.

--- a/docs/roadmap_execution.md
+++ b/docs/roadmap_execution.md
@@ -9,6 +9,7 @@ Use this alongside:
 - [Development roadmap KPI governance](development_roadmap.md)
 
 > **Phase framework note:** Use phase numbering/names from `docs/development_roadmap.md` as canonical when interpreting milestones in this execution plan.
+> **Capability metadata note:** Feature status, ownership modules, and validation artifact references live in `docs/capabilities.yaml`; CI verifies strategy/vision status sections stay synchronized with that matrix.
 
 ## KPI tracking fields (apply to every milestone)
 
@@ -25,17 +26,20 @@ Record these fields in milestone notes, release checklists, or issue templates:
 Threshold values above are the initial governance defaults and are expected to
 be tightened as test coverage, profile breadth, and benchmark stability improve.
 
-## MVP gate (release-blocking)
+## Phase-gate measurable checks (execution mapping)
 
-The following gate is a required pass/fail checklist for promoting MVP releases.
-Any failure is release-blocking until a documented exception is approved by the
-roadmap governance owners.
+`docs/development_roadmap.md` is the only canonical phase-gate definition.
+This section is an implementation-facing mapping that ties each canonical gate
+to explicit measurable checks, repository evidence paths, and execution commands.
 
-| Gate KPI | Artifact(s) | Pass criterion | Fail condition |
-| --- | --- | --- | --- |
-| Decode success by preset | `tests/test_pipeline*.py` | All MVP preset pipeline tests pass and computed decode success is `>= 0.95` per preset in the CI report summary. | Any MVP preset test failure or decode success `< 0.95` for a covered preset. |
-| Reproducibility stability | `tests/test_simulator_seed_reproducibility.py` | CI job passes and rolling reproducibility pass rate is `>= 0.99`. | Test failure, flaky rerun not resolved, or rolling rate `< 0.99`. |
-| Throughput/runtime budget | `benchmarks/throughput.py` | Median runtime is `<= 45 s/MB` for the benchmarked MVP workload and profile matrix. | Runtime median exceeds `45 s/MB` without an approved waiver. |
+| Canonical gate | Measurable check | Threshold | Explicit check command(s) | Evidence/docs links |
+| --- | --- | --- | --- | --- |
+| Phase 1 -> Phase 2 | Weekly usage sustainability | `oligos_per_week >= 1,000` for 4 consecutive ISO weeks | `genecli stats` and `/metrics` export review | `~/.genecoder/metrics.json`, `docs/metrics.md` |
+| Phase 2 -> Phase 3 | Deterministic reproducibility stability | 100% pass for deterministic seed/profile checks across two consecutive weeks | `pytest tests/test_simulator_seed_reproducibility.py tests/test_illumina_coverage_quality.py tests/test_nanopore_context_profile.py` | CI pytest logs, `docs/reproducibility.md` |
+| Phase 2 -> Phase 3 | Throughput floor | Median Base-4 encode throughput `>= 2.0 MB/s` | `PYTHONPATH=src python benchmarks/throughput.py` | Benchmark stdout artifact, `docs/performance.md` |
+| Phase 3 -> Phase 4 | BER baseline quality | BER `<= 0.01` for baseline profile/seed | `PYTHONPATH=src python benchmarks/error_rate.py` | Benchmark stdout artifact, `docs/performance.md` |
+| Phase 3 -> Phase 4 | Suite category health | Green CI across CLI/API, pipeline/simulation, and plugins/security test categories | `pytest tests/test_cli*.py tests/test_web_api*.py`<br>`pytest tests/test_pipeline*.py tests/test_simulator*.py`<br>`pytest tests/test_plugin*.py tests/test_security*.py` | CI pytest summaries, `docs/development_roadmap.md` |
+| Phase 4 release gate | Plugin policy compliance | 100% pass for plugin spec/security checks before publication | `pytest tests/test_plugin_spec_validation.py tests/test_plugin_security.py` | CI logs, `configs/registry.yaml`, `docs/plugins.md` |
 
 ## KPI governance ownership and revision policy
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -4,6 +4,22 @@ GeneCoder aims to make DNA data storage experimentation practical and reproducib
 
 ## Vision and Current State
 
+
+> Phase-gate criteria are canonically defined in [`docs/development_roadmap.md`](development_roadmap.md). This vision doc is a narrative summary only.
+
+<!-- capabilities:vision-status:start -->
+## Capability status snapshot (generated from `docs/capabilities.yaml`)
+
+| Capability | Status | Phase | Owner modules | Validation artifacts |
+| --- | --- | --- | --- | --- |
+| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_cli_bundle.py`, `docs/mvp_checklist.md` |
+| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/simulator.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
+| Nanopore simulation with context-aware profile controls | `implemented` | 1 | `src/genecoder/simulators/nanopore.py`<br>`src/genecoder/simulators/nanopore_profiles.py` | `tests/test_nanopore_context_profile.py`, `docs/channel_profiles.md` |
+| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/main.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
+| Standardized benchmark depth and parity validation | `partial` | 3 | `benchmarks/throughput.py`<br>`benchmarks/error_rate.py` | `benchmarks/throughput.py`, `benchmarks/error_rate.py`, `docs/performance.md` |
+| Plugin registry policy/security automation | `partial` | 4 | `src/genecoder/plugin_manager.py`<br>`configs/registry.yaml` | `tests/test_plugin_spec_validation.py`, `tests/test_plugin_security.py`, `docs/plugins.md` |
+<!-- capabilities:vision-status:end -->
+
 GeneCoder already ships an end-to-end simulation path for common DNA storage experiments. The current implementation includes:
 
 - **Built-in sequencing simulators and presets** for **Illumina** and **Nanopore** workflows, including profile-driven runs in the bundled pipeline examples.

--- a/scripts/check_capability_docs_sync.py
+++ b/scripts/check_capability_docs_sync.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate generated capability status sections against docs/capabilities.yaml."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "docs" / "capabilities.yaml"
+
+DOC_CONFIGS = {
+    ROOT / "docs" / "product_strategy.md": {
+        "marker": "capabilities:strategy-status",
+        "sections": [
+            ("product_strategy_current_capabilities", "### Capability status snapshot (generated from `docs/capabilities.yaml`)"),
+            ("product_strategy_priority_gaps", "### Priority gap status snapshot (generated from `docs/capabilities.yaml`)"),
+        ],
+    },
+    ROOT / "docs" / "vision.md": {
+        "marker": "capabilities:vision-status",
+        "sections": [
+            ("vision_capability_status", "## Capability status snapshot (generated from `docs/capabilities.yaml`)"),
+        ],
+    },
+}
+
+
+def _artifact_list(capability: dict) -> str:
+    entries = capability.get("validation_artifacts", [])
+    if not entries:
+        return "_No artifacts listed_"
+    return ", ".join(f"`{entry['path']}`" for entry in entries)
+
+
+def _render_table(title: str, capabilities: list[dict]) -> str:
+    lines = [
+        title,
+        "",
+        "| Capability | Status | Phase | Owner modules | Validation artifacts |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for cap in capabilities:
+        owners = "<br>".join(f"`{path}`" for path in cap.get("owner_modules", [])) or "_Unspecified_"
+        lines.append(
+            f"| {cap['name']} | `{cap['status']}` | {cap['phase']} | {owners} | {_artifact_list(cap)} |"
+        )
+    return "\n".join(lines)
+
+
+def _replace_marker_block(content: str, marker: str, new_block: str) -> tuple[str, bool]:
+    start = f"<!-- {marker}:start -->"
+    end = f"<!-- {marker}:end -->"
+    if start not in content or end not in content:
+        raise ValueError(f"Missing marker block {start} ... {end}")
+
+    prefix, rest = content.split(start, 1)
+    middle, suffix = rest.split(end, 1)
+    replacement = f"{start}\n{new_block}\n{end}"
+    updated = f"{prefix}{replacement}{suffix}"
+    return updated, middle.strip() != new_block.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true", help="rewrite docs with generated sections")
+    args = parser.parse_args()
+
+    matrix = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+    caps_by_id = {item["id"]: item for item in matrix.get("capabilities", [])}
+    strategy_sections = matrix.get("strategy_sections", {})
+
+    changed_files: list[Path] = []
+    for doc_path, cfg in DOC_CONFIGS.items():
+        rendered_blocks = []
+        for section_key, title in cfg["sections"]:
+            include_ids = strategy_sections[section_key]["include_ids"]
+            selected = [caps_by_id[item_id] for item_id in include_ids]
+            rendered_blocks.append(_render_table(title, selected))
+
+        rendered = "\n\n".join(rendered_blocks)
+
+        original = doc_path.read_text(encoding="utf-8")
+        updated, changed = _replace_marker_block(original, cfg["marker"], rendered)
+        if changed:
+            if args.write:
+                doc_path.write_text(updated, encoding="utf-8")
+                changed_files.append(doc_path)
+            else:
+                print(f"Out-of-sync generated capability section in {doc_path.relative_to(ROOT)}")
+                return 1
+
+    print("Capability matrix/doc sync check passed." if not changed_files else "Updated generated sections:")
+    for path in changed_files:
+        print(f" - {path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Provide a single machine-readable source of truth for capability status, owners, and validation artifacts so narrative docs cannot drift silently. 
- Make roadmap phase gates explicit and measurable by tying gates to concrete tests/benchmarks and evidence artifacts. 
- Enforce synchronization between the capability matrix and strategy/vision docs via CI to prevent stale prose from becoming authoritative. 

### Description

- Add `docs/capabilities.yaml` as a machine-readable capability matrix with capability status, owner module paths, validation artifacts, strategy-section mappings, and per-phase measurable checks. 
- Add `scripts/check_capability_docs_sync.py` which renders and validates marked capability-status blocks in docs; it supports a CI-friendly check mode and a `--write` update mode. 
- Insert generated capability-status blocks into `docs/product_strategy.md` and `docs/vision.md` and add a generated priority-gap snapshot to the product strategy doc. 
- Update `docs/roadmap_execution.md` to include an execution mapping table that ties canonical phase gates to explicit measurable checks, commands, thresholds, and evidence links. 
- Reinforce canonical gating in `docs/development_roadmap.md` and make `docs/DEVELOPMENT_VISION.md` a reference/summary pointing phase-gate authority to `development_roadmap.md`. 
- Add CI enforcement in `.github/workflows/docs.yml` to run `python scripts/check_capability_docs_sync.py` during docs builds so the job fails when generated sections are out of sync. 

### Testing

- Ran `python scripts/check_capability_docs_sync.py --write` to generate and update the docs; the script updated the intended files successfully. (passed) 
- Ran `python scripts/check_capability_docs_sync.py` in check mode to validate sync without writing; the check passed. (passed) 
- Installed `pyyaml` so the script can parse YAML and executed `yaml.safe_load` on the workflow file to validate YAML syntax. (passed) 
- Ran `ruff check scripts/check_capability_docs_sync.py` to lint the new Python script; linter checks passed. (passed) 
- Note: an initial mis-invocation of `ruff` against the YAML workflow produced parse errors; the workflow YAML was corrected and validated, and subsequent linter runs targeted only the Python script and passed. (issue resolved)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83dec81248326aa40815fe2af982b)