### PR TITLE
Add constraint policy search optimization mode and reporting

### DIFF
--- a/configs/channel_demo.yaml
+++ b/configs/channel_demo.yaml
@@ -8,6 +8,8 @@ synthesis:
   min_length: 25
   max_length: 300
   max_homopolymer: 4
+  optimization:
+    mode: fixed_checks
 
 simulators:
   - name: illumina

--- a/configs/constraint_policy_search_balanced.yaml
+++ b/configs/constraint_policy_search_balanced.yaml
@@ -4,36 +4,31 @@ gc_min: 0.45
 gc_max: 0.55
 max_homopolymer: 3
 restriction_site_bans:
-  - GAATTC  # EcoRI
-  - AAGCTT  # HindIII
+  - GAATTC
+  - AAGCTT
 repair:
   enabled: true
-  strategy: deterministic
+  profile: balanced
+  strategy: external_solver
   ecc_protected_prefix: 16
-
 optimization:
   mode: policy_search
-  search_candidates: 12
+  search_candidates: 16
   search_mutations: 2
-  seed: 13
-
+  seed: 7
 objectives:
   solver: deterministic
-  replay_seed: 13
   hard_constraints: [length, gc, homopolymer]
   soft_objectives:
-    - key: gc_deviation
-      weight: 1.0
+    - key: gc_range_penalty
+      weight: 1.5
       goal: min
-      target: 0.5
-    - key: homopolymer_excess
+    - key: homopolymer_cap_penalty
+      weight: 1.3
+      goal: min
+    - key: restriction_site_penalty
+      weight: 2.0
+      goal: min
+    - key: decode_success_proxy
       weight: 1.2
-      goal: min
-      target: 0.0
-    - key: redundancy
-      weight: 0.3
-      goal: min
-      target: 1.0
-    - key: recovery_proxy
-      weight: 0.9
       goal: max

--- a/configs/constraint_policy_search_recovery.yaml
+++ b/configs/constraint_policy_search_recovery.yaml
@@ -1,0 +1,30 @@
+min_length: 80
+max_length: 180
+gc_min: 0.42
+gc_max: 0.58
+max_homopolymer: 4
+repair:
+  enabled: true
+  profile: exploratory
+  strategy: stochastic
+optimization:
+  mode: policy_search
+  search_candidates: 24
+  search_mutations: 3
+  seed: 42
+objectives:
+  solver: stochastic
+  hard_constraints: [length, gc, homopolymer]
+  soft_objectives:
+    - key: decode_success_proxy
+      weight: 2.2
+      goal: max
+    - key: gc_range_penalty
+      weight: 0.8
+      goal: min
+    - key: homopolymer_cap_penalty
+      weight: 0.6
+      goal: min
+    - key: restriction_site_penalty
+      weight: 0.4
+      goal: min

--- a/configs/gold.yaml
+++ b/configs/gold.yaml
@@ -23,6 +23,11 @@ simulate:
     max_homopolymer: 3
     min_length: 25
     max_length: 300
+    optimization:
+      mode: policy_search
+      search_candidates: 10
+      search_mutations: 2
+      seed: 5
   pipeline:
     illumina_profile: miseq
     coverage_distribution:

--- a/configs/pipeline_demo.yaml
+++ b/configs/pipeline_demo.yaml
@@ -9,6 +9,15 @@ encode:
   method: base4_direct
   fec: hamming_7_4
 simulate:
+  synthesis:
+    gc_min: 0.45
+    gc_max: 0.55
+    max_homopolymer: 3
+    optimization:
+      mode: policy_search
+      search_candidates: 8
+      search_mutations: 1
+      seed: 11
   simulators:
     - name: indel
       profile: illumina_adapter  # Delegates to IlluminaChannel (MiSeq V3 preset)

--- a/configs/schema/bundle.schema.json
+++ b/configs/schema/bundle.schema.json
@@ -240,6 +240,42 @@
           "type": "number",
           "minimum": 0,
           "maximum": 1
