### PR TITLE
Add validated-commit stamping script and protected-branch CI check

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,6 +16,25 @@ on:
       - 'benchmarks/**'
       - 'docs/mvp_checklist.md'
 
+  push:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'mypy.ini'
+      - 'ruff.toml'
+      - '.github/workflows/**'
+      - 'scripts/**'
+      - 'configs/**'
+      - 'benchmarks/**'
+      - 'docs/mvp_checklist.md'
+      - 'docs/product_strategy.md'
+      - 'docs/development_roadmap.md'
+      - 'docs/roadmap_execution.md'
+      - 'docs/cloud.md'
+      - 'docs/cloud_worker.md'
+
 # Ensure only a single workflow run per PR or branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -62,7 +81,8 @@ jobs:
       - name: Detect comment-only changes
         id: comment_check
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: python scripts/only_comments_changed.py
 
   secret-scan:
@@ -781,3 +801,38 @@ jobs:
           path: |
             artifacts/optional-integration-dependency-report.md
             artifacts/optional-integration-dependency-report.json
+
+
+  validated-commit-stamp:
+    needs:
+      - changes
+      - check-comments
+      - lint
+      - glossary
+      - capability-deterministic-reproducibility
+      - capability-benchmark-depth-and-parity
+      - capability-plugin-registry-policy
+      - capability-completion-evidence
+      - benchmark-throughput
+      - benchmark-error-rate
+      - benchmark-gates-from-artifacts
+      - build
+      - docker
+      - devcontainer
+      - sbom
+      - bundle-integration
+      - test-tier-matrix
+    if: github.event_name == 'push' && github.ref_protected == true
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Verify stamped docs match HEAD
+        run: python scripts/stamp_validated_commits.py

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,3 +24,24 @@ When maintainers need to update strategy data:
 4. Include the regenerated changes in the same commit as the model update.
 
 `last_validated_commit` is injected automatically from Git metadata during generation and should not be manually edited in generated blocks.
+
+## Release validation stamp workflow
+
+The strategy and roadmap snapshots in the following docs are release stamps that must point at the exact commit being promoted:
+
+- `docs/product_strategy.md`
+- `docs/development_roadmap.md`
+- `docs/roadmap_execution.md`
+- `docs/cloud.md`
+- `docs/cloud_worker.md`
+
+Use the workflow below when preparing a protected-branch release or release-candidate update:
+
+1. Let the required QA jobs finish successfully in CI for the branch head you intend to release.
+2. After those jobs are green, stamp the docs with the exact branch head:
+   - `python scripts/stamp_validated_commits.py --write`
+3. Review the doc-only diff to confirm every `last_validated_commit` value matches `git rev-parse HEAD`.
+4. Commit the stamped docs and push them to the protected branch.
+5. Confirm the protected-branch CI check passes; it will fail if any stamped document points at a different commit.
+
+The protected-branch validation job intentionally runs this check only after the required QA jobs complete so the docs reflect a fully validated commit instead of an intermediate revision.

--- a/scripts/render_strategy_docs.py
+++ b/scripts/render_strategy_docs.py
@@ -26,7 +26,7 @@ DOC_CONFIGS = {
 }
 
 
-def _git_head_commit() -> str:
+def git_head_commit() -> str:
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=ROOT,
@@ -150,7 +150,7 @@ def main() -> int:
     args = parser.parse_args()
 
     model = yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
-    commit_sha = _git_head_commit()
+    commit_sha = git_head_commit()
     rendered_by_doc = render_sections(model, commit_sha)
 
     changed_files: list[Path] = []

