### PR TITLE
Add benchmark CI jobs, gate alignment checker, artifacts, and docs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -176,6 +176,9 @@ jobs:
     - name: Run mypy
       run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary
 
+    - name: Validate benchmark gate alignment
+      run: python scripts/check_benchmark_gate_alignment.py
+
   glossary:
     needs: [changes, check-comments, lint]
     if: needs.changes.outputs.src == 'true' && needs['check-comments'].outputs.only_comments != 'true'
@@ -201,6 +204,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
+    - name: Install package dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
 
     - name: Run throughput benchmark
       shell: bash
@@ -236,6 +244,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
+    - name: Install package dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
 
     - name: Run BER benchmark
       shell: bash
@@ -331,6 +344,9 @@ jobs:
 
     - name: Run mypy
       run: mypy --config-file pyproject.toml --show-error-codes --no-error-summary
+
+    - name: Validate benchmark gate alignment
+      run: python scripts/check_benchmark_gate_alignment.py
 
 
     - name: Setup Node

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -35,7 +35,9 @@ For operational details behind each KPI, use:
 - [`docs/performance.md`](performance.md) for throughput and BER benchmark
   scripts (`benchmarks/throughput.py`, `benchmarks/error_rate.py`) and CI gate
   implementation details (`scripts/evaluate_benchmark_gates.py`,
-  `configs/benchmark_thresholds.json`, workflow benchmark artifacts).
+  `scripts/check_benchmark_gate_alignment.py`,
+  `configs/benchmark_thresholds.json`, `.github/workflows/python-ci.yml`
+  benchmark artifacts).
 
 ### Phase 1 → Phase 2 (Foundation sustainment to Robust Encoding Pipeline)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,7 +39,8 @@ Actual numbers will depend on your machine and Python version.
 Benchmark gate thresholds are centralized in
 `configs/benchmark_thresholds.json` and evaluated by
 `scripts/evaluate_benchmark_gates.py` so updates are intentional and reviewed
-in one place.
+in one place. Alignment to roadmap/capability gate definitions is validated by
+`scripts/check_benchmark_gate_alignment.py`.
 
 The Python CI workflow runs both benchmark commands and evaluates them against
 the phase-gate thresholds defined in `docs/development_roadmap.md` and
@@ -52,8 +53,12 @@ the phase-gate thresholds defined in `docs/development_roadmap.md` and
 
 Each run publishes artifacts for auditability:
 
-- Raw benchmark stdout (`*.stdout`)
-- Machine-readable gate evaluation JSON (`*-gate.json`)
+- Throughput job artifact `benchmark-throughput` with:
+  - `artifacts/benchmarks/throughput.stdout`
+  - `artifacts/benchmarks/throughput-gate.json`
+- BER job artifact `benchmark-error-rate` with:
+  - `artifacts/benchmarks/error_rate.stdout`
+  - `artifacts/benchmarks/error_rate-gate.json`
 
 You can run a local gate check with:
 
@@ -63,4 +68,10 @@ python scripts/evaluate_benchmark_gates.py \
   --benchmark throughput \
   --stdout-file throughput.stdout \
   --output-json throughput-gate.json
