### PR TITLE
Add cost modeling metrics to pipeline outputs and dashboards

### DIFF
--- a/configs/pipeline_metrics.yaml
+++ b/configs/pipeline_metrics.yaml
@@ -19,6 +19,13 @@ simulate:
     gc_min: 0.0
     gc_max: 1.0
     max_homopolymer: 8
+  cost_model:
+    synthesis:
+      usd_per_nt: 0.002
+    sequencing:
+      usd_per_read: 0.0004
+    redundancy:
+      baseline_coverage: 4
   pipeline:
     dropout_rate: 0.2
     coverage_distribution:

--- a/configs/schema/bundle.schema.json
+++ b/configs/schema/bundle.schema.json
@@ -439,6 +439,45 @@
             "integer",
             "null"
           ]
+        },
+        "cost_model": {
+          "$ref": "#/$defs/costModelAssumptions"
+        }
+      }
+    },
+    "costModelAssumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "synthesis": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "usd_per_nt": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "sequencing": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "usd_per_read": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "redundancy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "baseline_coverage": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          }
         }
       }
     }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -53,3 +53,20 @@ Simulation outputs such as `metrics.json` also include per-window distribution
 data. The `gc_distribution` entry records the GC fraction of each 50 base pair
 window as a value between 0 and 1. Visual dashboards multiply these values by
 100 to present min/mean/max summaries and line charts in percentage units.
+
+
+## Scenario cost analysis
+
+Bundle manifests can include a `simulate.cost_model` block to estimate economics for each run:
+
+- `synthesis.usd_per_nt`
+- `sequencing.usd_per_read`
+- `redundancy.baseline_coverage`
+
+When present, GeneCoder emits these derived metrics into decoded metrics/manifests:
+
+- `cost_per_recovered_bit`
+- `reads_per_successful_decode`
+- `redundancy_cost_ratio`
+
+Use `genecli stats bundle --runs <cache_dir>` to aggregate scenario outputs across runs.

--- a/docs/pipeline_examples.md
+++ b/docs/pipeline_examples.md
@@ -79,6 +79,33 @@ jq '.metrics.oligo_metrics.dropout_flags' decoded_fountain.txt.json
 
 ## Pipeline Configurations
 
