### PR TITLE
Replace home-path KPI evidence with run-scoped artifacts

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -215,13 +215,37 @@ jobs:
       run: |
         mkdir -p artifacts/benchmarks
         PYTHONPATH=src python benchmarks/throughput.py | tee artifacts/benchmarks/throughput.stdout
+        python - <<'PY2'
+        import json
+        import re
+        from pathlib import Path
+        text = Path('artifacts/benchmarks/throughput.stdout').read_text(encoding='utf-8')
+        match = None
+        pattern = re.compile(r'^Base-4\s+encode:\s+([0-9.]+)\s+MB/s\s+decode:\s+([0-9.]+)\s+MB/s$')
+        for line in text.splitlines():
+            found = pattern.match(line.strip())
+            if found:
+                match = found
+                break
+        if match is None:
+            raise SystemExit('Unable to parse throughput benchmark output')
+        payload = {
+            'benchmark': 'throughput',
+            'parsed_metrics': {
+                'base4_encode_mb_s': float(match.group(1)),
+                'base4_decode_mb_s': float(match.group(2)),
+            },
+            'evidence_artifact': 'artifacts/benchmarks/throughput.stdout',
+        }
+        Path('artifacts/benchmarks/throughput.kpi.json').write_text(json.dumps(payload, indent=2), encoding='utf-8')
+        PY2
 
     - name: Evaluate throughput gate
       shell: bash
       run: |
         python scripts/evaluate_benchmark_gates.py \
           --benchmark throughput \
-          --stdout-file artifacts/benchmarks/throughput.stdout \
+          --artifact-json artifacts/benchmarks/throughput.kpi.json \
           --output-json artifacts/benchmarks/throughput-gate.json
 
     - name: Upload throughput benchmark artifacts
@@ -229,7 +253,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-throughput
-        path: artifacts/benchmarks/throughput.*
+        path: |
+          artifacts/benchmarks/throughput.*
+          artifacts/benchmarks/throughput.kpi.json
 
   benchmark-error-rate:
     needs: [changes, check-comments, lint]
@@ -255,13 +281,38 @@ jobs:
       run: |
         mkdir -p artifacts/benchmarks
         PYTHONPATH=src python benchmarks/error_rate.py | tee artifacts/benchmarks/error_rate.stdout
+        python - <<'PY2'
+        import json
+        import re
+        from pathlib import Path
+        text = Path('artifacts/benchmarks/error_rate.stdout').read_text(encoding='utf-8')
+        match = None
+        pattern = re.compile(r'^encode:\s+([0-9.]+)\s+MB/s\s+decode:\s+([0-9.]+)\s+MB/s\s+BER:\s+([0-9.]+)$')
+        for line in text.splitlines():
+            found = pattern.match(line.strip())
+            if found:
+                match = found
+                break
+        if match is None:
+            raise SystemExit('Unable to parse error-rate benchmark output')
+        payload = {
+            'benchmark': 'error_rate',
+            'parsed_metrics': {
+                'encode_mb_s': float(match.group(1)),
+                'decode_mb_s': float(match.group(2)),
+                'ber': float(match.group(3)),
+            },
+            'evidence_artifact': 'artifacts/benchmarks/error_rate.stdout',
+        }
+        Path('artifacts/benchmarks/error_rate.kpi.json').write_text(json.dumps(payload, indent=2), encoding='utf-8')
+        PY2
 
     - name: Evaluate BER gate
       shell: bash
       run: |
         python scripts/evaluate_benchmark_gates.py \
           --benchmark error_rate \
-          --stdout-file artifacts/benchmarks/error_rate.stdout \
+          --artifact-json artifacts/benchmarks/error_rate.kpi.json \
           --output-json artifacts/benchmarks/error_rate-gate.json
 
     - name: Upload BER benchmark artifacts
