### PR TITLE
Add stateless pipeline service contract and dry-run API planning endpoint

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -7,3 +7,10 @@
 - `cloud_enabled`: `False`
 - `cloud_worker_enabled`: `False`
 - `local_execution_only`: `True`
+
+## Non-goals and current constraints
+
+- No managed cloud control plane is provided in the current release.
+- No remote queue workers are supported; all jobs execute in-process on the local host.
+- No SLA for distributed retries, preemption, or cross-node artifact durability.
+- New service contract endpoints (for example dry-run planning) validate requests only and do not imply remote execution guarantees.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,3 +40,10 @@ GeneCoder now maintains a single **primary UI track** for deployments:
 All UI adapters must call the same headless application contract (`genecoder.app.ui_service.UIService`) for pipeline runs, run comparison, plugin/profile discovery, and artifact load/export. This keeps behavior consistent across transport layers.
 
 For production deployments, use CLI automation and/or the React dashboard as the default operator surface. Optional adapters may lag behind in feature parity and are not part of the strict deployment compatibility guarantee.
+
+## Current constraints and explicit non-goals
+
+- **Local-only guarantee:** the FastAPI deployment model is single-node and local execution only.
+- **No queue backend yet:** async metadata in API responses is preparatory and does not indicate background worker processing.
+- **No hosted orchestration:** this repository does not ship managed job scheduling, tenancy, or remote artifact storage.
+- **Dry-run mode is validation-only:** `/pipeline/dry-run` checks payload compatibility and returns a planned graph without running encode/simulate/decode workloads.

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -11,14 +11,33 @@ from pathlib import Path
 from typing import Any, Mapping
 import warnings
 
-from .compat.v1.pipeline_adapter import SequencePipeline, core, init_plugins, run_pipeline
-from .results.schema import canonical_comparison_metrics, canonical_metrics_view, migrate_run_schema
+from .compat.v1.pipeline_adapter import (
+    SequencePipeline,
+    core,
+    init_plugins,
+    run_pipeline,
+)
+from .pipeline_service_contract import (
+    AsyncJobMetadata,
+    PipelineDryRunResponse,
+    PipelineJobRequest,
+    bundle_config_to_job_request,
+    make_async_job_metadata,
+    planned_execution_graph,
+)
+from .results.schema import (
+    canonical_comparison_metrics,
+    canonical_metrics_view,
+    migrate_run_schema,
+)
 from .results.repro_report import generate_reproducibility_report
 
 KPI_BUNDLE_VERSION = "1.0"
 
 
-def build_kpi_bundle(run_schema: Mapping[str, Any], *, artifact_path: str | None = None) -> dict[str, Any]:
+def build_kpi_bundle(
+    run_schema: Mapping[str, Any], *, artifact_path: str | None = None
+) -> dict[str, Any]:
     """Return the machine-readable KPI bundle for a canonical run artifact."""
 
     canonical_run = migrate_run_schema(run_schema)
