### PR TITLE
Refactor runtime orchestration boundaries and lock compat modules

### DIFF
--- a/docs/legacy_deprecation_matrix.md
+++ b/docs/legacy_deprecation_matrix.md
@@ -7,11 +7,21 @@ phase/KPI evidence required before removal.
 
 | Legacy module | Replacement path | Status | Removal phase (roadmap) | KPI/release evidence required before removal |
 | --- | --- | --- | --- | --- |
-| `genecoder.pipeline` | `genecoder.app.pipeline_runtime` + `genecoder.app.pipeline_use_case` | Compatibility shim only | Phase 2 completion gate | `decode_success_profile_x >= 0.95` and `reproducibility_pass_rate >= 0.99` across CI pipeline tests and release checklist artifacts. |
+| `genecoder.pipeline` | `genecoder.app.RunPipelineUseCase` (+ `genecoder.app.pipeline_runtime` internals) | Compatibility shim only | Phase 2 completion gate | `decode_success_profile_x >= 0.95` and `reproducibility_pass_rate >= 0.99` across CI pipeline tests and release checklist artifacts. |
 | `genecoder.api` | `genecoder.sdk.plugins` | Compatibility shim only | Phase 2 completion gate | No direct production imports outside approved adapters plus plugin interface tests green in release branch. |
 | `genecoder.channel_sim` | `genecoder.compat.channel_sim` (shim) + `genecoder.channel_engine` | Compatibility shim only | v0.15.0 removal window | Channel-equivalence tests green and runtime budget (`runtime_seconds_per_mb`) within roadmap threshold. |
 | `genecoder.error_simulation` | `genecoder.compat.error_simulation` (shim) + `genecoder.channel_engine` | Compatibility shim only | v0.15.0 removal window | Channel profile parity tests, reproducibility checks, and benchmark trend evidence attached to release decision. |
+| `genecoder.compat.channel_cli` | `genecoder.core` | Compatibility shim only | v0.17.0 removal window | CLI profile adaptation parity tests green and no non-compat imports of `genecoder.compat.channel_cli`. |
+| `genecoder.compat.legacy.sequence_pipeline` | `genecoder.app.sequence_pipeline` (deprecated helper) | Compatibility shim only | v0.17.0 removal window | Sequence pipeline compatibility tests green and orchestration docs point to `RunPipelineUseCase` as the canonical runtime entrypoint. |
 | `genecoder.simulation_engine.legacy_adapter` | `genecoder.simulation_engine.executors` and profile-driven execution | Migration in progress | Phase 3 hardening gate | Executor path coverage in CI and reproducibility KPI pass-rate maintained for rolling window. |
+
+## Deprecation removal schedule
+
+| Release | Planned action |
+| --- | --- |
+| `v0.16.x` | Freeze compatibility surfaces: no new runtime/product logic in `genecoder.compat.*`; all orchestration updates land in `genecoder.app.*` and `genecoder.core`. |
+| `v0.17.0` | Remove `genecoder.compat.channel_cli` and `genecoder.compat.legacy.sequence_pipeline` module bodies (keep only import stubs if patch-level grace period is needed). |
+| `v0.18.0` | Remove `genecoder.core.run_pipeline`/compat orchestration façades after migration to `RunPipelineUseCase` is complete. |
 
 ## Approved compatibility adapters
 

--- a/src/genecoder/app/pipeline_runtime.py
+++ b/src/genecoder/app/pipeline_runtime.py
@@ -18,7 +18,7 @@ ProfileParameterOverrides: TypeAlias = Mapping[str, ProfileParameterValue]
 
 __all__ = ["SequencePipeline", "run_pipeline", "ProfileParameterOverrides", "ProfileParameterValue"]
 
-from genecoder.compat.legacy import SequencePipeline
+from .sequence_pipeline import SequencePipeline
 
 
 def _flag_from_metadata(value: object) -> bool:

