### PR TITLE
Support profile parameter overrides in pipeline runtime and persist applied parameters/provenance

### DIFF
--- a/src/genecoder/app/pipeline_runtime.py
+++ b/src/genecoder/app/pipeline_runtime.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 """Simple pipeline for processing sequences step by step."""
 
 from collections.abc import MutableMapping
+import json
 from pathlib import Path
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping, Tuple, TypeAlias
 
 from genecoder.plugin_manager import init_plugins
 from genecoder.formats import SequenceBatch
@@ -12,7 +13,10 @@ from genecoder.simulators.batch_utils import RESULT_COVERAGE_KEY, RESULT_DROPOUT
 from genecoder import core
 from genecoder.runtime import RunContext, make_run_context
 
-__all__ = ["SequencePipeline", "run_pipeline"]
+ProfileParameterValue: TypeAlias = str | int | float | bool
+ProfileParameterOverrides: TypeAlias = Mapping[str, ProfileParameterValue]
+
+__all__ = ["SequencePipeline", "run_pipeline", "ProfileParameterOverrides", "ProfileParameterValue"]
 
 from genecoder.compat.legacy import SequencePipeline
 
@@ -70,6 +74,7 @@ def run_pipeline(
     output_path: str,
     filter_mutated: bool = False,
     run_context: RunContext | None = None,
+    profile_parameter_overrides: ProfileParameterOverrides | None = None,
 ) -> Tuple[bytes, dict[str, Any], Mapping[str, Any] | None]:
     """Process ``input_path`` through the selected codec, FEC and channel.
 
@@ -90,6 +95,7 @@ def run_pipeline(
         original_data,
         filter_mutated=filter_mutated,
         run_context=runtime_seed_context,
+        channel_parameters=profile_parameter_overrides,
     )
 
     simulated_batch = runtime.simulated_batch
@@ -112,7 +118,21 @@ def run_pipeline(
     decoded = runtime.decoded
     Path(output_path).write_bytes(decoded)
 
-    metrics_dict = runtime.metrics
+    metrics_dict = dict(runtime.metrics)
+
+    provenance_raw = simulated_batch.metadata.get("sim_stage_provenance")
+    if provenance_raw is not None:
+        try:
+            metrics_dict["_sim_stage_provenance"] = json.loads(provenance_raw) if isinstance(provenance_raw, str) else provenance_raw
+        except Exception:
+            metrics_dict["_sim_stage_provenance"] = provenance_raw
+
+    applied_params_raw = simulated_batch.metadata.get("sim_channel_parameters")
+    if applied_params_raw is not None:
+        try:
+            metrics_dict["_applied_channel_parameters"] = json.loads(applied_params_raw) if isinstance(applied_params_raw, str) else applied_params_raw
+        except Exception:
+            metrics_dict["_applied_channel_parameters"] = applied_params_raw
 
     if (
         fec_backend == "fountain"

--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from genecoder.manifest import generate_manifest
-from .pipeline_runtime import run_pipeline
+from .pipeline_runtime import ProfileParameterOverrides, run_pipeline
 from genecoder.results.schema import RUN_SCHEMA_VERSION, canonical_metrics_view
 from genecoder.html_report import generate_html_report
 from genecoder.runtime import make_run_context
@@ -24,7 +24,7 @@ from genecoder.profiles.registry import canonicalize_profile_name
 @dataclass(frozen=True)
 class ChannelProfile:
     name: str
-    parameters: Mapping[str, Any] = field(default_factory=dict)
+    parameters: ProfileParameterOverrides = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -105,7 +105,11 @@ class RunPipelineUseCase:
             output_path=request.output_path,
             filter_mutated=request.filter_mutated,
             run_context=run_context,
+            profile_parameter_overrides=(request.profile.parameters if request.profile else None),
         )
+
+        sim_stage_provenance = metrics.pop("_sim_stage_provenance", [])
+        applied_channel_parameters = metrics.pop("_applied_channel_parameters", dict(request.profile.parameters) if request.profile else {})
 
         metrics_path = Path(request.artifacts.metrics_path or str(request.output_path) + ".json")
         run_schema: dict[str, Any] = {
@@ -141,6 +145,8 @@ class RunPipelineUseCase:
                 },
                 "simulate": {
                     "profile": resolved_profile_name if resolved_profile_name else resolved_channel_name,
+                    "parameters": dict(applied_channel_parameters) if isinstance(applied_channel_parameters, Mapping) else {},
+                    "provenance": sim_stage_provenance,
                     "metrics": {
                         "substitutions": metrics.get("substitutions"),
                         "insertions": metrics.get("insertions"),
@@ -178,7 +184,7 @@ class RunPipelineUseCase:
                 "channel_profile": (
                     {
                         "name": resolved_profile_name or request.profile.name,
-                        "parameters": dict(request.profile.parameters),
+                        "parameters": dict(applied_channel_parameters) if isinstance(applied_channel_parameters, Mapping) else {},
                     }
                     if request.profile
                     else None

--- a/src/genecoder/channel_config.py
+++ b/src/genecoder/channel_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Mapping
 
 __all__ = ["ChannelConfig"]
 
@@ -15,6 +16,9 @@ class ChannelConfig:
     use_mpi: bool = False
     illumina_profile: str | None = None
     nanopore_profile: str | None = None
+    illumina_parameters: Mapping[str, Any] | None = None
+    nanopore_parameters: Mapping[str, Any] | None = None
+    profile_parameters: Mapping[str, Any] | None = None
     dropout_rate: float | None = None
     coverage_distribution: dict[int, float] | None = None
     synthesis_loss: float | None = None

--- a/src/genecoder/channel_engine/interfaces.py
+++ b/src/genecoder/channel_engine/interfaces.py
@@ -45,6 +45,7 @@ class StageProvenance:
     seed: int | None
     mutation_totals: StageMutationTotals = field(default_factory=StageMutationTotals)
     metadata: Mapping[str, str] = field(default_factory=dict)
+    parameters: Mapping[str, object] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -55,6 +56,7 @@ class StageProvenance:
             "seed": self.seed,
             "mutation_totals": self.mutation_totals.to_dict(),
             "metadata": dict(self.metadata),
+            "parameters": dict(self.parameters),
         }
 
 
@@ -65,6 +67,7 @@ class StageResult:
     output_batch: SequenceBatch
     profile_version: str | None = None
     metadata: Mapping[str, str] = field(default_factory=dict)
+    parameters: Mapping[str, object] = field(default_factory=dict)
 
 
 class SimulatorStage(Protocol):

--- a/src/genecoder/channel_engine/pipeline.py
+++ b/src/genecoder/channel_engine/pipeline.py
@@ -106,6 +106,7 @@ class ChannelPipeline:
                     seed=stage_seed,
                     mutation_totals=StageMutationTotals(**mutation_totals_from_batch(current)),
                     metadata=dict(result.metadata),
+                    parameters=dict(result.parameters),
                 )
             )
 

--- a/src/genecoder/channel_engine/plugins.py
+++ b/src/genecoder/channel_engine/plugins.py
@@ -10,6 +10,23 @@ from ..simulators.batch_utils import apply_legacy_simulator
 from .interfaces import StageContext, StageResult
 
 
+def simulator_parameters(simulator: BaseChannel) -> dict[str, object]:
+    keys = (
+        "error_rate",
+        "substitution_rate",
+        "insertion_rate",
+        "deletion_rate",
+        "coverage",
+        "read_length",
+        "profile",
+    )
+    params: dict[str, object] = {}
+    for key in keys:
+        if hasattr(simulator, key):
+            params[key] = getattr(simulator, key)
+    return params
+
+
 @dataclass
 class SimulatorStagePlugin:
     """Adapter that exposes an existing simulator as a channel stage plugin."""
@@ -49,7 +66,12 @@ class SimulatorStagePlugin:
         merged_metadata.update(context.metadata)
         merged_metadata["sim_stage"] = self.stage_name
         out.metadata.update(merged_metadata)
-        return StageResult(output_batch=out, profile_version=profile, metadata=merged_metadata)
+        return StageResult(
+            output_batch=out,
+            profile_version=profile,
+            metadata=merged_metadata,
+            parameters=simulator_parameters(sim),
+        )
 
 
 def mutation_totals_from_batch(batch: SequenceBatch) -> dict[str, int]:

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
 import json
+import inspect
 import time
 import warnings
 from collections import Counter
@@ -472,6 +473,7 @@ def run_canonical_pipeline(
     original_data: bytes,
     *,
     filter_mutated: bool = False,
+    channel_parameters: Mapping[str, Any] | None = None,
     run_context: RunContext | None = None,
 ) -> CanonicalRuntimeResult:
     """Execute the canonical internal runtime route: encode → simulate → decode."""
@@ -486,12 +488,30 @@ def run_canonical_pipeline(
         simulated, subs, ins, dels, coverage = simulate(
             channel,
             encoded_batch,
+            channel_parameters=channel_parameters,
             run_context=runtime_context,
         )
     except TypeError as exc:
-        if "run_context" not in str(exc):
+        message = str(exc)
+        if "channel_parameters" in message:
+            try:
+                simulated, subs, ins, dels, coverage = simulate(
+                    channel,
+                    encoded_batch,
+                    run_context=runtime_context,
+                )
+            except TypeError as nested_exc:
+                if "run_context" not in str(nested_exc):
+                    raise
+                simulated, subs, ins, dels, coverage = simulate(channel, encoded_batch)
+        elif "run_context" in message:
+            simulated, subs, ins, dels, coverage = simulate(
+                channel,
+                encoded_batch,
+                channel_parameters=channel_parameters,
+            )
+        else:
             raise
-        simulated, subs, ins, dels, coverage = simulate(channel, encoded_batch)
     simulated_batch = (
         simulated if isinstance(simulated, SequenceBatch) else _wrap_single_sequence(str(simulated))
     )
@@ -557,10 +577,32 @@ def _estimate_coverage(batch: SequenceBatch) -> int | None:
     return None
 
 
+def _apply_channel_constructor_parameters(simulator: object, parameters: Mapping[str, Any] | None) -> object:
+    if not parameters:
+        return simulator
+    signature = inspect.signature(type(simulator).__init__)
+    accepted = {
+        name
+        for name, param in signature.parameters.items()
+        if name != "self" and param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+    }
+    kwargs = {key: value for key, value in parameters.items() if key in accepted}
+    if not kwargs:
+        return simulator
+    current_profile = getattr(simulator, "profile", None)
+    if "profile" in accepted and "profile" not in kwargs and current_profile is not None:
+        kwargs["profile"] = current_profile
+    try:
+        return type(simulator)(**kwargs)
+    except Exception:
+        return simulator
+
+
 def simulate(
     channel: str | None,
     dna: SequenceBatch | str,
     *,
+    channel_parameters: Mapping[str, Any] | None = None,
     run_context: RunContext | None = None,
 ) -> Tuple[SequenceBatch | str, int | None, int | None, int | None, int | None]:
     """Return ``dna`` possibly mutated by ``channel`` and error counts."""
@@ -572,12 +614,16 @@ def simulate(
     if channel and channel != "none":
         if channel not in SIMULATOR_REGISTRY:
             raise ValueError(f"Unknown channel: {channel}")
-        sim = SIMULATOR_REGISTRY[channel]
+        sim = _apply_channel_constructor_parameters(SIMULATOR_REGISTRY[channel], channel_parameters)
         pipeline = ChannelPipeline.from_simulators([(channel, sim)])
-        mutated_batch, _ = pipeline.run(
+        mutated_batch, provenance = pipeline.run(
             original_batch,
             run_context=runtime_context,
         )
+
+        mutated_batch.metadata["sim_stage_provenance"] = json.dumps(provenance)
+        if channel_parameters:
+            mutated_batch.metadata["sim_channel_parameters"] = json.dumps(dict(channel_parameters))
 
         original_sequence = original_batch.combined_sequence()
         mutated_sequence = mutated_batch.combined_sequence()
@@ -1047,6 +1093,7 @@ def run_pipeline(
     channel: str | None,
     input_path: str,
     output_path: str,
+    channel_parameters: Mapping[str, Any] | None = None,
 ) -> Tuple[bytes, Dict[str, Any]]:
     """Process ``input_path`` through the selected codec, FEC and channel.
 
