### PR TITLE
Add two-tier pytest architecture with core/integration CI matrix

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -671,3 +671,68 @@ jobs:
           GENECODER_SIM_SEED: "5"
         run: |
           poetry run pytest -vv tests/test_bundle_cli_integration.py
+
+  test-tier-matrix:
+    needs: [changes, check-comments, lint]
+    if: needs.changes.outputs.src == 'true' && needs['check-comments'].outputs.only_comments != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tier: [core, integration]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install core test dependencies
+        if: matrix.tier == 'core'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pytest pytest-xdist pytest-cov
+
+      - name: Run core test tier
+        if: matrix.tier == 'core'
+        run: |
+          pytest -m core --test-tier=core --junitxml=artifacts/core-junit.xml -q
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+          xml_path = Path('artifacts/core-junit.xml')
+          root = ET.parse(xml_path).getroot()
+          skipped = int(root.attrib.get('skipped', '0'))
+          if skipped != 0:
+              raise SystemExit(f'core tier cannot skip tests; observed {skipped} skipped tests')
+          print('core tier skip check passed (0 skipped tests)')
+          PY
+
+      - name: Install integration dependencies
+        if: matrix.tier == 'integration'
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --with gui,web,dev --extras ldpc --extras fountain --extras bch --extras raptorq --extras deepdna --extras chamaeleo --no-interaction --no-root
+
+      - name: Generate optional integration dependency report
+        if: matrix.tier == 'integration'
+        run: |
+          python scripts/report_optional_test_dependencies.py
+
+      - name: Run optional integration test tier
+        if: matrix.tier == 'integration'
+        run: |
+          poetry run pytest -m integration_optional --test-tier=integration -rs -q
+
+      - name: Upload integration dependency report
+        if: matrix.tier == 'integration' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: optional-integration-dependency-report
+          path: |
+            artifacts/optional-integration-dependency-report.md
+            artifacts/optional-integration-dependency-report.json

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -270,3 +270,36 @@ External simulators accept additional flags through environment variables. Set
 `GENECODER_D2SIM_OPTIONS`, `GENECODER_DNARSIM_OPTIONS` or
 `GENECODER_SQUIGULATOR_OPTIONS` to pass options to the respective tool. Use
 `GENECODER_SIM_SEED` to make runs reproducible.
+
+
+## Two-tier test dependency profiles
+
+GeneCoder supports a two-tier test architecture:
+
+- `core` tests (`@pytest.mark.core`) are required for minimal environments.
+- `integration_optional` tests (`@pytest.mark.integration_optional`) validate optional integrations and external tools.
+
+### Minimal core profile
+
+Use this profile when you only need the required test tier:
+
+```bash
+python -m pip install -e . pytest pytest-xdist pytest-cov
+pytest -m core --test-tier=core -q
+```
+
+Core CI enforces **zero skipped tests** for this tier.
+
+### Optional integration profile
+
+Use this profile for full ecosystem coverage (GUI, web, optional codecs, and external integrations):
+
+```bash
+poetry install --with gui,web,dev   --extras ldpc --extras fountain --extras bch   --extras raptorq --extras deepdna --extras chamaeleo   --no-interaction --no-root
+poetry run pytest -m integration_optional --test-tier=integration -rs -q
+python scripts/report_optional_test_dependencies.py
+```
+
+The integration tier allows skips and requires publishing the dependency report
+(`artifacts/optional-integration-dependency-report.md`) so missing tools are
+explicitly documented.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -118,3 +118,33 @@ measure the new rates (optionally seeding `GENECODER_SIM_SEED` for repeatable
 experiments) and tighten the assertions once the numbers stabilise. This keeps
 future regression runs honest and provides a lightweight checklist for
 contributors submitting improved sequencing statistics.