+        },
+        "optimization": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "fixed_checks",
+                "policy_search"
+              ]
+            },
+            "search_candidates": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "search_mutations": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "seed": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
         }
       }
     },

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,6 +16,7 @@ GeneCoder provides a CLI and GUI for encoding and decoding data into simulated D
 * **CSV export for synthesis** with length and [homopolymer](glossary.md#homopolymer) validation. The analysis command warns when sequences violate these constraints.
 * **Mirror encoding** via `--mirror` to output forward and reverse-complement sequences.
 * **Fix my sequence** button adjusts GC balance and homopolymers on the fly.
+* **Constraint policy search optimization** mode can evaluate weighted objectives (GC range, homopolymer cap, restriction-site avoidance, decode-success proxy) instead of only fixed pass/fail checks.
 
 
 ## Visualizer
@@ -75,3 +76,8 @@ decoded, _ = decode_data_deepdna(encoded, info)
 ## Sequence Design Interface
 
 Browse to `/design` on the running server to access a small tool for validating and fixing short DNA sequences. Enter a sequence and click **Validate** to call `/design/validate`; the response shows whether the sequence is within the GC and homopolymer limits. Press **Fix** to invoke `/design/fix`, which returns an adjusted sequence that satisfies the constraints. The updated sequence and metrics are displayed underneath the buttons.
+
+
+## Constraint Policy Search Examples
+
+Use `configs/constraint_policy_search_balanced.yaml` or `configs/constraint_policy_search_recovery.yaml` to run weighted policy search. The `optimization.mode: policy_search` section enables candidate generation, while `objectives.soft_objectives` controls weighting.

--- a/src/genecoder/constraints/__init__.py
+++ b/src/genecoder/constraints/__init__.py
@@ -1,5 +1,6 @@
 from .engine import ConstraintEngine
 from .report import ConstraintReport, ConstraintViolation, RepairResult
+from .optimizer import ConstraintOptimizer, OptimizationResult, OptimizationScore
 from .policy import ConstraintPolicy, ObjectivePolicy, ObjectiveTerm, RepairPolicy, load_constraint_policy
 from .repair_pipeline import ConstraintRepairPipeline, ConstraintStageGateError, RepairPipelineResult
 from .rules import (
@@ -22,6 +23,9 @@ __all__ = [
     "ConstraintReport",
     "ConstraintViolation",
     "RepairResult",
+    "ConstraintOptimizer",
+    "OptimizationScore",
+    "OptimizationResult",
     "ConstraintPolicy",
     "ObjectivePolicy",
     "ObjectiveTerm",

--- a/src/genecoder/constraints/optimizer.py
+++ b/src/genecoder/constraints/optimizer.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Callable
+
+from .policy import ConstraintPolicy
+
+
+@dataclass(frozen=True)
+class OptimizationScore:
+    score: float
+    objectives: dict[str, float]
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    sequence: str
+    score: float
+    objectives: dict[str, float]
+    mode: str
+    candidate_count: int
+
+    def to_dict(self) -> dict[str, float | int | str | dict[str, float]]:
+        return {
+            "mode": self.mode,
+            "score": self.score,
+            "candidate_count": self.candidate_count,
+            "objectives": dict(self.objectives),
+        }
+
+
+class ConstraintOptimizer:
+    """Score and select candidate encodings under weighted policy objectives."""
+
+    def __init__(self, policy: ConstraintPolicy):
+        self.policy = policy
+
+    def score(self, sequence: str) -> OptimizationScore:
+        length = max(1, len(sequence))
+        gc = sum(1 for base in sequence if base in {"G", "C"}) / length
+
+        max_run = 1
+        run = 1
+        for i in range(1, len(sequence)):
+            if sequence[i] == sequence[i - 1]:
+                run += 1
+                max_run = max(max_run, run)
+            else:
+                run = 1
+
+        gc_range_penalty = 0.0
+        if gc < self.policy.gc_min:
+            gc_range_penalty = self.policy.gc_min - gc
+        elif gc > self.policy.gc_max:
+            gc_range_penalty = gc - self.policy.gc_max
+
+        restriction_hits = 0
+        for motif in self.policy.restriction_site_bans:
+            if motif:
+                restriction_hits += sequence.count(motif)
+
+        decode_success_proxy = max(
+            0.0,
+            1.0
+            - abs(gc - 0.5)
+            - (max(0, max_run - self.policy.max_homopolymer) / length)
+            - (restriction_hits / length),
+        )
+        objectives = {
+            "gc_range_penalty": gc_range_penalty,
+            "homopolymer_cap_penalty": float(max(0, max_run - self.policy.max_homopolymer)),
+            "restriction_site_penalty": float(restriction_hits),
+            "decode_success_proxy": decode_success_proxy,
+            # Backward-compatible aliases used by older configs/reports.
+            "gc_deviation": abs(gc - 0.5),
+            "homopolymer_excess": float(max(0, max_run - self.policy.max_homopolymer)),
+            "recovery_proxy": decode_success_proxy,
+            "redundancy": 1.0,
+        }
+
+        total = 0.0
+        for term in self.policy.objectives.soft_objectives:
+            raw = float(objectives.get(term.key, 0.0))
+            if term.goal == "max":
+                contribution = -raw
+            elif term.goal == "target":
+                contribution = abs(raw - float(term.target or 0.0))
+            else:
+                contribution = raw
+            total += float(term.weight) * contribution
+        return OptimizationScore(score=total, objectives=objectives)
+
+    def optimize(
+        self,
+        sequence: str,
+        *,
+        validate_candidate: Callable[[str], bool] | None = None,
+    ) -> OptimizationResult:
+        mode = self.policy.objectives.optimization_mode
+        if mode != "policy_search":
+            baseline = self.score(sequence)
+            return OptimizationResult(
+                sequence=sequence,
+                score=baseline.score,
+                objectives=baseline.objectives,
+                mode=mode,
+                candidate_count=1,
+            )
+
+        rng = random.Random(self.policy.objectives.replay_seed)
+        candidates = [sequence]
+        for _ in range(max(1, self.policy.objectives.search_candidates) - 1):
+            chars = list(sequence)
+            for _m in range(max(1, self.policy.objectives.search_mutations)):
+                if not chars:
+                    break
+                idx = rng.randrange(len(chars))
+                base = chars[idx]
+                options = [b for b in "ACGT" if b != base]
+                chars[idx] = rng.choice(options)
+            candidates.append("".join(chars))
+
+        best_seq = sequence
+        best_score = self.score(sequence)
+        for candidate in candidates[1:]:
+            if validate_candidate is not None and not validate_candidate(candidate):
+                continue
+            scored = self.score(candidate)
+            if scored.score < best_score.score:
+                best_seq = candidate
+                best_score = scored
+
+        return OptimizationResult(
+            sequence=best_seq,
+            score=best_score.score,
+            objectives=best_score.objectives,
+            mode=mode,
+            candidate_count=len(candidates),
+        )
+

--- a/src/genecoder/constraints/policy.py
+++ b/src/genecoder/constraints/policy.py
@@ -50,10 +50,19 @@ class ObjectivePolicy:
     )
     solver: str = "deterministic"
     replay_seed: int = 0
+    optimization_mode: str = "fixed_checks"
+    search_candidates: int = 12
+    search_mutations: int = 2
 
     def validate(self) -> None:
         if not self.hard_constraints:
             raise ValueError("hard_constraints cannot be empty")
+        if self.optimization_mode not in {"fixed_checks", "policy_search"}:
+            raise ValueError("optimization_mode must be 'fixed_checks' or 'policy_search'")
+        if self.search_candidates < 1:
+            raise ValueError("search_candidates must be >= 1")
+        if self.search_mutations < 1:
+            raise ValueError("search_mutations must be >= 1")
         for term in self.soft_objectives:
             term.validate()
 
@@ -66,6 +75,9 @@ class ObjectivePolicy:
             ],
             "solver": self.solver,
             "replay_seed": self.replay_seed,
+            "optimization_mode": self.optimization_mode,
+            "search_candidates": self.search_candidates,
+            "search_mutations": self.search_mutations,
         }
 
     @classmethod
