### PR TITLE
Create shared UI presentation contract and align adapter support tiers

### DIFF
--- a/docs/architecture_layers.md
+++ b/docs/architecture_layers.md
@@ -9,7 +9,7 @@ avoid long-term wrapper accumulation.
 | --- | --- | --- |
 | Domain | `genecoder.coding`, `genecoder.constraints`, `genecoder.simulators` | Core DNA coding, constraints, and channel/simulator behavior. |
 | Application | `genecoder.app` | Use-cases and orchestration contracts (`RunPipelineUseCase`, `EncodeUseCase`, `AnalyzeUseCase`) plus the headless UI boundary contract (`UIService`). |
-| Interfaces | `genecoder.cli`, `genecoder.dashboard`, `genecoder.dashboard_streamlit`, `genecoder.sdk` | User/program entry points that parse IO and call application services; primary maintained interfaces are CLI + React web, with Flet/Streamlit treated as optional adapters. |
+| Interfaces | `genecoder.cli`, `genecoder.dashboard`, `genecoder.dashboard_streamlit`, `genecoder.sdk` | User/program entry points that parse IO and call application services. All UI adapters must consume the shared presentation contract (`genecoder.app.ui_dto.UIPresentationPayload`) rather than bespoke metric parsing. |
 | Infrastructure | `genecoder.plugin_runtime`, `genecoder.*_adapter` modules | Plugin runtime, registry integration, and external-tool adapters. |
 | Compatibility | `genecoder.pipeline`, `genecoder.api`, `genecoder.channel_sim` | Legacy import shims only; no new behavior is allowed here. |
 
@@ -38,3 +38,16 @@ CI. They verify:
 These checks make architectural drift visible at review time and ensure that new
 integrations are implemented in the target layers instead of adding additional
 legacy wrappers.
+
+
+## UI support tiers
+
+- **Tier 1 (primary maintained UI): React web dashboard (`web/helix-ui`, served via FastAPI).**
+  - Full feature development and UX improvements happen here first.
+  - New UI-level capabilities must be implemented against `UIPresentationPayload`.
+- **Tier 2 (adapter maintenance mode): Flet and Streamlit adapters.**
+  - Scope is limited to parity on core run summary and oligo/constraint presentation via shared DTOs.
+  - No guarantee of immediate support for net-new interactive features beyond contract parity.
+  - Changes should prefer wiring existing `UIService`/DTO outputs over adding adapter-local logic.
+
+This tiering keeps one operator UI fully optimized while preserving reliable, low-drift fallback adapters.

--- a/src/genecoder/app/__init__.py
+++ b/src/genecoder/app/__init__.py
@@ -13,7 +13,13 @@ from .pipeline_use_case import (
     RunPipelineUseCase,
     SeedProfile,
 )
-from .ui_dto import UIMetricsSummary, UIRunRequest, UIRunResult
+from .ui_dto import (
+    UIConstraintLimits,
+    UIMetricsSummary,
+    UIPresentationPayload,
+    UIRunRequest,
+    UIRunResult,
+)
 
 __all__ = [
     "AnalyzeRequest",
@@ -35,4 +41,6 @@ __all__ = [
     "UIRunRequest",
     "UIRunResult",
     "UIMetricsSummary",
+    "UIConstraintLimits",
+    "UIPresentationPayload",
 ]

--- a/src/genecoder/app/ui_dto.py
+++ b/src/genecoder/app/ui_dto.py
@@ -3,6 +3,36 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+
+@dataclass(frozen=True)
+class UIConstraintLimits:
+    gc_min: float = 0.4
+    gc_max: float = 0.6
+    max_homopolymer: int = 8
+
+
+@dataclass(frozen=True)
+class UIPresentationPayload:
+    """Canonical UI payload used by all presentation adapters.
+
+    This DTO normalizes metric-derived fields that multiple frontends render,
+    so adapters (Flet/Streamlit/React) consume identical data semantics.
+    """
+
+    metrics: Mapping[str, Any]
+    constraint_limits: UIConstraintLimits
+    oligo_records: tuple[Mapping[str, Any], ...]
+
+    @classmethod
+    def from_metrics(cls, metrics: Mapping[str, Any]) -> "UIPresentationPayload":
+        limits = _constraint_limits(metrics)
+        records = _extract_oligo_records(metrics)
+        return cls(
+            metrics=dict(metrics),
+            constraint_limits=limits,
+            oligo_records=tuple(records),
+        )
+
 from .pipeline_use_case import (
     ArtifactOutputPolicy,
     BatchSweepMatrix,
@@ -92,3 +122,73 @@ class UIMetricsSummary:
             ),
             constraint_violations=violation_count,
         )