@@ -269,7 +320,54 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-error-rate
-        path: artifacts/benchmarks/error_rate.*
+        path: |
+          artifacts/benchmarks/error_rate.*
+          artifacts/benchmarks/error_rate.kpi.json
+
+  benchmark-gates-from-artifacts:
+    needs: [benchmark-throughput, benchmark-error-rate]
+    if: always()
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Download throughput artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-throughput
+        path: artifacts/benchmarks
+
+    - name: Download BER artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: benchmark-error-rate
+        path: artifacts/benchmarks
+
+    - name: Evaluate gates from run-scoped KPI artifacts
+      shell: bash
+      run: |
+        python scripts/evaluate_benchmark_gates.py \
+          --benchmark throughput \
+          --artifact-json artifacts/benchmarks/throughput.kpi.json \
+          --output-json artifacts/benchmarks/throughput-gate-from-artifact.json
+        python scripts/evaluate_benchmark_gates.py \
+          --benchmark error_rate \
+          --artifact-json artifacts/benchmarks/error_rate.kpi.json \
+          --output-json artifacts/benchmarks/error_rate-gate-from-artifact.json
+
+    - name: Upload artifact-based gate reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-gates-from-artifacts
+        path: artifacts/benchmarks/*-gate-from-artifact.json
 
   mvp-checklist:
     needs: [changes, check-comments]

--- a/configs/schema/kpi_report.schema.json
+++ b/configs/schema/kpi_report.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GeneCoder KPI report artifact",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "kpis"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "kpis": {
+      "type": "object",
+      "required": [
+        "comparison",
+        "dashboard"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "comparison": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "number",
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "dashboard": {
+          "type": "object"
+        }
+      }
+    },
+    "benchmark": {
+      "type": "string"
+    },
+    "parsed_metrics": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "evidence_artifact": {
+      "type": "string"
+    }
+  }
+}

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -6,20 +6,20 @@
 
 | Metric | Threshold | Evidence |
 | --- | --- | --- |
-| Weekly usage (oligos_per_week) | >= 1,000 simulated oligos/week for 4 consecutive ISO weeks | `~/.genecoder/metrics.json`, `docs/metrics.md` |
+| Weekly usage (oligos_per_week) | >= 1,000 simulated oligos/week for 4 consecutive ISO weeks | run-scoped artifacts under output directories (for example `<run>/metrics.json`, `<run>/metrics.kpi.json`), `docs/metrics.md` |
 
 ## Phase 2 -> Phase 3
 
 | Metric | Threshold | Evidence |
 | --- | --- | --- |
 | Deterministic reproducibility stability | 100% deterministic seed/profile checks for 2 consecutive weeks | `tests/test_simulator_seed_reproducibility.py`, `tests/test_illumina_coverage_quality.py`, `tests/test_nanopore_context_profile.py` |
-| Throughput floor | >= 2.0 MB/s Base-4 encode throughput | `benchmarks/throughput.py`, `docs/performance.md` |
+| Throughput floor | >= 2.0 MB/s Base-4 encode throughput | `PYTHONPATH=src python benchmarks/throughput.py`, run artifact `artifacts/benchmarks/throughput.kpi.json`, gate report `artifacts/benchmarks/throughput-gate.json`, `docs/performance.md` |
 
 ## Phase 3 -> Phase 4
 
 | Metric | Threshold | Evidence |
 | --- | --- | --- |
-| BER baseline quality | <= 0.01 BER on baseline profile/seed | `benchmarks/error_rate.py`, `docs/performance.md` |
+| BER baseline quality | <= 0.01 BER on baseline profile/seed | `PYTHONPATH=src python benchmarks/error_rate.py`, run artifact `artifacts/benchmarks/error_rate.kpi.json`, gate report `artifacts/benchmarks/error_rate-gate.json`, `docs/performance.md` |
 | Suite category health | Green CI across CLI/API, pipeline/simulation, and plugins/security suites | `tests/test_cli*.py`, `tests/test_pipeline*.py`, `tests/test_plugin*.py` |
 
 ## Phase 4 release gate

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 # Usage Metrics
 
-GeneCoder records basic usage statistics in a `metrics.json` file located in `~/.genecoder/` by default. The following counters are tracked:
+GeneCoder records usage statistics into run-scoped artifact files. For pipeline and bundle workflows, keep `metrics.json` and `metrics.kpi.json` next to each run output directory (for example `artifacts/runs/<run-id>/`). The following counters are tracked:
 
 - `encode_runs` – times the `encode` command has been executed.
 - `bundle_runs` – number of `bundle run` workflows executed.
@@ -9,11 +9,10 @@ GeneCoder records basic usage statistics in a `metrics.json` file located in `~/
   aggregation.
 - `oligos_per_week` – aggregated counts of simulated sequences per ISO week.
 
-Pass `--metrics-path /path/to/metrics.json` to `genecli bundle run` or
-`genecli pipeline` to override the default metrics destination for a specific
-invocation. Set the `GENECODER_METRICS_PATH` environment variable to update the
-default location for every command (useful for web dashboards or headless
-deployments).
+Pass `--metrics-path /path/to/run/metrics.json` to `genecli bundle run` or
+`genecli pipeline` so the metrics and KPI evidence live with each run's outputs.
+`genecli pipeline` always emits a sibling `metrics.kpi.json` artifact with a
+machine-readable KPI bundle contract.
 
 GeneCoder's north-star goal is to accelerate DNA storage research by enabling more oligos to be simulated each week. The `oligos_per_week` metric aggregates `oligos_simulated_ts` into ISO weeks, providing a clear view of weekly usage trends.
 

--- a/scripts/evaluate_benchmark_gates.py
+++ b/scripts/evaluate_benchmark_gates.py
@@ -45,6 +45,26 @@ def _parse_error_rate(stdout_text: str) -> dict[str, float]:
     raise ValueError("Could not parse BER output from benchmark stdout.")
 
 
+def _parsed_from_artifact(benchmark: str, artifact_data: dict[str, object]) -> dict[str, float]:
+    parsed_metrics = artifact_data.get("parsed_metrics")
+    if not isinstance(parsed_metrics, dict):
+        raise ValueError("Artifact payload missing 'parsed_metrics' object.")
+
+    if benchmark == "throughput":
+        encode = parsed_metrics.get("base4_encode_mb_s")
+        decode = parsed_metrics.get("base4_decode_mb_s")
+        if not isinstance(encode, (int, float)) or not isinstance(decode, (int, float)):
+            raise ValueError("Throughput artifact must contain numeric base4_encode_mb_s/base4_decode_mb_s.")
+        return {"base4_encode_mb_s": float(encode), "base4_decode_mb_s": float(decode)}
+
+    encode = parsed_metrics.get("encode_mb_s")
+    decode = parsed_metrics.get("decode_mb_s")
+    ber = parsed_metrics.get("ber")
+    if not isinstance(encode, (int, float)) or not isinstance(decode, (int, float)) or not isinstance(ber, (int, float)):
+        raise ValueError("Error-rate artifact must contain numeric encode_mb_s/decode_mb_s/ber.")
+    return {"encode_mb_s": float(encode), "decode_mb_s": float(decode), "ber": float(ber)}
+
+
 def _evaluate(benchmark: str, parsed: dict[str, float], config: dict[str, object]) -> tuple[bool, list[str]]:
     thresholds = config["thresholds"]
     checks: list[str] = []
@@ -71,9 +91,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--stdout-file",
-        required=True,
         type=Path,
         help="Path to benchmark stdout file.",
+    )
+    parser.add_argument(
+        "--artifact-json",
+        type=Path,
+        help="Path to benchmark artifact JSON containing parsed_metrics.",
     )
     parser.add_argument(
         "--output-json",
@@ -85,13 +109,22 @@ def main() -> int:
 
     threshold_config = _load_threshold_config()
     benchmark_config = threshold_config[args.benchmark]
-    stdout_text = args.stdout_file.read_text(encoding="utf-8")
 
-    parsed = (
-        _parse_throughput(stdout_text)
-        if args.benchmark == "throughput"
-        else _parse_error_rate(stdout_text)
-    )
+    if args.artifact_json:
+        artifact_payload = json.loads(args.artifact_json.read_text(encoding="utf-8"))
+        parsed = _parsed_from_artifact(args.benchmark, artifact_payload)
+        evidence = str(args.artifact_json)
+    else:
+        if not args.stdout_file:
+            raise SystemExit("Either --stdout-file or --artifact-json is required.")
+        stdout_text = args.stdout_file.read_text(encoding="utf-8")
+        parsed = (
+            _parse_throughput(stdout_text)
+            if args.benchmark == "throughput"
+            else _parse_error_rate(stdout_text)
+        )
+        evidence = str(args.stdout_file)
+
     passed, checks = _evaluate(args.benchmark, parsed, benchmark_config)
 
     report = {
@@ -103,6 +136,7 @@ def main() -> int:
         "thresholds": benchmark_config["thresholds"],
         "parsed_metrics": parsed,
         "checks": checks,
+        "evidence_artifact": evidence,
         "passed": passed,
     }
 

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -16,6 +16,7 @@ from genecoder.config.loader import load_mapping_file, validate_bundle_document
 from genecoder.core import encode, decode, inspect_coding_plan
 from genecoder.formats import SequenceBatch
 from genecoder.parallel import parallel_map
+from genecoder.pipeline import build_kpi_bundle
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
@@ -702,6 +703,7 @@ def _handle_command(args: argparse.Namespace) -> None:
         )
         return artifact
 
+    artifact: Dict[str, Any] | None = None
     if args.mpi_workers:
         parallel_map(
             lambda _: _execute(),
@@ -710,10 +712,18 @@ def _handle_command(args: argparse.Namespace) -> None:
             use_mpi=True,
         )[0]
     else:
-        _execute()
+        artifact = _execute()
 
     metrics_path = Path(str(metrics_override) if metrics_override else str(args.output) + ".json")
     logger.info("Run artifact written to %s", metrics_path)
+
+    kpi_bundle_path = metrics_path.with_suffix(".kpi.json")
+    source_artifact = artifact
+    if source_artifact is None:
+        source_artifact = json.loads(metrics_path.read_text(encoding="utf-8"))
+    kpi_bundle = build_kpi_bundle(source_artifact, artifact_path=str(metrics_path))
+    kpi_bundle_path.write_text(json.dumps(kpi_bundle, indent=2), encoding="utf-8")
+    logger.info("KPI bundle written to %s", kpi_bundle_path)
 
     manifest_path = metrics_path.with_suffix(".manifest.json")
     if manifest_path.exists():

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -1,12 +1,53 @@
 from __future__ import annotations
 
-"""Backward-compatible facade for legacy pipeline imports."""
+"""Backward-compatible facade for legacy pipeline imports.
 
+This module also provides the run-scoped KPI bundle contract used by CLI
+wrappers and CI gate checks.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
 import warnings
 
 from .compat.v1.pipeline_adapter import SequencePipeline, core, init_plugins, run_pipeline
+from .results.schema import canonical_comparison_metrics, canonical_metrics_view, migrate_run_schema
 
-__all__ = ["SequencePipeline", "run_pipeline", "core", "init_plugins"]
+KPI_BUNDLE_VERSION = "1.0"
+
+
+def build_kpi_bundle(run_schema: Mapping[str, Any], *, artifact_path: str | None = None) -> dict[str, Any]:
+    """Return the machine-readable KPI bundle for a canonical run artifact."""
+
+    canonical_run = migrate_run_schema(run_schema)
+    run_id = str(canonical_run.get("run_id") or "run")
+    metrics_view = canonical_metrics_view(canonical_run)
+    comparison = canonical_comparison_metrics(canonical_run)
+
+    bundle: dict[str, Any] = {
+        "schema_version": KPI_BUNDLE_VERSION,
+        "source": "genecoder.pipeline",
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "kpis": {
+            "comparison": comparison,
+            "dashboard": metrics_view,
+        },
+    }
+    if artifact_path:
+        bundle["artifacts"] = {"run_schema": str(Path(artifact_path))}
+    return bundle
+
+
+__all__ = [
+    "SequencePipeline",
+    "run_pipeline",
+    "core",
+    "init_plugins",
+    "KPI_BUNDLE_VERSION",
+    "build_kpi_bundle",
+]
 
 warnings.warn(
     "genecoder.pipeline is deprecated and will be removed in v0.16.0; "

--- a/tests/test_evaluate_benchmark_gates.py
+++ b/tests/test_evaluate_benchmark_gates.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_evaluate_benchmark_gates_from_artifact_json(tmp_path: Path) -> None:
+    artifact = tmp_path / "throughput.kpi.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "benchmark": "throughput",
+                "parsed_metrics": {
+                    "base4_encode_mb_s": 2.5,
+                    "base4_decode_mb_s": 5.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "gate.json"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_benchmark_gates.py",
+            "--benchmark",
+            "throughput",
+            "--artifact-json",
+            str(artifact),
+            "--output-json",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["passed"] is True
+    assert report["evidence_artifact"] == str(artifact)
+    assert report["parsed_metrics"]["base4_encode_mb_s"] == 2.5

--- a/tests/test_pipeline_kpi_bundle.py
+++ b/tests/test_pipeline_kpi_bundle.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genecoder.pipeline import build_kpi_bundle
+from tests.test_cli import run_cli_command
+
+
+def test_build_kpi_bundle_includes_comparison_and_dashboard() -> None:
+    run_schema = {
+        "schema_version": "1.2",
+        "run_id": "example-run",
+        "profiles": {"encoding": "base4_direct", "simulation": "none", "decode": "base4_direct"},
+        "seeds": {"global": 1, "encode": 1, "simulate": 1, "decode": 1},
+        "runtime": {"total_seconds": 0.1, "encode_seconds": 0.01, "simulate_seconds": 0.02, "decode_seconds": 0.07},
+        "stages": {
+            "encode": {"metrics": {"gc_content": 0.5, "gc_variance": 0.0, "max_homopolymer": 2}},
+            "simulate": {"metrics": {"substitutions": 0, "insertions": 0, "deletions": 0, "coverage": 1}},
+            "decode": {"metrics": {"decode_success": True, "decode_success_rate": 1.0, "ecc_success_rates": {}}},
+        },
+        "outcome": {"metrics": {"ber": 0.0, "throughput": 1.0}},
+        "constraint_outcomes": {"summary": None, "by_oligo": {}, "stages": []},
+        "decode_outcomes": {"decode_success": True, "decode_success_rate": 1.0, "ecc_success_rates": {}},
+        "provenance": {"source_format": "test", "generator": "test"},
+    }
+
+    bundle = build_kpi_bundle(run_schema, artifact_path="artifacts/runs/example-run/metrics.json")
+    assert bundle["run_id"] == "example-run"
+    assert "comparison" in bundle["kpis"]
+    assert "dashboard" in bundle["kpis"]
+    assert bundle["artifacts"]["run_schema"].endswith("metrics.json")
+
+
+def test_cli_pipeline_emits_kpi_bundle_artifact(tmp_path: Path) -> None:
+    input_file = tmp_path / "input.bin"
+    output_file = tmp_path / "decoded.bin"
+    input_file.write_bytes(b"hello")
+
+    result = run_cli_command(
+        [
+            "pipeline",
+            "--codec",
+            "reverse",
+            "--channel",
+            "none",
+            str(input_file),
+            str(output_file),
+            "--seed",
+            "123",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+
+    metrics_path = Path(str(output_file) + ".json")
+    kpi_path = metrics_path.with_suffix(".kpi.json")
+    assert kpi_path.exists()
+    payload = json.loads(kpi_path.read_text(encoding="utf-8"))
+    assert payload["run_id"] == output_file.stem
+    assert payload["artifacts"]["run_schema"] == str(metrics_path)


### PR DESCRIPTION
### Motivation
- Move KPI/benchmark evidence away from a centralized home path and ensure run-scoped, machine-readable KPI artifacts are always emitted with pipeline runs so CI and dashboards can rely on run-local evidence files.
- Provide a stable export contract for KPI bundles so downstream consumers (CI jobs, dashboards, gate evaluators) can parse and evaluate KPIs consistently.

### Description
- Added a pipeline-level KPI export contract in `src/genecoder/pipeline.py` with `KPI_BUNDLE_VERSION` and `build_kpi_bundle(run_schema, artifact_path=...)` that produces a machine-readable KPI bundle including comparison and dashboard KPI views. (`src/genecoder/pipeline.py`)
- Updated the `genecli pipeline` CLI wrapper to always write a sibling KPI artifact `<run>.kpi.json` adjacent to the canonical run schema JSON; the CLI reads the emitted run artifact when MPI/forking paths prevent an in-memory bundle. (`src/genecoder/cli/pipeline.py`)
- Added a JSON schema for KPI bundles at `configs/schema/kpi_report.schema.json` to document and validate the artifact shape.
- Extended `scripts/evaluate_benchmark_gates.py` to accept `--artifact-json` (run-scoped KPI/parsed metrics) in addition to the existing stdout parsing fallback, and to include `evidence_artifact` in gate reports. (`scripts/evaluate_benchmark_gates.py`)
- Updated CI workflow to emit `throughput.kpi.json` and `error_rate.kpi.json` from benchmark steps, evaluate gates from those artifacts, and added a `benchmark-gates-from-artifacts` job to download/upload artifact-based gate reports. (`.github/workflows/python-ci.yml`)
- Updated docs to reference run output artifacts instead of `~/.genecoder` (`docs/development_roadmap.md`, `docs/metrics.md`).
- Added automated tests for KPI bundle generation and artifact-driven gate evaluation (`tests/test_pipeline_kpi_bundle.py`, `tests/test_evaluate_benchmark_gates.py`).

### Testing
- Ran linter: `ruff check src/genecoder/pipeline.py src/genecoder/cli/pipeline.py scripts/evaluate_benchmark_gates.py tests/test_pipeline_kpi_bundle.py tests/test_evaluate_benchmark_gates.py` and all checks passed.
- Ran unit tests: `pytest -q tests/test_pipeline_kpi_bundle.py tests/test_evaluate_benchmark_gates.py` and the test suite passed (all tests in those files succeeded, with only non-blocking deprecation warnings).
- Exercised relevant CLI pipeline tests: targeted `pytest` cases for pipeline CLI behavior (indel and dropout tests) passed after the changes.
- Validated benchmark gate alignment with `python scripts/check_benchmark_gate_alignment.py` and updated roadmap text so the alignment check passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9be03f86483268a1cf18faec456f2)