@@ -90,6 +102,9 @@ class ObjectivePolicy:
             soft_objectives=tuple(terms) if terms else cls().soft_objectives,
             solver=str(src.get("solver", "deterministic")),
             replay_seed=int(src.get("replay_seed", 0)),
+            optimization_mode=str(src.get("optimization_mode", "fixed_checks")),
+            search_candidates=int(src.get("search_candidates", 12)),
+            search_mutations=int(src.get("search_mutations", 2)),
         )
         objective.validate()
         return objective
@@ -172,6 +187,18 @@ class ConstraintPolicy:
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "ConstraintPolicy":
         src = dict(data or {})
         repair_raw = src.get("repair") if isinstance(src.get("repair"), Mapping) else {}
+        opt_raw = src.get("optimization") if isinstance(src.get("optimization"), Mapping) else {}
+        objective_raw = src.get("objectives") if isinstance(src.get("objectives"), Mapping) else {}
+        merged_objectives = dict(objective_raw)
+        if "mode" in opt_raw and "optimization_mode" not in merged_objectives:
+            merged_objectives["optimization_mode"] = opt_raw.get("mode")
+        if "search_candidates" in opt_raw and "search_candidates" not in merged_objectives:
+            merged_objectives["search_candidates"] = opt_raw.get("search_candidates")
+        if "search_mutations" in opt_raw and "search_mutations" not in merged_objectives:
+            merged_objectives["search_mutations"] = opt_raw.get("search_mutations")
+        if "seed" in opt_raw and "replay_seed" not in merged_objectives:
+            merged_objectives["replay_seed"] = opt_raw.get("seed")
+
         policy = cls(
             min_length=int(src.get("min_length", 25)),
             max_length=int(src.get("max_length", 300)),
@@ -187,9 +214,7 @@ class ConstraintPolicy:
                 ecc_protected_prefix=int(repair_raw.get("ecc_protected_prefix", 0)),
             ),
             assumption_mode=str(src.get("assumption_mode", "repair")),
