### PR TITLE
Make docs/strategy_model.yaml the canonical strategy source; add generators and CI drift detection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,12 +47,10 @@ jobs:
         run: pip install pre-commit
       - name: Check Markdown links
         run: pre-commit run markdown-link-check --files README.md $(git ls-files "docs/**/*.md")
-      - name: Fail on missing capability metadata paths or stale generated sections
-        run: python scripts/check_capability_docs_sync.py
-      - name: Fail on stale generated strategy sections
-        run: python scripts/check_strategy_docs_sync.py
-      - name: Fail on stale capability maturity badges
-        run: python scripts/render_capability_maturity_badges.py
+      - name: Regenerate strategy-derived docs
+        run: python scripts/generate_strategy_artifacts.py --write
+      - name: Fail on generated-doc drift
+        run: git diff --exit-code -- docs/capabilities.yaml docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/capability_maturity_badges.md
       - name: Build docs
         run: mkdocs build --strict
       - name: Upload PDF

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,6 +15,10 @@ on:
       - 'configs/**'
       - 'benchmarks/**'
       - 'docs/mvp_checklist.md'
+      - 'docs/strategy_model.yaml'
+      - 'docs/capabilities.yaml'
+      - 'docs/vision.md'
+      - 'docs/capability_maturity_badges.md'
 
   push:
     paths:
@@ -34,6 +38,10 @@ on:
       - 'docs/roadmap_execution.md'
       - 'docs/cloud.md'
       - 'docs/cloud_worker.md'
+      - 'docs/strategy_model.yaml'
+      - 'docs/capabilities.yaml'
+      - 'docs/vision.md'
+      - 'docs/capability_maturity_badges.md'
 
 # Ensure only a single workflow run per PR or branch
 concurrency:
@@ -198,6 +206,12 @@ jobs:
 
     - name: Validate benchmark gate alignment
       run: python scripts/check_benchmark_gate_alignment.py
+
+    - name: Regenerate strategy-derived docs
+      run: python scripts/generate_strategy_artifacts.py --write
+
+    - name: Fail on generated-doc drift
+      run: git diff --exit-code -- docs/capabilities.yaml docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/capability_maturity_badges.md
 
   glossary:
     needs: [changes, check-comments, lint]

--- a/docs/capabilities.yaml
+++ b/docs/capabilities.yaml
@@ -1,6 +1,8 @@
+# GENERATED FILE - DO NOT EDIT DIRECTLY.
+# Canonical source: docs/strategy_model.yaml
+# Regenerate with: python scripts/generate_strategy_artifacts.py --write
 version: 1
-last_updated: "2026-03-06"
-
+last_updated: generated-from-strategy-model
 capabilities:
   - id: cli_bundle_presets
     name: CLI bundle presets for end-to-end pipelines
@@ -12,7 +14,6 @@ capabilities:
     validation_artifacts:
       - type: test
         path: tests/test_bundle.py
-
   - id: illumina_simulation_profiles
     name: Illumina simulation with profile-resolved errors
     status: implemented
@@ -23,7 +24,6 @@ capabilities:
     validation_artifacts:
       - type: test
         path: tests/test_illumina_coverage_quality.py
-
   - id: nanopore_simulation_profiles
     name: Nanopore simulation with context-aware profile controls
     status: implemented
@@ -34,7 +34,6 @@ capabilities:
     validation_artifacts:
       - type: test
         path: tests/test_nanopore_context_profile.py
-
   - id: deterministic_reproducibility_governance
     name: Deterministic seed/profile reproducibility governance
     status: partial
@@ -47,7 +46,6 @@ capabilities:
         path: tests/test_acceptance_deterministic_reproducibility_governance.py
     ci_status_checks:
       - capability-deterministic-reproducibility
-
   - id: benchmark_depth_and_parity
     name: Standardized benchmark depth and parity validation
     status: partial
@@ -60,7 +58,6 @@ capabilities:
         path: tests/test_acceptance_benchmark_depth_and_parity.py
     ci_status_checks:
       - capability-benchmark-depth-and-parity
-
   - id: plugin_registry_policy_automation
     name: Plugin registry policy/security automation
     status: partial
@@ -73,7 +70,6 @@ capabilities:
         path: tests/test_acceptance_plugin_registry_policy_automation.py
     ci_status_checks:
       - capability-plugin-registry-policy
-
 strategy_sections:
   product_strategy_current_capabilities:
     include_ids:
@@ -93,13 +89,12 @@ strategy_sections:
       - deterministic_reproducibility_governance
       - benchmark_depth_and_parity
       - plugin_registry_policy_automation
-
 phase_gates:
-  - gate: "Phase 1 -> Phase 2"
-    canonical_source: docs/development_roadmap.md
+  - gate: Phase 1 -> Phase 2
+    canonical_source: docs/strategy_model.yaml
     measurable_checks:
       - metric: Weekly usage (oligos_per_week)
-        threshold: ">= 1,000 simulated oligos/week for 4 consecutive ISO weeks"
+        threshold: '>= 1,000 simulated oligos/week for 4 consecutive ISO weeks'
         tests_or_checks:
           - genecli stats
           - /metrics endpoint export
@@ -108,12 +103,11 @@ phase_gates:
         evidence_artifacts:
           - artifacts/runs/<run-id>/metrics.json
           - artifacts/runs/<run-id>/metrics.kpi.json
-
-  - gate: "Phase 2 -> Phase 3"
-    canonical_source: docs/development_roadmap.md
+  - gate: Phase 2 -> Phase 3
+    canonical_source: docs/strategy_model.yaml
     measurable_checks:
       - metric: Reproducibility pass rate
-        threshold: "100% deterministic seed/profile checks for 2 consecutive weeks"
+        threshold: 100% deterministic seed/profile checks for 2 consecutive weeks
         tests_or_checks:
           - pytest -q tests/test_acceptance_deterministic_reproducibility_governance.py
         docs_links:
@@ -121,7 +115,8 @@ phase_gates:
         evidence_artifacts:
           - CI pytest logs
       - metric: Throughput median floor
-        threshold: ">= 2.0 MB/s Base-4 encode throughput with BER observed at baseline 0.0"
+        threshold: '>= 2.0 MB/s Base-4 encode throughput with BER observed at baseline
+          0.0'
         tests_or_checks:
           - PYTHONPATH=src python benchmarks/throughput.py
           - pytest -q tests/test_acceptance_benchmark_depth_and_parity.py -k throughput_gate_definition
@@ -130,12 +125,11 @@ phase_gates:
         evidence_artifacts:
           - benchmark stdout artifact
           - benchmark gate JSON artifact
-
-  - gate: "Phase 3 -> Phase 4"
-    canonical_source: docs/development_roadmap.md
+  - gate: Phase 3 -> Phase 4
+    canonical_source: docs/strategy_model.yaml
     measurable_checks:
       - metric: BER baseline quality
-        threshold: "<= 0.01 BER on documented baseline profile/seed"
+        threshold: <= 0.01 BER on documented baseline profile/seed
         tests_or_checks:
           - PYTHONPATH=src python benchmarks/error_rate.py
           - pytest -q tests/test_acceptance_benchmark_depth_and_parity.py -k error_rate_gate_definition
@@ -145,22 +139,24 @@ phase_gates:
           - benchmark stdout artifact
           - benchmark gate JSON artifact
       - metric: Suite category health
-        threshold: "Green CI across CLI/API, pipeline/simulation, plugins/security categories"
+        threshold: Green CI across CLI/API, pipeline/simulation, plugins/security
+          categories
         tests_or_checks:
           - pytest -q tests/test_acceptance_plugin_registry_policy_automation.py
         docs_links:
           - docs/development_roadmap.md
         evidence_artifacts:
           - CI pytest summaries
-
-  - gate: "Phase 4 release gate"
-    canonical_source: docs/development_roadmap.md
+  - gate: Phase 4 release gate
+    canonical_source: docs/strategy_model.yaml
     measurable_checks:
       - metric: Plugin policy compliance
-        threshold: "100% pass on plugin spec/security checks before registry publication"
+        threshold: 100% pass on plugin spec/security checks before registry publication
         tests_or_checks:
-          - pytest -q tests/test_acceptance_plugin_registry_policy_automation.py -k phase_four_release_gate_readiness_conditions
-          - pytest -q tests/test_plugin_supply_chain_policy.py tests/test_plugin_lifecycle_conformance.py tests/test_cli_plugin_registry.py
+          - pytest -q tests/test_acceptance_plugin_registry_policy_automation.py -k
+            phase_four_release_gate_readiness_conditions
+          - pytest -q tests/test_plugin_supply_chain_policy.py tests/test_plugin_lifecycle_conformance.py
+            tests/test_cli_plugin_registry.py
         docs_links:
           - docs/plugins.md
         evidence_artifacts:

--- a/docs/capability_maturity_badges.md
+++ b/docs/capability_maturity_badges.md
@@ -1,6 +1,8 @@
+<!-- GENERATED FILE: derived from docs/strategy_model.yaml via docs/capabilities.yaml; edit docs/strategy_model.yaml and rerun `python scripts/generate_strategy_artifacts.py --write`. -->
+
 # Capability maturity badges
 