+
+
+def _parse_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(int(value))
+    if isinstance(value, str):
+        norm = value.strip().lower()
+        if norm in {"1", "true", "yes", "on"}:
+            return True
+    return False
+
+
+def _constraint_limits(metrics: Mapping[str, Any]) -> UIConstraintLimits:
+    gc_min = 0.4
+    gc_max = 0.6
+    max_hp = 8
+    violations = metrics.get("constraint_violations")
+    if isinstance(violations, Mapping):
+        limits = violations.get("limits")
+        if isinstance(limits, Mapping):
+            gc_min_val = limits.get("gc_min")
+            gc_max_val = limits.get("gc_max")
+            max_hp_val = limits.get("max_homopolymer")
+            if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
+                gc_min = float(gc_min_val)
+            if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
+                gc_max = float(gc_max_val)
+            if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
+                max_hp = int(max_hp_val)
+    return UIConstraintLimits(gc_min=gc_min, gc_max=gc_max, max_homopolymer=max_hp)
+
+
+def _extract_oligo_records(metrics: Mapping[str, Any]) -> list[dict[str, Any]]:
+    oligo = metrics.get("oligo_metrics")
+    if not isinstance(oligo, Mapping):
+        return []
+    gc_vals = [float(v) for v in oligo.get("gc_percentages", []) if isinstance(v, (int, float))]
+    hp_vals = [float(v) for v in oligo.get("max_homopolymers", []) if isinstance(v, (int, float))]
+    dropout_flags = [_parse_bool(v) for v in oligo.get("dropout_flags", [])]
+
+    ecc_map: dict[str, list[float]] = {}
+    ecc = oligo.get("ecc_success")
+    if isinstance(ecc, Mapping):
+        for name, values in ecc.items():
+            if isinstance(values, list):
+                filtered = [float(v) for v in values if isinstance(v, (int, float, bool))]
+                if filtered:
+                    ecc_map[str(name)] = [float(v) if not isinstance(v, bool) else (1.0 if v else 0.0) for v in filtered]
+
+    base_lengths = [len(gc_vals), len(hp_vals), len(dropout_flags)]
+    max_len = max(base_lengths + [len(v) for v in ecc_map.values()]) if (base_lengths or ecc_map) else 0
+    if max_len == 0:
+        return []
+
+    records: list[dict[str, Any]] = []
+    for idx in range(max_len):
+        record: dict[str, Any] = {"Index": idx + 1}
+        if idx < len(gc_vals):
+            record["GC%"] = gc_vals[idx]
+        if idx < len(hp_vals):
+            record["Max Homopolymer"] = hp_vals[idx]
+        if idx < len(dropout_flags):
+            record["Dropout"] = dropout_flags[idx]
+        for name, values in ecc_map.items():
+            if idx < len(values):
+                record[f"ECC:{name}"] = values[idx]
+        records.append(record)
+    return records

--- a/src/genecoder/app/ui_service.py
+++ b/src/genecoder/app/ui_service.py
@@ -14,7 +14,7 @@ from genecoder.results.schema import compare_runs, load_run_schema, canonical_me
 from genecoder.profiles.registry import available_profiles
 
 from .pipeline_use_case import RunPipelineRequest, RunPipelineResponse, RunPipelineUseCase
-from .ui_dto import UIMetricsSummary, UIRunRequest, UIRunResult
+from .ui_dto import UIMetricsSummary, UIPresentationPayload, UIRunRequest, UIRunResult
 
 
 @dataclass(frozen=True)
@@ -39,6 +39,9 @@ class UIService:
 
     def summarize_metrics(self, metrics: Mapping[str, Any]) -> UIMetricsSummary:
         return UIMetricsSummary.from_metrics(metrics)
+
+    def build_presentation_payload(self, metrics: Mapping[str, Any]) -> UIPresentationPayload:
+        return UIPresentationPayload.from_metrics(metrics)
 
     def run_encode(self, input_data: bytes, options: EncodeOptions) -> EncodeResult:
         return perform_encoding(input_data, options)

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -16,6 +16,7 @@ from typing import IO, Any, Iterable, Callable, cast
 from .bool_parsing import parse_bool_like
 from .results.schema import canonical_metrics_view, require_canonical_run_fields
 from .app.ui_service import UIService