+### Scenario cost modeling
+
+Add cost assumptions to the `simulate` section for what-if analysis:
+
+```yaml
+simulate:
+  simulators:
+    - illumina
+  cost_model:
+    synthesis:
+      usd_per_nt: 0.002
+    sequencing:
+      usd_per_read: 0.0004
+    redundancy:
+      baseline_coverage: 4
+```
+
+Then run and inspect cost metrics:
+
+```bash
+genecli bundle run configs/pipeline_metrics.yaml --metrics-path runs/cost_metrics.json
+jq '.metrics.cost_per_recovered_bit' runs/<timestamp>/decoded/*.json
+jq '.metrics.reads_per_successful_decode' runs/<timestamp>/decoded/*.json
+jq '.metrics.redundancy_cost_ratio' runs/<timestamp>/decoded/*.json
+```
+
+
 ### Reed–Solomon with Illumina
 
 ```yaml

--- a/src/genecoder/bundle_metrics.py
+++ b/src/genecoder/bundle_metrics.py
@@ -51,6 +51,9 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
     total_cov = 0
     total_viol = 0
     bpn_values: list[float] = []
+    cost_per_bit_values: list[float] = []
+    reads_per_success_values: list[float] = []
+    redundancy_ratio_values: list[float] = []
     for manifest in parse_manifests(root):
         total_files += 1
         metrics = manifest.get("metrics", {})
@@ -78,7 +81,31 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
                 total_cov += cov
             viol = metrics.get("constraint_violations")
             total_viol += _extract_violation_count(viol)
+            cost_per_bit = metrics.get("cost_per_recovered_bit")
+            if isinstance(cost_per_bit, (int, float)):
+                cost_per_bit_values.append(float(cost_per_bit))
+            reads_per_success = metrics.get("reads_per_successful_decode")
+            if isinstance(reads_per_success, (int, float)):
+                reads_per_success_values.append(float(reads_per_success))
+            redundancy_ratio = metrics.get("redundancy_cost_ratio")
+            if isinstance(redundancy_ratio, (int, float)):
+                redundancy_ratio_values.append(float(redundancy_ratio))
     avg_bpn = sum(bpn_values) / len(bpn_values) if bpn_values else 0.0
+    avg_cost_per_recovered_bit = (
+        sum(cost_per_bit_values) / len(cost_per_bit_values)
+        if cost_per_bit_values
+        else 0.0
+    )
+    avg_reads_per_successful_decode = (
+        sum(reads_per_success_values) / len(reads_per_success_values)
+        if reads_per_success_values
+        else 0.0
+    )
+    avg_redundancy_cost_ratio = (
+        sum(redundancy_ratio_values) / len(redundancy_ratio_values)
+        if redundancy_ratio_values
+        else 0.0
+    )
     return {
         "files": total_files,
         "total_original_size": total_bytes,
@@ -89,4 +116,7 @@ def aggregate_metrics(root: Path) -> dict[str, Any]:
         "total_deletions": total_dels,
         "total_coverage": total_cov,
         "total_constraint_violations": total_viol,
+        "avg_cost_per_recovered_bit": avg_cost_per_recovered_bit,
+        "avg_reads_per_successful_decode": avg_reads_per_successful_decode,
+        "avg_redundancy_cost_ratio": avg_redundancy_cost_ratio,
     }

--- a/src/genecoder/cli/bundle.py
+++ b/src/genecoder/cli/bundle.py
@@ -60,6 +60,7 @@ from genecoder.synthesis import SynthesisConstraints
 from genecoder.constraints import load_constraint_policy
 from genecoder.profiles.registry import canonicalize_profile_name
 from genecoder.app import ArtifactOutputPolicy, RunPipelineRequest, RunPipelineUseCase
+from genecoder.cost_model import compute_cost_outputs, parse_cost_model_inputs
 from genecoder.results.repro_report import generate_reproducibility_report
 
 
@@ -698,10 +699,14 @@ def _write_decoded_metrics(
 
     channel_config = {}
     pipeline_cfg = {}
+    cost_model_cfg: dict[str, Any] = {}
     if isinstance(sim_cfg, Mapping):
         pipeline_obj = sim_cfg.get("pipeline")
         if isinstance(pipeline_obj, Mapping):
             pipeline_cfg = dict(pipeline_obj)
+        cost_model_obj = sim_cfg.get("cost_model")
+        if isinstance(cost_model_obj, Mapping):
+            cost_model_cfg = dict(cost_model_obj)
         known_fields = {
             key: value
             for key, value in sim_cfg.items()
@@ -767,6 +772,22 @@ def _write_decoded_metrics(
         "seed": sequence_seed,
         "metadata": sequence_metadata,
     }
+
+    if cost_model_cfg:
+        assumptions = parse_cost_model_inputs(cost_model_cfg)
+        cost_outputs = compute_cost_outputs(
+            inputs=assumptions,
+            total_nt=sum(len(seq) for seq in sequences),
+            total_reads=total_reads_int,
+            recovered_bytes=len(decoded_bytes),
+            decode_success_rate=float(metrics_data.get("decode_success_rate") or 0.0),
+        )
+        metrics_data["cost_assumptions"] = cost_model_cfg
+        metrics_data["cost_per_recovered_bit"] = cost_outputs.cost_per_recovered_bit
+        metrics_data["reads_per_successful_decode"] = (
+            cost_outputs.reads_per_successful_decode
+        )
+        metrics_data["redundancy_cost_ratio"] = cost_outputs.redundancy_cost_ratio
 
     metrics_data["channel"] = channel_metrics
     metrics_data["dropout_count"] = dropout_count

--- a/src/genecoder/cli/stats.py
+++ b/src/genecoder/cli/stats.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import TypeAlias, cast
 
@@ -44,6 +45,19 @@ def _handle_bundle_command(args: argparse.Namespace) -> None:
     if args.output:
         args.output.write_text(output + "\n", encoding="utf-8")
     print(output)
+    print(
+        f"cost_per_recovered_bit (avg): {float(metrics.get('avg_cost_per_recovered_bit', 0.0)):.6f}",
+        file=sys.stderr,
+    )
+    print(
+        "reads_per_successful_decode (avg): "
+        f"{float(metrics.get('avg_reads_per_successful_decode', 0.0)):.2f}",
+        file=sys.stderr,
+    )
+    print(
+        f"redundancy_cost_ratio (avg): {float(metrics.get('avg_redundancy_cost_ratio', 0.0)):.4f}",
+        file=sys.stderr,
+    )
 
 
 StatsData: TypeAlias = dict[str, int | list[str] | dict[str, int]]

--- a/src/genecoder/cost_model.py
+++ b/src/genecoder/cost_model.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Any
+
+
+@dataclass(frozen=True)
+class SynthesisCostAssumptions:
+    usd_per_nt: float = 0.0
+
+
+@dataclass(frozen=True)
+class SequencingCostAssumptions:
+    usd_per_read: float = 0.0
+
+
+@dataclass(frozen=True)
+class RedundancySettings:
+    baseline_coverage: float = 1.0
+
+
+@dataclass(frozen=True)
+class CostModelInputs:
+    synthesis: SynthesisCostAssumptions
+    sequencing: SequencingCostAssumptions
+    redundancy: RedundancySettings
+
+
+@dataclass(frozen=True)
+class CostOutputs:
+    cost_per_recovered_bit: float
+    reads_per_successful_decode: float
+    redundancy_cost_ratio: float
+
+
+def _as_float(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed
+
+
+def parse_cost_model_inputs(raw: Mapping[str, Any] | None) -> CostModelInputs:
+    payload = dict(raw or {})
+    synthesis_raw = payload.get("synthesis")
+    sequencing_raw = payload.get("sequencing")
+    redundancy_raw = payload.get("redundancy")
+
+    synthesis = dict(synthesis_raw) if isinstance(synthesis_raw, Mapping) else {}
+    sequencing = dict(sequencing_raw) if isinstance(sequencing_raw, Mapping) else {}
+    redundancy = dict(redundancy_raw) if isinstance(redundancy_raw, Mapping) else {}
+
+    return CostModelInputs(
+        synthesis=SynthesisCostAssumptions(
+            usd_per_nt=max(0.0, _as_float(synthesis.get("usd_per_nt"), 0.0))
+        ),
+        sequencing=SequencingCostAssumptions(
+            usd_per_read=max(0.0, _as_float(sequencing.get("usd_per_read"), 0.0))
+        ),
+        redundancy=RedundancySettings(
+            baseline_coverage=max(1e-9, _as_float(redundancy.get("baseline_coverage"), 1.0))
+        ),
+    )
+
+
+def compute_cost_outputs(
+    *,
+    inputs: CostModelInputs,
+    total_nt: int,
+    total_reads: int,
+    recovered_bytes: int,
+    decode_success_rate: float,
+) -> CostOutputs:
+    recovered_bits = max(0, int(recovered_bytes)) * 8
+    success_rate = min(max(float(decode_success_rate), 0.0), 1.0)
+    expected_successes = max(success_rate, 1e-9)
+
+    synthesis_cost = max(0, int(total_nt)) * inputs.synthesis.usd_per_nt
+    sequencing_cost = max(0, int(total_reads)) * inputs.sequencing.usd_per_read
+    total_cost = synthesis_cost + sequencing_cost
+
+    cost_per_recovered_bit = total_cost / max(recovered_bits, 1)
+    reads_per_successful_decode = max(0, int(total_reads)) / expected_successes
+    redundancy_cost_ratio = (max(0.0, float(total_reads)) / inputs.redundancy.baseline_coverage)
+
+    return CostOutputs(
+        cost_per_recovered_bit=cost_per_recovered_bit,
+        reads_per_successful_decode=reads_per_successful_decode,
+        redundancy_cost_ratio=redundancy_cost_ratio,
+    )

--- a/src/genecoder/dashboard.py
+++ b/src/genecoder/dashboard.py
@@ -57,6 +57,9 @@ _DEF_METRICS: dict[str, Any] = {
     "coverage_distribution": [],
     "constraint_violations": None,
     "oligo_metrics": {},
+    "cost_per_recovered_bit": None,
+    "reads_per_successful_decode": None,
+    "redundancy_cost_ratio": None,
 }
 
 
@@ -667,6 +670,21 @@ def main(results_paths: Iterable[str] | str | None = None) -> None:  # pragma: n
                 st.bar_chart({"Coverage": coverage})
             else:
                 st.write("No coverage data.")
+
+        subheader("Cost Model")
+        cost_per_bit = data.get("cost_per_recovered_bit")
+        reads_per_decode = data.get("reads_per_successful_decode")
+        redundancy_ratio = data.get("redundancy_cost_ratio")
+        if any(isinstance(val, (int, float)) for val in (cost_per_bit, reads_per_decode, redundancy_ratio)):
+            cost_cols = columns(3)
+            if isinstance(cost_per_bit, (int, float)):
+                cost_cols[0].metric("Cost / recovered bit", f"${float(cost_per_bit):.6f}")
+            if isinstance(reads_per_decode, (int, float)):
+                cost_cols[1].metric("Reads / successful decode", f"{float(reads_per_decode):.2f}")
+            if isinstance(redundancy_ratio, (int, float)):
+                cost_cols[2].metric("Redundancy cost ratio", f"{float(redundancy_ratio):.3f}")
+        else:
+            st.write("No cost model data.")
 
         subheader("Constraint Violations")
         summary = data.get("constraint_violation_summary")

--- a/src/genecoder/results/schema.py
+++ b/src/genecoder/results/schema.py
@@ -143,6 +143,9 @@ def canonical_metrics_view(run_data: Mapping[str, Any]) -> dict[str, Any]:
             "objective_score": metrics.get("objective_score")
             if metrics.get("objective_score") is not None
             else _mapping((constraint_outcomes.get("stages") or [{}])[0]).get("objective_score"),
+            "cost_per_recovered_bit": metrics.get("cost_per_recovered_bit"),
+            "reads_per_successful_decode": metrics.get("reads_per_successful_decode"),
+            "redundancy_cost_ratio": metrics.get("redundancy_cost_ratio"),
         }
     )
     return metrics

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -1,0 +1,22 @@
+from genecoder.cost_model import compute_cost_outputs, parse_cost_model_inputs
+
+
+def test_compute_cost_outputs() -> None:
+    inputs = parse_cost_model_inputs(
+        {
+            "synthesis": {"usd_per_nt": 0.001},
+            "sequencing": {"usd_per_read": 0.01},
+            "redundancy": {"baseline_coverage": 5},
+        }
+    )
+    outputs = compute_cost_outputs(
+        inputs=inputs,
+        total_nt=100,
+        total_reads=50,
+        recovered_bytes=25,
+        decode_success_rate=0.5,
+    )
+
+    assert outputs.cost_per_recovered_bit > 0
+    assert outputs.reads_per_successful_decode == 100
+    assert outputs.redundancy_cost_ratio == 10

--- a/tests/test_web_bundle_metrics.py
+++ b/tests/test_web_bundle_metrics.py
@@ -48,6 +48,9 @@ def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
                     ],
                     "type_counts": {"gc_low": 1},
                 },
+                "cost_per_recovered_bit": 0.0025,
+                "reads_per_successful_decode": 12.0,
+                "redundancy_cost_ratio": 1.8,
             },
         })
     )
@@ -64,3 +67,8 @@ def test_bundle_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     assert data["total_coverage"] == 5
     assert data["total_constraint_violations"] == 1
 
+
+
+    assert abs(data["avg_cost_per_recovered_bit"] - 0.0025) < 1e-9
+    assert abs(data["avg_reads_per_successful_decode"] - 12.0) < 1e-9
+    assert abs(data["avg_redundancy_cost_ratio"] - 1.8) < 1e-9

--- a/web/helix-ui/src/MetricsCharts.jsx
+++ b/web/helix-ui/src/MetricsCharts.jsx
@@ -20,8 +20,12 @@ export default function MetricsCharts() {
     canvasRef.current.height = height;
     ctx.clearRect(0, 0, width, height);
     const metrics = data.outcome?.metrics || {};
-    const vals = [metrics.total_original_size || 0, metrics.total_dna_length || 0];
-    const labels = ['Bytes', 'Bases'];
+    const vals = [
+      metrics.total_original_size || 0,
+      metrics.total_dna_length || 0,
+      metrics.avg_reads_per_successful_decode || 0,
+    ];
+    const labels = ['Bytes', 'Bases', 'Reads/Decode'];
     const maxVal = Math.max(...vals, 1);
     const barWidth = width / vals.length;
     vals.forEach((v, i) => {
@@ -44,6 +48,8 @@ export default function MetricsCharts() {
       <canvas ref={canvasRef} />
       <p>Files: {data.outcome?.metrics?.files ?? 0}</p>
       <p>Avg bits/nt: {Number(data.outcome?.metrics?.avg_bits_per_nt ?? 0).toFixed(2)}</p>
+      <p>Avg cost/recovered bit: ${Number(data.outcome?.metrics?.avg_cost_per_recovered_bit ?? 0).toFixed(6)}</p>
+      <p>Avg redundancy cost ratio: {Number(data.outcome?.metrics?.avg_redundancy_cost_ratio ?? 0).toFixed(3)}</p>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide simple scenario-cost analysis for encode/simulate/decode workflows so economics can be estimated alongside technical KPIs.  
- Allow pipeline configs to declare synthesis/sequencing/redundancy assumptions and propagate derived cost KPIs into run manifests and bundle aggregates.  
- Surface cost KPIs in CLI and dashboards so users can compare economic outcomes across runs.

### Description

- Introduced a new cost model module `src/genecoder/cost_model.py` that parses input assumptions and computes `cost_per_recovered_bit`, `reads_per_successful_decode`, and `redundancy_cost_ratio`.  
- Wired cost evaluation into bundle decoded-metrics generation in `src/genecoder/cli/bundle.py` so manifests and metrics files emit the cost outputs when `simulate.cost_model` is present.  
- Extended configuration schema `configs/schema/bundle.schema.json` and example `configs/pipeline_metrics.yaml` to accept a `simulate.cost_model` block with `synthesis`, `sequencing`, and `redundancy` assumptions.  
- Propagated cost fields into canonical metrics (`src/genecoder/results/schema.py`), bundle aggregation (`src/genecoder/bundle_metrics.py`), CLI stats rendering (`src/genecoder/cli/stats.py`) and dashboards (Streamlit in `src/genecoder/dashboard.py` and Helix UI in `web/helix-ui/src/MetricsCharts.jsx`).  
- Added documentation snippets to `docs/metrics.md` and `docs/pipeline_examples.md` describing how to declare cost assumptions and inspect results.  
- Added tests: `tests/test_cost_model.py` (unit verification of math) and updated `tests/test_web_bundle_metrics.py` to assert aggregated cost averages.

### Testing

- Ran linting on modified files with `ruff check` (targeted files); the checks passed.  
- Ran unit tests: `pytest -q tests/test_cost_model.py tests/test_cli_stats.py`; both tests passed after the changes.  
- Exercised frontend unit tests with `npm test --prefix web/helix-ui`; the Helix UI test suite passed.  
- Captured an updated dashboard screenshot to validate the UI changes interactively.  
- Note: an earlier pipeline metrics test failed during iterative development and was addressed; the final targeted test runs listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d35cc7688326b4c2237b8f1891fa)