-Generated from `docs/capabilities.yaml` and `.github/workflows/python-ci.yml`.
+Generated from `docs/strategy_model.yaml`, `docs/capabilities.yaml`, and `.github/workflows/python-ci.yml`.
 
 | Capability ID | Status | CI checks present | Maturity badge |
 | --- | --- | --- | --- |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,15 +12,15 @@ for external dependencies are documented in `NOTICE`.
 
 ## Updating strategy model fields and generated docs
 
-`docs/strategy_model.yaml` is the authoritative source for strategy phases, feature capabilities, KPI gates, and deployment posture fields.
+`docs/strategy_model.yaml` is the authoritative source for strategy phases, feature capabilities, KPI gates, deployment posture fields, capability validation artifacts, and strategy-derived documentation metadata.
 
 When maintainers need to update strategy data:
 
-1. Edit `docs/strategy_model.yaml` only (do not hand-edit generated strategy blocks).
-2. Regenerate strategy sections:
-   - `python scripts/render_strategy_docs.py --write`
+1. Edit `docs/strategy_model.yaml` only (do not hand-edit generated files).
+2. Regenerate strategy-derived artifacts:
+   - `python scripts/generate_strategy_artifacts.py --write`
 3. Validate there is no drift:
-   - `python scripts/check_strategy_docs_sync.py`
+   - `python scripts/generate_strategy_artifacts.py`
 4. Include the regenerated changes in the same commit as the model update.
 
 `last_validated_commit` is injected automatically from Git metadata during generation and should not be manually edited in generated blocks.

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,3 +1,5 @@
+<!-- GENERATED FILE: derived from docs/strategy_model.yaml; edit docs/strategy_model.yaml and rerun `python scripts/generate_strategy_artifacts.py --write`. -->
+
 # Development Roadmap
 
 This roadmap tracks KPI gates from the canonical strategy model.
@@ -6,7 +8,7 @@ This roadmap tracks KPI gates from the canonical strategy model.
 ## KPI gates and evidence (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `ace9f6cbe53fdbbf78a7bef0e628afce31cca5cf`
+> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
 
 ### Phase 1 -> Phase 2
 

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -1,3 +1,5 @@
+<!-- GENERATED FILE: derived from docs/strategy_model.yaml; edit docs/strategy_model.yaml and rerun `python scripts/generate_strategy_artifacts.py --write`. -->
+
 # Product Strategy
 
 This document includes generated strategy metadata. Update `docs/strategy_model.yaml` and re-render generated sections instead of editing the generated block directly.