+from .app.ui_dto import UIPresentationPayload
 from types import ModuleType
 
 try:  # pragma: no cover - optional dependency for tests
@@ -176,73 +177,12 @@ def _split_error_metric(val: object) -> tuple[float | None, list[int]]:
 
 
 def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
-    oligo = data.get("oligo_metrics")
-    if not isinstance(oligo, dict):
-        return []
-    gc_vals = [
-        float(v) for v in oligo.get("gc_percentages", []) if isinstance(v, (int, float))
-    ]
-    hp_vals = [
-        float(v) for v in oligo.get("max_homopolymers", []) if isinstance(v, (int, float))
-    ]
-    dropout_flags = [_parse_bool(v) for v in oligo.get("dropout_flags", [])]
-    ecc = oligo.get("ecc_success")
-    ecc_map: dict[str, list[float]] = {}
-    if isinstance(ecc, dict):
-        for name, values in ecc.items():
-            if isinstance(values, list):
-                filtered = [
-                    float(val)
-                    for val in values
-                    if isinstance(val, (int, float)) or isinstance(val, bool)
-                ]
-                if filtered:
-                    ecc_map[str(name)] = [
-                        float(val) if not isinstance(val, bool) else (1.0 if val else 0.0)
-                        for val in filtered
-                    ]
-
-    base_lengths = [len(gc_vals), len(hp_vals), len(dropout_flags)]
-    extra_lengths = [len(values) for values in ecc_map.values()]
-    max_len = max(base_lengths + extra_lengths) if base_lengths or extra_lengths else 0
-    if max_len == 0:
-        return []
-
-    records: list[dict[str, Any]] = []
-    for idx in range(max_len):
-        record: dict[str, Any] = {"Index": idx + 1}
-        if idx < len(gc_vals):
-            record["GC%"] = gc_vals[idx]
-        if idx < len(hp_vals):
-            record["Max Homopolymer"] = hp_vals[idx]
-        if idx < len(dropout_flags):
-            record["Dropout"] = dropout_flags[idx]
-        for name, values in ecc_map.items():
-            if idx < len(values):
-                record[f"ECC:{name}"] = values[idx]
-        records.append(record)
-    return records
+    return [dict(record) for record in UIPresentationPayload.from_metrics(data).oligo_records]
 
 
 def _constraint_limits(data: dict[str, Any]) -> tuple[float, float, int]:
-    gc_min = _DEFAULT_GC_MIN
-    gc_max = _DEFAULT_GC_MAX
-    max_hp = _DEFAULT_MAX_HOMOPOLYMER
-
-    violations = data.get("constraint_violations")
-    if isinstance(violations, dict):
-        limits = violations.get("limits")
-        if isinstance(limits, dict):
-            gc_min_val = limits.get("gc_min")
-            gc_max_val = limits.get("gc_max")
-            max_hp_val = limits.get("max_homopolymer")
-            if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
-                gc_min = float(gc_min_val)
-            if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
-                gc_max = float(gc_max_val)
-            if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
-                max_hp = int(max_hp_val)
-    return gc_min, gc_max, max_hp
+    limits = UIPresentationPayload.from_metrics(data).constraint_limits
+    return limits.gc_min, limits.gc_max, limits.max_homopolymer
 
 
 def _parse_constraint_violations(value: object) -> dict[str, Any]:

--- a/src/genecoder/dashboard_streamlit.py
+++ b/src/genecoder/dashboard_streamlit.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable, IO, cast
 from types import ModuleType
 
 from .results.schema import canonical_metrics_view, load_run_schema, require_canonical_run_fields
+from .app.ui_dto import UIPresentationPayload
 
 try:  # pragma: no cover - optional dependency
     import streamlit as _st
@@ -142,79 +143,12 @@ def _coverage_value(data: dict[str, Any]) -> float | None:
 
 
 def _constraint_limits(data: dict[str, Any]) -> tuple[float, float, int]:
-    gc_min = _DEFAULT_GC_MIN
-    gc_max = _DEFAULT_GC_MAX
-    max_hp = _DEFAULT_MAX_HOMOPOLYMER
-
-    violations = data.get("constraint_violations")
-    if isinstance(violations, dict):
-        limits = violations.get("limits")
-        if isinstance(limits, dict):
-            gc_min_val = limits.get("gc_min")
-            gc_max_val = limits.get("gc_max")
-            max_hp_val = limits.get("max_homopolymer")
-            if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
-                gc_min = float(gc_min_val)
-            if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
-                gc_max = float(gc_max_val)
-            if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
-                max_hp = int(max_hp_val)
-    return gc_min, gc_max, max_hp
+    limits = UIPresentationPayload.from_metrics(data).constraint_limits
+    return limits.gc_min, limits.gc_max, limits.max_homopolymer
 
 
 def _extract_oligo_records(data: dict[str, Any]) -> list[dict[str, Any]]:
-    oligo = data.get("oligo_metrics")
-    if not isinstance(oligo, dict):
-        return []
-    gc_vals = [
-        float(v) for v in oligo.get("gc_percentages", []) if isinstance(v, (int, float))
-    ]
-    hp_vals = [
-        float(v) for v in oligo.get("max_homopolymers", []) if isinstance(v, (int, float))
-    ]
-    dropout_flags = [
-        bool(v) if isinstance(v, bool) else bool(int(v))
-        for v in oligo.get("dropout_flags", [])
-    ]
-    ecc = oligo.get("ecc_success")
-    ecc_map: dict[str, list[float]] = {}
-    if isinstance(ecc, dict):
-        for name, values in ecc.items():
-            if isinstance(values, list):
-                filtered = [
-                    float(val)
-                    for val in values
-                    if isinstance(val, (int, float)) or isinstance(val, bool)
-                ]
-                if filtered:
-                    ecc_map[str(name)] = [
-                        float(val) if not isinstance(val, bool) else (1.0 if val else 0.0)
-                        for val in filtered
-                    ]
-
-    max_len = max(
-        [len(gc_vals), len(hp_vals), len(dropout_flags)]
-        + [len(values) for values in ecc_map.values()] 
-        if ecc_map
-        else [len(gc_vals), len(hp_vals), len(dropout_flags)]
-    )
-    if max_len == 0:
-        return []
-
-    records: list[dict[str, Any]] = []
-    for idx in range(max_len):
-        record: dict[str, Any] = {"Index": idx + 1}
-        if idx < len(gc_vals):
-            record["GC%"] = gc_vals[idx]
-        if idx < len(hp_vals):
-            record["Max Homopolymer"] = hp_vals[idx]
-        if idx < len(dropout_flags):
-            record["Dropout"] = dropout_flags[idx]
-        for name, values in ecc_map.items():
-            if idx < len(values):
-                record[f"ECC:{name}"] = values[idx]
-        records.append(record)
-    return records
+    return [dict(record) for record in UIPresentationPayload.from_metrics(data).oligo_records]
 
 
 def _plotting_status() -> tuple[bool, list[str]]:

--- a/src/genecoder/flet_handlers.py
+++ b/src/genecoder/flet_handlers.py
@@ -32,6 +32,7 @@ from .plotting import (
 )
 from .app_helpers import EncodeResult
 from .app.ui_service import UIService
+from .app.ui_dto import UIPresentationPayload
 from .flet_ws import ws_clients
 
 logger = logging.getLogger(__name__)