@@ -49,6 +68,12 @@ __all__ = [
     "KPI_BUNDLE_VERSION",
     "build_kpi_bundle",
     "generate_reproducibility_report",
+    "PipelineJobRequest",
+    "PipelineDryRunResponse",
+    "AsyncJobMetadata",
+    "planned_execution_graph",
+    "make_async_job_metadata",
+    "bundle_config_to_job_request",
 ]
 
 warnings.warn(

--- a/src/genecoder/pipeline_service_contract.py
+++ b/src/genecoder/pipeline_service_contract.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+"""Service-facing stateless contract for pipeline job execution."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+import uuid
+
+from genecoder.app import (
+    ArtifactOutputPolicy,
+    BatchSweepMatrix,
+    ChannelProfile,
+    ConstraintProfile,
+    RunPipelineRequest,
+    SeedProfile,
+)
+
+
+@dataclass(frozen=True)
+class AsyncJobMetadata:
+    """Async metadata envelope for future queue-backed execution."""
+
+    job_id: str
+    status: str
+    submitted_at: str
+    mode: str = "local-inline"
+
+
+@dataclass(frozen=True)
+class PipelineJobRequest:
+    codec: str
+    input_path: str
+    output_path: str
+    fec: str | None = None
+    channel: str | None = None
+    filter_mutated: bool = False
+    profile_name: str | None = None
+    profile_parameters: Mapping[str, Any] = field(default_factory=dict)
+    seeds: Mapping[str, int | None] = field(default_factory=dict)
+    matrix_axes: Mapping[str, tuple[Any, ...]] = field(default_factory=dict)
+    constraints: Mapping[str, Any] = field(default_factory=dict)
+    artifacts: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "PipelineJobRequest":
+        codec = str(payload.get("codec") or "").strip()
+        input_path = str(payload.get("input_path") or "").strip()
+        output_path = str(payload.get("output_path") or "").strip()
+        if not codec:
+            raise ValueError("codec is required")
+        if not input_path:
+            raise ValueError("input_path is required")
+        if not output_path:
+            raise ValueError("output_path is required")
+
+        profile_parameters = payload.get("profile_parameters")
+        if not isinstance(profile_parameters, Mapping):
+            profile_parameters = {}
+        seeds = payload.get("seeds")
+        if not isinstance(seeds, Mapping):
+            seeds = {}
+        matrix_axes = payload.get("matrix_axes")
+        if not isinstance(matrix_axes, Mapping):
+            matrix_axes = {}
+        constraints = payload.get("constraints")
+        if not isinstance(constraints, Mapping):
+            constraints = {}
+        artifacts = payload.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            artifacts = {}
+
+        return cls(
+            codec=codec,
+            input_path=input_path,
+            output_path=output_path,
+            fec=str(payload["fec"]) if payload.get("fec") else None,
+            channel=str(payload["channel"]) if payload.get("channel") else None,
+            filter_mutated=bool(payload.get("filter_mutated", False)),
+            profile_name=(str(payload.get("profile_name") or "").strip() or None),
+            profile_parameters=dict(profile_parameters),
+            seeds={str(key): value for key, value in seeds.items()},
+            matrix_axes={
+                str(key): tuple(value) if isinstance(value, (list, tuple)) else (value,)
+                for key, value in matrix_axes.items()
+            },
+            constraints=dict(constraints),
+            artifacts=dict(artifacts),
+        )
+
+    def to_use_case_request(self) -> RunPipelineRequest:
+        profile = (
+            ChannelProfile(
+                name=self.profile_name,
+                parameters=dict(self.profile_parameters),
+            )
+            if self.profile_name
+            else None
+        )
+        return RunPipelineRequest(
+            codec=self.codec,
+            input_path=self.input_path,
+            output_path=self.output_path,
+            fec=self.fec,
+            channel=self.channel,
+            filter_mutated=self.filter_mutated,
+            profile=profile,
+            seeds=SeedProfile(
+                global_seed=_to_optional_int(self.seeds.get("global_seed")),
+                encode_seed=_to_optional_int(self.seeds.get("encode_seed")),
+                simulate_seed=_to_optional_int(self.seeds.get("simulate_seed")),
+                decode_seed=_to_optional_int(self.seeds.get("decode_seed")),
+            ),
+            matrix=BatchSweepMatrix(axes=dict(self.matrix_axes)),
+            constraints=ConstraintProfile(
+                min_length=_to_optional_int(self.constraints.get("min_length")),
+                max_length=_to_optional_int(self.constraints.get("max_length")),
+                gc_min=_to_optional_float(self.constraints.get("gc_min")),
+                gc_max=_to_optional_float(self.constraints.get("gc_max")),
+                max_homopolymer=_to_optional_int(
+                    self.constraints.get("max_homopolymer")
+                ),
+            ),
+            artifacts=ArtifactOutputPolicy(
+                metrics_path=_to_optional_str(self.artifacts.get("metrics_path")),
+                emit_manifest=bool(self.artifacts.get("emit_manifest", True)),
+                emit_html_report=bool(self.artifacts.get("emit_html_report", False)),
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PipelineDryRunResponse:
+    metadata: AsyncJobMetadata
+    request: PipelineJobRequest
+    execution_graph: Mapping[str, Any]
+
+
+def make_async_job_metadata(status: str) -> AsyncJobMetadata:
+    return AsyncJobMetadata(
+        job_id=uuid.uuid4().hex,
+        status=status,
+        submitted_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def planned_execution_graph(request: PipelineJobRequest) -> dict[str, Any]:
+    return {
+        "nodes": [
+            {"id": "encode", "kind": "stage", "codec": request.codec},
+            {
+                "id": "simulate",
+                "kind": "stage",
+                "channel": request.channel,
+                "profile": request.profile_name,
+            },
+            {"id": "decode", "kind": "stage", "codec": request.codec},
+            {
+                "id": "artifacts",
+                "kind": "sink",
+                "metrics_path": request.artifacts.get("metrics_path"),
+                "output_path": request.output_path,
+            },
+        ],
+        "edges": [
+            {"from": "encode", "to": "simulate"},
+            {"from": "simulate", "to": "decode"},
+            {"from": "decode", "to": "artifacts"},
+        ],
+    }
+
+
+def bundle_config_to_job_request(
+    bundle_config: Mapping[str, Any],
+    *,
+    input_path: str,
+    output_path: str,
+) -> PipelineJobRequest:
+    encode_cfg = bundle_config.get("encode")
+    simulate_cfg = bundle_config.get("simulate")
+
+    if not isinstance(encode_cfg, Mapping):
+        raise ValueError("bundle encode section must be a mapping")
+
+    codec = str(encode_cfg.get("method") or "base4_direct")
+    fec = _resolve_fec(encode_cfg)
+
+    channel: str | None = None
+    profile_name: str | None = None
+    profile_parameters: dict[str, Any] = {}
+    constraints: dict[str, Any] = {}
+
+    if isinstance(simulate_cfg, Mapping):
+        simulators = simulate_cfg.get("simulators")
+        if isinstance(simulators, list) and simulators:
+            candidate = simulators[0]
+            if isinstance(candidate, Mapping):
+                channel = str(candidate.get("name") or "") or None
+                profile_name = str(candidate.get("profile") or "") or None
+                profile_parameters = {
+                    str(k): v
+                    for k, v in candidate.items()
+                    if k not in {"name", "profile"}
+                }
+            elif isinstance(candidate, str):
+                channel = candidate
+
+        synthesis_cfg = simulate_cfg.get("synthesis")
+        if isinstance(synthesis_cfg, Mapping):
+            constraints = {
+                key: synthesis_cfg.get(key)
+                for key in (
+                    "min_length",
+                    "max_length",
+                    "gc_min",
+                    "gc_max",
+                    "max_homopolymer",
+                )
+                if key in synthesis_cfg
+            }
+
+    return PipelineJobRequest(
+        codec=codec,
+        input_path=str(Path(input_path)),
+        output_path=str(Path(output_path)),
+        fec=fec,
+        channel=channel,
+        profile_name=profile_name,
+        profile_parameters=profile_parameters,
+        constraints=constraints,
+    )
+
+
+def _resolve_fec(encode_cfg: Mapping[str, Any]) -> str | None:
+    fec = encode_cfg.get("fec")
+    if isinstance(fec, str) and fec:
+        return fec
+    layers = encode_cfg.get("layers")
+    if isinstance(layers, list):
+        for layer in layers:
+            if not isinstance(layer, Mapping):
+                continue
+            if str(layer.get("type", "")).lower() == "fec":
+                name = layer.get("name")
+                if isinstance(name, str) and name:
+                    return name
+    return None
+
+
+def _to_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_optional_str(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/tests/test_pipeline_service_contract.py
+++ b/tests/test_pipeline_service_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genecoder.pipeline_service_contract import (
+    PipelineJobRequest,
+    bundle_config_to_job_request,
+    planned_execution_graph,
+)
+
+yaml = pytest.importorskip("yaml")
+
+
+def test_bundle_config_maps_to_pipeline_contract_gold() -> None:
+    config_path = Path("configs/gold.yaml")
+    bundle_cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    req = bundle_config_to_job_request(
+        bundle_cfg,
+        input_path="tests/data/vertical_slice.txt",
+        output_path="tmp/decoded.bin",
+    )
+
+    assert req.codec == "gc_balanced"
+    assert req.fec == "reed_solomon"
+    assert req.channel == "insilicoseq"
+    assert req.profile_name == "miseq"
+    assert req.constraints["gc_min"] == pytest.approx(0.4)
+    assert req.constraints["gc_max"] == pytest.approx(0.6)
+
+
+def test_pipeline_contract_validates_and_builds_graph() -> None:
+    req = PipelineJobRequest.from_mapping(
+        {
+            "codec": "base4_direct",
+            "input_path": "in.bin",
+            "output_path": "out.bin",
+            "channel": "illumina",
+            "seeds": {"global_seed": 3},
+            "matrix_axes": {"coverage": [5, 10]},
+        }
+    )
+
+    graph = planned_execution_graph(req)
+    node_ids = [node["id"] for node in graph["nodes"]]
+    assert node_ids == ["encode", "simulate", "decode", "artifacts"]
+    assert graph["edges"][0] == {"from": "encode", "to": "simulate"}
+
+
+def test_pipeline_contract_requires_core_fields() -> None:
+    with pytest.raises(ValueError, match="codec is required"):
+        PipelineJobRequest.from_mapping({"input_path": "in", "output_path": "out"})

--- a/tests/test_web_api_analyze_report.py
+++ b/tests/test_web_api_analyze_report.py
@@ -47,10 +47,44 @@ def test_dashboard_metrics_with_token() -> None:
     r = client.post("/dashboard/metrics", headers=AUTH_HEADERS, json=payload)
     assert r.status_code == 200
     data = r.json()
-    assert set(data) >= {"gc_content", "max_homopolymer", "error_rate", "plot", "oligo_metrics", "substitution_rate", "insertion_rate", "deletion_rate"}
+    assert set(data) >= {
+        "gc_content",
+        "max_homopolymer",
+        "error_rate",
+        "plot",
+        "oligo_metrics",
+        "substitution_rate",
+        "insertion_rate",
+        "deletion_rate",
+    }
     assert data["oligo_metrics"]["gc_percentages"]
 
 
 def test_report_invalid_request() -> None:
     r = client.post("/report", json={"data": "bad", "type": "encode"})
     assert r.status_code == 422
+
+
+def test_pipeline_dry_run_endpoint_with_token() -> None:
+    payload = {
+        "codec": "base4_direct",
+        "input_path": "input.bin",
+        "output_path": "decoded.bin",
+        "channel": "illumina",
+    }
+    r = client.post("/pipeline/dry-run", headers=AUTH_HEADERS, json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["metadata"]["status"] == "validated"
+    assert data["request"]["codec"] == "base4_direct"
+    assert data["execution_graph"]["nodes"][0]["id"] == "encode"
+
+
+def test_pipeline_dry_run_requires_token() -> None:
+    payload = {
+        "codec": "base4_direct",
+        "input_path": "input.bin",
+        "output_path": "decoded.bin",
+    }
+    r = client.post("/pipeline/dry-run", json=payload)
+    assert r.status_code == 401

--- a/web/main.py
+++ b/web/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from dataclasses import asdict
 import asyncio
 import base64
@@ -39,6 +39,13 @@ from genecoder.report import (
 )
 from genecoder.metrics import get_metrics, oligos_per_week
 from genecoder.bundle_metrics import aggregate_metrics
+from genecoder.pipeline_service_contract import (
+    AsyncJobMetadata as ContractAsyncJobMetadata,
+    PipelineJobRequest,
+    PipelineDryRunResponse,
+    make_async_job_metadata,
+    planned_execution_graph,
+)
 from typing import Any, cast
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
@@ -64,13 +71,12 @@ PYODIDE_SRC = os.getenv(
 )
 
 
-
-
 def verify_token(
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> None:
     if credentials is None or credentials.credentials != API_TOKEN:
         raise HTTPException(status_code=401, detail="Invalid or missing token")
+
 
 app = FastAPI(title="GeneCoder Web")
 origins = [origin.strip() for origin in CORS_ORIGINS.split(",") if origin.strip()]
@@ -86,9 +92,7 @@ async def _startup() -> None:
         API_TOKEN = secrets.token_urlsafe(16)
         print(f"Generated API token: {API_TOKEN}")
     if REDIS_URL:
-        r = redis.from_url(
-            REDIS_URL, encoding="utf-8", decode_responses=True
-        )
+        r = redis.from_url(REDIS_URL, encoding="utf-8", decode_responses=True)
         await FastAPILimiter.init(r)
 
 
@@ -102,6 +106,8 @@ async def rate_limit(request: Request, response: Response) -> None:
     if FastAPILimiter.redis:
         limiter = RateLimiter(times=5, seconds=1)
         await limiter(request, response)
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -134,14 +140,13 @@ design_index_path = helix_ui_dir / "dist" / "design.html"
 if not design_index_path.is_file():
     design_index_path = helix_ui_dir / "design.html"
 
+
 @app.get("/", response_class=HTMLResponse)
 async def index() -> str:
     html = index_path.read_text(encoding="utf-8")
-    return (
-        html.replace(
-            "__GENECODER_OFFLINE__", "true" if GENECODER_OFFLINE else "false"
-        ).replace("__PYODIDE_SRC__", PYODIDE_SRC)
-    )
+    return html.replace(
+        "__GENECODER_OFFLINE__", "true" if GENECODER_OFFLINE else "false"
+    ).replace("__PYODIDE_SRC__", PYODIDE_SRC)
 
 
 @app.get("/helix", response_class=HTMLResponse)
@@ -156,12 +161,38 @@ async def dashboard() -> str:
     return dashboard_index_path.read_text(encoding="utf-8")
 
 
-
-
 @app.get("/design", response_class=HTMLResponse)
 async def design_page() -> str:
     """Return the React-based sequence design interface."""
     return design_index_path.read_text(encoding="utf-8")
+
+
+class PipelineJobRequestModel(BaseModel):
+    codec: str
+    input_path: str
+    output_path: str
+    fec: str | None = None
+    channel: str | None = None
+    filter_mutated: bool = False
+    profile_name: str | None = None
+    profile_parameters: dict[str, object] = Field(default_factory=dict)
+    seeds: dict[str, int | None] = Field(default_factory=dict)
+    matrix_axes: dict[str, list[object]] = Field(default_factory=dict)
+    constraints: dict[str, object] = Field(default_factory=dict)
+    artifacts: dict[str, object] = Field(default_factory=dict)
+
+
+class AsyncJobMetadataModel(BaseModel):
+    job_id: str
+    status: str
+    submitted_at: str
+    mode: str
+
+
+class PipelineDryRunResponseModel(BaseModel):
+    metadata: AsyncJobMetadataModel
+    request: PipelineJobRequestModel
+    execution_graph: dict[str, object]
 
 
 class EncodeOptionsModel(BaseModel):
@@ -220,6 +251,7 @@ class DeepDNADecodeRequest(BaseModel):
     encoded: str
     info: dict[str, object]
 
+
 @app.post("/encode")
 async def encode(
     req: EncodeRequest,
@@ -236,9 +268,7 @@ async def decode(
     req: DecodeRequest,
     _: None = Depends(verify_token),
 ) -> dict[str, object]:
-    result = await asyncio.to_thread(
-        perform_decoding, req.fasta_data, req.alphabet
-    )
+    result = await asyncio.to_thread(perform_decoding, req.fasta_data, req.alphabet)
     return {
         "decoded_bytes": base64.b64encode(result.decoded_bytes).decode("utf-8"),
         "status_message": result.status_message,
@@ -281,9 +311,7 @@ async def dashboard_deepdna(
         raise HTTPException(status_code=503, detail="DeepDNA not available") from exc
 
     encoded = base64.b64decode(req.encoded, validate=True)
-    decoded, corrected = await asyncio.to_thread(
-        decode_data_deepdna, encoded, req.info
-    )
+    decoded, corrected = await asyncio.to_thread(decode_data_deepdna, encoded, req.info)
     return {
         "decoded_bytes": base64.b64encode(decoded).decode("utf-8"),
         "corrected": corrected,
@@ -332,16 +360,13 @@ async def dashboard_metrics(
     gc_data = calculate_windowed_gc_content(seq, req.window_size, req.step_size)
     _, gc_values = gc_data
     gc_var = (
-        sum((v - gc) ** 2 for v in gc_values) / len(gc_values)
-        if gc_values
-        else 0.0
+        sum((v - gc) ** 2 for v in gc_values) / len(gc_values) if gc_values else 0.0
     )
     hp_regions = identify_homopolymer_regions(seq, req.min_homopolymer_len)
     buf = generate_sequence_analysis_plot(gc_data, hp_regions, len(seq))
     plot_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
     buf.close()
     try:
-
         orig_bytes, orig_indices = cast(
             tuple[bytes, list[int]], decode_base4_direct(seq)
         )
@@ -525,9 +550,7 @@ async def report(req: ReportRequest) -> dict[str, str]:
     else:
         data = req.data.copy()
         if isinstance(data.get("decoded_bytes"), str):
-            data["decoded_bytes"] = base64.b64decode(
-                cast(str, data["decoded_bytes"])
-            )
+            data["decoded_bytes"] = base64.b64decode(cast(str, data["decoded_bytes"]))
         result = DecodeResult(**cast(dict[str, Any], data))
         if req.format == "markdown":
             text = decode_to_markdown(result)
@@ -559,6 +582,7 @@ async def upload_chunk(
     await asyncio.to_thread(chunk_path.write_bytes, chunk_bytes)
     manifest_path = base_dir / "upload.manifest"
     h = hashlib.sha256(chunk_bytes).hexdigest()
+
     def _append() -> None:
         with open(manifest_path, "a", encoding="utf-8") as mf:
             mf.write(json.dumps({"offset": req.offset, "hash": h}) + "\n")
@@ -600,6 +624,61 @@ class ExportArtifactsRequest(BaseModel):
     run_id: str
 
 
+def _to_contract_async_metadata(
+    meta: ContractAsyncJobMetadata,
+) -> AsyncJobMetadataModel:
+    return AsyncJobMetadataModel(
+        job_id=meta.job_id,
+        status=meta.status,
+        submitted_at=meta.submitted_at,
+        mode=meta.mode,
+    )
+
+
+def _to_pipeline_job_request(req: PipelineJobRequestModel) -> PipelineJobRequest:
+    return PipelineJobRequest.from_mapping(req.model_dump())
+
+
+def _to_dry_run_model(response: PipelineDryRunResponse) -> PipelineDryRunResponseModel:
+    request_dict = {
+        "codec": response.request.codec,
+        "input_path": response.request.input_path,
+        "output_path": response.request.output_path,
+        "fec": response.request.fec,
+        "channel": response.request.channel,
+        "filter_mutated": response.request.filter_mutated,
+        "profile_name": response.request.profile_name,
+        "profile_parameters": dict(response.request.profile_parameters),
+        "seeds": dict(response.request.seeds),
+        "matrix_axes": {k: list(v) for k, v in response.request.matrix_axes.items()},
+        "constraints": dict(response.request.constraints),
+        "artifacts": dict(response.request.artifacts),
+    }
+    return PipelineDryRunResponseModel(
+        metadata=_to_contract_async_metadata(response.metadata),
+        request=PipelineJobRequestModel(**request_dict),
+        execution_graph=dict(response.execution_graph),
+    )
+
+
+@app.post("/pipeline/dry-run", response_model=PipelineDryRunResponseModel)
+async def pipeline_dry_run(
+    req: PipelineJobRequestModel,
+    _: None = Depends(verify_token),
+) -> PipelineDryRunResponseModel:
+    try:
+        contract_req = _to_pipeline_job_request(req)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    response = PipelineDryRunResponse(
+        metadata=make_async_job_metadata("validated"),
+        request=contract_req,
+        execution_graph=planned_execution_graph(contract_req),
+    )
+    return _to_dry_run_model(response)
+
+
 @app.get("/profiles")
 async def list_profiles() -> dict[str, object]:
     return _ui_service.list_profiles()
@@ -611,7 +690,9 @@ async def compare_runs_endpoint(
     _: None = Depends(verify_token),
 ) -> dict[str, object]:
     if not req.candidates:
-        raise HTTPException(status_code=400, detail="At least one candidate run is required")
+        raise HTTPException(
+            status_code=400, detail="At least one candidate run is required"
+        )
     baseline = req.baseline
     first = req.candidates[0]
     others = req.candidates[1:]
@@ -656,8 +737,6 @@ async def install_plugin(
     except SystemExit as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}
-
-
 
 
 @app.get("/metrics")


### PR DESCRIPTION
### Motivation

- Introduce a lightweight, stateless service contract for pipeline jobs to support future service-oriented and queue-backed execution without changing the existing orchestration internals. 
- Provide a safe, low-risk “dry-run” API that validates incoming job payloads and returns a planned execution graph so clients can preview work before running heavy encode/simulate/decode workloads. 
- Make the web endpoints and CLI bundle mapping interoperable by aligning payload schemas between bundle configs and the web API. 

### Description

- Added a new service contract module `src/genecoder/pipeline_service_contract.py` containing `PipelineJobRequest`, `PipelineDryRunResponse`, `AsyncJobMetadata`, a `planned_execution_graph` planner, and helpers including `bundle_config_to_job_request` and `to_use_case_request` translation. 
- Exposed the new contract types from the legacy facade by re-exporting them in `src/genecoder/pipeline.py` for backward compatibility (`PipelineJobRequest`, `PipelineDryRunResponse`, `AsyncJobMetadata`, `planned_execution_graph`, `make_async_job_metadata`, `bundle_config_to_job_request`). 
- Added API request/response Pydantic models and an authenticated endpoint `POST /pipeline/dry-run` to `web/main.py` that validates the payload via the contract and returns async metadata plus a planned execution graph without executing workloads. 
- Added a small compatibility test suite `tests/test_pipeline_service_contract.py` that verifies bundle YAML -> contract mapping and the planned graph, and extended `tests/test_web_api_analyze_report.py` with dry-run endpoint coverage. 
- Updated docs (`docs/cloud.md` and `docs/deployment.md`) with explicit non-goals/current constraints clarifying the current local-only guarantees and that dry-run is validation-only. 

### Testing

- Ran static checks with `ruff check` and formatted updated files with `ruff format`, which completed successfully. 
- Verified syntax by compiling modules with `python -m py_compile` which succeeded. 
- Executed unit tests `pytest -q tests/test_pipeline_service_contract.py tests/test_web_api_analyze_report.py`, where contract tests passed and the FastAPI-dependent tests were exercised but skipped in this environment when `fastapi` is unavailable (overall `3 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8081e36288326a62fa4c7693f6a73)