### PR TITLE
Establish canonical RunPipelineUseCase orchestration path and isolate legacy compatibility shims

### DIFF
--- a/docs/compatibility_shims.md
+++ b/docs/compatibility_shims.md
@@ -26,3 +26,6 @@ Legacy imports are routed through versioned adapters under `genecoder.compat.v1`
 
 
 - `genecoder.channel_engine.legacy_adapter` is now treated as a compatibility-only implementation detail and must not be imported from interface packages (`genecoder.cli`, `genecoder.sdk`, `genecoder.dashboard`).
+
+
+See `docs/orchestration_migration.md` for a direct import-to-import migration table.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,6 +9,10 @@ Starting in **v0.14.0**, GeneCoder supports external integrations only through:
 
 Deprecated facades (`genecoder.api`, `genecoder.pipeline`) now forward through versioned adapters in `genecoder.compat.v1` and do **not** add behavior beyond forwarding.
 
+## Orchestration entrypoint migration
+
+See [`docs/orchestration_migration.md`](orchestration_migration.md) for the authoritative mapping from deprecated orchestration imports (`genecoder.pipeline`, `genecoder.api`, and `SequencePipeline`) to canonical APIs.
+
 ## Explicit removal milestones
 
 - **v0.15.0**: last release where `genecoder.api` and `genecoder.pipeline` remain available with deprecation warnings.

--- a/docs/orchestration_migration.md
+++ b/docs/orchestration_migration.md
@@ -1,0 +1,29 @@
+# Orchestration Migration Map
+
+## Authoritative orchestration entrypoint
+
+The single supported orchestration entrypoint is:
+
+- `genecoder.app.RunPipelineUseCase`
+
+Canonical runtime execution is modeled by:
+
+- `genecoder.core.CanonicalRuntimeResult`
+
+`RunPipelineUseCase` is the transport-agnostic boundary for CLI, SDK, and UI integrations.
+Compatibility facades remain available only during deprecation windows.
+
+## Legacy import migration map
+
+| Legacy import | Status | Canonical replacement |
+| --- | --- | --- |
+| `genecoder.pipeline` | Deprecated facade | `genecoder.app.RunPipelineUseCase` (primary), `genecoder.core.run_canonical_pipeline` (internal runtime) |
+| `genecoder.api` | Deprecated facade | `genecoder.sdk.plugins` |
+| `genecoder.app.pipeline_runtime.SequencePipeline` | Deprecated compatibility adapter | `genecoder.app.RunPipelineUseCase` |
+| `SequencePipeline` (from `genecoder` package root) | Deprecated compatibility adapter | `genecoder.app.RunPipelineUseCase` |
+
+## Boundary policy
+
+- New orchestration features **must not** be added in `genecoder.compat.*`.
+- Deprecated module updates are limited to forwarding, warning text, or removal work.
+- CI tests enforce that new modules do not import deprecated facades outside approved boundary files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Implemented Features: features.md
       - Technology Stack: technology_stack.md
   - Migration Guide: migration.md
+  - Orchestration Migration Map: orchestration_migration.md
   - Development:
       - Development Roadmap: development_roadmap.md
       - Architecture Boundaries: architecture_layers.md

--- a/src/genecoder/app/pipeline_runtime.py
+++ b/src/genecoder/app/pipeline_runtime.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from collections.abc import MutableMapping
 from pathlib import Path
-import warnings
-from typing import Any, Callable, Iterable, Mapping, Sequence, Tuple
+from typing import Any, Mapping, Tuple
 
 from genecoder.plugin_manager import init_plugins
-from genecoder.parallel import parallel_map
 from genecoder.formats import SequenceBatch
 from genecoder.simulators.batch_utils import RESULT_COVERAGE_KEY, RESULT_DROPOUT_FLAG_KEY
 from genecoder import core
@@ -16,50 +14,7 @@ from genecoder.runtime import RunContext, make_run_context
 
 __all__ = ["SequencePipeline", "run_pipeline"]
 