-            objectives=ObjectivePolicy.from_mapping(
-                src.get("objectives") if isinstance(src.get("objectives"), Mapping) else None
-            ),
+            objectives=ObjectivePolicy.from_mapping(merged_objectives),
         )
         policy.validate()
         return policy

--- a/src/genecoder/constraints/repair_pipeline.py
+++ b/src/genecoder/constraints/repair_pipeline.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Sequence
 
 from .engine import ConstraintEngine
+from .optimizer import ConstraintOptimizer
 from .policy import ConstraintPolicy
 from .report import ConstraintReport, RepairResult
 from .solvers import resolve_solver
@@ -34,6 +35,7 @@ class ConstraintRepairPipeline:
     def __init__(self, policy: ConstraintPolicy):
         self.policy = policy
         self.engine = ConstraintEngine(policy.to_rule_set())
+        self.optimizer = ConstraintOptimizer(policy)
 
     def _build_strategy(self) -> DeterministicRepairStrategy | StochasticRepairStrategy | ExternalSolverRepairStrategy:
         strategy_name = self.policy.strategy_name()
@@ -56,38 +58,22 @@ class ConstraintRepairPipeline:
         return StochasticRepairStrategy()
 
     def _objective_score(self, sequence: str) -> tuple[float, dict[str, float]]:
-        length = len(sequence)
-        gc = (sum(1 for b in sequence if b in {"G", "C"}) / length) if length else 0.0
-        max_run = 1
-        run = 1
-        for i in range(1, len(sequence)):
-            if sequence[i] == sequence[i - 1]:
-                run += 1
-                max_run = max(max_run, run)
-            else:
-                run = 1
-        values = {
-            "gc_deviation": abs(gc - 0.5),
-            "homopolymer_excess": max(0.0, float(max_run - self.policy.max_homopolymer)),
-            "redundancy": 1.0,
-            "recovery_proxy": max(0.0, 1.0 - abs(gc - 0.5) - (max_run / max(1, length))),
-        }
-        score = 0.0
-        for term in self.policy.objectives.soft_objectives:
-            raw = values.get(term.key, 0.0)
-            if term.goal == "max":
-                contribution = -raw
-            elif term.goal == "target":
-                contribution = abs(raw - float(term.target or 0.0))
-            else:
-                contribution = raw
-            score += float(term.weight) * contribution
-        return score, values
+        scored = self.optimizer.score(sequence)
+        return scored.score, scored.objectives
 
     def run(self, sequence: str, *, stage: str = "encode") -> RepairPipelineResult:
         before_report = self.engine.validate(sequence)
