### PR TITLE
Add reproducibility report generator, canonical config, CLI flags and CI validator

### DIFF
--- a/configs/reproducibility.yaml
+++ b/configs/reproducibility.yaml
@@ -1,0 +1,40 @@
+version: 1
+required_artifacts:
+  bundle_run:
+    - summary.json
+    - sequence_batches.json
+    - decoded/*.json
+    - decoded/*.kpi.json
+  bundle_sweep:
+    - manifest_index.json
+    - reproducibility_report.json
+comparison:
+  deterministic_expectations:
+    decode_success:
+      type: equals
+      value: true
+  tolerances:
+    ber:
+      mode: absolute
+      max_delta: 0.0
+    dropout_rate:
+      mode: absolute
+      max_delta: 0.0
+    gc_stress:
+      mode: absolute
+      max_delta: 0.0
+    homopolymer_stress:
+      mode: absolute
+      max_delta: 0.0
+    runtime_total_seconds:
+      mode: relative
+      max_delta: 0.25
+    runtime_encode_seconds:
+      mode: relative
+      max_delta: 0.25
+    runtime_simulate_seconds:
+      mode: relative
+      max_delta: 0.25
+    runtime_decode_seconds:
+      mode: relative
+      max_delta: 0.25

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -148,3 +148,49 @@ poetry run pytest -m integration_optional --test-tier=integration -rs -q
 
 Keeping these commands and dependency profiles pinned in automation makes test
 outcomes easier to compare across machines and over time.
+
+
+## Required reproducibility artifact set (strict)
+
+GeneCoder now defines the canonical reproducibility contract in
+`configs/reproducibility.yaml`.
+
+Required artifacts are validated by `scripts/validate_reproducibility_artifacts.py`.
+
+- **Bundle run (`bundle_run`)**
+  - `summary.json`
+  - `sequence_batches.json`
+  - `decoded/*.json`
+  - `decoded/*.kpi.json`
+- **Bundle sweep (`bundle_sweep`)**
+  - `manifest_index.json`
+  - `reproducibility_report.json`
+
+Generate reports during execution:
+
+```bash
+genecli pipeline input.bin decoded.bin --codec reverse --channel none --seed 42 --emit-repro-report
+genecli bundle run configs/gold.yaml --cache-dir runs --emit-repro-report
+genecli bundle sweep configs/*.yaml --cache-dir runs --emit-repro-report
+```
+
+Validate artifacts and tolerances in CI:
+
+```bash
+python scripts/validate_reproducibility_artifacts.py --artifact-root runs --mode bundle_sweep
+```
+
+## Reproducibility report interpretation
+
+The generated report (`*.repro.json` for pipeline, `reproducibility_report.json`
+for bundles) compares runs grouped by the same **simulation profile + global
+seed** and enforces deterministic/tolerance checks from
+`configs/reproducibility.yaml`.
+
+- `summary.pass=true`: all deterministic expectations and tolerance gates passed.
+- `summary.tolerance_violations>0`: one or more metrics drifted beyond configured
+  limits.
+- `summary.deterministic_violations>0`: one or more deterministic expectations
+  (for example `decode_success == true`) were violated.
+- `comparisons[].metric_checks[]`: per-metric baseline/candidate values and
+  whether each check stayed within tolerance.

--- a/scripts/validate_reproducibility_artifacts.py
+++ b/scripts/validate_reproducibility_artifacts.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from genecoder.results.repro_report import load_reproducibility_config
+
+
+def _required_for_mode(config: Mapping[str, Any], mode: str) -> list[str]:
+    required = config.get("required_artifacts")
+    if not isinstance(required, Mapping):
+        return []
+    entries = required.get(mode)
+    if not isinstance(entries, list):
+        return []
+    return [str(item) for item in entries]
+
+
+def _missing_patterns(root: Path, patterns: list[str]) -> list[str]:
+    missing: list[str] = []
+    for pattern in patterns:
+        matches = list(root.glob(pattern))
+        if not matches:
+            missing.append(pattern)
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate reproducibility artifacts and tolerance outcomes"
+    )
+    parser.add_argument(
+        "--artifact-root", type=Path, required=True, help="Bundle run/sweep directory"
+    )
+    parser.add_argument(
+        "--mode", choices=["bundle_run", "bundle_sweep"], default="bundle_sweep"
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=None,
+        help="Path to reproducibility report JSON (defaults to <artifact-root>/reproducibility_report.json)",
+    )
+    parser.add_argument(
+        "--config", type=Path, default=None, help="Override reproducibility config path"
+    )
+    args = parser.parse_args()
+
+    config = load_reproducibility_config(args.config)
+    required = _required_for_mode(config, args.mode)
+    missing = _missing_patterns(args.artifact_root, required)
+    if missing:
+        raise SystemExit(f"Missing reproducibility artifacts: {', '.join(missing)}")
+
+    report_path = args.report_path or (
+        args.artifact_root / "reproducibility_report.json"
+    )
+    if not report_path.exists():
+        raise SystemExit(f"Reproducibility report not found: {report_path}")
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    summary = (
+        report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    )
+    if not bool(summary.get("pass", False)):
+        tol = summary.get("tolerance_violations", 0)
+        det = summary.get("deterministic_violations", 0)
+        raise SystemExit(
+            f"Reproducibility validation failed: tolerance_violations={tol}, deterministic_violations={det}"
+        )
+
+    print("Reproducibility artifacts validated successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping, Sequence, cast
 
 import importlib.util
 
+
 def _has_jsonschema() -> bool:
     try:
         return importlib.util.find_spec("jsonschema") is not None
@@ -29,6 +30,7 @@ if _HAS_JSONSCHEMA:
     from jsonschema import Draft202012Validator, ValidationError
     from jsonschema.exceptions import best_match
 else:  # pragma: no cover - used when jsonschema is unavailable
+
     class ValidationError(Exception):
         """Fallback validation error when jsonschema is unavailable."""
 
@@ -44,6 +46,7 @@ else:  # pragma: no cover - used when jsonschema is unavailable
     def best_match(_errors: Sequence[ValidationError] | None) -> ValidationError | None:
         return None
 
+
 from . import cli as cli_module
 from genecoder.formats import SequenceBatch
 from genecoder.html_report import generate_html_report
@@ -57,6 +60,7 @@ from genecoder.synthesis import SynthesisConstraints
 from genecoder.constraints import load_constraint_policy
 from genecoder.profiles.registry import canonicalize_profile_name
 from genecoder.app import ArtifactOutputPolicy, RunPipelineRequest, RunPipelineUseCase
+from genecoder.results.repro_report import generate_reproducibility_report
 
 
 @dataclass
@@ -76,7 +80,9 @@ class ChannelArgs:
     threads: int | None = None
     processes: int | None = None
 
+
 logger = logging.getLogger(__name__)
+
 
 def _effective_fec(enc_cfg: Mapping[str, object] | None) -> str | None:
     if not isinstance(enc_cfg, Mapping):
@@ -94,6 +100,7 @@ def _effective_fec(enc_cfg: Mapping[str, object] | None) -> str | None:
             if layer_type == "fec" and isinstance(layer_name, str) and layer_name:
                 return layer_name
     return None
+
 
 def _parse_int(value: object) -> int | None:
     try:
@@ -130,7 +137,11 @@ def _augment_schema(schema: dict[str, Any]) -> dict[str, Any]:
     fec_choices = set(FEC_REGISTRY.keys()) | {"triple_repeat", "hamming_7_4"}
     fec_prop = defs.get("encode", {}).get("properties", {}).get("fec")
     if isinstance(fec_prop, dict):
-        existing = set(fec_prop.get("enum", [])) if isinstance(fec_prop.get("enum"), list) else set()
+        existing = (
+            set(fec_prop.get("enum", []))
+            if isinstance(fec_prop.get("enum"), list)
+            else set()
+        )
         values = sorted(existing | fec_choices)
         if values:
             fec_prop["enum"] = values
@@ -140,7 +151,11 @@ def _augment_schema(schema: dict[str, Any]) -> dict[str, Any]:
     simulator_choices = set(SIMULATOR_REGISTRY.keys())
     sim_name_def = defs.get("simulatorName")
     if isinstance(sim_name_def, dict):
-        existing = set(sim_name_def.get("enum", [])) if isinstance(sim_name_def.get("enum"), list) else set()
+        existing = (
+            set(sim_name_def.get("enum", []))
+            if isinstance(sim_name_def.get("enum"), list)
+            else set()
+        )
         values = sorted(existing | simulator_choices)
         if values:
             sim_name_def["enum"] = values
@@ -162,7 +177,11 @@ def _format_schema_error(error: ValidationError) -> str:
             schema_props = (
                 error.schema.get("properties") if isinstance(error.schema, dict) else {}
             )
-            allowed = {str(k) for k in schema_props} if isinstance(schema_props, Mapping) else set()
+            allowed = (
+                {str(k) for k in schema_props}
+                if isinstance(schema_props, Mapping)
+                else set()
+            )
             extras = sorted(instance_keys - allowed)
         if not extras and "'" in error.message:
             parts = [seg for seg in error.message.split("'") if seg.strip()]
@@ -191,10 +210,10 @@ def _validate_bundle_config(config: Mapping[str, object], config_path: Path) -> 
         raise ValueError(f"Invalid bundle config at {config_path} ({exc})") from exc
 
 
-def register_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    parser = subparsers.add_parser(
-        "bundle", help="Manage bundled workflows"
-    )
+def register_subcommand(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser("bundle", help="Manage bundled workflows")
     bundle_sub = parser.add_subparsers(dest="bundle_command", required=True)
     run_parser = bundle_sub.add_parser(
         "run", help="Run encode/decode steps from a YAML config"
@@ -230,6 +249,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--emit-manifest-report",
         action="store_true",
         help="Generate HTML reports for decoded manifests",
+    )
+    run_parser.add_argument(
+        "--emit-repro-report",
+        action="store_true",
+        help="Generate reproducibility report for run artifacts.",
     )
     run_parser.add_argument(
         "--allow-missing-fec",
@@ -291,6 +315,11 @@ def register_subcommand(subparsers: argparse._SubParsersAction[argparse.Argument
         "--emit-manifest-report",
         action="store_true",
         help="Generate HTML reports for decoded manifests",
+    )
+    sweep_parser.add_argument(
+        "--emit-repro-report",
+        action="store_true",
+        help="Generate a combined reproducibility report across sweep artifacts.",
     )
     sweep_parser.add_argument(
         "--allow-missing-fec",
@@ -360,12 +389,14 @@ def _simple_args(prefix: str, opts: dict[str, object], allowed: set[str]) -> lis
     return args
 
 
-
-
-
-
-def _backfill_manifest_metrics(manifest_path: Path, original_path: Path, encoded_path: Path) -> None:
-    if not manifest_path.exists() or not original_path.exists() or not encoded_path.exists():
+def _backfill_manifest_metrics(
+    manifest_path: Path, original_path: Path, encoded_path: Path
+) -> None:
+    if (
+        not manifest_path.exists()
+        or not original_path.exists()
+        or not encoded_path.exists()
+    ):
         return
     try:
         payload = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -395,6 +426,7 @@ def _backfill_manifest_metrics(manifest_path: Path, original_path: Path, encoded
     metrics_payload.setdefault("bits_per_nt", bits_per_nt)
     manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
+
 def _run_bundle_pipeline_use_case(
     *,
     codec: str,
@@ -417,6 +449,7 @@ def _run_bundle_pipeline_use_case(
             ),
         )
     )
+
 
 def _run_cli(args_list: list[str]) -> None:
     try:
@@ -510,7 +543,9 @@ def _derive_constraints(
         return None
 
 
-def _constraints_limits(constraints: SynthesisConstraints | None) -> dict[str, float | int]:
+def _constraints_limits(
+    constraints: SynthesisConstraints | None,
+) -> dict[str, float | int]:
     if constraints is None:
         return {}
     return {
@@ -533,9 +568,7 @@ def _write_decoded_metrics(
 ) -> None:
     constraints = _derive_constraints(enc_cfg, sim_cfg)
     try:
-        batch = SequenceBatch.from_fasta(
-            simulated_path.read_text(encoding="utf-8")
-        )
+        batch = SequenceBatch.from_fasta(simulated_path.read_text(encoding="utf-8"))
         sequences = [ol.sequence for ol in batch.oligos] or [batch.primary_sequence()]
     except Exception:
         sequences = [simulated_path.read_text(encoding="utf-8").strip()]
@@ -558,7 +591,9 @@ def _write_decoded_metrics(
                 if isinstance(params, Mapping):
                     normalized["parameters"] = dict(params)
                 opts = item.get("options")
-                if isinstance(opts, Sequence) and not isinstance(opts, (str, bytes, bytearray)):
+                if isinstance(opts, Sequence) and not isinstance(
+                    opts, (str, bytes, bytearray)
+                ):
                     normalized["options"] = [str(opt) for opt in opts if str(opt)]
                 elif isinstance(opts, str) and opts:
                     normalized["options"] = [opt for opt in opts.split() if opt]
@@ -566,9 +601,7 @@ def _write_decoded_metrics(
 
     coverage_info = manifest_data.get("coverage", {})
     histogram_raw = (
-        coverage_info.get("histogram", {})
-        if isinstance(coverage_info, Mapping)
-        else {}
+        coverage_info.get("histogram", {}) if isinstance(coverage_info, Mapping) else {}
     )
     histogram: dict[str, int] = {}
     if isinstance(histogram_raw, Mapping):
@@ -617,7 +650,9 @@ def _write_decoded_metrics(
         except (TypeError, ValueError):
             synthesis_fraction = 0.0
 
-    average_cov = coverage_info.get("average") if isinstance(coverage_info, Mapping) else None
+    average_cov = (
+        coverage_info.get("average") if isinstance(coverage_info, Mapping) else None
+    )
     if average_cov is None:
         average_cov = sum(coverage_counts) / max(1, len(coverage_counts))
     try:
@@ -625,9 +660,13 @@ def _write_decoded_metrics(
     except (TypeError, ValueError):
         average_cov_float = 0.0
 
-    total_reads = coverage_info.get("total_reads") if isinstance(coverage_info, Mapping) else None
+    total_reads = (
+        coverage_info.get("total_reads") if isinstance(coverage_info, Mapping) else None
+    )
     try:
-        total_reads_int = int(total_reads) if total_reads is not None else sum(coverage_counts)
+        total_reads_int = (
+            int(total_reads) if total_reads is not None else sum(coverage_counts)
+        )
     except (TypeError, ValueError):
         total_reads_int = sum(coverage_counts)
 
@@ -752,14 +791,15 @@ def _write_decoded_metrics(
         html = generate_html_report(str(manifest_output))
         html_report_path.write_text(html, encoding="utf-8")
 
-def _launch_dashboard_if_requested(launch_dashboard: bool, metrics_override: Path | None) -> None:
+
+def _launch_dashboard_if_requested(
+    launch_dashboard: bool, metrics_override: Path | None
+) -> None:
     if not launch_dashboard:
         return
     target = metrics_override or metrics.path
     if not target.exists():
-        logger.warning(
-            "Metrics file %s not found, skipping dashboard launch", target
-        )
+        logger.warning("Metrics file %s not found, skipping dashboard launch", target)
         return
     _run_cli(["dashboard", str(target)])
 
@@ -849,6 +889,7 @@ def _run_single_bundle(
     launch_dashboard: bool,
     dry_run: bool,
     allow_missing_fec: bool,
+    emit_repro_report: bool = False,
 ) -> BundleRunResult:
     cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -908,7 +949,10 @@ def _run_single_bundle(
     fec_downgraded = False
     ecc_status = None
     ecc_warning = None
-    if _effective_fec(enc_cfg) == "reed_solomon" and importlib.util.find_spec("reedsolo") is None:
+    if (
+        _effective_fec(enc_cfg) == "reed_solomon"
+        and importlib.util.find_spec("reedsolo") is None
+    ):
         if not allow_missing_fec:
             raise RuntimeError(
                 "Reed-Solomon FEC requires the 'reedsolo' package. Install reedsolo "
@@ -957,7 +1001,9 @@ def _run_single_bundle(
                 batch_metadata=None,
                 config_name=config_name,
                 channel_profile=_extract_channel_profile(sim_cfg_raw),
-                ecc_type=str(_effective_fec(enc_cfg)) if _effective_fec(enc_cfg) else None,
+                ecc_type=str(_effective_fec(enc_cfg))
+                if _effective_fec(enc_cfg)
+                else None,
                 ecc_status=ecc_status,
                 ecc_warning=ecc_warning,
                 metrics_target=metrics_override or metrics.path,
@@ -973,7 +1019,9 @@ def _run_single_bundle(
             summary_path=summary_path,
         )
 
-    constraints = _derive_constraints(enc_cfg, sim_cfg_raw if isinstance(sim_cfg_raw, dict) else None)
+    constraints = _derive_constraints(
+        enc_cfg, sim_cfg_raw if isinstance(sim_cfg_raw, dict) else None
+    )
     if constraints is not None:
         enc_cfg["gc_min"] = constraints.gc_min
         enc_cfg["gc_max"] = constraints.gc_max
@@ -1042,8 +1090,12 @@ def _run_single_bundle(
     _run_cli(enc_args)
 
     original_inputs = [Path(p) for p in enc_cfg.get("input_files", [])]
-    input_files = [encoded_dir / (Path(p).name + ".fasta") for p in enc_cfg.get("input_files", [])]
-    encoded_to_original = {encoded: original for original, encoded in zip(original_inputs, input_files)}
+    input_files = [
+        encoded_dir / (Path(p).name + ".fasta") for p in enc_cfg.get("input_files", [])
+    ]
+    encoded_to_original = {
+        encoded: original for original, encoded in zip(original_inputs, input_files)
+    }
     batch_summary: dict[str, object] = {}
     for fasta_path in input_files:
         if not fasta_path.exists():
@@ -1120,11 +1172,15 @@ def _run_single_bundle(
         # pipeline definitions), serialize it to a temporary YAML file for each
         # input and invoke ``channel run`` using that config. This allows bundle
         # configs to reuse the richer channel pipeline syntax.
-        if isinstance(sim_cfg, dict) and "config" not in sim_cfg and {
-            key
-            for key in sim_cfg
-            if key not in {f.name for f in fields(ChannelArgs)}
-        }:
+        if (
+            isinstance(sim_cfg, dict)
+            and "config" not in sim_cfg
+            and {
+                key
+                for key in sim_cfg
+                if key not in {f.name for f in fields(ChannelArgs)}
+            }
+        ):
             try:  # Optional dependency – mirror channel CLI behaviour
                 import yaml  # type: ignore
             except Exception:  # pragma: no cover - optional dependency fallback
@@ -1229,6 +1285,18 @@ def _run_single_bundle(
                     emit_manifest_report=emit_manifest_report,
                 )
 
+    if emit_repro_report:
+        run_artifacts = sorted(run_dir.glob("decoded/*.json"))
+        run_artifacts = [
+            p
+            for p in run_artifacts
+            if not p.name.endswith(".kpi.json") and not p.name.endswith(".repro.json")
+        ]
+        if run_artifacts:
+            repro_path = run_dir / "reproducibility_report.json"
+            generate_reproducibility_report(run_artifacts, output_path=repro_path)
+            logger.info("Reproducibility report written to %s", repro_path)
+
     logger.info("Bundle output written to %s", run_dir)
     summary_path = _write_summary_file(
         run_dir,
@@ -1303,7 +1371,10 @@ def _collect_manifest_index(
             if isinstance(loaded, dict) and isinstance(loaded.get("runs"), list):
                 index_data = {"runs": list(loaded["runs"])}
         except json.JSONDecodeError:
-            logger.warning("Existing manifest index at %s is invalid; regenerating", manifest_index_path)
+            logger.warning(
+                "Existing manifest index at %s is invalid; regenerating",
+                manifest_index_path,
+            )
 
     new_entries = []
     for res in results:
@@ -1326,8 +1397,7 @@ def _collect_manifest_index(
     deduped = [
         entry
         for entry in index_data["runs"]
-        if entry.get("config_hash")
-        not in {e["config_hash"] for e in new_entries}
+        if entry.get("config_hash") not in {e["config_hash"] for e in new_entries}
     ]
     deduped.extend(new_entries)
     index_data["runs"] = deduped
@@ -1335,7 +1405,9 @@ def _collect_manifest_index(
 
 
 def _handle_run(args: argparse.Namespace) -> None:
-    metrics_override: Path | None = Path(args.metrics_path) if args.metrics_path else None
+    metrics_override: Path | None = (
+        Path(args.metrics_path) if args.metrics_path else None
+    )
     if metrics_override:
         set_metrics_path(metrics_override)
 
@@ -1350,11 +1422,14 @@ def _handle_run(args: argparse.Namespace) -> None:
         launch_dashboard=args.launch_dashboard,
         dry_run=args.dry_run,
         allow_missing_fec=args.allow_missing_fec,
+        emit_repro_report=bool(args.emit_repro_report),
     )
 
 
 def _handle_sweep(args: argparse.Namespace) -> None:
-    metrics_override: Path | None = Path(args.metrics_path) if args.metrics_path else None
+    metrics_override: Path | None = (
+        Path(args.metrics_path) if args.metrics_path else None
+    )
     if metrics_override:
         set_metrics_path(metrics_override)
 
@@ -1368,7 +1443,9 @@ def _handle_sweep(args: argparse.Namespace) -> None:
             _run_single_bundle(
                 cfg_path,
                 cache_dir=Path(args.cache_dir),
-                export_archive=Path(args.export_archive) if args.export_archive else None,
+                export_archive=Path(args.export_archive)
+                if args.export_archive
+                else None,
                 author=args.author,
                 description=args.description,
                 emit_manifest_report=args.emit_manifest_report,
@@ -1376,6 +1453,7 @@ def _handle_sweep(args: argparse.Namespace) -> None:
                 launch_dashboard=False,
                 dry_run=args.dry_run,
                 allow_missing_fec=args.allow_missing_fec,
+                emit_repro_report=False,
             )
         )
 
@@ -1387,5 +1465,21 @@ def _handle_sweep(args: argparse.Namespace) -> None:
             else Path(args.cache_dir) / "manifest_index.json"
         ),
     )
+
+    if args.emit_repro_report:
+        repro_artifacts: list[Path] = []
+        for res in results:
+            repro_artifacts.extend(
+                [
+                    p
+                    for p in sorted(res.run_dir.glob("decoded/*.json"))
+                    if not p.name.endswith(".kpi.json")
+                    and not p.name.endswith(".repro.json")
+                ]
+            )
+        if repro_artifacts:
+            repro_path = Path(args.cache_dir) / "reproducibility_report.json"
+            generate_reproducibility_report(repro_artifacts, output_path=repro_path)
+            logger.info("Sweep reproducibility report written to %s", repro_path)
 
     _launch_dashboard_if_requested(args.launch_dashboard, metrics_override)

--- a/src/genecoder/cli/pipeline.py
+++ b/src/genecoder/cli/pipeline.py
@@ -16,7 +16,12 @@ from genecoder.config.loader import load_mapping_file, validate_bundle_document
 from genecoder.core import encode, decode, inspect_coding_plan
 from genecoder.formats import SequenceBatch
 from genecoder.parallel import parallel_map
-from genecoder.results.schema import canonical_comparison_metrics, canonical_metrics_view, migrate_run_schema
+from genecoder.results.schema import (
+    canonical_comparison_metrics,
+    canonical_metrics_view,
+    migrate_run_schema,
+)
+from genecoder.results.repro_report import generate_reproducibility_report
 from genecoder.plugin_manager import (
     CODEC_REGISTRY,
     FEC_REGISTRY,
@@ -53,7 +58,10 @@ from genecoder.app import (
 
 RUN_PROFILE_VERSION = "2026.02"
 
-def build_kpi_bundle(run_schema: Mapping[str, Any], *, artifact_path: str | None = None) -> dict[str, Any]:
+
+def build_kpi_bundle(
+    run_schema: Mapping[str, Any], *, artifact_path: str | None = None
+) -> dict[str, Any]:
     """Return the machine-readable KPI bundle for a canonical run artifact."""
 
     canonical_run = migrate_run_schema(run_schema)
@@ -110,12 +118,16 @@ def _is_truthy(value: object) -> bool:
     return bool(value)
 
 
-
 def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]]:
     """Parse pipeline settings from a YAML/JSON ``path``."""
 
     data = dict(load_mapping_file(path))
-    validate_bundle_document({"encode": {"input_files": ["placeholder"], "method": "base4_direct"}, "simulate": data})
+    validate_bundle_document(
+        {
+            "encode": {"input_files": ["placeholder"], "method": "base4_direct"},
+            "simulate": data,
+        }
+    )
 
     codec = data.get("codec")
     if not isinstance(codec, str):
@@ -141,7 +153,9 @@ def _load_config(path: str) -> tuple[str, str | None, str | None, Dict[str, Any]
     return codec, fec, channel, channel_params
 
 
-def _build_constraints_from_channel(channel_params: Mapping[str, Any]) -> SynthesisConstraints | None:
+def _build_constraints_from_channel(
+    channel_params: Mapping[str, Any],
+) -> SynthesisConstraints | None:
     """Return synthesis constraints defined in ``channel_params`` when present."""
 
     if not channel_params:
@@ -154,7 +168,9 @@ def _build_constraints_from_channel(channel_params: Mapping[str, Any]) -> Synthe
         return None
 
 
-def _constraints_limits(constraints: SynthesisConstraints | None) -> dict[str, float | int]:
+def _constraints_limits(
+    constraints: SynthesisConstraints | None,
+) -> dict[str, float | int]:
     if constraints is None:
         return {}
     return {
@@ -218,7 +234,9 @@ def _run_with_params(
         channel_config = ChannelConfig(
             parallel=_is_truthy(config_candidates.get("parallel", False)),
             workers=_parse_int(config_candidates.get("workers")),
-            use_process_pool=_is_truthy(config_candidates.get("use_process_pool", False)),
+            use_process_pool=_is_truthy(
+                config_candidates.get("use_process_pool", False)
+            ),
             use_mpi=_is_truthy(config_candidates.get("use_mpi", False)),
             illumina_profile=(
                 str(config_candidates.get("illumina_profile"))
@@ -244,9 +262,7 @@ def _run_with_params(
             try:
                 channel_instance = type(base_channel)(**channel_constructor_params)
             except Exception as exc:
-                logger.error(
-                    "Invalid channel parameters for %s: %s", channel, exc
-                )
+                logger.error("Invalid channel parameters for %s: %s", channel, exc)
                 raise SystemExit(1)
         else:
             channel_instance = base_channel
@@ -274,11 +290,12 @@ def _run_with_params(
     if isinstance(result, SequenceBatch):
         mutated_batch = result
     else:
-        header = simulation_batch.first_header() if simulation_batch.oligos else "pipeline"
+        header = (
+            simulation_batch.first_header() if simulation_batch.oligos else "pipeline"
+        )
         mutated_batch = SequenceBatch.build(
             [(header, str(result))],
             batch_id=simulation_batch.batch_id,
-
         )
 
     mutated_sequence = mutated_batch.primary_sequence()
@@ -308,9 +325,7 @@ def _run_with_params(
             mutated_oligo.metadata[RESULT_COVERAGE_KEY] = str(coverage_value)
         coverage_counts.append(int(coverage_value))
 
-        dropout_flag = _is_truthy(
-            mutated_oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY)
-        )
+        dropout_flag = _is_truthy(mutated_oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY))
         if RESULT_DROPOUT_FLAG_KEY not in mutated_oligo.metadata:
             dropout_flag = coverage_value <= 0 or mutated_oligo.sequence == ""
             mutated_oligo.metadata[RESULT_DROPOUT_FLAG_KEY] = (
@@ -345,9 +360,7 @@ def _run_with_params(
                 ins = int(totals_data["insertions"])
                 dele = int(totals_data["deletions"])
         if totals_data is None:
-            sub, ins, dele = mutation_counts(
-                original_sequence, mutated_oligo.sequence
-            )
+            sub, ins, dele = mutation_counts(original_sequence, mutated_oligo.sequence)
             mutated_oligo.metadata[RESULT_MUTATION_TOTALS_KEY] = json.dumps(
                 {
                     "substitutions": sub,
@@ -441,7 +454,9 @@ def _run_with_params(
         )
     )
     collector.record_decode(
-        DecodeStageEvent(output_path=output_path, decoded_data=decoded, constraints=constraints)
+        DecodeStageEvent(
+            output_path=output_path, decoded_data=decoded, constraints=constraints
+        )
     )
     artifact = collector.emit()
     artifact.setdefault("input_config", {}).update(
@@ -461,7 +476,9 @@ def _run_with_params(
             oligo = embedded.setdefault("oligo_metrics", {})
             if isinstance(oligo, dict):
                 oligo.setdefault("coverage_counts", coverage_counts)
-                oligo.setdefault("dropout_flags", [bool(flag) for flag in dropout_flags])
+                oligo.setdefault(
+                    "dropout_flags", [bool(flag) for flag in dropout_flags]
+                )
                 oligo.setdefault(
                     "mutation_totals",
                     [
@@ -483,7 +500,6 @@ def _run_with_params(
             )
 
     return artifact
-
 
 
 def register_subcommand(
@@ -576,6 +592,11 @@ def register_subcommand(
         help="Generate HTML reports for decoded manifests",
     )
     parser.add_argument(
+        "--emit-repro-report",
+        action="store_true",
+        help="Generate a reproducibility report for the run artifact.",
+    )
+    parser.add_argument(
         "--launch-dashboard",
         action="store_true",
         help="Launch the dashboard for the metrics file after the run",
@@ -645,16 +666,33 @@ def _handle_command(args: argparse.Namespace) -> None:
     if resolved_channel_config.nanopore_profile is not None:
         channel_params["nanopore_profile"] = resolved_channel_config.nanopore_profile
 
-    if channel in {"illumina", "illumina_builtin", "illumina_d2sim", "illumina_insilicoseq"}:
+    if channel in {
+        "illumina",
+        "illumina_builtin",
+        "illumina_d2sim",
+        "illumina_insilicoseq",
+    }:
         selected_illumina_profile = resolved_channel_config.illumina_profile
-        if selected_illumina_profile is None and channel_params.get("profile") is not None:
+        if (
+            selected_illumina_profile is None
+            and channel_params.get("profile") is not None
+        ):
             selected_illumina_profile = str(channel_params["profile"])
         if selected_illumina_profile is not None:
             channel_params["profile"] = selected_illumina_profile
 
-    if channel in {"nanopore", "nanopore_d2sim", "nanopore_desp", "nanopore_dnarsim", "dnarsim"}:
+    if channel in {
+        "nanopore",
+        "nanopore_d2sim",
+        "nanopore_desp",
+        "nanopore_dnarsim",
+        "dnarsim",
+    }:
         selected_nanopore_profile = resolved_channel_config.nanopore_profile
-        if selected_nanopore_profile is None and channel_params.get("profile") is not None:
+        if (
+            selected_nanopore_profile is None
+            and channel_params.get("profile") is not None
+        ):
             selected_nanopore_profile = str(channel_params["profile"])
         if selected_nanopore_profile is not None:
             channel_params["profile"] = selected_nanopore_profile
@@ -693,7 +731,9 @@ def _handle_command(args: argparse.Namespace) -> None:
                 "coding": {"channel_errors": ["substitution", "insertion", "deletion"]},
             }
         )
-        logger.info("Coding planner: %s", json.dumps(explanation, indent=2, sort_keys=True))
+        logger.info(
+            "Coding planner: %s", json.dumps(explanation, indent=2, sort_keys=True)
+        )
 
     def _execute() -> Dict[str, Any]:
         response = RunPipelineUseCase().execute(
@@ -703,7 +743,11 @@ def _handle_command(args: argparse.Namespace) -> None:
                 channel=channel,
                 input_path=args.input,
                 output_path=args.output,
-                profile=(ChannelProfile(name=channel, parameters=channel_params) if channel and channel != "none" else None),
+                profile=(
+                    ChannelProfile(name=channel, parameters=channel_params)
+                    if channel and channel != "none"
+                    else None
+                ),
                 seeds=SeedProfile(global_seed=args.seed),
                 artifacts=ArtifactOutputPolicy(
                     metrics_path=(str(metrics_override) if metrics_override else None),
@@ -733,7 +777,9 @@ def _handle_command(args: argparse.Namespace) -> None:
     else:
         artifact = _execute()
 
-    metrics_path = Path(str(metrics_override) if metrics_override else str(args.output) + ".json")
+    metrics_path = Path(
+        str(metrics_override) if metrics_override else str(args.output) + ".json"
+    )
     logger.info("Run artifact written to %s", metrics_path)
 
     kpi_bundle_path = metrics_path.with_suffix(".kpi.json")
@@ -743,6 +789,15 @@ def _handle_command(args: argparse.Namespace) -> None:
     kpi_bundle = build_kpi_bundle(source_artifact, artifact_path=str(metrics_path))
     kpi_bundle_path.write_text(json.dumps(kpi_bundle, indent=2), encoding="utf-8")
     logger.info("KPI bundle written to %s", kpi_bundle_path)
+
+    if args.emit_repro_report:
+        repro_path = metrics_path.with_suffix(".repro.json")
+        report = generate_reproducibility_report([metrics_path], output_path=repro_path)
+        logger.info(
+            "Reproducibility report written to %s (comparisons=%s)",
+            repro_path,
+            report.get("summary", {}).get("comparison_count", 0),
+        )
 
     manifest_path = metrics_path.with_suffix(".manifest.json")
     if manifest_path.exists():

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -13,6 +13,7 @@ import warnings
 
 from .compat.v1.pipeline_adapter import SequencePipeline, core, init_plugins, run_pipeline
 from .results.schema import canonical_comparison_metrics, canonical_metrics_view, migrate_run_schema
+from .results.repro_report import generate_reproducibility_report
 
 KPI_BUNDLE_VERSION = "1.0"
 
@@ -47,6 +48,7 @@ __all__ = [
     "init_plugins",
     "KPI_BUNDLE_VERSION",
     "build_kpi_bundle",
+    "generate_reproducibility_report",
 ]
 
 warnings.warn(

--- a/src/genecoder/results/__init__.py
+++ b/src/genecoder/results/__init__.py
@@ -11,6 +11,7 @@ from .schema import (
     translate_decode_summary,
     translate_manifest,
 )
+from .repro_report import generate_reproducibility_report, load_reproducibility_config
 
 __all__ = [
     "RUN_SCHEMA_VERSION",
@@ -24,4 +25,6 @@ __all__ = [
     "translate_bundle_metrics",
     "translate_decode_summary",
     "translate_manifest",
+    "generate_reproducibility_report",
+    "load_reproducibility_config",
 ]

--- a/src/genecoder/results/repro_report.py
+++ b/src/genecoder/results/repro_report.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from genecoder.config.loader import load_mapping_file
+from genecoder.results.schema import canonical_comparison_metrics, migrate_run_schema
+
+DEFAULT_REPRO_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "configs" / "reproducibility.yaml"
+)
+
+
+@dataclass(frozen=True)
+class ReproCheck:
+    metric: str
+    baseline: float | bool | None
+    candidate: float | bool | None
+    within_tolerance: bool
+    tolerance: Mapping[str, Any]
+    delta: float | None
+
+
+def load_reproducibility_config(
+    config_path: str | Path | None = None,
+) -> dict[str, Any]:
+    source = Path(config_path) if config_path else DEFAULT_REPRO_CONFIG_PATH
+    loaded = load_mapping_file(source)
+    return dict(loaded)
+
+
+def _normalize_profile(run_data: Mapping[str, Any]) -> str:
+    profiles = run_data.get("profiles")
+    if not isinstance(profiles, Mapping):
+        return "unknown"
+    simulation = profiles.get("simulation")
+    if simulation is None:
+        return "unknown"
+    return str(simulation)
+
+
+def _normalize_seed(run_data: Mapping[str, Any]) -> str:
+    seeds = run_data.get("seeds")
+    if not isinstance(seeds, Mapping):
+        return "unset"
+    seed = seeds.get("global")
+    if seed is None:
+        return "unset"
+    return str(seed)
+
+
+def _float_value(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _evaluate_metric(
+    metric: str,
+    baseline: float | bool | None,
+    candidate: float | bool | None,
+    tolerance: Mapping[str, Any],
+) -> ReproCheck:
+    if isinstance(baseline, bool) or isinstance(candidate, bool):
+        within = baseline == candidate
+        return ReproCheck(
+            metric=metric,
+            baseline=baseline,
+            candidate=candidate,
+            within_tolerance=within,
+            tolerance=tolerance,
+            delta=None,
+        )
+
+    baseline_num = _float_value(baseline)
+    candidate_num = _float_value(candidate)
+    if baseline_num is None or candidate_num is None:
+        return ReproCheck(
+            metric=metric,
+            baseline=baseline,
+            candidate=candidate,
+            within_tolerance=False,
+            tolerance=tolerance,
+            delta=None,
+        )
+
+    mode = str(tolerance.get("mode", "absolute"))
+    max_delta = float(tolerance.get("max_delta", 0.0))
+    delta = abs(candidate_num - baseline_num)
+    if mode == "relative":
+        denominator = abs(baseline_num) if baseline_num != 0 else 1.0
+        normalized_delta = delta / denominator
+        within = normalized_delta <= max_delta
+    else:
+        within = delta <= max_delta
+    return ReproCheck(
+        metric=metric,
+        baseline=baseline_num,
+        candidate=candidate_num,
+        within_tolerance=within,
+        tolerance=tolerance,
+        delta=delta,
+    )
+
+
+def _deterministic_violations(
+    metrics: Mapping[str, float | bool | None],
+    expectations: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    for metric, rule in expectations.items():
+        if str(rule.get("type", "equals")) != "equals":
+            continue
+        expected = rule.get("value")
+        actual = metrics.get(metric)
+        if actual != expected:
+            violations.append(
+                {"metric": metric, "expected": expected, "actual": actual}
+            )
+    return violations
+
+
+def generate_reproducibility_report(
+    run_artifacts: Sequence[str | Path],
+    *,
+    config_path: str | Path | None = None,
+    output_path: str | Path | None = None,
+) -> dict[str, Any]:
+    config = load_reproducibility_config(config_path)
+    comparison = (
+        config.get("comparison")
+        if isinstance(config.get("comparison"), Mapping)
+        else {}
+    )
+    tolerances = (
+        comparison.get("tolerances")
+        if isinstance(comparison.get("tolerances"), Mapping)
+        else {}
+    )
+    deterministic = (
+        comparison.get("deterministic_expectations")
+        if isinstance(comparison.get("deterministic_expectations"), Mapping)
+        else {}
+    )
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    run_index: list[dict[str, Any]] = []
+    for artifact_path in run_artifacts:
+        path = Path(artifact_path)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        run_data = migrate_run_schema(raw)
+        profile = _normalize_profile(run_data)
+        seed = _normalize_seed(run_data)
+        metrics = canonical_comparison_metrics(run_data)
+        grouped.setdefault((profile, seed), []).append(
+            {"path": str(path), "metrics": metrics, "run_id": run_data.get("run_id")}
+        )
+        run_index.append(
+            {
+                "path": str(path),
+                "profile": profile,
+                "seed": seed,
+                "run_id": run_data.get("run_id"),
+            }
+        )
+
+    comparisons: list[dict[str, Any]] = []
+    tolerance_violations = 0
+    deterministic_violations = 0
+    for (profile, seed), runs in sorted(grouped.items()):
+        if len(runs) < 2:
+            continue
+        baseline = runs[0]
+        for candidate in runs[1:]:
+            metric_checks: list[dict[str, Any]] = []
+            for metric, rule in sorted(tolerances.items()):
+                if not isinstance(rule, Mapping):
+                    continue
+                check = _evaluate_metric(
+                    metric,
+                    baseline["metrics"].get(metric),
+                    candidate["metrics"].get(metric),
+                    rule,
+                )
+                metric_checks.append(
+                    {
+                        "metric": check.metric,
+                        "baseline": check.baseline,
+                        "candidate": check.candidate,
+                        "delta": check.delta,
+                        "within_tolerance": check.within_tolerance,
+                        "tolerance": dict(check.tolerance),
+                    }
+                )
+                if not check.within_tolerance:
+                    tolerance_violations += 1
+
+            baseline_det = _deterministic_violations(
+                baseline["metrics"],
+                {k: v for k, v in deterministic.items() if isinstance(v, Mapping)},
+            )
+            candidate_det = _deterministic_violations(
+                candidate["metrics"],
+                {k: v for k, v in deterministic.items() if isinstance(v, Mapping)},
+            )
+            deterministic_violations += len(baseline_det) + len(candidate_det)
+            comparisons.append(
+                {
+                    "profile": profile,
+                    "seed": seed,
+                    "baseline": baseline["path"],
+                    "candidate": candidate["path"],
+                    "metric_checks": metric_checks,
+                    "deterministic_expectation_violations": {
+                        "baseline": baseline_det,
+                        "candidate": candidate_det,
+                    },
+                }
+            )
+
+    report: dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "config_path": str(
+            Path(config_path) if config_path else DEFAULT_REPRO_CONFIG_PATH
+        ),
+        "runs": run_index,
+        "summary": {
+            "group_count": len(grouped),
+            "comparison_count": len(comparisons),
+            "tolerance_violations": tolerance_violations,
+            "deterministic_violations": deterministic_violations,
+            "pass": tolerance_violations == 0 and deterministic_violations == 0,
+        },
+        "comparisons": comparisons,
+    }
+    if output_path:
+        Path(output_path).write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report

--- a/tests/test_repro_report.py
+++ b/tests/test_repro_report.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genecoder.results.repro_report import generate_reproducibility_report
+from tests.test_cli import run_cli_command
+
+
+def _make_run(
+    path: Path,
+    *,
+    run_id: str,
+    profile: str,
+    seed: int,
+    ber: float,
+    runtime_total: float,
+    decode_success: bool = True,
+) -> None:
+    payload = {
+        "schema_version": "1.2",
+        "run_id": run_id,
+        "profiles": {"encoding": "reverse", "simulation": profile, "decode": "reverse"},
+        "seeds": {
+            "global": seed,
+            "encode": seed,
+            "simulate": seed,
+            "decode": seed,
+            "provenance": {},
+        },
+        "runtime": {
+            "total_seconds": runtime_total,
+            "encode_seconds": runtime_total / 3,
+            "simulate_seconds": runtime_total / 3,
+            "decode_seconds": runtime_total / 3,
+        },
+        "stages": {
+            "encode": {"metrics": {}},
+            "simulate": {"metrics": {}},
+            "decode": {"metrics": {"decode_success": decode_success}},
+        },
+        "outcome": {
+            "ber": ber,
+            "decode_success": decode_success,
+            "dropout_rate": 0.0,
+            "gc_stress": 0.0,
+            "homopolymer_stress": 0.0,
+            "throughput": 1.0,
+            "metrics": {},
+        },
+        "constraint_outcomes": {"summary": {}, "by_oligo": {}, "stages": []},
+        "decode_outcomes": {
+            "decode_success": decode_success,
+            "decode_success_rate": 1.0 if decode_success else 0.0,
+            "ecc_success_rates": {},
+        },
+        "provenance": {"source_format": "test", "generator": "test"},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_generate_reproducibility_report_pass(tmp_path: Path) -> None:
+    run_a = tmp_path / "run_a.json"
+    run_b = tmp_path / "run_b.json"
+    _make_run(
+        run_a, run_id="a", profile="illumina", seed=11, ber=0.0, runtime_total=1.0
+    )
+    _make_run(
+        run_b, run_id="b", profile="illumina", seed=11, ber=0.0, runtime_total=1.1
+    )
+
+    report = generate_reproducibility_report([run_a, run_b])
+    assert report["summary"]["comparison_count"] == 1
+    assert report["summary"]["pass"] is True
+
+
+def test_generate_reproducibility_report_detects_violation(tmp_path: Path) -> None:
+    run_a = tmp_path / "run_a.json"
+    run_b = tmp_path / "run_b.json"
+    _make_run(
+        run_a, run_id="a", profile="illumina", seed=11, ber=0.0, runtime_total=1.0
+    )
+    _make_run(
+        run_b, run_id="b", profile="illumina", seed=11, ber=0.2, runtime_total=1.0
+    )
+
+    report = generate_reproducibility_report([run_a, run_b])
+    assert report["summary"]["pass"] is False
+    assert report["summary"]["tolerance_violations"] >= 1
+
+
+def test_bundle_run_emit_repro_report(tmp_path: Path) -> None:
+    bundle_cfg = tmp_path / "bundle.yml"
+    in_file = tmp_path / "msg.txt"
+    in_file.write_text("hello")
+    import yaml
+
+    bundle_cfg.write_text(
+        yaml.safe_dump(
+            {
+                "encode": {"input_files": [str(in_file)], "method": "base4_direct"},
+                "decode": {"method": "base4_direct"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    cache_dir = tmp_path / "runs"
+    result = run_cli_command(
+        [
+            "bundle",
+            "run",
+            str(bundle_cfg),
+            "--cache-dir",
+            str(cache_dir),
+            "--emit-repro-report",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    reports = list(cache_dir.glob("*/*/reproducibility_report.json"))
+    assert reports

