### PR TITLE
Validate capability metadata file references and refresh generated docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: pip install pre-commit
       - name: Check Markdown links
         run: pre-commit run markdown-link-check --files README.md $(git ls-files "docs/**/*.md")
-      - name: Check capability matrix/doc consistency
+      - name: Check capability matrix references and generated doc consistency
         run: python scripts/check_capability_docs_sync.py
       - name: Build docs
         run: mkdocs build --strict

--- a/docs/capabilities.yaml
+++ b/docs/capabilities.yaml
@@ -11,7 +11,7 @@ capabilities:
       - src/genecoder/pipeline.py
     validation_artifacts:
       - type: test
-        path: tests/test_cli_bundle.py
+        path: tests/test_bundle.py
       - type: doc
         path: docs/mvp_checklist.md
 
@@ -20,7 +20,7 @@ capabilities:
     status: implemented
     phase: 1
     owner_modules:
-      - src/genecoder/simulators/illumina/simulator.py
+      - src/genecoder/simulators/illumina/channel.py
       - src/genecoder/simulators/illumina/profiles.py
     validation_artifacts:
       - type: test
@@ -47,7 +47,7 @@ capabilities:
     phase: 2
     owner_modules:
       - src/genecoder/pipeline.py
-      - src/genecoder/cli/main.py
+      - src/genecoder/cli/cli.py
     validation_artifacts:
       - type: test
         path: tests/test_simulator_seed_reproducibility.py

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -31,15 +31,15 @@ Operational outputs include FASTA and manifest artifacts, metrics exports, and d
 
 | Capability | Status | Phase | Owner modules | Validation artifacts |
 | --- | --- | --- | --- | --- |
-| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_cli_bundle.py`, `docs/mvp_checklist.md` |
-| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/simulator.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
+| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_bundle.py`, `docs/mvp_checklist.md` |
+| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/channel.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
 | Nanopore simulation with context-aware profile controls | `implemented` | 1 | `src/genecoder/simulators/nanopore.py`<br>`src/genecoder/simulators/nanopore_profiles.py` | `tests/test_nanopore_context_profile.py`, `docs/channel_profiles.md` |
 
 ### Priority gap status snapshot (generated from `docs/capabilities.yaml`)
 
 | Capability | Status | Phase | Owner modules | Validation artifacts |
 | --- | --- | --- | --- | --- |
-| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/main.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
+| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/cli.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
 | Standardized benchmark depth and parity validation | `partial` | 3 | `benchmarks/throughput.py`<br>`benchmarks/error_rate.py` | `benchmarks/throughput.py`, `benchmarks/error_rate.py`, `docs/performance.md` |
 | Plugin registry policy/security automation | `partial` | 4 | `src/genecoder/plugin_manager.py`<br>`configs/registry.yaml` | `tests/test_plugin_spec_validation.py`, `tests/test_plugin_security.py`, `docs/plugins.md` |
 <!-- capabilities:strategy-status:end -->

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -12,10 +12,10 @@ GeneCoder aims to make DNA data storage experimentation practical and reproducib
 
 | Capability | Status | Phase | Owner modules | Validation artifacts |
 | --- | --- | --- | --- | --- |
-| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_cli_bundle.py`, `docs/mvp_checklist.md` |
-| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/simulator.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
+| CLI bundle presets for end-to-end pipelines | `implemented` | 1 | `src/genecoder/cli/bundle.py`<br>`src/genecoder/pipeline.py` | `tests/test_bundle.py`, `docs/mvp_checklist.md` |
+| Illumina simulation with profile-resolved errors | `implemented` | 1 | `src/genecoder/simulators/illumina/channel.py`<br>`src/genecoder/simulators/illumina/profiles.py` | `tests/test_illumina_coverage_quality.py`, `docs/channel_profiles.md` |
 | Nanopore simulation with context-aware profile controls | `implemented` | 1 | `src/genecoder/simulators/nanopore.py`<br>`src/genecoder/simulators/nanopore_profiles.py` | `tests/test_nanopore_context_profile.py`, `docs/channel_profiles.md` |
-| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/main.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
+| Deterministic seed/profile reproducibility governance | `partial` | 2 | `src/genecoder/pipeline.py`<br>`src/genecoder/cli/cli.py` | `tests/test_simulator_seed_reproducibility.py`, `docs/reproducibility.md` |
 | Standardized benchmark depth and parity validation | `partial` | 3 | `benchmarks/throughput.py`<br>`benchmarks/error_rate.py` | `benchmarks/throughput.py`, `benchmarks/error_rate.py`, `docs/performance.md` |
 | Plugin registry policy/security automation | `partial` | 4 | `src/genecoder/plugin_manager.py`<br>`configs/registry.yaml` | `tests/test_plugin_spec_validation.py`, `tests/test_plugin_security.py`, `docs/plugins.md` |
 <!-- capabilities:vision-status:end -->

--- a/scripts/check_capability_docs_sync.py
+++ b/scripts/check_capability_docs_sync.py
@@ -29,6 +29,22 @@ DOC_CONFIGS = {
 }
 
 
+def _collect_missing_matrix_paths(matrix: dict, root: Path) -> list[str]:
+    missing: list[str] = []
+    for capability in matrix.get("capabilities", []):
+        capability_id = capability.get("id", "<unknown>")
+        for owner_module in capability.get("owner_modules", []):
+            if not (root / owner_module).exists():
+                missing.append(f"{capability_id}: owner_modules -> {owner_module}")
+        for artifact in capability.get("validation_artifacts", []):
+            artifact_path = artifact.get("path")
+            if artifact_path and not (root / artifact_path).exists():
+                missing.append(
+                    f"{capability_id}: validation_artifacts.path -> {artifact_path}"
+                )
+    return missing
+
+
 def _artifact_list(capability: dict) -> str:
     entries = capability.get("validation_artifacts", [])
     if not entries:
@@ -70,6 +86,13 @@ def main() -> int:
     args = parser.parse_args()
 
     matrix = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+    missing_matrix_paths = _collect_missing_matrix_paths(matrix, ROOT)
+    if missing_matrix_paths:
+        print("Missing files referenced by docs/capabilities.yaml:")
+        for entry in missing_matrix_paths:
+            print(f" - {entry}")
+        return 1
+
     caps_by_id = {item["id"]: item for item in matrix.get("capabilities", [])}
     strategy_sections = matrix.get("strategy_sections", {})
 

--- a/tests/test_capability_docs_sync.py
+++ b/tests/test_capability_docs_sync.py
@@ -1,0 +1,47 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_checker_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check_capability_docs_sync.py"
+    spec = spec_from_file_location("check_capability_docs_sync", script_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_collect_missing_matrix_paths_valid_and_invalid(tmp_path):
+    checker = _load_checker_module()
+
+    (tmp_path / "src/genecoder/cli").mkdir(parents=True)
+    (tmp_path / "tests").mkdir(parents=True)
+    (tmp_path / "src/genecoder/cli/cli.py").write_text("", encoding="utf-8")
+    (tmp_path / "tests/test_cli.py").write_text("", encoding="utf-8")
+
+    valid_matrix = {
+        "capabilities": [
+            {
+                "id": "valid_capability",
+                "owner_modules": ["src/genecoder/cli/cli.py"],
+                "validation_artifacts": [{"type": "test", "path": "tests/test_cli.py"}],
+            }
+        ]
+    }
+    assert checker._collect_missing_matrix_paths(valid_matrix, tmp_path) == []
+
+    invalid_matrix = {
+        "capabilities": [
+            {
+                "id": "invalid_capability",
+                "owner_modules": ["src/genecoder/cli/missing.py"],
+                "validation_artifacts": [
+                    {"type": "test", "path": "tests/test_missing.py"}
+                ],
+            }
+        ]
+    }
+    assert checker._collect_missing_matrix_paths(invalid_matrix, tmp_path) == [
+        "invalid_capability: owner_modules -> src/genecoder/cli/missing.py",
+        "invalid_capability: validation_artifacts.path -> tests/test_missing.py",
+    ]


### PR DESCRIPTION
### Motivation
- Ensure `docs/capabilities.yaml` references real implementation files and artifacts so generated doc sections remain accurate and CI can catch broken metadata links early.
- Prevent silent drift between capability metadata and the code/tests/docs that validate those capabilities by hard-failing the docs check when references are missing.

### Description
- Updated `docs/capabilities.yaml` to point owner and artifact entries at existing files, including `src/genecoder/simulators/illumina/channel.py`, `src/genecoder/cli/cli.py`, and `tests/test_bundle.py`.
- Extended `scripts/check_capability_docs_sync.py` with `_collect_missing_matrix_paths(...)` and an early failure in `main()` so every `owner_modules` and `validation_artifacts.path` is verified to exist in the repo.
- Updated the docs workflow step label in `.github/workflows/docs.yml` to reflect capability-reference validation and left it running the strengthened checker.
- Regenerated marker-managed sections in `docs/product_strategy.md` and `docs/vision.md` to reflect the updated metadata and added a unit test `tests/test_capability_docs_sync.py` that exercises one valid and one intentionally invalid matrix fixture for the new path checks.

### Testing
- Ran the new unit test with `pytest tests/test_capability_docs_sync.py` which passed (1 passed).
- Ran the linter on the checker and test with `ruff` which reported no issues (All checks passed).
- Executed `python scripts/check_capability_docs_sync.py` to regenerate the marker-based sections and confirm the script returns success (Capability matrix/doc sync check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84c3ee80c8326a6a244b722bddeb6)