+        optimized = self.optimizer.optimize(
+            sequence,
+            validate_candidate=lambda cand: self.engine.validate(cand).count == 0,
+        )
+        if optimized.mode == "policy_search" and optimized.sequence != sequence and before_report.count == 0:
+            sequence = optimized.sequence
+            before_report = self.engine.validate(sequence)
         if before_report.count == 0:
             score, values = self._objective_score(sequence)
+            values["optimization_mode"] = optimized.mode
+            values["candidate_count"] = float(optimized.candidate_count)
             return RepairPipelineResult(
                 sequence=sequence,
                 report_before=before_report,
@@ -105,6 +91,8 @@ class ConstraintRepairPipeline:
             )
         if not self.policy.repair.enabled:
             score, values = self._objective_score(sequence)
+            values["optimization_mode"] = optimized.mode
+            values["candidate_count"] = float(optimized.candidate_count)
             return RepairPipelineResult(
                 sequence=sequence,
                 report_before=before_report,
@@ -127,7 +115,16 @@ class ConstraintRepairPipeline:
             raise ConstraintStageGateError(
                 f"Constraint stage gate '{stage}' still has {after_report.count} residual violation(s) after repair"
             )
+        if optimized.mode == "policy_search":
+            post = self.optimizer.optimize(
+                repaired,
+                validate_candidate=lambda cand: self.engine.validate(cand).count == 0,
+            )
+            repaired = post.sequence
+            after_report = self.engine.validate(repaired)
         score, values = self._objective_score(repaired)
+        values["optimization_mode"] = optimized.mode
+        values["candidate_count"] = float(optimized.candidate_count)
         return RepairPipelineResult(
             sequence=repaired,
             report_before=before_report,

--- a/src/genecoder/html_report.py
+++ b/src/genecoder/html_report.py
@@ -105,6 +105,32 @@ def _render_oligo_section(metrics: dict[str, Any], html_lines: list[str]) -> Non
 
 
 
+
+
+def _render_optimization_section(metrics: dict[str, Any], html_lines: list[str]) -> None:
+    summary = metrics.get("optimization_summary")
+    if not isinstance(summary, dict):
+        return
+    html_lines.append("<h2>Constraint Policy Optimization</h2>")
+    html_lines.append("<ul>")
+    mode = summary.get("mode")
+    if mode is not None:
+        html_lines.append(f"<li><strong>Mode:</strong> {escape(str(mode))}</li>")
+    candidate_count = summary.get("candidate_count")
+    if isinstance(candidate_count, (int, float)):
+        html_lines.append(f"<li><strong>Candidates Evaluated:</strong> {int(candidate_count)}</li>")
+    score = summary.get("objective_score")
+    if isinstance(score, (int, float)):
+        html_lines.append(f"<li><strong>Weighted Objective Score:</strong> {float(score):.4f}</li>")
+    weighted = summary.get("weighted_objectives")
+    if isinstance(weighted, dict) and weighted:
+        html_lines.append("<li><strong>Objectives:</strong><ul>")
+        for key, val in weighted.items():
+            if isinstance(val, (int, float)):
+                html_lines.append(f"<li>{escape(str(key))}: {float(val):.4f}</li>")
+        html_lines.append("</ul></li>")
+    html_lines.append("</ul>")
+
 def _render_constraint_section(metrics: dict[str, Any], html_lines: list[str]) -> None:
     pressure = metrics.get("constraint_pressure")
     if not isinstance(pressure, dict):
@@ -207,6 +233,7 @@ def generate_html_report(manifest_path: str) -> str:
 
     _render_oligo_section(metrics, html_lines)
     _render_constraint_section(metrics, html_lines)
+    _render_optimization_section(metrics, html_lines)
 
     html_lines.extend(["</body>", "</html>"])
     return "\n".join(html_lines)

--- a/src/genecoder/manifest.py
+++ b/src/genecoder/manifest.py
@@ -12,6 +12,23 @@ from .results.schema import translate_manifest
 REQUIRED_ENCODING_KEYS: set[str] = {"method"}
 
 
+def _optimization_summary(metrics: Mapping[str, Any]) -> dict[str, Any] | None:
+    outcomes = metrics.get("constraint_outcomes")
+    if not isinstance(outcomes, Mapping):
+        return None
+    stages = outcomes.get("stages")
+    if not isinstance(stages, list) or not stages:
+        return None
+    stage = stages[0] if isinstance(stages[0], Mapping) else {}
+    tradeoff = stage.get("objective_tradeoff") if isinstance(stage.get("objective_tradeoff"), Mapping) else {}
+    return {
+        "mode": tradeoff.get("optimization_mode", "fixed_checks"),
+        "candidate_count": tradeoff.get("candidate_count", 1),
+        "objective_score": stage.get("objective_score"),
+        "weighted_objectives": dict(tradeoff),
+    }
+
+
 def generate_manifest(
     file_name: str | os.PathLike[str],
     encoding_params: Mapping[str, Any] | object,
@@ -36,4 +53,8 @@ def generate_manifest(
 
     file_basename = os.path.basename(Path(file_name).as_posix())
 
-    return translate_manifest({"file": file_basename, "encoding_parameters": params, "metrics": dict(metrics)})
+    metrics_payload = dict(metrics)
+    opt_summary = _optimization_summary(metrics_payload)
+    if opt_summary is not None:
+        metrics_payload.setdefault("optimization_summary", opt_summary)
+    return translate_manifest({"file": file_basename, "encoding_parameters": params, "metrics": metrics_payload})

--- a/tests/test_constraint_policy.py
+++ b/tests/test_constraint_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from genecoder.constraints import (
     ConstraintEngine,
+    ConstraintOptimizer,
     ConstraintPolicy,
     ConstraintRepairPipeline,
     ObjectivePolicy,
@@ -95,3 +96,89 @@ def test_constraint_repair_pipeline_objective_tradeoff_payload() -> None:
     assert result.objective_score is not None
     assert isinstance(result.objective_tradeoff, dict)
     assert "gc_deviation" in (result.objective_tradeoff or {})
+
+
+def test_constraint_optimizer_policy_search_is_deterministic_with_seed() -> None:
+    policy = ConstraintPolicy(
+        min_length=1,
+        max_length=20,
+        gc_min=0.2,
+        gc_max=0.8,
+        max_homopolymer=3,
+        objectives=ObjectivePolicy(
+            optimization_mode="policy_search",
+            replay_seed=123,
+            search_candidates=10,
+            search_mutations=2,
+            soft_objectives=(
+                ObjectivePolicy().soft_objectives[0],
+                ObjectivePolicy().soft_objectives[1],
+            ),
+        ),
+    )
+    optimizer = ConstraintOptimizer(policy)
+    first = optimizer.optimize("AAAATTTTCCCCGGGG")
+    second = optimizer.optimize("AAAATTTTCCCCGGGG")
+    assert first.sequence == second.sequence
+    assert first.score == second.score
+
+
+def test_constraint_optimizer_respects_weighted_objective_priority() -> None:
+    policy_gc = ConstraintPolicy(
+        min_length=1,
+        max_length=20,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=4,
+        restriction_site_bans=("GAATTC",),
+        objectives=ObjectivePolicy.from_mapping(
+            {
+                "soft_objectives": [
+                    {"key": "gc_range_penalty", "weight": 5.0, "goal": "min"},
+                    {"key": "restriction_site_penalty", "weight": 0.1, "goal": "min"},
+                ]
+            }
+        ),
+    )
+    policy_restriction = ConstraintPolicy(
+        min_length=1,
+        max_length=20,
+        gc_min=0.45,
+        gc_max=0.55,
+        max_homopolymer=4,
+        restriction_site_bans=("GAATTC",),
+        objectives=ObjectivePolicy.from_mapping(
+            {
+                "soft_objectives": [
+                    {"key": "gc_range_penalty", "weight": 0.1, "goal": "min"},
+                    {"key": "restriction_site_penalty", "weight": 5.0, "goal": "min"},
+                ]
+            }
+        ),
+    )
+    seq = "GAATTCGGGGGG"
+    gc_score = ConstraintOptimizer(policy_gc).score(seq).score
+    restriction_score = ConstraintOptimizer(policy_restriction).score(seq).score
+    assert gc_score != restriction_score
+
+
+def test_constraint_policy_parses_optimization_mode_from_alias_block() -> None:
+    policy = load_constraint_policy(
+        {
+            "min_length": 10,
+            "max_length": 20,
+            "gc_min": 0.4,
+            "gc_max": 0.6,
+            "max_homopolymer": 3,
+            "optimization": {
+                "mode": "policy_search",
+                "search_candidates": 6,
+                "search_mutations": 2,
+                "seed": 9,
+            },
+        }
+    )
+    assert policy.objectives.optimization_mode == "policy_search"
+    assert policy.objectives.search_candidates == 6
+    assert policy.objectives.search_mutations == 2
+    assert policy.objectives.replay_seed == 9

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -25,6 +25,15 @@ def _make_manifest(path: Path) -> Path:
                 "aggregate": {"before": 3, "after": 1, "violations": 1, "pressure": 0.01},
                 "by_oligo": {"ol-1": {"violations_before": 2, "violations_after": 0}},
             },
+            "optimization_summary": {
+                "mode": "policy_search",
+                "candidate_count": 8,
+                "objective_score": 0.42,
+                "weighted_objectives": {
+                    "gc_range_penalty": 0.01,
+                    "homopolymer_cap_penalty": 0.0,
+                },
+            },
         },
     }
     path.write_text(json.dumps(data))
@@ -45,6 +54,8 @@ def test_generate_html_report(tmp_path: Path) -> None:
     assert "Coverage:</strong> 42" in html
     assert "Constraint Pressure" in html
     assert "before 3, after 1" in html
+    assert "Constraint Policy Optimization" in html
+    assert "Mode:</strong> policy_search" in html
 
 
 def test_cli_html_report_stdout(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide a small, local optimizer to evaluate candidate encodings against weighted objectives (GC range, homopolymer cap, restriction-site avoidance, decode-success proxy) so users can run a “constraint policy search” instead of only pass/fail checks.
- Allow pipeline/config users to opt into policy search via configs and surface the optimization outcome in manifests and HTML reports for observability.
- Keep existing behavior unchanged when optimization is not enabled and make the search deterministic when a seed is supplied.

### Description
- Added a new optimizer module `src/genecoder/constraints/optimizer.py` implementing `ConstraintOptimizer`, `OptimizationScore`, and `OptimizationResult` which scores sequences and can generate candidate mutations using seeded RNG. 
- Extended `ObjectivePolicy` in `src/genecoder/constraints/policy.py` with `optimization_mode`, `search_candidates`, and `search_mutations` and added logic to accept an `optimization` alias block when loading policies so YAML/JSON configs can set `optimization.mode/search_candidates/search_mutations/seed`.
- Integrated the optimizer into `ConstraintRepairPipeline` (`src/genecoder/constraints/repair_pipeline.py`) so policy-search candidates are evaluated (and optionally applied) while preserving fixed-check / repair semantics when `optimization_mode` is `fixed_checks`.
- Exposed optimizer types on the package surface (`src/genecoder/constraints/__init__.py`), extended the bundle schema (`configs/schema/bundle.schema.json`) with `simulate.synthesis.optimization`, and added canonical example configs (`configs/constraint_policy_search_balanced.yaml`, `configs/constraint_policy_search_recovery.yaml`) plus updates to sample configs and `examples/constraint_policy.yaml`.
- Surface optimization summaries in generated manifests (`src/genecoder/manifest.py`) and in the HTML report (`src/genecoder/html_report.py`) via a new “Constraint Policy Optimization” section; also updated `docs/features.md` to document usage.
- Added unit tests in `tests/test_constraint_policy.py` (determinism, weighted-objective behavior, optimization alias parsing) and extended `tests/test_html_report.py` to assert rendering of the new optimization section.

### Testing
- Ran linter: `ruff check ...` on modified files and related tests; all checks passed.
- Ran static typing: `mypy ...` on changed modules which reported a failure in an unrelated pre-existing file (`src/genecoder/simulation_engine/profiles.py`).
- Ran unit tests: `pytest -q tests/test_constraint_policy.py tests/test_html_report.py` and the added/affected tests passed (the run showed the suite for those files completed successfully).
- Ran a larger bundle test subset `pytest -q tests/test_channel_demo_config.py tests/test_bundle_pipeline_metrics_config.py` where one pre-existing/behavioral failure surfaced in `test_bundle_pipeline_metrics_config` (metrics payload did not include `oligos_simulated`); this failure appears unrelated to the optimizer changes and was observed during validation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cfe7b2dc8326aca96627919dfe5b)