@@ -6,7 +8,7 @@ This document includes generated strategy metadata. Update `docs/strategy_model.
 ## Strategy model snapshot (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `ace9f6cbe53fdbbf78a7bef0e628afce31cca5cf`
+> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
 
 ### Phase definitions
 

--- a/docs/strategy_model.yaml
+++ b/docs/strategy_model.yaml
@@ -1,5 +1,14 @@
 version: 1
 
+metadata:
+  canonical_file: docs/strategy_model.yaml
+  generated_files:
+    - docs/capabilities.yaml
+    - docs/product_strategy.md
+    - docs/vision.md
+    - docs/development_roadmap.md
+    - docs/capability_maturity_badges.md
+
 phases:
   - id: 1
     name: Foundation sustainment
@@ -26,6 +35,9 @@ feature_capabilities:
     owner_modules:
       - src/genecoder/cli/bundle.py
       - src/genecoder/pipeline.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_bundle.py
     completion_criteria:
       - id: bundle_cli_acceptance
         description: Bundle CLI integration and preset validation tests pass.
@@ -43,6 +55,9 @@ feature_capabilities:
     owner_modules:
       - src/genecoder/simulators/illumina/channel.py
       - src/genecoder/simulators/illumina/profiles.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_illumina_coverage_quality.py
     completion_criteria:
       - id: illumina_profile_quality_acceptance
         description: Illumina profile quality and validation checks pass.
@@ -59,6 +74,9 @@ feature_capabilities:
     owner_modules:
       - src/genecoder/simulators/nanopore.py
       - src/genecoder/simulators/nanopore_profiles.py
+    validation_artifacts:
+      - type: test
+        path: tests/test_nanopore_context_profile.py
     completion_criteria:
       - id: nanopore_context_acceptance
         description: Nanopore context profile behavior is verified by acceptance tests.
@@ -76,6 +94,11 @@ feature_capabilities:
     owner_modules:
       - src/genecoder/pipeline.py
       - src/genecoder/cli/cli.py
+    validation_artifacts:
+      - type: acceptance_test
+        path: tests/test_acceptance_deterministic_reproducibility_governance.py
+    ci_status_checks:
+      - capability-deterministic-reproducibility
     completion_criteria:
       - id: deterministic_repro_acceptance
         description: Deterministic reproducibility governance acceptance checks pass.
@@ -93,6 +116,11 @@ feature_capabilities:
     owner_modules:
       - benchmarks/throughput.py
       - benchmarks/error_rate.py
+    validation_artifacts:
+      - type: acceptance_test
+        path: tests/test_acceptance_benchmark_depth_and_parity.py
+    ci_status_checks:
+      - capability-benchmark-depth-and-parity
     completion_criteria:
       - id: throughput_gate_floor
         description: Throughput benchmark meets the minimum encode-speed floor.
@@ -137,6 +165,11 @@ feature_capabilities:
     owner_modules:
       - src/genecoder/plugin_manager.py
       - src/genecoder/plugin_runtime/registry.py
+    validation_artifacts:
+      - type: acceptance_test
+        path: tests/test_acceptance_plugin_registry_policy_automation.py
+    ci_status_checks:
+      - capability-plugin-registry-policy
     completion_criteria:
       - id: plugin_policy_acceptance
         description: Plugin registry policy acceptance tests and policy suites pass.
@@ -213,3 +246,95 @@ support_policy:
     - src/genecoder/cloud/
   deprecated_module_prefixes:
     - src/genecoder/compat/legacy/
+
+strategy_sections:
+  product_strategy_current_capabilities:
+    include_ids:
+      - cli_bundle_presets
+      - illumina_simulation_profiles
+      - nanopore_simulation_profiles
+  product_strategy_priority_gaps:
+    include_ids:
+      - deterministic_reproducibility_governance
+      - benchmark_depth_and_parity
+      - plugin_registry_policy_automation
+  vision_capability_status:
+    include_ids:
+      - cli_bundle_presets
+      - illumina_simulation_profiles
+      - nanopore_simulation_profiles
+      - deterministic_reproducibility_governance
+      - benchmark_depth_and_parity
+      - plugin_registry_policy_automation
+
+phase_gates:
+  - gate: "Phase 1 -> Phase 2"
+    canonical_source: docs/strategy_model.yaml
+    measurable_checks:
+      - metric: Weekly usage (oligos_per_week)
+        threshold: ">= 1,000 simulated oligos/week for 4 consecutive ISO weeks"
+        tests_or_checks:
+          - genecli stats
+          - /metrics endpoint export
+        docs_links:
+          - docs/metrics.md
+        evidence_artifacts:
+          - artifacts/runs/<run-id>/metrics.json
+          - artifacts/runs/<run-id>/metrics.kpi.json
+
+  - gate: "Phase 2 -> Phase 3"
+    canonical_source: docs/strategy_model.yaml
+    measurable_checks:
+      - metric: Reproducibility pass rate
+        threshold: "100% deterministic seed/profile checks for 2 consecutive weeks"
+        tests_or_checks:
+          - pytest -q tests/test_acceptance_deterministic_reproducibility_governance.py
+        docs_links:
+          - docs/reproducibility.md
+        evidence_artifacts:
+          - CI pytest logs
+      - metric: Throughput median floor
+        threshold: ">= 2.0 MB/s Base-4 encode throughput with BER observed at baseline 0.0"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/throughput.py
+          - pytest -q tests/test_acceptance_benchmark_depth_and_parity.py -k throughput_gate_definition
+        docs_links:
+          - docs/performance.md
+        evidence_artifacts:
+          - benchmark stdout artifact
+          - benchmark gate JSON artifact
+
+  - gate: "Phase 3 -> Phase 4"
+    canonical_source: docs/strategy_model.yaml
+    measurable_checks:
+      - metric: BER baseline quality
+        threshold: "<= 0.01 BER on documented baseline profile/seed"
+        tests_or_checks:
+          - PYTHONPATH=src python benchmarks/error_rate.py
+          - pytest -q tests/test_acceptance_benchmark_depth_and_parity.py -k error_rate_gate_definition
+        docs_links:
+          - docs/performance.md
+        evidence_artifacts:
+          - benchmark stdout artifact
+          - benchmark gate JSON artifact
+      - metric: Suite category health
+        threshold: "Green CI across CLI/API, pipeline/simulation, plugins/security categories"
+        tests_or_checks:
+          - pytest -q tests/test_acceptance_plugin_registry_policy_automation.py
+        docs_links:
+          - docs/development_roadmap.md
+        evidence_artifacts:
+          - CI pytest summaries
+
+  - gate: "Phase 4 release gate"
+    canonical_source: docs/strategy_model.yaml
+    measurable_checks:
+      - metric: Plugin policy compliance
+        threshold: "100% pass on plugin spec/security checks before registry publication"
+        tests_or_checks:
+          - pytest -q tests/test_acceptance_plugin_registry_policy_automation.py -k phase_four_release_gate_readiness_conditions
+          - pytest -q tests/test_plugin_supply_chain_policy.py tests/test_plugin_lifecycle_conformance.py tests/test_cli_plugin_registry.py
+        docs_links:
+          - docs/plugins.md
+        evidence_artifacts:
+          - CI logs and registry validation output

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,3 +1,5 @@
+<!-- GENERATED FILE: derived from docs/strategy_model.yaml; edit docs/strategy_model.yaml and rerun `python scripts/generate_strategy_artifacts.py --write`. -->
+
 # Vision & Core Concept
 
 GeneCoder aims to make DNA data storage experimentation practical and reproducible by combining encoding, channel simulation, and decoding workflows in one toolkit.
@@ -11,7 +13,7 @@ GeneCoder aims to make DNA data storage experimentation practical and reproducib
 ## Strategy-aligned phase and capability narrative (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `ace9f6cbe53fdbbf78a7bef0e628afce31cca5cf`
+> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
 
 ### Phase intent
 

--- a/scripts/check_benchmark_gate_alignment.py
+++ b/scripts/check_benchmark_gate_alignment.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 THRESHOLDS_PATH = ROOT / "configs" / "benchmark_thresholds.json"
 CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
@@ -16,22 +18,8 @@ def _load_thresholds() -> dict[str, dict[str, object]]:
     return json.loads(THRESHOLDS_PATH.read_text(encoding="utf-8"))
 
 
-def _extract_gate_block(text: str, gate: str) -> str:
-    marker = f'- gate: "{gate}"'
-    start = text.find(marker)
-    if start == -1:
-        raise ValueError(f"Missing gate {gate!r} in {CAPABILITIES_PATH}.")
-    next_start = text.find('\n  - gate: "', start + len(marker))
-    return text[start:] if next_start == -1 else text[start:next_start]
-
-
-def _extract_metric_block(gate_block: str, metric: str) -> str:
-    marker = f"- metric: {metric}"
-    start = gate_block.find(marker)
-    if start == -1:
-        raise ValueError(f"Missing measurable check metric {metric!r} in capabilities gate block.")
-    next_start = gate_block.find("\n      - metric:", start + len(marker))
-    return gate_block[start:] if next_start == -1 else gate_block[start:next_start]
+def _load_capabilities() -> dict:
+    return yaml.safe_load(CAPABILITIES_PATH.read_text(encoding="utf-8"))
 
 
 def _threshold_tokens(config_name: str) -> list[str]:
@@ -40,7 +28,7 @@ def _threshold_tokens(config_name: str) -> list[str]:
 
 def main() -> int:
     thresholds = _load_thresholds()
-    capabilities_text = CAPABILITIES_PATH.read_text(encoding="utf-8")
+    capabilities = _load_capabilities()
     roadmap_text = ROADMAP_PATH.read_text(encoding="utf-8")
 
     failures: list[str] = []
@@ -52,8 +40,16 @@ def main() -> int:
         metric = str(benchmark_cfg["metric"])
         benchmark_command = str(benchmark_cfg["benchmark_command"])
 
-        gate_block = _extract_gate_block(capabilities_text, gate)
-        metric_block = _extract_metric_block(gate_block, metric)
+        gate_cfg = next((item for item in capabilities.get("phase_gates", []) if item["gate"] == gate), None)
+        if gate_cfg is None:
+            raise ValueError(f"Missing gate {gate!r} in {CAPABILITIES_PATH}.")
+        metric_cfg = next(
+            (item for item in gate_cfg.get("measurable_checks", []) if item["metric"] == metric),
+            None,
+        )
+        if metric_cfg is None:
+            raise ValueError(f"Missing measurable check metric {metric!r} in capabilities gate block.")
+        metric_block = json.dumps(metric_cfg, sort_keys=True)
 
         for token in _threshold_tokens(benchmark_name):
             if token not in metric_block:

--- a/scripts/check_capability_docs_sync.py
+++ b/scripts/check_capability_docs_sync.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate docs/capabilities.yaml references and generated capability sections."""
+"""Validate generated capabilities metadata references."""
 
 from __future__ import annotations
 
@@ -11,8 +11,6 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = ROOT / "docs" / "capabilities.yaml"
-
-DOC_CONFIGS: dict[Path, dict] = {}
 
 
 def _collect_missing_matrix_paths(matrix: dict, root: Path) -> list[str]:
@@ -41,45 +39,10 @@ def _collect_missing_matrix_paths(matrix: dict, root: Path) -> list[str]:
     return missing
 
 
-def _artifact_list(capability: dict) -> str:
-    entries = capability.get("validation_artifacts", [])
-    if not entries:
-        return "_No artifacts listed_"
-    return ", ".join(f"`{entry['path']}`" for entry in entries)
-
-
-def _render_table(title: str, capabilities: list[dict]) -> str:
-    lines = [
-        title,
-        "",
-        "| Capability | Status | Phase | Owner modules | Validation artifacts |",
-        "| --- | --- | --- | --- | --- |",
-    ]
-    for cap in capabilities:
-        owners = "<br>".join(f"`{path}`" for path in cap.get("owner_modules", [])) or "_Unspecified_"
-        lines.append(
-            f"| {cap['name']} | `{cap['status']}` | {cap['phase']} | {owners} | {_artifact_list(cap)} |"
-        )
-    return "\n".join(lines)
-
-
-def _replace_marker_block(content: str, marker: str, new_block: str) -> tuple[str, bool]:
-    start = f"<!-- {marker}:start -->"
-    end = f"<!-- {marker}:end -->"
-    if start not in content or end not in content:
-        raise ValueError(f"Missing marker block {start} ... {end}")
-
-    prefix, rest = content.split(start, 1)
-    middle, suffix = rest.split(end, 1)
-    replacement = f"{start}\n{new_block}\n{end}"
-    updated = f"{prefix}{replacement}{suffix}"
-    return updated, middle.strip() != new_block.strip()
-
-
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--write", action="store_true", help="rewrite docs with generated sections")
-    args = parser.parse_args()
+    parser.add_argument("--write", action="store_true", help="reserved for compatibility")
+    parser.parse_args()
 
     matrix = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
     missing_matrix_paths = _collect_missing_matrix_paths(matrix, ROOT)
@@ -89,32 +52,7 @@ def main() -> int:
             print(f" - {entry}")
         return 1
 
-    caps_by_id = {item["id"]: item for item in matrix.get("capabilities", [])}
-    strategy_sections = matrix.get("strategy_sections", {})
-
-    changed_files: list[Path] = []
-    for doc_path, cfg in DOC_CONFIGS.items():
-        rendered_blocks = []
-        for section_key, title in cfg["sections"]:
-            include_ids = strategy_sections[section_key]["include_ids"]
-            selected = [caps_by_id[item_id] for item_id in include_ids]
-            rendered_blocks.append(_render_table(title, selected))
-
-        rendered = "\n\n".join(rendered_blocks)
-
-        original = doc_path.read_text(encoding="utf-8")
-        updated, changed = _replace_marker_block(original, cfg["marker"], rendered)
-        if changed:
-            if args.write:
-                doc_path.write_text(updated, encoding="utf-8")
-                changed_files.append(doc_path)
-            else:
-                print(f"Out-of-sync generated capability section in {doc_path.relative_to(ROOT)}")
-                return 1
-
-    print("Capability matrix/doc sync check passed." if not changed_files else "Updated generated sections:")
-    for path in changed_files:
-        print(f" - {path.relative_to(ROOT)}")
+    print("Capability metadata sync check passed.")
     return 0
 
 

--- a/scripts/generate_strategy_artifacts.py
+++ b/scripts/generate_strategy_artifacts.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate all strategy-derived docs from docs/strategy_model.yaml."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
+CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "python-ci.yml"
+BADGES_PATH = ROOT / "docs" / "capability_maturity_badges.md"
+
+GENERATED_YAML_HEADER = [
+    "# GENERATED FILE - DO NOT EDIT DIRECTLY.",
+    "# Canonical source: docs/strategy_model.yaml",
+    "# Regenerate with: python scripts/generate_strategy_artifacts.py --write",
+]
+
+
+class _IndentedSafeDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+        super().increase_indent(flow, False)
+
+
+def _load_model() -> dict:
+    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+
+
+def _render_generated_yaml(data: dict) -> str:
+    body = yaml.dump(data, Dumper=_IndentedSafeDumper, sort_keys=False, default_flow_style=False)
+    return "\n".join(GENERATED_YAML_HEADER) + "\n" + body
+
+
+def render_capabilities_yaml(model: dict) -> str:
+    payload = {
+        "version": model["version"],
+        "last_updated": model.get("last_updated", "generated-from-strategy-model"),
+        "capabilities": [
+            {
+                key: capability[key]
+                for key in (
+                    "id",
+                    "name",
+                    "status",
+                    "phase",
+                    "owner_modules",
+                    "validation_artifacts",
+                    "ci_status_checks",
+                )
+                if key in capability
+            }
+            for capability in model.get("feature_capabilities", [])
+            if capability.get("status") != "deprecated"
+        ],
+        "strategy_sections": model.get("strategy_sections", {}),
+        "phase_gates": model.get("phase_gates", []),
+    }
+    return _render_generated_yaml(payload)
+
+
+def _run(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, cwd=ROOT, check=False, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"command failed: {cmd}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true", help="rewrite generated artifacts")
+    args = parser.parse_args()
+
+    model = _load_model()
+    rendered_capabilities = render_capabilities_yaml(model)
+
+    existing = CAPABILITIES_PATH.read_text(encoding="utf-8") if CAPABILITIES_PATH.exists() else ""
+    if existing != rendered_capabilities:
+        if not args.write:
+            print("Generated capabilities metadata is out of date. Run:")
+            print("  python scripts/generate_strategy_artifacts.py --write")
+            return 1
+        CAPABILITIES_PATH.write_text(rendered_capabilities, encoding="utf-8")
+
+    try:
+        if args.write:
+            _run([sys.executable, "scripts/render_strategy_docs.py", "--write"])
+            _run([sys.executable, "scripts/render_capability_maturity_badges.py", "--write"])
+        else:
+            _run([sys.executable, "scripts/check_strategy_docs_sync.py"])
+            _run([sys.executable, "scripts/render_capability_maturity_badges.py"])
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+
+    print("Generated strategy artifacts updated." if args.write else "Generated strategy artifacts are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render_capability_maturity_badges.py
+++ b/scripts/render_capability_maturity_badges.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render capability maturity badges from capabilities metadata and CI job coverage."""
+"""Render capability maturity badges from strategy-derived capabilities metadata and CI job coverage."""
 
 from __future__ import annotations
 
@@ -13,6 +13,11 @@ ROOT = Path(__file__).resolve().parents[1]
 CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "python-ci.yml"
 OUTPUT_PATH = ROOT / "docs" / "capability_maturity_badges.md"
+GENERATED_HEADER = (
+    "<!-- GENERATED FILE: derived from docs/strategy_model.yaml via docs/capabilities.yaml; "
+    "edit docs/strategy_model.yaml and rerun "
+    "`python scripts/generate_strategy_artifacts.py --write`. -->"
+)
 
 
 def _badge_url(label: str, message: str, color: str) -> str:
@@ -32,9 +37,11 @@ def _maturity_message(status: str, ci_covered: bool) -> tuple[str, str]:
 def render_markdown(capabilities_data: dict, workflow_data: dict) -> str:
     jobs = workflow_data.get("jobs", {})
     lines = [
+        GENERATED_HEADER,
+        "",
         "# Capability maturity badges",
         "",
-        "Generated from `docs/capabilities.yaml` and `.github/workflows/python-ci.yml`.",
+        "Generated from `docs/strategy_model.yaml`, `docs/capabilities.yaml`, and `.github/workflows/python-ci.yml`.",
         "",
         "| Capability ID | Status | CI checks present | Maturity badge |",
         "| --- | --- | --- | --- |",

--- a/scripts/render_strategy_docs.py
+++ b/scripts/render_strategy_docs.py
@@ -25,6 +25,12 @@ DOC_CONFIGS = {
     },
 }
 
+GENERATED_HEADER = (
+    "<!-- GENERATED FILE: derived from docs/strategy_model.yaml; "
+    "edit docs/strategy_model.yaml and rerun "
+    "`python scripts/generate_strategy_artifacts.py --write`. -->"
+)
+
 
 def git_head_commit() -> str:
     result = subprocess.run(
@@ -50,6 +56,12 @@ def _replace_marker_block(content: str, marker: str, new_block: str) -> tuple[st
     replacement = f"{start}\n{new_block}\n{end}"
     updated = f"{prefix}{replacement}{suffix}"
     return updated, middle.strip() != new_block.strip()
+
+
+def ensure_generated_header(content: str) -> tuple[str, bool]:
+    if content.startswith(GENERATED_HEADER):
+        return content, False
+    return f"{GENERATED_HEADER}\n\n{content.lstrip()}", True
 
 
 def _format_checks(checks: list[dict]) -> str:
@@ -158,6 +170,8 @@ def main() -> int:
         marker = DOC_CONFIGS[doc_path]["marker"]
         original = doc_path.read_text(encoding="utf-8")
         updated, changed = _replace_marker_block(original, marker, rendered)
+        updated, header_changed = ensure_generated_header(updated)
+        changed = changed or header_changed
         if changed:
             if args.write:
                 doc_path.write_text(updated, encoding="utf-8")

--- a/tests/test_acceptance_benchmark_depth_and_parity.py
+++ b/tests/test_acceptance_benchmark_depth_and_parity.py
@@ -11,13 +11,13 @@ import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
 MATRIX_PATH = ROOT / "configs" / "benchmark_matrix.yaml"
 MUTATION_KEYS = ("substitution_prob", "insertion_prob", "deletion_prob", "dropout_prob")
 
 
 def _load_capabilities() -> dict:
-    return yaml.safe_load(CAPABILITIES_PATH.read_text(encoding="utf-8"))
+    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
 
 
 def _phase_gate(data: dict, gate_name: str) -> dict:
@@ -26,7 +26,7 @@ def _phase_gate(data: dict, gate_name: str) -> dict:
 
 def test_validation_artifact_targets_dedicated_acceptance_module() -> None:
     data = _load_capabilities()
-    capability = next(c for c in data["capabilities"] if c["id"] == "benchmark_depth_and_parity")
+    capability = next(c for c in data["feature_capabilities"] if c["id"] == "benchmark_depth_and_parity")
 
     assert capability["validation_artifacts"] == [
         {

--- a/tests/test_acceptance_deterministic_reproducibility_governance.py
+++ b/tests/test_acceptance_deterministic_reproducibility_governance.py
@@ -3,15 +3,15 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
 
 
 def _load_capabilities() -> dict:
-    return yaml.safe_load(CAPABILITIES_PATH.read_text(encoding="utf-8"))
+    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
 
 
 def _partial_capability(data: dict, capability_id: str) -> dict:
-    for capability in data["capabilities"]:
+    for capability in data["feature_capabilities"]:
         if capability["id"] == capability_id:
             return capability
     raise AssertionError(f"Missing capability {capability_id!r}")

--- a/tests/test_acceptance_plugin_registry_policy_automation.py
+++ b/tests/test_acceptance_plugin_registry_policy_automation.py
@@ -3,16 +3,16 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
 
 
 def _load_capabilities() -> dict:
-    return yaml.safe_load(CAPABILITIES_PATH.read_text(encoding="utf-8"))
+    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
 
 
 def test_validation_artifact_targets_dedicated_acceptance_module():
     data = _load_capabilities()
-    capability = next(c for c in data["capabilities"] if c["id"] == "plugin_registry_policy_automation")
+    capability = next(c for c in data["feature_capabilities"] if c["id"] == "plugin_registry_policy_automation")
 
     assert capability["validation_artifacts"] == [
         {


### PR DESCRIPTION
### Motivation

- Consolidate overlapping strategy/capability metadata into a single canonical model so derived docs and CI use one source of truth.
- Ensure validation artifacts and capability IDs are preserved and make out-of-date generated docs immediately visible in CI.

### Description

- Moved capability validation metadata, CI status checks, strategy-section selectors, and phase-gate definitions into `docs/strategy_model.yaml` and preserved capability `id` and `validation_artifacts` entries. 
- Added `scripts/generate_strategy_artifacts.py` to render `docs/capabilities.yaml`, regenerate strategy sections (`docs/product_strategy.md`, `docs/vision.md`, `docs/development_roadmap.md`) and maturity badges, and emit explicit generated-file headers in derivative docs. 
- Updated renderers/checkers to use the canonical model and to add a generated-file header: `scripts/render_strategy_docs.py`, `scripts/render_capability_maturity_badges.py`, and simplified capability sync checks in `scripts/check_capability_docs_sync.py`. 
- Wired CI to regenerate artifacts then fail on any `git diff` (docs and Python CI workflows), and updated benchmark-alignment logic to read structured generated metadata rather than brittle text parsing. Also updated `docs/contributing.md` to document the new regeneration workflow.

### Testing

- Ran the acceptance and doc sync test suite: `python -m pytest -q tests/test_strategy_docs_sync.py tests/test_capability_docs_sync.py tests/test_capability_maturity_badges.py tests/test_acceptance_deterministic_reproducibility_governance.py tests/test_acceptance_benchmark_depth_and_parity.py tests/test_acceptance_plugin_registry_policy_automation.py`, all tests passed (17 passed).
- Ran linters: `ruff check` against changed scripts and tests, which completed successfully.
- Verified generation and drift checks: `python scripts/generate_strategy_artifacts.py --write` followed by `python scripts/check_benchmark_gate_alignment.py` and `python scripts/check_strategy_docs_sync.py` completed with no failures, and CI workflow changes now regenerate artifacts and use `git diff --exit-code` to detect drift.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab9bcc7bc83268d7395d63d4348dc)