--- a/src/genecoder/app/sequence_pipeline.py
+++ b/src/genecoder/app/sequence_pipeline.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Legacy string-oriented sequence pipeline kept in application layer."""
+
+import warnings
+from typing import Callable, Iterable, Sequence
+
+from genecoder.parallel import parallel_map
+
+
+class SequencePipeline:
+    """Legacy string-based pipeline wrapper."""
+
+    def __init__(self, steps: Iterable[Callable[[str], str]] | None = None) -> None:
+        warnings.warn(
+            "SequencePipeline is deprecated; use genecoder.app.RunPipelineUseCase instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.steps: list[Callable[[str], str]] = list(steps or [])
+
+    def add_step(self, step: Callable[[str], str]) -> None:
+        self.steps.append(step)
+
+    def run(self, sequence: str) -> str:
+        for step in self.steps:
+            sequence = step(sequence)
+        return sequence
+
+    def run_batch(
+        self,
+        sequences: Sequence[str],
+        *,
+        parallel: bool = False,
+        workers: int | None = None,
+        use_processes: bool = False,
+    ) -> list[str]:
+        if parallel:
+            return parallel_map(
+                self.run,
+                sequences,
+                workers=workers,
+                use_processes=use_processes,
+            )
+        return [self.run(s) for s in sequences]

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -16,7 +16,7 @@ from genecoder.config.loader import load_mapping_file, validate_bundle_document
 from genecoder.core import encode, decode, inspect_coding_plan
 from genecoder.formats import SequenceBatch
 from genecoder.parallel import parallel_map
-from genecoder.pipeline import build_kpi_bundle
+from genecoder.results.schema import canonical_comparison_metrics, canonical_metrics_view, migrate_run_schema
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
@@ -52,6 +52,25 @@ from genecoder.app import (
 )
 
 RUN_PROFILE_VERSION = "2026.02"
+
+def build_kpi_bundle(run_schema: Mapping[str, Any], *, artifact_path: str | None = None) -> dict[str, Any]:
+    """Return the machine-readable KPI bundle for a canonical run artifact."""
+
+    canonical_run = migrate_run_schema(run_schema)
+    run_id = str(canonical_run.get("run_id") or "run")
+    metrics_view = canonical_metrics_view(canonical_run)
+    comparison = canonical_comparison_metrics(canonical_run)
+
+    bundle: dict[str, Any] = {
+        "schema_version": "1.0",
+        "source": "genecoder.cli.pipeline",
+        "run_id": run_id,
+        "kpis": {"comparison": comparison, "dashboard": metrics_view},
+    }
+    if artifact_path:
+        bundle["artifacts"] = {"run_schema": str(Path(artifact_path))}
+    return bundle
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/genecoder/compat/channel_cli.py
+++ b/src/genecoder/compat/channel_cli.py
@@ -1,55 +1,27 @@
 from __future__ import annotations
 
-from typing import Final
+"""Compatibility adapter for legacy channel CLI helpers."""
 
-MODERN_INDEL_PROFILES: Final[dict[str, dict[str, float]]] = {
-    "illumina": {
-        "substitution_prob": 0.002,
-        "insertion_prob": 0.0001,
-        "deletion_prob": 0.0001,
-    },
-    "nanopore": {
-        "substitution_prob": 0.01,
-        "insertion_prob": 0.02,
-        "deletion_prob": 0.02,
-    },
-}
+import warnings
 
-LEGACY_INDEL_PROFILE_ALIASES: Final[dict[str, str]] = {
-    "illumina_adapter": "illumina",
-    "nanopore_adapter": "nanopore",
-}
+from genecoder.core import (
+    LEGACY_DEFAULT_INDEL_PROFILE,
+    LEGACY_INDEL_PROFILE_ALIASES,
+    LEGACY_INDEL_PROFILE_NAMES,
+    MODERN_INDEL_PROFILES,
+    resolve_indel_profile,
+)
 
-LEGACY_INDEL_PROFILE_NAMES: Final[set[str]] = set(LEGACY_INDEL_PROFILE_ALIASES)
-LEGACY_DEFAULT_INDEL_PROFILE: Final[str] = "illumina_adapter"
+__all__ = [
+    "MODERN_INDEL_PROFILES",
+    "LEGACY_INDEL_PROFILE_ALIASES",
+    "LEGACY_INDEL_PROFILE_NAMES",
+    "LEGACY_DEFAULT_INDEL_PROFILE",
+    "resolve_indel_profile",
+]
 
-
-def resolve_indel_profile(
-    *,
-    requested_profile: str | None,
-    has_explicit_rates: bool,
-) -> tuple[str | None, list[str]]:
-    warnings: list[str] = []
-    profile = requested_profile
-    if profile is None and not has_explicit_rates:
-        profile = LEGACY_DEFAULT_INDEL_PROFILE
-        warnings.append(
-            "Using legacy implicit indel default profile; migrate to --simulator indel --indel-profile illumina."
-        )
-    if profile is None:
-        return None, warnings
-
-    lowered = profile.lower()
-    if lowered in LEGACY_INDEL_PROFILE_ALIASES:
-        warnings.append(
-            f"Legacy indel profile '{profile}' is deprecated; using '{LEGACY_INDEL_PROFILE_ALIASES[lowered]}' instead."
-        )
-        return LEGACY_INDEL_PROFILE_ALIASES[lowered], warnings
-    if lowered in MODERN_INDEL_PROFILES:
-        if requested_profile is not None:
-            warnings.append(
-                "--indel-profile is a compatibility flag and may be removed; prefer simulator config in workflow YAML."
-            )
-        return lowered, warnings
-    raise ValueError(f"Unknown indel profile: {profile}")
-
+warnings.warn(
+    "genecoder.compat.channel_cli is deprecated; import indel profile helpers from genecoder.core.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/sequence_pipeline.py
+++ b/src/genecoder/compat/legacy/sequence_pipeline.py
@@ -1,52 +1,15 @@
 from __future__ import annotations
 
-"""Legacy string-oriented pipeline shim.
-
-`SequencePipeline` remains available only for backwards compatibility with older
-integrations that built pipeline stages around plain strings.
-
-No new feature work should target this adapter. New orchestration must go
-through `genecoder.app.RunPipelineUseCase` and `genecoder.core.CanonicalRuntimeResult`.
-"""
+"""Compatibility shim for deprecated ``SequencePipeline`` import path."""
 
 import warnings
-from typing import Callable, Iterable, Sequence
 
-from genecoder.parallel import parallel_map
+from genecoder.app.sequence_pipeline import SequencePipeline
 
+__all__ = ["SequencePipeline"]
 
-class SequencePipeline:
-    """Legacy string-based pipeline wrapper."""
-
-    def __init__(self, steps: Iterable[Callable[[str], str]] | None = None) -> None:
-        warnings.warn(
-            "SequencePipeline is deprecated; use genecoder.app.RunPipelineUseCase instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.steps: list[Callable[[str], str]] = list(steps or [])
-
-    def add_step(self, step: Callable[[str], str]) -> None:
-        self.steps.append(step)
-
-    def run(self, sequence: str) -> str:
-        for step in self.steps:
-            sequence = step(sequence)
-        return sequence
-
-    def run_batch(
-        self,
-        sequences: Sequence[str],
-        *,
-        parallel: bool = False,
-        workers: int | None = None,
-        use_processes: bool = False,
-    ) -> list[str]:
-        if parallel:
-            return parallel_map(
-                self.run,
-                sequences,
-                workers=workers,
-                use_processes=use_processes,
-            )
-        return [self.run(s) for s in sequences]
+warnings.warn(
+    "genecoder.compat.legacy.sequence_pipeline is deprecated; import SequencePipeline from genecoder.app.sequence_pipeline.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -47,9 +47,65 @@ __all__ = [
     "run_pipeline",
     "compile_coding_stack",
     "inspect_coding_plan",
+    "MODERN_INDEL_PROFILES",
+    "LEGACY_INDEL_PROFILE_ALIASES",
+    "LEGACY_INDEL_PROFILE_NAMES",
+    "LEGACY_DEFAULT_INDEL_PROFILE",
+    "resolve_indel_profile",
 ]
 
 ORCHESTRATION_DEPRECATION_GATE = "v0.18.0"
+
+MODERN_INDEL_PROFILES: dict[str, dict[str, float]] = {
+    "illumina": {
+        "substitution_prob": 0.002,
+        "insertion_prob": 0.0001,
+        "deletion_prob": 0.0001,
+    },
+    "nanopore": {
+        "substitution_prob": 0.01,
+        "insertion_prob": 0.02,
+        "deletion_prob": 0.02,
+    },
+}
+
+LEGACY_INDEL_PROFILE_ALIASES: dict[str, str] = {
+    "illumina_adapter": "illumina",
+    "nanopore_adapter": "nanopore",
+}
+
+LEGACY_INDEL_PROFILE_NAMES: set[str] = set(LEGACY_INDEL_PROFILE_ALIASES)
+LEGACY_DEFAULT_INDEL_PROFILE: str = "illumina_adapter"
+
+
+def resolve_indel_profile(
+    *,
+    requested_profile: str | None,
+    has_explicit_rates: bool,
+) -> tuple[str | None, list[str]]:
+    profile_warnings: list[str] = []
+    profile = requested_profile
+    if profile is None and not has_explicit_rates:
+        profile = LEGACY_DEFAULT_INDEL_PROFILE
+        profile_warnings.append(
+            "Using legacy implicit indel default profile; migrate to --simulator indel --indel-profile illumina."
+        )
+    if profile is None:
+        return None, profile_warnings
+
+    lowered = profile.lower()
+    if lowered in LEGACY_INDEL_PROFILE_ALIASES:
+        profile_warnings.append(
+            f"Legacy indel profile '{profile}' is deprecated; using '{LEGACY_INDEL_PROFILE_ALIASES[lowered]}' instead."
+        )
+        return LEGACY_INDEL_PROFILE_ALIASES[lowered], profile_warnings
+    if lowered in MODERN_INDEL_PROFILES:
+        if requested_profile is not None:
+            profile_warnings.append(
+                "--indel-profile is a compatibility flag and may be removed; prefer simulator config in workflow YAML."
+            )
+        return lowered, profile_warnings
+    raise ValueError(f"Unknown indel profile: {profile}")
 
 
 def _warn_orchestration_deprecation(name: str) -> None:

--- a/src/genecoder/simulators/channel_cli_adapter.py
+++ b/src/genecoder/simulators/channel_cli_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Sequence
 
-from genecoder.compat.channel_cli import (
+from genecoder.core import (
     LEGACY_INDEL_PROFILE_NAMES,
     MODERN_INDEL_PROFILES,
     resolve_indel_profile,

--- a/tests/test_compat_import_boundaries.py
+++ b/tests/test_compat_import_boundaries.py
@@ -3,62 +3,73 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-SRC_ROOT = Path("src/genecoder")
+COMPAT_ROOT = Path("src/genecoder/compat")
 
-DEPRECATED_COMPAT_FACADES = {
-    "genecoder.compat",
-    "genecoder.compat.v1",
-    "genecoder.compat.channel_sim",
-    "genecoder.compat.error_simulation",
-}
 
-ALLOWED_IMPORTERS = {
-    "genecoder.channel_sim",
-    "genecoder.error_simulation",
-    "genecoder.pipeline",
-    "genecoder.api",
-    "genecoder.simulators.channel_cli_adapter",
-    "genecoder.cli.channel",
-    "genecoder.app.pipeline_runtime",
-    "genecoder.compat.v1.pipeline_adapter",
-    "genecoder.compat.v1.api_adapter",
-}
+def _is_docstring_expr(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _is_warning_call(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+        return False
+    func = node.value.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "warn"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "warnings"
+    )
+
+
+def _is_all_export_assignment(node: ast.stmt) -> bool:
+    if isinstance(node, ast.Assign):
+        return all(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets)
+    if isinstance(node, ast.AnnAssign):
+        return isinstance(node.target, ast.Name) and node.target.id == "__all__"
+    return False
 
 
 def _module_name(path: Path) -> str:
     return ".".join(path.relative_to("src").with_suffix("").parts)
 
 
-def _resolve_from(module: str, node: ast.ImportFrom) -> str | None:
-    if node.level == 0:
-        return node.module
-    parts = module.split(".")
-    anchor = parts[:-node.level]
-    if node.module:
-        anchor.extend(node.module.split("."))
-    return ".".join(anchor) if anchor else None
-
-
-def _imports_for(path: Path) -> set[str]:
-    module = _module_name(path)
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    imports: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imports.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom):
-            resolved = _resolve_from(module, node)
-            if resolved:
-                imports.add(resolved)
-    return imports
-
-
-def test_only_boundary_modules_import_compatibility_facades() -> None:
+def test_compat_modules_are_forwarders_only() -> None:
     violations: list[str] = []
-    for path in SRC_ROOT.rglob("*.py"):
+    for path in COMPAT_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            if _is_docstring_expr(node):
+                continue
+            if _is_warning_call(node):
+                continue
+            if _is_all_export_assignment(node):
+                continue
+            violations.append(f"{_module_name(path)}:{node.__class__.__name__}")
+    assert not violations, "\n".join(violations)
+
+
+def test_runtime_does_not_depend_on_compat_module_logic() -> None:
+    violations: list[str] = []
+    for path in Path("src/genecoder").rglob("*.py"):
+        if path.is_relative_to(COMPAT_ROOT):
+            continue
         module = _module_name(path)
-        imports = _imports_for(path)
-        bad = sorted(i for i in imports if i in DEPRECATED_COMPAT_FACADES)
-        if bad and module not in ALLOWED_IMPORTERS and not module.startswith("genecoder.compat"):
-            violations.append(f"{module} imports {bad}")
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                imports = [node.module] if node.module else []
+            else:
+                continue
+            if any(name and name.startswith("genecoder.compat") for name in imports):
+                violations.append(f"{module} imports {imports}")
+                break
     assert not violations, "\n".join(violations)


### PR DESCRIPTION
### Motivation
- Consolidate orchestration runtime into `genecoder.app.RunPipelineUseCase` and `genecoder.core` so compat shims contain no runtime logic.
- Ensure deprecated `genecoder.compat.*` modules are forwarding-only to make future removals safe and auditable.
- Add automated import-boundary checks and a published deprecation schedule to enforce the new import contract.

### Description
- Moved the legacy `SequencePipeline` implementation into the application layer at `src/genecoder/app/sequence_pipeline.py` and updated `src/genecoder/app/pipeline_runtime.py` to import it from there so orchestration logic lives outside compat shims.
- Centralized legacy indel-profile helpers into `genecoder.core` (`MODERN_INDEL_PROFILES`, `LEGACY_INDEL_PROFILE_ALIASES`, `LEGACY_DEFAULT_INDEL_PROFILE`, and `resolve_indel_profile`) and updated simulator adapters to import those canonical helpers instead of `genecoder.compat`.
- Reduced compat modules to forwarding + deprecation warnings only (`src/genecoder/compat/channel_cli.py`, `src/genecoder/compat/legacy/sequence_pipeline.py`) so they only re-export symbols and emit deprecation notices.
- Added `tests/test_compat_import_boundaries.py` to assert compat modules contain only imports/warnings/exports and that runtime code does not depend on `genecoder.compat.*`.
- Localized KPI bundle construction into `src/genecoder/cli/pipeline.py` to remove a direct CLI dependency on the deprecated `genecoder.pipeline` facade.
- Published an updated removal schedule in `docs/legacy_deprecation_matrix.md` documenting phase targets and gate criteria for deprecations.

### Testing
- Ran `ruff` on the changed files: `ruff check src/genecoder/core.py src/genecoder/cli/pipeline.py src/genecoder/app/sequence_pipeline.py src/genecoder/app/pipeline_runtime.py src/genecoder/compat/channel_cli.py src/genecoder/compat/legacy/sequence_pipeline.py src/genecoder/simulators/channel_cli_adapter.py tests/test_compat_import_boundaries.py` and it passed.
- Ran unit tests: `pytest -q tests/test_compat_import_boundaries.py tests/test_sequence_pipeline.py tests/test_cli_channel.py tests/test_architecture_boundaries.py`; most tests passed but one related to illumina profile parsing failed: `tests/test_cli_channel.py::test_cli_illumina_profile_path` (error: `illumina profile mappings must be versioned with schema_version/name/parameters`).
- The failing test appears pre-existing to this refactor surface and is noted for follow-up; import-boundary checks and the new compat tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0b3944d4832689c930162abb1e4c)