### PR TITLE
Instrument stage-level runtime telemetry in canonical pipeline schema

### DIFF
--- a/src/genecoder/app/pipeline_runtime.py
+++ b/src/genecoder/app/pipeline_runtime.py
@@ -119,6 +119,7 @@ def run_pipeline(
     Path(output_path).write_bytes(decoded)
 
     metrics_dict = dict(runtime.metrics)
+    metrics_dict["_runtime"] = dict(runtime.runtime)
 
     provenance_raw = simulated_batch.metadata.get("sim_stage_provenance")
     if provenance_raw is not None:
@@ -133,6 +134,13 @@ def run_pipeline(
             metrics_dict["_applied_channel_parameters"] = json.loads(applied_params_raw) if isinstance(applied_params_raw, str) else applied_params_raw
         except Exception:
             metrics_dict["_applied_channel_parameters"] = applied_params_raw
+
+    stage_metrics_raw = simulated_batch.metadata.get("sim_stage_metrics")
+    if stage_metrics_raw is not None:
+        try:
+            metrics_dict["_sim_stage_metrics"] = json.loads(stage_metrics_raw) if isinstance(stage_metrics_raw, str) else stage_metrics_raw
+        except Exception:
+            metrics_dict["_sim_stage_metrics"] = stage_metrics_raw
 
     if (
         fec_backend == "fountain"

--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -109,7 +109,13 @@ class RunPipelineUseCase:
         )
 
         sim_stage_provenance = metrics.pop("_sim_stage_provenance", [])
+        sim_stage_metrics = metrics.pop("_sim_stage_metrics", [])
+        runtime_metrics = metrics.pop("_runtime", {})
         applied_channel_parameters = metrics.pop("_applied_channel_parameters", dict(request.profile.parameters) if request.profile else {})
+
+        constraint_outcomes_payload = metrics.get("constraint_outcomes") if isinstance(metrics.get("constraint_outcomes"), Mapping) else {}
+        constraint_by_oligo = constraint_outcomes_payload.get("by_oligo") if isinstance(constraint_outcomes_payload.get("by_oligo"), Mapping) else {}
+        constraint_stage_breakdown = constraint_outcomes_payload.get("stages") if isinstance(constraint_outcomes_payload.get("stages"), list) else []
 
         metrics_path = Path(request.artifacts.metrics_path or str(request.output_path) + ".json")
         run_schema: dict[str, Any] = {
@@ -129,10 +135,10 @@ class RunPipelineUseCase:
                 "provenance": run_context.seed_provenance(),
             },
             "runtime": {
-                "total_seconds": None,
-                "encode_seconds": None,
-                "simulate_seconds": None,
-                "decode_seconds": None,
+                "total_seconds": runtime_metrics.get("total_seconds"),
+                "encode_seconds": runtime_metrics.get("encode_seconds"),
+                "simulate_seconds": runtime_metrics.get("simulate_seconds"),
+                "decode_seconds": runtime_metrics.get("decode_seconds"),
             },
             "stages": {
                 "encode": {
@@ -154,6 +160,7 @@ class RunPipelineUseCase:
                         "coverage": metrics.get("coverage"),
                         "dropout_count": metrics.get("dropout_count"),
                         "dropout_fraction": metrics.get("dropout_fraction"),
+                        "stage_metrics": sim_stage_metrics if isinstance(sim_stage_metrics, list) else [],
                     },
                 },
                 "decode": {
@@ -196,7 +203,8 @@ class RunPipelineUseCase:
             },
             "constraint_outcomes": {
                 "summary": metrics.get("constraint_violations"),
-                "by_oligo": {},
+                "by_oligo": dict(constraint_by_oligo),
+                "stages": list(constraint_stage_breakdown),
             },
             "decode_outcomes": {
                 "decode_success": metrics.get("decode_success"),

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -83,6 +83,7 @@ class CanonicalRuntimeResult:
     insertions: int | None
     deletions: int | None
     coverage: int | None
+    runtime: Mapping[str, float]
 
 
 
@@ -483,7 +484,13 @@ def run_canonical_pipeline(
     init_plugins()
     runtime_context = run_context or make_run_context()
 
+    total_started_at = time.perf_counter()
+
+    encode_started_at = time.perf_counter()
     encoded_batch, fec_info = encode(codec, fec, original_data, run_context=runtime_context)
+    encode_seconds = time.perf_counter() - encode_started_at
+
+    simulate_started_at = time.perf_counter()
     try:
         simulated, subs, ins, dels, coverage = simulate(
             channel,
@@ -512,10 +519,14 @@ def run_canonical_pipeline(
             )
         else:
             raise
+    simulate_seconds = time.perf_counter() - simulate_started_at
+
     simulated_batch = (
         simulated if isinstance(simulated, SequenceBatch) else _wrap_single_sequence(str(simulated))
     )
     decode_input = _batch_for_decode(simulated_batch, filter_mutated=filter_mutated)
+
+    decode_started_at = time.perf_counter()
     decoded = decode(
         codec,
         fec,
@@ -525,6 +536,8 @@ def run_canonical_pipeline(
         survivor_batch=decode_input,
         run_context=runtime_context,
     )
+    decode_seconds = time.perf_counter() - decode_started_at
+
     metrics_dict = metrics(
         simulated_batch,
         original_data,
@@ -539,6 +552,8 @@ def run_canonical_pipeline(
             dict(fec_info).get("constraint_outcomes") if isinstance(fec_info, Mapping) else None
         ),
     )
+    total_seconds = time.perf_counter() - total_started_at
+
     return CanonicalRuntimeResult(
         original_data=original_data,
         encoded_batch=encoded_batch,
@@ -552,6 +567,12 @@ def run_canonical_pipeline(
         insertions=ins,
         deletions=dels,
         coverage=coverage,
+        runtime={
+            "total_seconds": total_seconds,
+            "encode_seconds": encode_seconds,
+            "simulate_seconds": simulate_seconds,
+            "decode_seconds": decode_seconds,
+        },
     )
 
 

--- a/src/genecoder/results/schema.py
+++ b/src/genecoder/results/schema.py
@@ -92,6 +92,7 @@ def canonical_metrics_view(run_data: Mapping[str, Any]) -> dict[str, Any]:
 
     run = require_canonical_run_fields(migrate_run_schema(run_data))
     stages = _mapping(run.get("stages"))
+    runtime = _normalize_runtime(_mapping(run.get("runtime")))
     encode_metrics = _mapping(_mapping(stages.get("encode")).get("metrics"))
     simulate_metrics = _mapping(_mapping(stages.get("simulate")).get("metrics"))
     outcome = _mapping(run.get("outcome"))
@@ -130,6 +131,12 @@ def canonical_metrics_view(run_data: Mapping[str, Any]) -> dict[str, Any]:
             "dropout_rate": outcome.get("dropout_rate"),
             "ber": outcome.get("ber"),
             "throughput": outcome.get("throughput"),
+            "runtime_total_seconds": runtime.get("total_seconds"),
+            "runtime_encode_seconds": runtime.get("encode_seconds"),
+            "runtime_simulate_seconds": runtime.get("simulate_seconds"),
+            "runtime_decode_seconds": runtime.get("decode_seconds"),
+            "constraint_stage_outcomes": constraint_outcomes.get("stages", []),
+            "simulate_stage_metrics": simulate_metrics.get("stage_metrics", []),
         }
     )
     return metrics
@@ -138,6 +145,7 @@ def canonical_metrics_view(run_data: Mapping[str, Any]) -> dict[str, Any]:
 def canonical_comparison_metrics(run_data: Mapping[str, Any]) -> dict[str, float | bool | None]:
     run = migrate_run_schema(run_data)
     outcome = _mapping(run.get("outcome"))
+    runtime = _normalize_runtime(_mapping(run.get("runtime")))
     decode = _mapping(_mapping(_mapping(run.get("stages")).get("decode")).get("metrics"))
     return {
         "ber": _as_float(outcome.get("ber")),
@@ -150,6 +158,10 @@ def canonical_comparison_metrics(run_data: Mapping[str, Any]) -> dict[str, float
             if decode.get("decode_success") is not None
             else outcome.get("decode_success")
         ),
+        "runtime_total_seconds": _as_float(runtime.get("total_seconds")),
+        "runtime_encode_seconds": _as_float(runtime.get("encode_seconds")),
+        "runtime_simulate_seconds": _as_float(runtime.get("simulate_seconds")),
+        "runtime_decode_seconds": _as_float(runtime.get("decode_seconds")),
     }
 
 

--- a/tests/test_results_schema.py
+++ b/tests/test_results_schema.py
@@ -103,6 +103,10 @@ def test_kpi_contract_fields_present_for_comparison_views() -> None:
         "gc_stress",
         "homopolymer_stress",
         "decode_success",
+        "runtime_total_seconds",
+        "runtime_encode_seconds",
+        "runtime_simulate_seconds",
+        "runtime_decode_seconds",
     }
     assert expected.issubset(metrics)
     assert metrics["decode_success"] is True

--- a/tests/test_runtime_contract_cli_sdk.py
+++ b/tests/test_runtime_contract_cli_sdk.py
@@ -38,6 +38,8 @@ def test_cli_and_sdk_emit_same_run_schema_structure_for_seeded_profile_request(t
         input=str(source),
         output=str(output),
         emit_manifest_report=False,
+        illumina_profile=None,
+        nanopore_profile=None,
     )
     pipeline_cli._handle_command(cli_args)
     cli_schema = json.loads(Path(str(output) + ".json").read_text(encoding="utf-8"))
@@ -57,3 +59,43 @@ def test_cli_and_sdk_emit_same_run_schema_structure_for_seeded_profile_request(t
     )
 
     assert _schema_shape(cli_schema) == _schema_shape(dict(sdk_result.canonical_run))
+
+
+def test_successful_pipeline_runs_emit_non_null_runtime_telemetry(tmp_path: Path) -> None:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"runtime-telemetry")
+
+    output = tmp_path / "decoded.bin"
+    cli_args = argparse.Namespace(
+        seed=7,
+        metrics_path=None,
+        launch_dashboard=False,
+        config=None,
+        codec="reverse",
+        fec=None,
+        channel="simple",
+        sub_rate=0.0,
+        ins_rate=0.0,
+        del_rate=0.0,
+        explain_coding_stack=False,
+        mpi_workers=None,
+        input=str(source),
+        output=str(output),
+        emit_manifest_report=False,
+        illumina_profile=None,
+        nanopore_profile=None,
+    )
+    pipeline_cli._handle_command(cli_args)
+    cli_schema = json.loads(Path(str(output) + ".json").read_text(encoding="utf-8"))
+
+    runtime = cli_schema["runtime"]
+    assert runtime["total_seconds"] is not None
+    assert runtime["encode_seconds"] is not None
+    assert runtime["simulate_seconds"] is not None
+    assert runtime["decode_seconds"] is not None
+
+    dashboard_metrics = cli_schema["dashboard_metrics"]
+    assert dashboard_metrics["runtime_total_seconds"] == runtime["total_seconds"]
+    assert dashboard_metrics["runtime_encode_seconds"] == runtime["encode_seconds"]
+    assert dashboard_metrics["runtime_simulate_seconds"] == runtime["simulate_seconds"]
+    assert dashboard_metrics["runtime_decode_seconds"] == runtime["decode_seconds"]


### PR DESCRIPTION
### Motivation
- Capture wall-clock durations for encode, simulate, decode, and total pipeline runtime so dashboards and comparators can use real telemetry instead of placeholders. 
- Surface simulator stage-level metrics and constraint-stage breakdowns into the canonical run schema to improve analysis and auditability of pipeline runs. 
- Add schema-level regression tests to enforce non-null runtime telemetry for standard successful runs and keep comparison contracts stable.

### Description
- Add timing instrumentation to `run_canonical_pipeline` and expose measured durations on the returned `CanonicalRuntimeResult.runtime` as `total_seconds`, `encode_seconds`, `simulate_seconds`, and `decode_seconds` (changes in `src/genecoder/core.py`).
- Propagate runtime telemetry and simulator stage metrics from the runtime into the pipeline-level metrics payload by emitting `_runtime` and `_sim_stage_metrics` in `app.pipeline_runtime.run_pipeline` (changes in `src/genecoder/app/pipeline_runtime.py`).
- Populate `run_schema.runtime` from the measured runtime values and include `simulate` stage `stage_metrics` and real `constraint_outcomes.by_oligo`/`stages` when available in `RunPipelineUseCase.execute` (changes in `src/genecoder/app/pipeline_use_case.py`).
- Extend the canonical metrics and comparison views to consume the new fields (`runtime_*`, `simulate_stage_metrics`, `constraint_stage_outcomes`) so dashboards and comparators include the new telemetry (changes in `src/genecoder/results/schema.py`).
- Update/add tests to assert the schema shape parity and that successful pipeline runs emit non-null runtime telemetry, and make minor test harness adjustments to exercise the CLI flow with the new fields (changes in `tests/test_results_schema.py` and `tests/test_runtime_contract_cli_sdk.py`).

### Testing
- Ran the project unit tests for the impacted areas with `python -m pytest tests/test_results_schema.py tests/test_runtime_contract_cli_sdk.py tests/test_pipeline_profile_parameters.py`, which completed with all tests passing (`15 passed`).
- Ran the linter with `python -m ruff check ...` on modified files, and the checks passed with no issues.
- Verified that the dashboard/comparison metrics view now returns the new runtime and stage-level fields via the existing `canonical_metrics_view` and `canonical_comparison_metrics` utilities during the test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a97500708326bafa0c72874b0b07)