+
+
+## Reproducible two-tier testing
+
+The CI pipeline runs tests in two deterministic tiers:
+
+1. **Core tier**: `pytest -m core --test-tier=core`
+   - Targets the minimal dependency profile.
+   - Must complete with **zero skipped tests**.
+2. **Optional integration tier**: `pytest -m integration_optional --test-tier=integration`
+   - Covers optional dependencies and external executables.
+   - Skips are allowed when dependencies are unavailable.
+   - A dependency availability report is generated via
+     `python scripts/report_optional_test_dependencies.py`.
+
+To reproduce CI behavior locally, run:
+
+```bash
+# Core (minimal)
+python -m pip install -e . pytest pytest-xdist pytest-cov
+pytest -m core --test-tier=core --junitxml=artifacts/core-junit.xml -q
+
+# Optional integrations
+poetry install --with gui,web,dev   --extras ldpc --extras fountain --extras bch   --extras raptorq --extras deepdna --extras chamaeleo   --no-interaction --no-root
+python scripts/report_optional_test_dependencies.py
+poetry run pytest -m integration_optional --test-tier=integration -rs -q
+```
+
+Keeping these commands and dependency profiles pinned in automation makes test
+outcomes easier to compare across machines and over time.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 addopts = -ra
 markers =
+    core: tests required to pass in a minimal dependency environment (no skips allowed)
+    integration_optional: tests that validate optional integrations or external tooling
     slow: marks tests as slow-running integration suites