--- a/scripts/stamp_validated_commits.py
+++ b/scripts/stamp_validated_commits.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Stamp strategy and roadmap docs with the current Git HEAD commit."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_TO_STAMP = (
+    ROOT / "docs" / "product_strategy.md",
+    ROOT / "docs" / "development_roadmap.md",
+    ROOT / "docs" / "roadmap_execution.md",
+    ROOT / "docs" / "cloud.md",
+    ROOT / "docs" / "cloud_worker.md",
+)
+STAMP_PATTERN = re.compile(r"(last_validated_commit:\s*`)([0-9a-f]{7,40})(`)")
+
+
+def git_head_commit() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Unable to resolve git commit: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def stamp_content(content: str, commit_sha: str) -> tuple[str, bool]:
+    updated, replacements = STAMP_PATTERN.subn(rf"\g<1>{commit_sha}\g<3>", content)
+    if replacements == 0:
+        raise ValueError("No last_validated_commit field found.")
+    return updated, updated != content
+
+
+def stamp_docs(commit_sha: str, write: bool) -> list[Path]:
+    changed: list[Path] = []
+    for doc_path in DOCS_TO_STAMP:
+        original = doc_path.read_text(encoding="utf-8")
+        updated, did_change = stamp_content(original, commit_sha)
+        if did_change:
+            changed.append(doc_path)
+            if write:
+                doc_path.write_text(updated, encoding="utf-8")
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true", help="rewrite docs with the current HEAD commit")
+    args = parser.parse_args(argv)
+
+    commit_sha = git_head_commit()
+    changed = stamp_docs(commit_sha, write=args.write)
+
+    if args.write:
+        print("Stamped last_validated_commit fields:" if changed else "Docs already stamped with the current HEAD commit.")
+        for path in changed:
+            print(f" - {path.relative_to(ROOT)}")
+        return 0
+
+    if changed:
+        print("Docs are not stamped with the current HEAD commit:")
+        for path in changed:
+            print(f" - {path.relative_to(ROOT)}")
+        print("Run `python scripts/stamp_validated_commits.py --write` after required QA jobs pass.")
+        return 1
+
+    print("All stamped docs already match the current HEAD commit.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_stamp_validated_commits.py
+++ b/tests/test_stamp_validated_commits.py
@@ -1,0 +1,31 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "stamp_validated_commits.py"
+    spec = spec_from_file_location("stamp_validated_commits", script_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stamp_content_rewrites_commit_sha() -> None:
+    module = _load_module()
+    original = "> last_validated_commit: `deadbeef`\n"
+
+    updated, changed = module.stamp_content(original, "0123456789abcdef")
+
+    assert changed is True
+    assert updated == "> last_validated_commit: `0123456789abcdef`\n"
+
+
+def test_stamp_content_is_noop_when_commit_matches() -> None:
+    module = _load_module()
+    original = "> last_validated_commit: `0123456789abcdef`\n"
+
+    updated, changed = module.stamp_content(original, "0123456789abcdef")
+
+    assert changed is False
+    assert updated == original

--- a/tests/test_strategy_docs_sync.py
+++ b/tests/test_strategy_docs_sync.py
@@ -17,13 +17,14 @@ def test_rendered_docs_include_last_validated_commit_and_posture_flags():
     renderer = _load_renderer_module()
     model_path = Path(__file__).resolve().parents[1] / "docs" / "strategy_model.yaml"
     model = yaml.safe_load(model_path.read_text(encoding="utf-8"))
+    commit_sha = "1234567890abcdef1234567890abcdef12345678"
 
-    rendered = renderer.render_docs(model)
+    rendered = renderer.render_sections(model, commit_sha)
 
     for content in rendered.values():
-        assert f"last_validated_commit: `{model['last_validated_commit']}`" in content
+        assert f"last_validated_commit: `{commit_sha}`" in content
 
-    cloud_doc = rendered[renderer.OUTPUT_DOCS["cloud"]]
-    assert "`cloud_enabled`: `False`" in cloud_doc
-    assert "`cloud_worker_enabled`: `False`" in cloud_doc
-    assert "`local_execution_only`: `True`" in cloud_doc
+    cloud_doc = rendered[renderer.ROOT / "docs" / "product_strategy.md"]
+    assert "`cloud_enabled` | `False`" in cloud_doc
+    assert "`cloud_worker_enabled` | `False`" in cloud_doc
+    assert "`local_execution_only` | `True`" in cloud_doc


### PR DESCRIPTION
### Motivation

- Ensure release/docs snapshots explicitly record the exact commit that passed QA so published strategy/roadmap docs point at a validated HEAD.
- Prevent accidental promotion of a branch where stamped `last_validated_commit` fields differ from the protected-branch HEAD after QA completes.

### Description

- Add `scripts/stamp_validated_commits.py` to verify or rewrite `last_validated_commit` fields in `docs/product_strategy.md`, `docs/development_roadmap.md`, `docs/roadmap_execution.md`, `docs/cloud.md`, and `docs/cloud_worker.md`, with a `--write` mode for post-QA stamping.
- Expose a shared `git_head_commit()` helper in `scripts/render_strategy_docs.py` so generated strategy content and the stamping logic use a consistent HEAD resolution.
- Extend `.github/workflows/python-ci.yml` to run on pushes that affect stamped docs and add a `validated-commit-stamp` job that runs on protected-branch `push` events after the required QA jobs and fails if any stamped doc does not match `git rev-parse HEAD`.
- Document the release validation stamp workflow in `docs/contributing.md` and add unit tests by updating `tests/test_strategy_docs_sync.py` and adding `tests/test_stamp_validated_commits.py` to cover stamping behavior.

### Testing

- Ran `ruff` on the changed scripts and tests (`ruff check scripts/stamp_validated_commits.py scripts/render_strategy_docs.py tests/test_strategy_docs_sync.py tests/test_stamp_validated_commits.py`) which completed successfully.
- Ran the targeted unit tests with `pytest -q tests/test_strategy_docs_sync.py tests/test_stamp_validated_commits.py tests/test_roadmap_support_policy_script.py` and all tests passed (`4 passed`).
- Verified the modified workflow YAML parses within the project test environment during CI validation steps (local `PyYAML` absence noted only outside the project test env).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab1c8c4908326851cb1bfb8a785ec)