-
-class SequencePipeline:
-    """Legacy string-based pipeline wrapper.
-
-    This adapter exists for backwards compatibility with older integrations
-    that expected ``SequencePipeline`` to operate on plain strings. New code
-    should prefer the SequenceBatch-aware helpers in :mod:`genecoder.core`.
-    """
-
-    def __init__(self, steps: Iterable[Callable[[str], str]] | None = None) -> None:
-        warnings.warn(
-            "SequencePipeline is deprecated; use genecoder.core helpers instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.steps: list[Callable[[str], str]] = list(steps or [])
-
-    def add_step(self, step: Callable[[str], str]) -> None:
-        """Append ``step`` to the pipeline."""
-        self.steps.append(step)
-
-    def run(self, sequence: str) -> str:
-        """Return ``sequence`` processed by each step."""
-        for step in self.steps:
-            sequence = step(sequence)
-        return sequence
-
-    def run_batch(
-        self,
-        sequences: Sequence[str],
-        *,
-        parallel: bool = False,
-        workers: int | None = None,
-        use_processes: bool = False,
-    ) -> list[str]:
-        """Apply the pipeline to ``sequences`` optionally in parallel."""
-        if parallel:
-            return parallel_map(
-                self.run,
-                sequences,
-                workers=workers,
-                use_processes=use_processes,
-            )
-        return [self.run(s) for s in sequences]
+from genecoder.compat.legacy import SequencePipeline
 
 
 def _flag_from_metadata(value: object) -> bool:

--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Authoritative application orchestration entrypoint.
+
+`RunPipelineUseCase` is the canonical public orchestration API for GeneCoder
+runtime execution. Internally it delegates to `genecoder.core.run_canonical_pipeline`
+via `genecoder.app.pipeline_runtime.run_pipeline`, which returns metrics derived
+from the canonical runtime model (`genecoder.core.CanonicalRuntimeResult`).
+"""
+
 from dataclasses import dataclass, field
 import json
 from pathlib import Path
@@ -75,6 +83,8 @@ class RunPipelineResponse:
 
 
 class RunPipelineUseCase:
+    """Execute the canonical encode/simulate/decode orchestration flow."""
+
     def execute(self, request: RunPipelineRequest) -> RunPipelineResponse:
         run_context = make_run_context(
             global_seed=request.seeds.global_seed if request.seeds else None,

--- a/src/genecoder/channel_sim.py
+++ b/src/genecoder/channel_sim.py
@@ -5,9 +5,9 @@ import warnings
 
 warnings.warn(
     "genecoder.channel_sim is deprecated and will be removed in v0.15.0; "
-    "use genecoder.channel_engine and genecoder.simulators instead.",
+    "use genecoder.app.RunPipelineUseCase and genecoder.simulators instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-from .channel_engine.legacy_adapter import *  # noqa: F403
+from .compat.channel_sim import *  # noqa: F403

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -50,12 +50,13 @@ from genecoder.html_report import generate_html_report
 from genecoder.metrics import metrics, set_metrics_path
 from genecoder.core import metrics as gather_metrics
 from genecoder.manifest import generate_manifest
-from genecoder.plugin_manager import FEC_REGISTRY, init_plugins
+from genecoder.plugin_manager import CODEC_REGISTRY, FEC_REGISTRY, init_plugins
 from genecoder.simulators import SIMULATOR_REGISTRY
 from genecoder.config.loader import validate_bundle_document
 from genecoder.synthesis import SynthesisConstraints
 from genecoder.constraints import load_constraint_policy
 from genecoder.profiles.registry import canonicalize_profile_name
+from genecoder.app import ArtifactOutputPolicy, RunPipelineRequest, RunPipelineUseCase
 
 
 @dataclass
@@ -358,6 +359,64 @@ def _simple_args(prefix: str, opts: dict[str, object], allowed: set[str]) -> lis
             args.extend([opt, str(value)])
     return args
 
+
+
+
+
+
+def _backfill_manifest_metrics(manifest_path: Path, original_path: Path, encoded_path: Path) -> None:
+    if not manifest_path.exists() or not original_path.exists() or not encoded_path.exists():
+        return
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return
+    if not isinstance(payload, dict):
+        return
+    metrics_payload = payload.setdefault("metrics", {})
+    if not isinstance(metrics_payload, dict):
+        return
+    required = {"original_size", "dna_length", "compression_ratio", "bits_per_nt"}
+    if required.issubset(metrics_payload):
+        return
+
+    original_size = len(original_path.read_bytes())
+    try:
+        batch = SequenceBatch.from_fasta(encoded_path.read_text(encoding="utf-8"))
+        dna_length = sum(len(ol.sequence) for ol in batch.oligos)
+    except Exception:
+        dna_length = 0
+    compression_ratio = (dna_length / original_size) if original_size else 0.0
+    bits_per_nt = ((original_size * 8) / dna_length) if dna_length else 0.0
+
+    metrics_payload.setdefault("original_size", original_size)
+    metrics_payload.setdefault("dna_length", dna_length)
+    metrics_payload.setdefault("compression_ratio", compression_ratio)
+    metrics_payload.setdefault("bits_per_nt", bits_per_nt)
+    manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+def _run_bundle_pipeline_use_case(
+    *,
+    codec: str,
+    fec: str | None,
+    input_path: Path,
+    output_path: Path,
+    metrics_path: Path,
+) -> None:
+    RunPipelineUseCase().execute(
+        RunPipelineRequest(
+            codec=codec,
+            fec=fec,
+            channel="none",
+            input_path=str(input_path),
+            output_path=str(output_path),
+            artifacts=ArtifactOutputPolicy(
+                metrics_path=str(metrics_path),
+                emit_manifest=False,
+                emit_html_report=False,
+            ),
+        )
+    )
 
 def _run_cli(args_list: list[str]) -> None:
     try:
@@ -984,6 +1043,7 @@ def _run_single_bundle(
 
     original_inputs = [Path(p) for p in enc_cfg.get("input_files", [])]
     input_files = [encoded_dir / (Path(p).name + ".fasta") for p in enc_cfg.get("input_files", [])]
+    encoded_to_original = {encoded: original for original, encoded in zip(original_inputs, input_files)}
     batch_summary: dict[str, object] = {}
     for fasta_path in input_files:
         if not fasta_path.exists():
@@ -1010,6 +1070,13 @@ def _run_single_bundle(
         metadata_path = fasta_path.with_suffix(fasta_path.suffix + ".batch.json")
         with open(metadata_path, "w", encoding="utf-8") as meta_f:
             json.dump(payload, meta_f, indent=2)
+        original_for_fasta = encoded_to_original.get(fasta_path)
+        if original_for_fasta is not None:
+            _backfill_manifest_metrics(
+                fasta_path.with_suffix(".manifest.json"),
+                original_for_fasta,
+                fasta_path,
+            )
         try:
             rel = fasta_path.relative_to(run_dir)
         except ValueError:
@@ -1111,28 +1178,56 @@ def _run_single_bundle(
         input_files = new_inputs
 
     if dec_cfg:
-        dec_args = _simple_args("decode", dec_cfg, {"method"})
-        dec_args += ["--input-files"] + [str(p) for p in input_files]
-        dec_args += ["--output-dir", str(decoded_dir)]
-        _run_cli(dec_args)
+        decode_method = dec_cfg.get("method") if isinstance(dec_cfg, dict) else None
+        can_use_canonical_path = (
+            sim_cfg is None
+            and isinstance(decode_method, str)
+            and decode_method == enc_cfg.get("method")
+            and str(decode_method) in CODEC_REGISTRY
+        )
 
-        for original, simulated in zip(original_inputs, input_files):
-            decoded_file = decoded_dir / (Path(simulated).stem + "_decoded.bin")
-            if not decoded_file.exists():
-                logger.warning(
-                    "Decoded output missing for %s; writing placeholder metrics",
-                    simulated,
-                )
+        if can_use_canonical_path:
+            for original in original_inputs:
+                decoded_file = decoded_dir / f"{Path(original).stem}_decoded.bin"
                 decoded_file.parent.mkdir(parents=True, exist_ok=True)
-                decoded_file.write_bytes(b"")
-            _write_decoded_metrics(
-                original,
-                Path(simulated),
-                decoded_file,
-                enc_cfg,
-                sim_cfg if isinstance(sim_cfg, dict) else None,
-                emit_manifest_report=emit_manifest_report,
-            )
+                _run_bundle_pipeline_use_case(
+                    codec=str(enc_cfg.get("method")),
+                    fec=_effective_fec(enc_cfg),
+                    input_path=Path(original),
+                    output_path=decoded_file,
+                    metrics_path=decoded_file.with_suffix(".json"),
+                )
+                _write_decoded_metrics(
+                    Path(original),
+                    Path(original),
+                    decoded_file,
+                    enc_cfg,
+                    None,
+                    emit_manifest_report=emit_manifest_report,
+                )
+        else:
+            dec_args = _simple_args("decode", dec_cfg, {"method"})
+            dec_args += ["--input-files"] + [str(p) for p in input_files]
+            dec_args += ["--output-dir", str(decoded_dir)]
+            _run_cli(dec_args)
+
+            for original, simulated in zip(original_inputs, input_files):
+                decoded_file = decoded_dir / (Path(simulated).stem + "_decoded.bin")
+                if not decoded_file.exists():
+                    logger.warning(
+                        "Decoded output missing for %s; writing placeholder metrics",
+                        simulated,
+                    )
+                    decoded_file.parent.mkdir(parents=True, exist_ok=True)
+                    decoded_file.write_bytes(b"")
+                _write_decoded_metrics(
+                    original,
+                    Path(simulated),
+                    decoded_file,
+                    enc_cfg,
+                    sim_cfg if isinstance(sim_cfg, dict) else None,
+                    emit_manifest_report=emit_manifest_report,
+                )
 
     logger.info("Bundle output written to %s", run_dir)
     summary_path = _write_summary_file(

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -46,8 +46,8 @@ from genecoder.app import (
     ArtifactOutputPolicy,
     ChannelProfile,
     RunPipelineRequest,
+    RunPipelineUseCase,
     SeedProfile,
-    UIService,
 )
 
 RUN_PROFILE_VERSION = "2026.02"
@@ -617,7 +617,7 @@ def _handle_command(args: argparse.Namespace) -> None:
         logger.info("Coding planner: %s", json.dumps(explanation, indent=2, sort_keys=True))
 
     def _execute() -> Dict[str, Any]:
-        response = UIService().run_pipeline(
+        response = RunPipelineUseCase().execute(
             RunPipelineRequest(
                 codec=codec,
                 fec=fec,

--- a/src/genecoder/compat/__init__.py
+++ b/src/genecoder/compat/__init__.py
@@ -1,1 +1,5 @@
-"""Compatibility-only modules scheduled for removal."""
+"""Compatibility-only modules scheduled for removal.
+
+Import boundaries: modules outside ``genecoder.compat`` should not depend on
+these adapters except explicit deprecated facade files.
+"""

--- a/src/genecoder/compat/channel_sim.py
+++ b/src/genecoder/compat/channel_sim.py
@@ -1,28 +1,7 @@
-"""Compatibility wrapper for legacy channel simulation imports."""
+"""Compatibility wrapper for legacy channel simulation imports.
+
+Compatibility-only module: do not add new feature logic.
+"""
 from __future__ import annotations
 
-from genecoder.channel_engine.legacy_adapter import (
-    ADAPTER_PROFILES,
-    DEFAULT_ADAPTER_PROFILE,
-    INDEL_PROFILES,
-    NUCLEOTIDES,
-    Channel,
-    apply_deletions,
-    apply_insertions,
-    apply_substitutions,
-    register,
-    simulate_errors,
-)
-
-__all__ = [
-    "apply_substitutions",
-    "apply_insertions",
-    "apply_deletions",
-    "Channel",
-    "register",
-    "NUCLEOTIDES",
-    "simulate_errors",
-    "INDEL_PROFILES",
-    "ADAPTER_PROFILES",
-    "DEFAULT_ADAPTER_PROFILE",
-]
+from genecoder.compat.legacy.channel_adapter_exports import *  # noqa: F403

--- a/src/genecoder/compat/error_simulation.py
+++ b/src/genecoder/compat/error_simulation.py
@@ -1,4 +1,7 @@
-"""Compatibility re-exports backed by channel_engine legacy adapter."""
+"""Compatibility wrapper for legacy error simulation imports.
+
+Compatibility-only module: do not add new feature logic.
+"""
 from __future__ import annotations
 
-from genecoder.channel_engine.legacy_adapter import *  # noqa: F403
+from genecoder.compat.legacy.channel_adapter_exports import *  # noqa: F403

--- a/src/genecoder/compat/legacy/__init__.py
+++ b/src/genecoder/compat/legacy/__init__.py
@@ -1,0 +1,9 @@
+"""Compatibility-only implementations for deprecated public import paths.
+
+This package is the single location for legacy shims. Do not add new product
+features here; only forwarding logic and deprecation bridges are allowed.
+"""
+
+from .sequence_pipeline import SequencePipeline
+
+__all__ = ["SequencePipeline"]

--- a/src/genecoder/compat/legacy/channel_adapter_exports.py
+++ b/src/genecoder/compat/legacy/channel_adapter_exports.py
@@ -1,0 +1,32 @@
+"""Shared legacy channel/error simulation re-exports.
+
+Compatibility-only module: no new feature work.
+"""
+
+from __future__ import annotations
+
+from genecoder.channel_engine.legacy_adapter import (
+    ADAPTER_PROFILES,
+    DEFAULT_ADAPTER_PROFILE,
+    INDEL_PROFILES,
+    NUCLEOTIDES,
+    Channel,
+    apply_deletions,
+    apply_insertions,
+    apply_substitutions,
+    register,
+    simulate_errors,
+)
+
+__all__ = [
+    "apply_substitutions",
+    "apply_insertions",
+    "apply_deletions",
+    "Channel",
+    "register",
+    "NUCLEOTIDES",
+    "simulate_errors",
+    "INDEL_PROFILES",
+    "ADAPTER_PROFILES",
+    "DEFAULT_ADAPTER_PROFILE",
+]

--- a/src/genecoder/compat/legacy/sequence_pipeline.py
+++ b/src/genecoder/compat/legacy/sequence_pipeline.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Legacy string-oriented pipeline shim.
+
+`SequencePipeline` remains available only for backwards compatibility with older
+integrations that built pipeline stages around plain strings.
+
+No new feature work should target this adapter. New orchestration must go
+through `genecoder.app.RunPipelineUseCase` and `genecoder.core.CanonicalRuntimeResult`.
+"""
+
+import warnings
+from typing import Callable, Iterable, Sequence
+
+from genecoder.parallel import parallel_map
+
+
+class SequencePipeline:
+    """Legacy string-based pipeline wrapper."""
+
+    def __init__(self, steps: Iterable[Callable[[str], str]] | None = None) -> None:
+        warnings.warn(
+            "SequencePipeline is deprecated; use genecoder.app.RunPipelineUseCase instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.steps: list[Callable[[str], str]] = list(steps or [])
+
+    def add_step(self, step: Callable[[str], str]) -> None:
+        self.steps.append(step)
+
+    def run(self, sequence: str) -> str:
+        for step in self.steps:
+            sequence = step(sequence)
+        return sequence
+
+    def run_batch(
+        self,
+        sequences: Sequence[str],
+        *,
+        parallel: bool = False,
+        workers: int | None = None,
+        use_processes: bool = False,
+    ) -> list[str]:
+        if parallel:
+            return parallel_map(
+                self.run,
+                sequences,
+                workers=workers,
+                use_processes=use_processes,
+            )
+        return [self.run(s) for s in sequences]

--- a/src/genecoder/compat/v1/pipeline_adapter.py
+++ b/src/genecoder/compat/v1/pipeline_adapter.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-"""Versioned compatibility adapter for deprecated ``genecoder.pipeline`` imports."""
+"""Versioned compatibility adapter for deprecated ``genecoder.pipeline`` imports.
+
+Compatibility-only module: do not add new product features here.
+"""
 
 from ... import core
-from ...app.pipeline_runtime import SequencePipeline, run_pipeline
+from ...app.pipeline_runtime import run_pipeline
+from ...compat.legacy.sequence_pipeline import SequencePipeline
 from ...plugin_manager import init_plugins
 
 __all__ = ["SequencePipeline", "run_pipeline", "core", "init_plugins"]

--- a/src/genecoder/error_simulation.py
+++ b/src/genecoder/error_simulation.py
@@ -5,9 +5,9 @@ import warnings
 
 warnings.warn(
     "genecoder.error_simulation is deprecated and will be removed in v0.15.0; "
-    "use genecoder.channel_engine and genecoder.simulators instead.",
+    "use genecoder.app.RunPipelineUseCase and genecoder.simulators instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-from .channel_engine.legacy_adapter import *  # noqa: F403
+from .compat.error_simulation import *  # noqa: F403

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -10,7 +10,7 @@ __all__ = ["SequencePipeline", "run_pipeline", "core", "init_plugins"]
 
 warnings.warn(
     "genecoder.pipeline is deprecated and will be removed in v0.16.0; "
-    "import pipeline runtime/use-case helpers from genecoder.app.",
+    "import genecoder.app.RunPipelineUseCase for orchestration.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/tests/test_compat_import_boundaries.py
+++ b/tests/test_compat_import_boundaries.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path("src/genecoder")
+
+DEPRECATED_COMPAT_FACADES = {
+    "genecoder.compat",
+    "genecoder.compat.v1",
+    "genecoder.compat.channel_sim",
+    "genecoder.compat.error_simulation",
+}
+
+ALLOWED_IMPORTERS = {
+    "genecoder.channel_sim",
+    "genecoder.error_simulation",
+    "genecoder.pipeline",
+    "genecoder.api",
+    "genecoder.simulators.channel_cli_adapter",
+    "genecoder.cli.channel",
+    "genecoder.app.pipeline_runtime",
+    "genecoder.compat.v1.pipeline_adapter",
+    "genecoder.compat.v1.api_adapter",
+}
+
+
+def _module_name(path: Path) -> str:
+    return ".".join(path.relative_to("src").with_suffix("").parts)
+
+
+def _resolve_from(module: str, node: ast.ImportFrom) -> str | None:
+    if node.level == 0:
+        return node.module
+    parts = module.split(".")
+    anchor = parts[:-node.level]
+    if node.module:
+        anchor.extend(node.module.split("."))
+    return ".".join(anchor) if anchor else None
+
+
+def _imports_for(path: Path) -> set[str]:
+    module = _module_name(path)
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            resolved = _resolve_from(module, node)
+            if resolved:
+                imports.add(resolved)
+    return imports
+
+
+def test_only_boundary_modules_import_compatibility_facades() -> None:
+    violations: list[str] = []
+    for path in SRC_ROOT.rglob("*.py"):
+        module = _module_name(path)
+        imports = _imports_for(path)
+        bad = sorted(i for i in imports if i in DEPRECATED_COMPAT_FACADES)
+        if bad and module not in ALLOWED_IMPORTERS and not module.startswith("genecoder.compat"):
+            violations.append(f"{module} imports {bad}")
+    assert not violations, "\n".join(violations)


### PR DESCRIPTION
### Motivation
- Provide a single authoritative orchestration entrypoint and runtime model for pipeline execution to simplify integration and future deprecation of legacy facades.
- Move legacy/compatibility adapters into an isolated compatibility package with explicit boundaries so new features are not introduced in shim code.
- Update CLI flows to use the canonical application use-case where possible, reducing indirection through legacy adapters.
- Add migration docs and CI checks to prevent accidental new dependencies on deprecated facades.

### Description
- Declared and documented the canonical orchestration entrypoint `genecoder.app.RunPipelineUseCase` and tied it to the canonical runtime model (`genecoder.core.CanonicalRuntimeResult`). (see `src/genecoder/app/pipeline_use_case.py`).
- Refactored CLI pipeline execution to call `RunPipelineUseCase().execute(...)` directly (replacing the legacy UI wrapper) and updated the bundle flow to prefer the canonical use-case for simple decode-only paths while retaining fallback to the legacy CLI flow when needed (`src/genecoder/cli/pipeline.py`, `src/genecoder/cli/bundle.py`).
- Isolated compatibility-only implementations into `genecoder.compat.legacy` (moved `SequencePipeline` and shared legacy channel exports there) and updated versioned adapters under `genecoder.compat.v1` to re-export from the isolated legacy package; updated top-level shim modules to forward from `genecoder.compat.*` only (`src/genecoder/compat/*`, `src/genecoder/compat/legacy/*`, `src/genecoder/pipeline.py`, `src/genecoder/channel_sim.py`, `src/genecoder/error_simulation.py`).
- Added a manifest metric backfill helper to ensure encoded manifests produced by bundle runs preserve expected metric keys for existing consumers (`src/genecoder/cli/bundle.py`).
- Added migration documentation and navigation entry (`docs/orchestration_migration.md`, updated `docs/migration.md`, `docs/compatibility_shims.md`, `mkdocs.yml`) describing legacy→canonical mappings and boundary policy.
- Added an architecture boundary test that asserts only approved modules may import compatibility facades (`tests/test_compat_import_boundaries.py`).

### Testing
- Ran linters: `ruff check` over the modified modules; all checks passed.
- Ran unit/integration tests: `pytest -q tests/test_sequence_pipeline.py tests/test_pipeline_legacy.py tests/test_bundle.py tests/test_deprecated_import_boundaries.py tests/test_architecture_boundaries.py tests/test_compat_import_boundaries.py` and related bundle tests; result: tests passed (25 passed, 1 skipped in the full targeted suite) and the added boundary tests passed.
- Re-ran bundle and compatibility test subsets to validate the bundle backfill and CLI refactor; those runs succeeded (all bundle tests passed when included in the suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a852af83b8832691487efbd6d68a58)