@@ -50,22 +51,6 @@ _LAST_CONSTRAINT_LIMITS: tuple[float, float, int] = (
 
 
 def _constraint_limits_from_payload(payload: object) -> tuple[float, float, int]:
-    gc_min = _DEFAULT_GC_MIN
-    gc_max = _DEFAULT_GC_MAX
-    max_hp = _DEFAULT_MAX_HOMOPOLYMER
-
-    def apply_limits(limits: dict[str, object]) -> None:
-        nonlocal gc_min, gc_max, max_hp
-        gc_min_val = limits.get("gc_min")
-        gc_max_val = limits.get("gc_max")
-        max_hp_val = limits.get("max_homopolymer")
-        if isinstance(gc_min_val, (int, float)) and not isinstance(gc_min_val, bool):
-            gc_min = float(gc_min_val)
-        if isinstance(gc_max_val, (int, float)) and not isinstance(gc_max_val, bool):
-            gc_max = float(gc_max_val)
-        if isinstance(max_hp_val, (int, float)) and not isinstance(max_hp_val, bool):
-            max_hp = int(max_hp_val)
-
     metrics: dict[str, object] | None = None
     if isinstance(payload, str):
         try:
@@ -79,13 +64,8 @@ def _constraint_limits_from_payload(payload: object) -> tuple[float, float, int]
             metrics = payload["metrics"]
         else:
             metrics = payload
-    if isinstance(metrics, dict):
-        violations = metrics.get("constraint_violations")
-        if isinstance(violations, dict):
-            limits = violations.get("limits")
-            if isinstance(limits, dict):
-                apply_limits(limits)
-    return gc_min, gc_max, max_hp
+    limits = UIPresentationPayload.from_metrics(metrics or {}).constraint_limits
+    return limits.gc_min, limits.gc_max, limits.max_homopolymer
 
 
 def make_encode_handler(

--- a/tests/test_ui_presentation_contract.py
+++ b/tests/test_ui_presentation_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from genecoder.app.ui_dto import UIPresentationPayload
+from genecoder import dashboard, dashboard_streamlit
+import pytest
+
+flet_handlers = pytest.importorskip("genecoder.flet_handlers")
+
+
+def _sample_metrics() -> dict[str, object]:
+    return {
+        "constraint_violations": {"limits": {"gc_min": 0.45, "gc_max": 0.55, "max_homopolymer": 5}},
+        "oligo_metrics": {
+            "gc_percentages": [0.4, 0.5],
+            "max_homopolymers": [4, 6],
+            "dropout_flags": [0, 1],
+            "ecc_success": {"rs": [1.0, 0.5]},
+        },
+    }
+
+
+def test_flet_streamlit_dashboard_use_identical_presentation_payload() -> None:
+    metrics = _sample_metrics()
+    payload = UIPresentationPayload.from_metrics(metrics)
+
+    assert dashboard._extract_oligo_records(metrics) == [dict(r) for r in payload.oligo_records]
+    assert dashboard_streamlit._extract_oligo_records(metrics) == [dict(r) for r in payload.oligo_records]
+    assert flet_handlers._constraint_limits_from_payload(metrics) == (
+        payload.constraint_limits.gc_min,
+        payload.constraint_limits.gc_max,
+        payload.constraint_limits.max_homopolymer,
+    )
+    assert dashboard._constraint_limits(metrics) == (
+        payload.constraint_limits.gc_min,
+        payload.constraint_limits.gc_max,
+        payload.constraint_limits.max_homopolymer,
+    )
+    assert dashboard_streamlit._constraint_limits(metrics) == (
+        payload.constraint_limits.gc_min,
+        payload.constraint_limits.gc_max,
+        payload.constraint_limits.max_homopolymer,
+    )

--- a/web/helix-ui/src/Dashboard.jsx
+++ b/web/helix-ui/src/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import HeatmapLoader from './HeatmapLoader.jsx';
-import { toLegacyMetrics, toRunSchema } from './runSchema.js';
+import { presentationPayloadFromMetrics, toLegacyMetrics, toRunSchema } from './runSchema.js';
 
 export default function Dashboard() {
   const [sequence, setSequence] = useState('ACGT');
@@ -59,38 +59,41 @@ export default function Dashboard() {
           <p>Max Homopolymer: {metrics.max_homopolymer ?? 'n/a'}</p>
           <p>Error Rate: {typeof metrics.error_rate === 'number' ? (metrics.error_rate * 100).toFixed(2) : 'n/a'}%</p>
           {metrics.plot && <img src={`data:image/png;base64,${metrics.plot}`} style={{ maxWidth: '100%' }} />}
-          {metrics.oligo_metrics && metrics.oligo_metrics.gc_percentages?.length > 0 && (
-            <div>
-              <h3>Per-oligo metrics</h3>
-              <ul>
-                {metrics.oligo_metrics.gc_percentages.map((gcVal, idx) => {
-                  const hp = metrics.oligo_metrics.max_homopolymers?.[idx];
-                  const drop = metrics.oligo_metrics.dropout_flags?.[idx];
-                  const ecc = metrics.oligo_metrics.ecc_success || {};
-                  const eccSummary = Object.entries(ecc)
-                    .map(([name, values]) => {
-                      const v = Array.isArray(values) ? values[idx] : undefined;
-                      return `${name}: ${v !== undefined ? (v * 100).toFixed(1) + '% success' : 'n/a'}`;
-                    })
-                    .join(' | ');
-                  const outOfBounds =
-                    (typeof gcVal === 'number' && (gcVal < 0.4 || gcVal > 0.6)) ||
-                    (typeof hp === 'number' && hp > 8) ||
-                    Boolean(drop);
-                  const tooltip = `HP=${hp ?? 'n/a'} | Dropout=${drop ? 'yes' : 'no'} | ${eccSummary}`;
-                  return (
-                    <li
-                      key={idx}
-                      title={tooltip}
-                      style={{ color: outOfBounds ? '#d32f2f' : 'inherit', fontWeight: outOfBounds ? '600' : '400' }}
-                    >
-                      Oligo {idx + 1}: {(gcVal * 100).toFixed(2)}%
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
+          {(() => {
+            const payload = presentationPayloadFromMetrics(metrics);
+            if (!payload.oligo_records.length) return null;
+            return (
+              <div>
+                <h3>Per-oligo metrics</h3>
+                <ul>
+                  {payload.oligo_records.map((record) => {
+                    const idx = record.Index - 1;
+                    const gcVal = record['GC%'];
+                    const hp = record['Max Homopolymer'];
+                    const drop = record.Dropout;
+                    const eccSummary = Object.entries(record)
+                      .filter(([k]) => k.startsWith('ECC:'))
+                      .map(([k, v]) => `${k.slice(4)}: ${typeof v === 'number' ? (v * 100).toFixed(1) + '% success' : 'n/a'}`)
+                      .join(' | ');
+                    const outOfBounds =
+                      (typeof gcVal === 'number' && (gcVal < payload.constraint_limits.gc_min || gcVal > payload.constraint_limits.gc_max)) ||
+                      (typeof hp === 'number' && hp > payload.constraint_limits.max_homopolymer) ||
+                      Boolean(drop);
+                    const tooltip = `HP=${hp ?? 'n/a'} | Dropout=${drop ? 'yes' : 'no'} | ${eccSummary}`;
+                    return (
+                      <li
+                        key={idx}
+                        title={tooltip}
+                        style={{ color: outOfBounds ? '#d32f2f' : 'inherit', fontWeight: outOfBounds ? '600' : '400' }}
+                      >
+                        Oligo {idx + 1}: {typeof gcVal === 'number' ? (gcVal * 100).toFixed(2) : 'n/a'}%
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })()}
           </>); })()}
           <HeatmapLoader sequence={sequence} />
           {deepdna && (

--- a/web/helix-ui/src/runSchema.contract.test.jsx
+++ b/web/helix-ui/src/runSchema.contract.test.jsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { presentationPayloadFromMetrics } from './runSchema.js';
+
+describe('presentationPayloadFromMetrics contract', () => {
+  it('normalizes limits and oligo records for shared UI rendering', () => {
+    const metrics = {
+      constraint_violations: { limits: { gc_min: 0.45, gc_max: 0.55, max_homopolymer: 5 } },
+      oligo_metrics: {
+        gc_percentages: [0.4, 0.5],
+        max_homopolymers: [4, 6],
+        dropout_flags: [0, 1],
+        ecc_success: { rs: [1.0, 0.5] },
+      },
+    };
+
+    const payload = presentationPayloadFromMetrics(metrics);
+
+    expect(payload.constraint_limits).toEqual({ gc_min: 0.45, gc_max: 0.55, max_homopolymer: 5 });
+    expect(payload.oligo_records).toEqual([
+      { Index: 1, 'GC%': 0.4, 'Max Homopolymer': 4, Dropout: false, 'ECC:rs': 1.0 },
+      { Index: 2, 'GC%': 0.5, 'Max Homopolymer': 6, Dropout: true, 'ECC:rs': 0.5 },
+    ]);
+  });
+});

--- a/web/helix-ui/src/runSchema.js
+++ b/web/helix-ui/src/runSchema.js
@@ -86,3 +86,52 @@ export function toLegacyMetrics(input) {
   if (metrics.max_homopolymer === undefined) metrics.max_homopolymer = run.outcome?.homopolymer_stress;
   return metrics;
 }
+
+
+const parseBool = (value) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number(value) !== 0;
+  if (typeof value === 'string') return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+  return false;
+};
+
+export function presentationPayloadFromMetrics(metrics = {}) {
+  const violations = metrics?.constraint_violations;
+  const limits = (violations && typeof violations === 'object' && violations.limits && typeof violations.limits === 'object')
+    ? violations.limits
+    : {};
+  const constraint_limits = {
+    gc_min: Number.isFinite(Number(limits.gc_min)) ? Number(limits.gc_min) : 0.4,
+    gc_max: Number.isFinite(Number(limits.gc_max)) ? Number(limits.gc_max) : 0.6,
+    max_homopolymer: Number.isFinite(Number(limits.max_homopolymer)) ? Number(limits.max_homopolymer) : 8,
+  };
+
+  const oligo = metrics?.oligo_metrics && typeof metrics.oligo_metrics === 'object' ? metrics.oligo_metrics : {};
+  const gc = Array.isArray(oligo.gc_percentages) ? oligo.gc_percentages.filter((v) => typeof v === 'number').map(Number) : [];
+  const hp = Array.isArray(oligo.max_homopolymers) ? oligo.max_homopolymers.filter((v) => typeof v === 'number').map(Number) : [];
+  const dropout = Array.isArray(oligo.dropout_flags) ? oligo.dropout_flags.map(parseBool) : [];
+
+  const ecc = {};
+  if (oligo.ecc_success && typeof oligo.ecc_success === 'object') {
+    Object.entries(oligo.ecc_success).forEach(([name, values]) => {
+      if (Array.isArray(values)) {
+        const filtered = values.filter((v) => typeof v === 'number' || typeof v === 'boolean').map((v) => (typeof v === 'boolean' ? (v ? 1 : 0) : Number(v)));
+        if (filtered.length) ecc[name] = filtered;
+      }
+    });
+  }
+
+  const maxLen = Math.max(gc.length, hp.length, dropout.length, ...Object.values(ecc).map((vals) => vals.length), 0);
+  const oligo_records = Array.from({ length: maxLen }, (_, idx) => {
+    const row = { Index: idx + 1 };
+    if (idx < gc.length) row['GC%'] = gc[idx];
+    if (idx < hp.length) row['Max Homopolymer'] = hp[idx];
+    if (idx < dropout.length) row.Dropout = dropout[idx];
+    Object.entries(ecc).forEach(([name, vals]) => {
+      if (idx < vals.length) row[`ECC:${name}`] = vals[idx];
+    });
+    return row;
+  });
+
+  return { metrics, constraint_limits, oligo_records };
+}


### PR DESCRIPTION
### Motivation
- Ensure all presentation UIs render identical semantics from pipeline metrics by centralizing normalization of limits and per-oligo records. 
- Reduce duplicate parsing logic across Flet, Streamlit and React adapters to prevent drift and ease maintenance. 
- Designate a single primary UI for full feature work while keeping other adapters in a parity-focused maintenance mode. 

### Description
- Add a shared presentation DTO and helpers in `src/genecoder/app/ui_dto.py`: `UIConstraintLimits` and `UIPresentationPayload` with normalization of constraint limits, dropout parsing and oligo record extraction. 
- Expose the DTO via the app boundary by adding `UIService.build_presentation_payload()` and exporting the new types in `src/genecoder/app/__init__.py`. 
- Refactor Python adapters to use the DTO: `src/genecoder/dashboard.py`, `src/genecoder/dashboard_streamlit.py`, and `src/genecoder/flet_handlers.py` now delegate oligo/limit parsing to `UIPresentationPayload`. 
- Update the React frontend with `presentationPayloadFromMetrics()` in `web/helix-ui/src/runSchema.js` and wire `web/helix-ui/src/Dashboard.jsx` to render from that payload. 
- Add cross-adapter contract tests: `tests/test_ui_presentation_contract.py` (Python) and `web/helix-ui/src/runSchema.contract.test.jsx` (Vitest/React), and update docs in `docs/architecture_layers.md` to codify UI support tiers (React = Tier 1, Flet/Streamlit = Tier 2). 

### Testing
- Ran `ruff` on the changed Python files and the check passed for the files touched. 
- Ran `pytest` for the new contract and dashboard-related suites (`tests/test_ui_presentation_contract.py`, `tests/test_dashboard.py`, `tests/test_dashboard_streamlit.py`, `tests/test_flet_handlers.py`) and they passed with expected skips when optional `flet`/`streamlit` deps were unavailable. 
- Ran the React unit test with `npm test -- --run src/runSchema.contract.test.jsx` in `web/helix-ui` and it passed. 
- Ran `mypy` which surfaced pre-existing, repository-wide typing issues unrelated to the UI contract changes (these typing errors were not introduced by this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee7e164288326aadecb9783689702)