--- a/scripts/report_optional_test_dependencies.py
+++ b/scripts/report_optional_test_dependencies.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Generate a dependency availability report for optional integration tests."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class DependencyStatus:
+    name: str
+    kind: str
+    required_by: str
+    available: bool
+    detail: str
+
+
+PYTHON_DEPS = {
+    "pyldpc": "LDPC/FEC integration tests",
+    "pyfinite": "fountain-code integration tests",
+    "bchlib": "BCH integration tests",
+    "raptorq": "RaptorQ integration tests",
+    "dnachisel": "DNA Chisel integration tests",
+    "chamaeleo": "Chamaeleo codec integration tests",
+    "deepdna": "DeepDNA codec integration tests",
+    "fastapi": "web API integration tests",
+    "fastapi_limiter": "web API limiter integration tests",
+    "httpx": "web API client integration tests",
+    "flet": "GUI integration tests",
+    "streamlit": "dashboard integration tests",
+    "playwright": "frontend browser integration tests",
+    "mpi4py": "MPI integration tests",
+    "cryptography": "security and signing integration tests",
+}
+
+EXECUTABLE_DEPS = {
+    "d2sim": "external simulator integration tests",
+    "dnarsim": "external simulator integration tests",
+    "squigulator": "external simulator integration tests",
+}
+
+
+def build_report() -> list[DependencyStatus]:
+    report: list[DependencyStatus] = []
+    for module, purpose in sorted(PYTHON_DEPS.items()):
+        spec = importlib.util.find_spec(module)
+        report.append(
+            DependencyStatus(
+                name=module,
+                kind="python-module",
+                required_by=purpose,
+                available=spec is not None,
+                detail="importable" if spec else "missing",
+            )
+        )
+    for exe, purpose in sorted(EXECUTABLE_DEPS.items()):
+        resolved = shutil.which(exe)
+        report.append(
+            DependencyStatus(
+                name=exe,
+                kind="executable",
+                required_by=purpose,
+                available=resolved is not None,
+                detail=resolved or "missing",
+            )
+        )
+    return report
+
+
+def render_markdown(rows: list[DependencyStatus]) -> str:
+    lines = [
+        "# Optional integration dependency report",
+        "",
+        "| Dependency | Kind | Required by | Available | Detail |",
+        "|---|---|---|---|---|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| `{row.name}` | {row.kind} | {row.required_by} | "
+            f"{'yes' if row.available else 'no'} | {row.detail} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        default="artifacts/optional-integration-dependency-report.md",
+        help="Path to write markdown dependency report.",
+    )
+    parser.add_argument(
+        "--json-output",
+        default="artifacts/optional-integration-dependency-report.json",
+        help="Path to write JSON dependency report.",
+    )
+    args = parser.parse_args()
+
+    rows = build_report()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_markdown(rows), encoding="utf-8")
+
+    json_path = Path(args.json_output)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps([asdict(row) for row in rows], indent=2), encoding="utf-8"
+    )
+
+    print(output_path.read_text(encoding="utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,89 @@ except Exception:  # pragma: no cover - import guard
     sys.modules.setdefault("jsonschema.exceptions", js_exc)
 
 
+OPTIONAL_INTEGRATION_HINTS = (
+    "pytest.importorskip(",
+    "shutil.which(",
+    "not _HAS_",
+    "@pytest.mark.skipif(",
+    "rapidfuzz",
+    "flet",
+    "streamlit",
+    "fastapi",
+    "playwright",
+    "mpi4py",
+    "dnachisel",
+    "chamaeleo",
+    "deepdna",
+    "raptorq",
+    "pyldpc",
+    "bchlib",
+    "pyfinite",
+)
+
+
+def _is_optional_integration_file(path: Path) -> bool:
+    if path.suffix != ".py" or not path.name.startswith("test_"):
+        return False
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return any(hint in content for hint in OPTIONAL_INTEGRATION_HINTS)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--test-tier",
+        action="store",
+        default="all",
+        choices=("all", "core", "integration"),
+        help="Select test tier: all (default), core, or integration.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "core: required tests for minimal environments; skips are not allowed in core CI",
+    )
+    config.addinivalue_line(
+        "markers",
+        "integration_optional: tests requiring optional dependencies or external tools",
+    )
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool:
+    tier = config.getoption("--test-tier")
+    if tier == "core" and _is_optional_integration_file(collection_path):
+        return True
+    return False
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    tier = config.getoption("--test-tier")
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+
+    for item in items:
+        item_path = Path(str(item.fspath))
+        if _is_optional_integration_file(item_path):
+            item.add_marker(pytest.mark.integration_optional)
+            is_optional = True
+        else:
+            item.add_marker(pytest.mark.core)
+            is_optional = False
+
+        if tier == "integration" and not is_optional:
+            deselected.append(item)
+        else:
+            selected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+
+
 from genecoder.sdk.plugins import Codec
 from genecoder.encoders import decode_base4_direct, encode_base4_direct
 from genecoder.formats import SequenceBatch


### PR DESCRIPTION
### Motivation
- Separate minimal, dependency-free tests from optional integration tests so core validation can run in a small environment while still exercising optional tooling when available.
- Ensure CI enforces that the `core` tier has no skipped tests while the `integration` tier can tolerate skips but records which external dependencies are missing.

### Description
- Register new pytest markers in `pytest.ini`: `core` and `integration_optional` to declare the two-tier contract at config level.
- Add tier-aware collection and automatic tagging in `tests/conftest.py` including a `--test-tier` option, heuristics to classify optional-integration test files, pre-import exclusion of optional modules in `core` mode, and automatic application of `@pytest.mark.core` / `@pytest.mark.integration_optional`.
- Add `scripts/report_optional_test_dependencies.py` which inspects Python modules and executables and writes a Markdown + JSON availability report for optional integration dependencies.
- Introduce a `test-tier-matrix` job in `.github/workflows/python-ci.yml` with a matrix over `tier: [core, integration]` where the `core` lane runs `pytest -m core --test-tier=core` and fails if any tests are skipped (via JUnit XML parsing), and the `integration` lane installs optional extras, runs `integration_optional` tests, and uploads the dependency report as an artifact.
- Document the two-tier testing profiles and reproducible commands in `docs/installation.md` and `docs/reproducibility.md`.

### Testing
- Ran `ruff check tests/conftest.py scripts/report_optional_test_dependencies.py` and it passed without issues.
- Ran `pytest -q tests/test_plugin_abc_validation.py --test-tier=core -m core` which passed (`3 passed`).
- Ran `pytest -q tests/test_raptorq_codec.py --test-tier=integration -m integration_optional` which executed the integration tier and reported skips for unavailable dependency (`2 skipped`).
- Executed `python scripts/report_optional_test_dependencies.py` which produced a Markdown report listing missing/available optional dependencies and printed a sample output successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0925385c832691c2a73450864a0f)