--- a/tests/test_validate_reproducibility_artifacts_script.py
+++ b/tests/test_validate_reproducibility_artifacts_script.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_validator_script_fails_when_report_missing(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_reproducibility_artifacts.py",
+            "--artifact-root",
+            str(tmp_path),
+            "--mode",
+            "bundle_sweep",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode != 0
+
+
+def test_validator_script_passes_with_report(tmp_path: Path) -> None:
+    (tmp_path / "manifest_index.json").write_text("{}", encoding="utf-8")
+    report = {
+        "summary": {
+            "pass": True,
+            "tolerance_violations": 0,
+            "deterministic_violations": 0,
+        }
+    }
+    (tmp_path / "reproducibility_report.json").write_text(
+        json.dumps(report), encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_reproducibility_artifacts.py",
+            "--artifact-root",
+            str(tmp_path),
+            "--mode",
+            "bundle_sweep",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
### Motivation
- Provide a single, machine-readable reproducibility contract and automated checks so seeded reruns across profiles can be compared consistently. 
- Make it easy to emit reproducibility artifacts from CLI runs and enforce them in CI with a simple validator.

### Description
- Added a reproducibility report generator at `src/genecoder/results/repro_report.py` that groups runs by `(simulation profile, global seed)`, compares canonical metrics using `canonical_comparison_metrics`, evaluates deterministic expectations and tolerances from a config, and emits a structured JSON report via `generate_reproducibility_report`.
- Introduced a canonical policy file `configs/reproducibility.yaml` that defines the required artifact set, deterministic expectations and per-metric tolerance rules as the single source of truth.
- Wired report emission into CLI flows by adding `--emit-repro-report` to `genecli pipeline` (`src/genecoder/cli/pipeline.py`) and to `genecli bundle run` / `genecli bundle sweep` (`src/genecoder/cli/bundle.py`), writing run/sweep-level reproducibility report files.
- Added a CI-facing validator script `scripts/validate_reproducibility_artifacts.py` that checks for required artifacts (per `configs/reproducibility.yaml`) and fails when the report summary indicates tolerance or deterministic violations.
- Exported the repro helpers through `genecoder.results` and the backward-compat `genecoder.pipeline` facade for reuse, and updated `docs/reproducibility.md` with a required artifact set, CLI examples and interpretation guidance.
- Added unit tests for the report generator and validator integration in `tests/test_repro_report.py` and `tests/test_validate_reproducibility_artifacts_script.py`.

### Testing
- Ran targeted pytest: `python -m pytest tests/test_repro_report.py tests/test_validate_reproducibility_artifacts_script.py tests/test_pipeline_kpi_bundle.py tests/test_bundle.py`, and all selected tests passed (17 passed, 0 failed).
- Ran lint/format checks: `python -m ruff check ...` (passed) and applied `python -m ruff format ...` where needed; `ruff check` reports no issues after formatting.
- Confirmed CLI wiring by exercising `bundle run` behavior in tests which assert `reproducibility_report.json` is emitted when `--emit-repro-report` is used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ca9dbb408326ba4e6399bef83c7a)