@@ -1054,6 +1101,6 @@ def run_pipeline(
     """
     _warn_orchestration_deprecation("run_pipeline")
     original_data = Path(input_path).read_bytes()
-    result = run_canonical_pipeline(codec, fec, channel, original_data)
+    result = run_canonical_pipeline(codec, fec, channel, original_data, channel_parameters=channel_parameters)
     Path(output_path).write_bytes(result.decoded)
     return result.decoded, result.metrics

--- a/src/genecoder/simulators/pipeline.py
+++ b/src/genecoder/simulators/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import inspect
 from typing import Iterable, List
 
 from ..channel_config import ChannelConfig
@@ -26,6 +27,25 @@ class ChannelPipeline(BaseChannel):
     def add_channel(self, channel: BaseChannel) -> None:
         self.channels.append(channel)
 
+    @staticmethod
+    def _apply_constructor_parameters(channel: BaseChannel, parameters: dict[str, object]) -> BaseChannel:
+        if not parameters:
+            return channel
+        signature = inspect.signature(type(channel).__init__)
+        accepted = {
+            name
+            for name, param in signature.parameters.items()
+            if name != "self" and param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+        }
+        kwargs = {key: value for key, value in parameters.items() if key in accepted}
+        if not kwargs:
+            return channel
+        try:
+            updated = type(channel)(**kwargs)
+        except Exception:
+            return channel
+        return updated if isinstance(updated, BaseChannel) else channel
+
     def _resolve_channels(self, config: ChannelConfig) -> list[BaseChannel]:
         from ..dnarsim_adapter import DNArSimChannel
         from ..insilicoseq_adapter import InSilicoSeqChannel
@@ -33,12 +53,19 @@ class ChannelPipeline(BaseChannel):
         from ..simulators.nanopore import NanoporeChannel
 
         resolved: list[BaseChannel] = []
+        shared_parameters = dict(config.profile_parameters or {})
         for channel in self.channels:
             ch = channel
             if config.illumina_profile is not None and isinstance(ch, (InSilicoSeqChannel, IlluminaChannel)):
                 ch = ch.with_profile(config.illumina_profile)
+                illumina_params = dict(shared_parameters)
+                illumina_params.update(dict(config.illumina_parameters or {}))
+                ch = self._apply_constructor_parameters(ch, illumina_params)
             elif config.nanopore_profile is not None and isinstance(ch, (DNArSimChannel, NanoporeChannel)):
                 ch = ch.with_profile(config.nanopore_profile)
+                nanopore_params = dict(shared_parameters)
+                nanopore_params.update(dict(config.nanopore_parameters or {}))
+                ch = self._apply_constructor_parameters(ch, nanopore_params)
             resolved.append(ch)
         return resolved
 

--- a/tests/test_pipeline_profile_parameters.py
+++ b/tests/test_pipeline_profile_parameters.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from genecoder.app.pipeline_use_case import ArtifactOutputPolicy, ChannelProfile, RunPipelineRequest, RunPipelineUseCase
+from genecoder.channel_config import ChannelConfig
+from genecoder.simulators.illumina import IlluminaChannel
+from genecoder.simulators.nanopore import NanoporeChannel
+from genecoder.simulators.pipeline import ChannelPipeline
+
+
+def test_use_case_persists_applied_profile_parameters_and_provenance(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_runtime(**kwargs):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return (
+            b"decoded",
+            {
+                "decode_success": True,
+                "_applied_channel_parameters": {"substitution_rate": 0.0},
+                "_sim_stage_provenance": [{"stage_name": "sequencing", "parameters": {"substitution_rate": 0.0}}],
+            },
+            None,
+        )
+
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+
+    output_file = tmp_path / "out.bin"
+    response = RunPipelineUseCase().execute(
+        RunPipelineRequest(
+            codec="huffman",
+            input_path="in.txt",
+            output_path=str(output_file),
+            profile=ChannelProfile(name="miseq", parameters={"substitution_rate": 0.0}),
+            artifacts=ArtifactOutputPolicy(metrics_path=str(tmp_path / "metrics.json")),
+        )
+    )
+
+    assert captured["profile_parameter_overrides"] == {"substitution_rate": 0.0}
+    assert response.run_schema["input_config"]["channel_profile"]["parameters"] == {"substitution_rate": 0.0}
+    assert response.run_schema["stages"]["simulate"]["provenance"] == [
+        {"stage_name": "sequencing", "parameters": {"substitution_rate": 0.0}}
+    ]
+
+
+def test_channel_config_profile_parameter_translation_for_illumina_and_nanopore() -> None:
+    illumina_pipeline = ChannelPipeline([IlluminaChannel(profile="miseq")])
+    illumina_resolved = illumina_pipeline._resolve_channels(
+        ChannelConfig(
+            illumina_profile="miseq",
+            profile_parameters={"substitution_rate": 0.0},
+            illumina_parameters={"coverage": 1.0},
+        )
+    )
+    illumina_channel = illumina_resolved[0]
+    assert isinstance(illumina_channel, IlluminaChannel)
+    assert illumina_channel.substitution_rate == 0.0
+    assert illumina_channel.coverage == 1.0
+
+    nanopore_pipeline = ChannelPipeline([NanoporeChannel(profile="minion")])
+    nanopore_resolved = nanopore_pipeline._resolve_channels(
+        ChannelConfig(
+            nanopore_profile="minion",
+            profile_parameters={"deletion_rate": 0.0},
+            nanopore_parameters={"coverage": 2.0},
+        )
+    )
+    nanopore_channel = nanopore_resolved[0]
+    assert isinstance(nanopore_channel, NanoporeChannel)
+    assert nanopore_channel.deletion_rate == 0.0
+    assert nanopore_channel.coverage == 2.0


### PR DESCRIPTION
### Motivation
- Allow callers to supply profile parameter overrides into pipeline execution so simulator constructors can receive explicit knobs at runtime for Illumina/Nanopore flows.
- Ensure the actual parameters applied to simulators are recorded so runs are reproducible and auditable (persisted into run schema and stage provenance).
- Add coverage for these behaviors with focused unit tests validating passthrough, translation, and schema round-trip.

### Description
- Extended `genecoder.app.pipeline_runtime.run_pipeline` signature to accept `profile_parameter_overrides` (typed `ProfileParameterOverrides`) and forward them into the canonical runtime invocation via `channel_parameters`.
- Updated `RunPipelineUseCase.execute` to pass `request.profile.parameters` into `run_pipeline` and to persist the applied channel parameters and simulation-stage provenance into `run_schema` under `input_config.channel_profile.parameters` and `stages.simulate.provenance`.
- Added `illumina_parameters`, `nanopore_parameters`, and `profile_parameters` to `ChannelConfig` and implemented constructor-level parameter application in `simulators.pipeline.ChannelPipeline` via `_apply_constructor_parameters`, merging shared `profile_parameters` with family-specific overrides.
- Extended core simulate flow to accept `channel_parameters`, safely construct profiled simulator instances via `_apply_channel_constructor_parameters`, and persist `sim_stage_provenance` and `sim_channel_parameters` into the resulting `SequenceBatch` metadata.
- Augmented channel engine provenance contract so `StageProvenance` and `StageResult` include `parameters`, and added `simulator_parameters` capture in `channel_engine.plugins` so stage-level snapshots reflect effective simulator fields (e.g. `error_rate`, `substitution_rate`, `coverage`, `profile`).
- Added tests in `tests/test_pipeline_profile_parameters.py` to assert parameter passthrough into runtime, persistence in `run_schema`, provenance entries, and translation from `ChannelConfig` into Illumina/Nanopore constructors.

### Testing
- Ran linter checks: `ruff check ...` targeting modified files and new tests which passed (`All checks passed`).
- Ran unit tests: `pytest -q tests/test_pipeline_profile_parameters.py tests/test_profile_registry_golden.py tests/test_simulation_engine_pipeline.py` and additional targeted runs such as `pytest -q tests/test_pipeline_roundtrip.py::test_pipeline_roundtrip_fountain_channels` and `pytest -q tests/test_profile_registry_golden.py tests/test_simulation_engine_pipeline.py tests/test_pipeline_legacy.py::test_pipeline_legacy_fountain_nanopore_dropouts`, all of which succeeded (reported test runs: multiple suites, e.g. `5 passed`, `4 passed`, `4 passed`).
- Ran `mypy` on the changed modules which surfaced pre-existing, repository-wide typing issues unrelated to this change set; type checking failed due to broader project strictness but the functional tests above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a30de29083269b90e16ec73075b6)