+```
+
+To verify thresholds and documentation stay in sync locally:
+
+```bash
+python scripts/check_benchmark_gate_alignment.py
 ```

--- a/scripts/check_benchmark_gate_alignment.py
+++ b/scripts/check_benchmark_gate_alignment.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Validate benchmark gate thresholds against capability and roadmap docs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+THRESHOLDS_PATH = ROOT / "configs" / "benchmark_thresholds.json"
+CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+ROADMAP_PATH = ROOT / "docs" / "development_roadmap.md"
+
+
+def _load_thresholds() -> dict[str, dict[str, object]]:
+    return json.loads(THRESHOLDS_PATH.read_text(encoding="utf-8"))
+
+
+def _extract_gate_block(text: str, gate: str) -> str:
+    marker = f'- gate: "{gate}"'
+    start = text.find(marker)
+    if start == -1:
+        raise ValueError(f"Missing gate {gate!r} in {CAPABILITIES_PATH}.")
+    next_start = text.find('\n  - gate: "', start + len(marker))
+    return text[start:] if next_start == -1 else text[start:next_start]
+
+
+def _extract_metric_block(gate_block: str, metric: str) -> str:
+    marker = f"- metric: {metric}"
+    start = gate_block.find(marker)
+    if start == -1:
+        raise ValueError(f"Missing measurable check metric {metric!r} in capabilities gate block.")
+    next_start = gate_block.find("\n      - metric:", start + len(marker))
+    return gate_block[start:] if next_start == -1 else gate_block[start:next_start]
+
+
+def _threshold_tokens(config_name: str, config_thresholds: dict[str, float]) -> list[str]:
+    if config_name == "throughput":
+        return [f"{float(config_thresholds['base4_encode_mb_s_min']):.1f} MB/s", "Base-4", "throughput"]
+    return [f"{float(config_thresholds['ber_max']):.2f}", "BER"]
+
+
+def main() -> int:
+    thresholds = _load_thresholds()
+    capabilities_text = CAPABILITIES_PATH.read_text(encoding="utf-8")
+    roadmap_text = ROADMAP_PATH.read_text(encoding="utf-8")
+
+    failures: list[str] = []
+
+    for benchmark_name, benchmark_cfg in thresholds.items():
+        gate = str(benchmark_cfg["gate"])
+        metric = str(benchmark_cfg["metric"])
+        benchmark_command = str(benchmark_cfg["benchmark_command"])
+        cfg_thresholds = dict(benchmark_cfg["thresholds"])
+
+        gate_block = _extract_gate_block(capabilities_text, gate)
+        metric_block = _extract_metric_block(gate_block, metric)
+
+        for token in _threshold_tokens(benchmark_name, cfg_thresholds):
+            if token not in metric_block:
+                failures.append(
+                    f"{benchmark_name}: capabilities threshold mismatch. expected token {token!r}."
+                )
+            if token not in roadmap_text:
+                failures.append(
+                    f"{benchmark_name}: roadmap threshold mismatch. expected token {token!r}."
+                )
+
+        if benchmark_command not in metric_block:
+            failures.append(
+                f"{benchmark_name}: benchmark command {benchmark_command!r} missing from capabilities tests_or_checks."
+            )
+        if benchmark_command not in roadmap_text:
+            failures.append(
+                f"{benchmark_name}: benchmark command {benchmark_command!r} missing from roadmap."
+            )
+
+        for artifact in ["benchmark stdout artifact", "benchmark gate JSON artifact"]:
+            if artifact not in metric_block:
+                failures.append(
+                    f"{benchmark_name}: capabilities evidence_artifacts missing {artifact!r}."
+                )
+
+    if failures:
+        print("Benchmark gate alignment failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Benchmark gate alignment check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_gate_alignment.py
+++ b/tests/test_benchmark_gate_alignment.py
@@ -1,0 +1,94 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check_benchmark_gate_alignment.py"
+    spec = spec_from_file_location("check_benchmark_gate_alignment", script_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fixtures(tmp_path: Path, throughput_threshold: str = ">= 2.0 MB/s Base-4 encode throughput"):
+    (tmp_path / "configs").mkdir(parents=True)
+    (tmp_path / "docs").mkdir(parents=True)
+
+    (tmp_path / "configs" / "benchmark_thresholds.json").write_text(
+        """{
+  "throughput": {
+    "gate": "Phase 2 -> Phase 3",
+    "metric": "Throughput median floor",
+    "benchmark_command": "PYTHONPATH=src python benchmarks/throughput.py",
+    "thresholds": {"base4_encode_mb_s_min": 2.0}
+  },
+  "error_rate": {
+    "gate": "Phase 3 -> Phase 4",
+    "metric": "BER baseline quality",
+    "benchmark_command": "PYTHONPATH=src python benchmarks/error_rate.py",
+    "thresholds": {"ber_max": 0.01}
+  }
+}
+""",
+        encoding="utf-8",
+    )
+
+    (tmp_path / "docs" / "capabilities.yaml").write_text(
+        f"""
+phase_gates:
+  - gate: "Phase 2 -> Phase 3"
+    measurable_checks:
+      - metric: Throughput median floor
+        threshold: "{throughput_threshold}"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/throughput.py
+        evidence_artifacts:
+          - benchmark stdout artifact
+          - benchmark gate JSON artifact
+  - gate: "Phase 3 -> Phase 4"
+    measurable_checks:
+      - metric: BER baseline quality
+        threshold: "<= 0.01 BER on documented baseline profile/seed"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/error_rate.py
+        evidence_artifacts:
+          - benchmark stdout artifact
+          - benchmark gate JSON artifact
+""",
+        encoding="utf-8",
+    )
+
+    (tmp_path / "docs" / "development_roadmap.md").write_text(
+        "\n".join(
+            [
+                "Throughput threshold: >= 2.0 MB/s Base-4 encode throughput",
+                "BER threshold: <= 0.01 BER",
+                "PYTHONPATH=src python benchmarks/throughput.py",
+                "PYTHONPATH=src python benchmarks/error_rate.py",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_benchmark_alignment_check_passes(tmp_path):
+    mod = _load_module()
+    _write_fixtures(tmp_path)
+
+    mod.THRESHOLDS_PATH = tmp_path / "configs" / "benchmark_thresholds.json"
+    mod.CAPABILITIES_PATH = tmp_path / "docs" / "capabilities.yaml"
+    mod.ROADMAP_PATH = tmp_path / "docs" / "development_roadmap.md"
+
+    assert mod.main() == 0
+
+
+def test_benchmark_alignment_check_fails_for_threshold_mismatch(tmp_path):
+    mod = _load_module()
+    _write_fixtures(tmp_path, throughput_threshold=">= 2.5 MB/s Base-4 encode throughput")
+
+    mod.THRESHOLDS_PATH = tmp_path / "configs" / "benchmark_thresholds.json"
+    mod.CAPABILITIES_PATH = tmp_path / "docs" / "capabilities.yaml"
+    mod.ROADMAP_PATH = tmp_path / "docs" / "development_roadmap.md"
+
+    assert mod.main() == 1


### PR DESCRIPTION
### Motivation
- Ensure benchmark runs in CI are reproducible and self-contained by installing project dependencies before running benchmarks and to make benchmark-based phase gates auditable and machine-checkable.  
- Prevent drift between threshold configuration and the roadmap/capability docs by adding an automated alignment check so gate definitions remain intentional and reviewable.  

### Description
- Updated CI workflow `.github/workflows/python-ci.yml` to install package dependencies before the throughput and BER benchmark steps and to run a new alignment check during the lint/mypy stage.  
- Added `scripts/check_benchmark_gate_alignment.py` which validates `configs/benchmark_thresholds.json` entries (threshold tokens, benchmark command, and required evidence artifact names) are present in `docs/capabilities.yaml` and `docs/development_roadmap.md`.  
- Added `tests/test_benchmark_gate_alignment.py` with passing and failing fixtures to exercise the new checker.  
- Documented CI benchmark artifacts and the alignment check in `docs/performance.md` and cross-linked the checker and workflow in `docs/development_roadmap.md`; artifacts produced by CI are `benchmark-throughput` (contains `artifacts/benchmarks/throughput.stdout` and `throughput-gate.json`) and `benchmark-error-rate` (contains `artifacts/benchmarks/error_rate.stdout` and `error_rate-gate.json`).  

### Testing
- Ran static checks with `python -m ruff check scripts/check_benchmark_gate_alignment.py tests/test_benchmark_gate_alignment.py` and the linter passed.  
- Executed unit tests with `pytest -q tests/test_benchmark_gate_alignment.py` and both tests passed.  
- Ran the alignment checker locally with `python scripts/check_benchmark_gate_alignment.py` which reports success against the repository fixtures.  
- Verified gate evaluation by invoking `scripts/evaluate_benchmark_gates.py` with sample stdout files for both `throughput` and `error_rate`, and both produced correct JSON gate reports showing `passed: true` for the sample inputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90f650b0c832697b169907de949e5)