### PR TITLE
Tighten deprecated-interface guardrails: telemetry, CI checks, migration docs, and parity tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -174,6 +174,9 @@ jobs:
     - name: Enforce deprecated import boundaries
       run: pytest -q tests/test_deprecated_import_boundaries.py
 
+    - name: Enforce deprecated reference guardrails
+      run: python scripts/check_deprecated_references.py
+
     - name: Restore pre-commit cache
       id: precommit-cache
       uses: actions/cache/restore@v3

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,45 +4,56 @@
 
 Starting in **v0.14.0**, GeneCoder supports external integrations only through:
 
-- `genecoder.sdk` (stable external SDK requests/results and plugin contracts).
-- `genecoder.app` (application-layer use-case contracts for runtime orchestration).
+- `genecoder.sdk` for stable request/result contracts and plugin interfaces.
+- `genecoder.app` for application-layer use cases and orchestration contracts.
 
-Deprecated facades (`genecoder.api`, `genecoder.pipeline`) now forward through versioned adapters in `genecoder.compat.v1` and do **not** add behavior beyond forwarding.
+Deprecated facades (`genecoder.api`, `genecoder.pipeline`, and `genecoder.compat.*`) remain compatibility-only bridges. They forward to canonical implementations, emit `DeprecationWarning`, and now record usage telemetry so release planning can confirm when removals are safe.
+
+## Migration priorities
+
+1. **Move orchestration calls to `genecoder.app`.** Replace `genecoder.pipeline` and any `SequencePipeline` compatibility imports with `RunPipelineUseCase`, `RunPipelineRequest`, and related dataclasses from `genecoder.app`.
+2. **Move plugin contracts and automation to `genecoder.sdk`.** Replace `genecoder.api` imports with `genecoder.sdk.plugins`, and use `genecoder.sdk.run_experiment` / `ExperimentRequest` for supported external workflows.
+3. **Eliminate direct `genecoder.compat.*` dependencies.** Compatibility packages are temporary shims only; new production code must not depend on them.
+
+## Versioned removal schedule
+
+| Release | Status | Concrete milestone | Required consumer action |
+| --- | --- | --- | --- |
+| **v0.14.x** | Current migration window | Canonical `genecoder.app` and `genecoder.sdk` interfaces are the only supported first-class APIs. Deprecated facades are warning-only compatibility bridges. | Start replacing imports in all maintained integrations and update tests to exercise canonical entrypoints. |
+| **v0.15.0** | Compatibility freeze | No new feature logic or new references to deprecated modules are allowed outside approved shims/tests. CI blocks new deprecated references and telemetry counts remaining usage. | Finish code migration away from `genecoder.api`, `genecoder.pipeline`, and `genecoder.compat.channel_sim` / `error_simulation`. |
+| **v0.16.0** | Planned removal | Remove `genecoder.api`, `genecoder.pipeline`, `genecoder.compat.v1.api_adapter`, and `genecoder.compat.v1.pipeline_adapter`. Root-package exports remain canonical-only. | All orchestration and plugin imports must already be on `genecoder.app` / `genecoder.sdk`. |
+| **v0.17.0** | Compatibility package cleanup | Remove `genecoder.compat.channel_cli`, `genecoder.compat.legacy.sequence_pipeline`, and test-only `genecoder.compat.legacy.cloud.*` shims unless telemetry-backed exception is documented in release notes. | Remove any remaining `genecoder.compat.*` imports from downstream maintenance branches. |
+| **v0.18.0** | Final cleanup gate | Remove any residual deprecated top-level compatibility re-export stubs that exist only for patch-level grace periods. | Downstream consumers must be fully canonical-interface only. |
+
+## Canonical replacement map
+
+| Deprecated path | Canonical replacement | Notes |
+| --- | --- | --- |
+| `genecoder.pipeline` | `genecoder.app.RunPipelineUseCase` and `genecoder.app.RunPipelineRequest` | Use `genecoder.app` for orchestration, artifact policy, and typed request modeling. |
+| `genecoder.api` | `genecoder.sdk.plugins` | Plugin interfaces are part of the supported SDK contract. |
+| `genecoder.compat.v1.pipeline_adapter` | `genecoder.app` | Versioned adapter is only a temporary forwarder. |
+| `genecoder.compat.v1.api_adapter` | `genecoder.sdk.plugins` | Versioned adapter is only a temporary forwarder. |
+| `genecoder.compat.legacy.sequence_pipeline` | `genecoder.app.sequence_pipeline` only as a temporary stepping stone, then `genecoder.app.RunPipelineUseCase` | Prefer migrating directly to `RunPipelineUseCase`. |
+| `genecoder.compat.channel_cli` | `genecoder.core` profile helpers | Use modern channel profile helpers. |
+| `genecoder.compat.channel_sim` / `genecoder.compat.error_simulation` | `genecoder.channel_engine` internals only where explicitly needed, otherwise canonical app/sdk workflows | Do not add new external usage. |
 
 ## Orchestration entrypoint migration
 
-See [`docs/orchestration_migration.md`](orchestration_migration.md) for the authoritative mapping from deprecated orchestration imports (`genecoder.pipeline`, `genecoder.api`, and `SequencePipeline`) to canonical APIs.
-
-## Explicit removal milestones
-
-- **v0.15.0**: last release where `genecoder.api` and `genecoder.pipeline` remain available with deprecation warnings.
-- **v0.16.0**: removal target for both deprecated facades; integrations must be on `genecoder.sdk` + `genecoder.app`.
-- **v0.16.0**: first-party tests are canonical-import only except dedicated compatibility/deprecation tests.
+See [`docs/orchestration_migration.md`](orchestration_migration.md) for the authoritative mapping from deprecated orchestration imports to canonical APIs.
 
 ## Channel attribute rename
 
-The `Channel.error_rate` attribute has been renamed to `Channel.substitution_prob`.
-Accessing or setting `error_rate` still works but raises a `DeprecationWarning` and
-will be removed in a future release. Update any code that relies on `error_rate`
-to use `substitution_prob` instead.
+The `Channel.error_rate` attribute has been renamed to `Channel.substitution_prob`. Accessing or setting `error_rate` still works but raises a `DeprecationWarning` and will be removed in a future release. Update any code that relies on `error_rate` to use `substitution_prob` instead.
 
-## Simulator ``SequenceBatch`` adoption
+## Simulator `SequenceBatch` adoption
 
-Simulators must return ``SequenceBatch`` objects from ``simulate``. When porting
-an older plugin:
+Simulators must return `SequenceBatch` objects from `simulate`. When porting an older plugin:
 
-1. Wrap raw ``str`` inputs by calling ``SequenceBatch.build`` with a ``batch_id``
-   and ``batch_seed``. The helper fills in deterministic oligo identifiers.
-2. Clone the batch with ``genecoder.simulators.batch_utils.clone_batch`` before
-   mutating to avoid rewriting the caller's data in place.
-3. Record coverage and dropout metadata via ``RESULT_*`` constants and then
-   invoke ``finalize_batch_statistics`` to generate aggregate metrics.
-4. Reuse ``apply_legacy_simulator`` for simple passthrough simulators that do not
-   yet understand batches; it automatically produces ``SequenceBatch`` outputs.
-
+1. Wrap raw `str` inputs by calling `SequenceBatch.build` with a `batch_id` and `batch_seed`.
+2. Clone the batch with `genecoder.simulators.batch_utils.clone_batch` before mutating it in place.
+3. Record coverage and dropout metadata via `RESULT_*` constants and invoke `finalize_batch_statistics` to generate aggregate metrics.
+4. Reuse `apply_legacy_simulator` for simple passthrough simulators that do not yet understand batches.
 
 ## Channel CLI legacy boundary
 
-`genecoder.cli.channel` now resolves profiles and mutation behavior from `genecoder.simulators.*` modules and the typed channel option adapter in `genecoder.simulators.channel_cli_adapter`.
-
-Legacy `channel_engine.legacy_adapter` usage is restricted to compatibility shims under `genecoder.compat.*` and deprecated top-level re-export modules. If you still use legacy flags such as `--indel-profile` with adapter-era aliases, the CLI emits migration warnings and maps them onto modern profile names (`illumina`, `nanopore`).
+`genecoder.cli.channel` now resolves profiles and mutation behavior from `genecoder.simulators.*` modules and the typed channel option adapter in `genecoder.simulators.channel_cli_adapter`. Legacy `channel_engine.legacy_adapter` usage is restricted to compatibility shims under `genecoder.compat.*` and deprecated top-level re-export modules. If you still use legacy flags such as `--indel-profile` with adapter-era aliases, the CLI emits migration warnings and maps them onto modern profile names (`illumina`, `nanopore`).

--- a/scripts/check_deprecated_references.py
+++ b/scripts/check_deprecated_references.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+DEPRECATED_MODULES = {
+    "genecoder.api",
+    "genecoder.pipeline",
+    "genecoder.compat.channel_cli",
+    "genecoder.compat.channel_sim",
+    "genecoder.compat.error_simulation",
+    "genecoder.compat.legacy",
+    "genecoder.compat.legacy.sequence_pipeline",
+    "genecoder.compat.legacy.channel_adapter_exports",
+    "genecoder.compat.legacy.cloud",
+    "genecoder.compat.legacy.cloud.worker",
+    "genecoder.compat.v1",
+    "genecoder.compat.v1.api_adapter",
+    "genecoder.compat.v1.pipeline_adapter",
+}
+
+APPROVED_REFERENCERS = {
+    Path("src/genecoder/api.py"),
+    Path("src/genecoder/pipeline.py"),
+    Path("src/genecoder/channel_sim.py"),
+    Path("src/genecoder/compat/__init__.py"),
+    Path("src/genecoder/compat/channel_cli.py"),
+    Path("src/genecoder/compat/channel_sim.py"),
+    Path("src/genecoder/compat/error_simulation.py"),
+    Path("src/genecoder/compat/legacy/__init__.py"),
+    Path("src/genecoder/compat/legacy/channel_adapter_exports.py"),
+    Path("src/genecoder/compat/legacy/sequence_pipeline.py"),
+    Path("src/genecoder/compat/legacy/cloud/__init__.py"),
+    Path("src/genecoder/compat/legacy/cloud/worker.py"),
+    Path("src/genecoder/compat/v1/__init__.py"),
+    Path("src/genecoder/compat/v1/api_adapter.py"),
+    Path("src/genecoder/compat/v1/pipeline_adapter.py"),
+    Path("tests/test_deprecated_import_boundaries.py"),
+    Path("tests/test_compat_import_boundaries.py"),
+    Path("tests/test_pipeline_legacy.py"),
+    Path("tests/test_sdk.py"),
+    Path("tests/test_architecture_boundaries.py"),
+    Path("tests/test_cli_channel.py"),
+    Path("tests/test_cloud_worker_offline.py"),
+    Path("tests/test_deprecated_module_telemetry.py"),
+    Path("tests/test_pipeline_kpi_bundle.py"),
+    Path("tests/test_worker_metrics.py"),
+    Path("tests/test_worker_security.py"),
+    Path("plugins-examples/starter_plugin/starter_plugin/__init__.py"),
+    Path("scripts/check_deprecated_references.py"),
+}
+
+SEARCH_ROOTS = (Path("src"), Path("tests"), Path("plugins-examples"), Path("scripts"))
+
+
+def _extract_references(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    references: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            references.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            references.add(node.module)
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            for module_name in DEPRECATED_MODULES:
+                if module_name in node.value:
+                    references.add(module_name)
+    return references
+
+
+def main() -> int:
+    violations: list[str] = []
+    for root in SEARCH_ROOTS:
+        for path in root.rglob("*.py"):
+            if path in APPROVED_REFERENCERS:
+                continue
+            bad = sorted(name for name in _extract_references(path) if name in DEPRECATED_MODULES)
+            if bad:
+                violations.append(f"{path}: {bad}")
+    if violations:
+        raise SystemExit("\n".join(violations))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -24,7 +24,6 @@ from .plugin_manager import (
 )
 from .simulators import SIMULATOR_REGISTRY, simulate_reads
 from .channel_config import ChannelConfig
-from .app.pipeline_runtime import SequencePipeline
 
 
 __all__ = [
@@ -40,7 +39,6 @@ __all__ = [
     "load_plugins",
     "install_registry_plugins",
     "ChannelConfig",
-    "SequencePipeline",
     "encrypt_data",
     "decrypt_data",
     "compute_checksum",

--- a/src/genecoder/_deprecation.py
+++ b/src/genecoder/_deprecation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Shared helpers for deprecated module telemetry and warnings."""
+
+from typing import Final
+import warnings
+
+from .metrics import increment
+
+_DEPRECATION_NAMESPACE: Final[str] = "deprecated.module"
+
+
+def record_deprecated_module_usage(module_name: str) -> None:
+    """Increment structured counters for deprecated module usage."""
+
+    normalized = module_name.replace("_", "-")
+    increment(f"{_DEPRECATION_NAMESPACE}.total.imports")
+    increment(f"{_DEPRECATION_NAMESPACE}.{normalized}.imports")
+
+
+def warn_with_telemetry(*, module_name: str, message: str, stacklevel: int = 2) -> None:
+    """Record deprecated module usage before emitting a deprecation warning."""
+
+    record_deprecated_module_usage(module_name)
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)

--- a/src/genecoder/api.py
+++ b/src/genecoder/api.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 """Backward-compatible facade for plugin abstract interfaces."""
 
-import warnings
-
+from ._deprecation import warn_with_telemetry
 from .compat.v1.api_adapter import Codec, FEC, Simulator, Visualizer
 
 __all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
 
-warnings.warn(
-    "genecoder.api is deprecated and will be removed in v0.16.0; "
-    "import plugin interfaces from genecoder.sdk.plugins.",
-    DeprecationWarning,
+warn_with_telemetry(
+    module_name="genecoder.api",
+    message=(
+        "genecoder.api is deprecated and will be removed in v0.16.0; "
+        "import plugin interfaces from genecoder.sdk.plugins."
+    ),
     stacklevel=2,
 )

--- a/src/genecoder/compat/channel_cli.py
+++ b/src/genecoder/compat/channel_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Compatibility adapter for legacy channel CLI helpers."""
 
-import warnings
+from genecoder._deprecation import warn_with_telemetry
 
 from genecoder.core import (
     LEGACY_DEFAULT_INDEL_PROFILE,
@@ -20,8 +20,8 @@ __all__ = [
     "resolve_indel_profile",
 ]
 
-warnings.warn(
-    "genecoder.compat.channel_cli is deprecated; import indel profile helpers from genecoder.core.",
-    DeprecationWarning,
+warn_with_telemetry(
+    module_name="genecoder.compat.channel_cli",
+    message="genecoder.compat.channel_cli is deprecated; import indel profile helpers from genecoder.core.",
     stacklevel=2,
 )

--- a/src/genecoder/compat/channel_sim.py
+++ b/src/genecoder/compat/channel_sim.py
@@ -4,4 +4,12 @@ Compatibility-only module: do not add new feature logic.
 """
 from __future__ import annotations
 
+from genecoder._deprecation import warn_with_telemetry
+
 from genecoder.compat.legacy.channel_adapter_exports import *  # noqa: F403
+
+warn_with_telemetry(
+    module_name="genecoder.compat.channel_sim",
+    message="genecoder.compat.channel_sim is deprecated; import channel functionality from genecoder.channel_engine or supported app/sdk entrypoints.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/error_simulation.py
+++ b/src/genecoder/compat/error_simulation.py
@@ -4,4 +4,12 @@ Compatibility-only module: do not add new feature logic.
 """
 from __future__ import annotations
 
+from genecoder._deprecation import warn_with_telemetry
+
 from genecoder.compat.legacy.channel_adapter_exports import *  # noqa: F403
+
+warn_with_telemetry(
+    module_name="genecoder.compat.error_simulation",
+    message="genecoder.compat.error_simulation is deprecated; import channel functionality from genecoder.channel_engine or supported app/sdk entrypoints.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/__init__.py
+++ b/src/genecoder/compat/legacy/__init__.py
@@ -4,6 +4,14 @@ This package is the single location for legacy shims. Do not add new product
 features here; only forwarding logic and deprecation bridges are allowed.
 """
 
+from genecoder._deprecation import warn_with_telemetry
+
 from .sequence_pipeline import SequencePipeline
 
 __all__ = ["SequencePipeline"]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.legacy",
+    message="genecoder.compat.legacy is deprecated; import supported interfaces from genecoder.app or genecoder.sdk.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/channel_adapter_exports.py
+++ b/src/genecoder/compat/legacy/channel_adapter_exports.py
@@ -5,6 +5,8 @@ Compatibility-only module: no new feature work.
 
 from __future__ import annotations
 
+from genecoder._deprecation import warn_with_telemetry
+
 from genecoder.channel_engine.legacy_adapter import (
     ADAPTER_PROFILES,
     DEFAULT_ADAPTER_PROFILE,
@@ -30,3 +32,9 @@ __all__ = [
     "ADAPTER_PROFILES",
     "DEFAULT_ADAPTER_PROFILE",
 ]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.legacy.channel_adapter_exports",
+    message="genecoder.compat.legacy.channel_adapter_exports is deprecated; use supported channel_engine or app/sdk interfaces instead.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/cloud/__init__.py
+++ b/src/genecoder/compat/legacy/cloud/__init__.py
@@ -1,5 +1,13 @@
 """Cloud worker stubs for tests."""
 
+from genecoder._deprecation import warn_with_telemetry
+
 from . import worker
 
 __all__ = ["worker"]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.legacy.cloud",
+    message="genecoder.compat.legacy.cloud is deprecated and retained only for compatibility tests.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/cloud/worker.py
+++ b/src/genecoder/compat/legacy/cloud/worker.py
@@ -9,6 +9,8 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+from genecoder._deprecation import warn_with_telemetry
+
 from fastapi import FastAPI, HTTPException, Header
 
 from genecoder.cli import bundle as bundle_cli
@@ -68,3 +70,9 @@ def create_job(job: dict[str, Any], authorization: str | None = Header(None)) ->
 
 # Expose bundle_cli for monkeypatching in tests
 __all__ = ["app", "API_TOKEN", "bundle_cli", "create_job"]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.legacy.cloud.worker",
+    message="genecoder.compat.legacy.cloud.worker is deprecated and retained only for compatibility tests.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/legacy/sequence_pipeline.py
+++ b/src/genecoder/compat/legacy/sequence_pipeline.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 """Compatibility shim for deprecated ``SequencePipeline`` import path."""
 
-import warnings
+from genecoder._deprecation import warn_with_telemetry
 
 from genecoder.app.sequence_pipeline import SequencePipeline
 
 __all__ = ["SequencePipeline"]
 
-warnings.warn(
-    "genecoder.compat.legacy.sequence_pipeline is deprecated; import SequencePipeline from genecoder.app.sequence_pipeline.",
-    DeprecationWarning,
+warn_with_telemetry(
+    module_name="genecoder.compat.legacy.sequence_pipeline",
+    message="genecoder.compat.legacy.sequence_pipeline is deprecated; import SequencePipeline from genecoder.app.sequence_pipeline.",
     stacklevel=2,
 )

--- a/src/genecoder/compat/v1/__init__.py
+++ b/src/genecoder/compat/v1/__init__.py
@@ -1,1 +1,9 @@
 """Versioned compatibility adapters for legacy import paths."""
+
+from genecoder._deprecation import warn_with_telemetry
+
+warn_with_telemetry(
+    module_name="genecoder.compat.v1",
+    message="genecoder.compat.v1 adapters are deprecated compatibility bridges; migrate to genecoder.app and genecoder.sdk.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/v1/api_adapter.py
+++ b/src/genecoder/compat/v1/api_adapter.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 """Versioned compatibility adapter for deprecated ``genecoder.api`` imports."""
 
+from genecoder._deprecation import warn_with_telemetry
+
 from ...plugin_api import Codec, FEC, Simulator, Visualizer
 
 __all__ = ["Codec", "FEC", "Simulator", "Visualizer"]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.v1.api_adapter",
+    message="genecoder.compat.v1.api_adapter is deprecated; import plugin interfaces from genecoder.sdk.plugins.",
+    stacklevel=2,
+)

--- a/src/genecoder/compat/v1/pipeline_adapter.py
+++ b/src/genecoder/compat/v1/pipeline_adapter.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 Compatibility-only module: do not add new product features here.
 """
 
+from genecoder._deprecation import warn_with_telemetry
+
 from ... import core
 from ...app.pipeline_runtime import run_pipeline
 from ...compat.legacy.sequence_pipeline import SequencePipeline
 from ...plugin_manager import init_plugins
 
 __all__ = ["SequencePipeline", "run_pipeline", "core", "init_plugins"]
+
+warn_with_telemetry(
+    module_name="genecoder.compat.v1.pipeline_adapter",
+    message="genecoder.compat.v1.pipeline_adapter is deprecated; import orchestration interfaces from genecoder.app.",
+    stacklevel=2,
+)

--- a/src/genecoder/pipeline.py
+++ b/src/genecoder/pipeline.py
@@ -9,7 +9,7 @@ wrappers and CI gate checks.
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
-import warnings
+from ._deprecation import warn_with_telemetry
 
 from .compat.v1.pipeline_adapter import (
     SequencePipeline,
@@ -103,9 +103,11 @@ __all__ = [
     "bundle_config_to_job_request",
 ]
 
-warnings.warn(
-    "genecoder.pipeline is deprecated and will be removed in v0.16.0; "
-    "import genecoder.app.RunPipelineUseCase for orchestration.",
-    DeprecationWarning,
+warn_with_telemetry(
+    module_name="genecoder.pipeline",
+    message=(
+        "genecoder.pipeline is deprecated and will be removed in v0.16.0; "
+        "import genecoder.app.RunPipelineUseCase for orchestration."
+    ),
     stacklevel=2,
 )

--- a/tests/test_canonical_interface_parity.py
+++ b/tests/test_canonical_interface_parity.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from genecoder.app import (
+    ArtifactOutputPolicy,
+    ChannelProfile,
+    ConstraintProfile,
+    RunPipelineRequest,
+    RunPipelineUseCase,
+    SeedProfile,
+)
+from genecoder.sdk import ExperimentRequest, run_experiment
+
+
+FAKE_METRICS = {
+    "gc_content": 0.52,
+    "gc_variance": 0.01,
+    "max_homopolymer": 2,
+    "substitutions": 1,
+    "insertions": 0,
+    "deletions": 0,
+    "coverage": 6,
+    "dropout_count": 0,
+    "dropout_fraction": 0.0,
+    "decode_success": True,
+    "decode_success_rate": 1.0,
+    "ecc_success_rates": {"parity": 1.0},
+    "constraint_violations": 0,
+    "constraint_outcomes": {"by_oligo": {"oligo-1": []}, "stages": []},
+    "_runtime": {
+        "total_seconds": 1.2,
+        "encode_seconds": 0.2,
+        "simulate_seconds": 0.4,
+        "decode_seconds": 0.6,
+    },
+    "_sim_stage_provenance": [{"stage": "simulate", "profile": "illumina"}],
+    "_sim_stage_metrics": [{"stage": "simulate", "coverage": 6}],
+    "_applied_channel_parameters": {"substitution_rate": 0.01},
+}
+
+
+def _build_app_request(tmp_path: Path) -> RunPipelineRequest:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"canonical-parity")
+    return RunPipelineRequest(
+        codec="reverse",
+        input_path=str(source),
+        output_path=str(tmp_path / "decoded.bin"),
+        channel="illumina",
+        profile=ChannelProfile(name="illumina", parameters={"substitution_rate": 0.01}),
+        seeds=SeedProfile(global_seed=7, encode_seed=8, simulate_seed=9, decode_seed=10),
+        constraints=ConstraintProfile(gc_min=0.4, gc_max=0.6, max_homopolymer=3),
+        artifacts=ArtifactOutputPolicy(
+            metrics_path=str(tmp_path / "run.metrics.json"),
+            emit_manifest=True,
+            emit_html_report=False,
+        ),
+    )
+
+
+def _fake_runtime(**_: object):
+    return b"canonical-parity", dict(FAKE_METRICS), {"backend": "stub"}
+
+
+def test_app_and_sdk_requests_share_supported_workflow_surface(tmp_path: Path) -> None:
+    app_request = _build_app_request(tmp_path)
+    sdk_request = ExperimentRequest(
+        codec=app_request.codec,
+        input_path=app_request.input_path,
+        output_path=app_request.output_path,
+        channel=app_request.channel,
+        profile=app_request.profile,
+        seeds=app_request.seeds,
+        matrix=app_request.matrix,
+        constraints=app_request.constraints,
+        artifacts=app_request.artifacts,
+    )
+
+    assert sdk_request.codec == app_request.codec
+    assert sdk_request.profile == app_request.profile
+    assert sdk_request.seeds == app_request.seeds
+    assert sdk_request.constraints == app_request.constraints
+    assert sdk_request.artifacts == app_request.artifacts
+
+
+def test_app_and_sdk_runtime_results_are_parity_aligned(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+
+    app_request = _build_app_request(tmp_path)
+    app_response = RunPipelineUseCase().execute(app_request)
+
+    sdk_request = ExperimentRequest(
+        codec=app_request.codec,
+        input_path=app_request.input_path,
+        output_path=app_request.output_path,
+        channel=app_request.channel,
+        profile=app_request.profile,
+        seeds=app_request.seeds,
+        matrix=app_request.matrix,
+        constraints=app_request.constraints,
+        artifacts=app_request.artifacts,
+    )
+    sdk_result = run_experiment(sdk_request)
+
+    assert sdk_result.decoded == app_response.decoded
+    assert sdk_result.dashboard_metrics == app_response.dashboard_metrics
+    assert sdk_result.canonical_run == app_response.run_schema
+    assert sdk_result.artifact_paths["metrics"] == app_response.metrics_path
+    assert sdk_result.artifact_paths["manifest"] == app_response.manifest_path
+    assert sdk_result.artifact_paths["html_report"] == app_response.html_report_path
+    assert sdk_result.fec_info == app_response.fec_info
+
+
+def test_sdk_yaml_and_dataclass_paths_match_app_contract(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+    app_request = _build_app_request(tmp_path)
+
+    yaml_path = tmp_path / "request.yaml"
+    yaml_path.write_text(
+        """
+codec: reverse
+input_path: {input_path}
+output_path: {output_path}
+channel: illumina
+profile:
+  name: illumina
+  parameters:
+    substitution_rate: 0.01
+seeds:
+  global_seed: 7
+  encode_seed: 8
+  simulate_seed: 9
+  decode_seed: 10
+constraints:
+  gc_min: 0.4
+  gc_max: 0.6
+  max_homopolymer: 3
+artifacts:
+  metrics_path: {metrics_path}
+  emit_manifest: true
+  emit_html_report: false
+""".format(
+            input_path=app_request.input_path,
+            output_path=app_request.output_path,
+            metrics_path=app_request.artifacts.metrics_path,
+        ),
+        encoding="utf-8",
+    )
+
+    app_response = RunPipelineUseCase().execute(app_request)
+    sdk_result = run_experiment(yaml_path)
+
+    assert sdk_result.canonical_run == app_response.run_schema
+    assert sdk_result.dashboard_metrics == app_response.dashboard_metrics

--- a/tests/test_compat_import_boundaries.py
+++ b/tests/test_compat_import_boundaries.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 COMPAT_ROOT = Path("src/genecoder/compat")
 
+NON_FORWARDER_COMPAT_MODULES = {
+    Path("src/genecoder/compat/legacy/cloud/worker.py"),
+}
+
 
 def _is_docstring_expr(node: ast.stmt) -> bool:
     return (
@@ -19,10 +23,13 @@ def _is_warning_call(node: ast.stmt) -> bool:
         return False
     func = node.value.func
     return (
-        isinstance(func, ast.Attribute)
-        and func.attr == "warn"
-        and isinstance(func.value, ast.Name)
-        and func.value.id == "warnings"
+        (
+            isinstance(func, ast.Attribute)
+            and func.attr == "warn"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "warnings"
+        )
+        or (isinstance(func, ast.Name) and func.id == "warn_with_telemetry")
     )
 
 
@@ -41,6 +48,8 @@ def _module_name(path: Path) -> str:
 def test_compat_modules_are_forwarders_only() -> None:
     violations: list[str] = []
     for path in COMPAT_ROOT.rglob("*.py"):
+        if path in NON_FORWARDER_COMPAT_MODULES:
+            continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in tree.body:
             if isinstance(node, (ast.Import, ast.ImportFrom)):

--- a/tests/test_deprecated_import_boundaries.py
+++ b/tests/test_deprecated_import_boundaries.py
@@ -1,37 +1,16 @@
 from __future__ import annotations
 
-import ast
-from pathlib import Path
 
-DEPRECATED_IMPORTS = {"genecoder.api", "genecoder.pipeline"}
-
-APPROVED_TEST_FILES = {
-    Path("tests/test_pipeline_legacy.py"),
-    Path("tests/test_sdk.py"),
-}
-
-SEARCH_ROOTS = (Path("tests"), Path("src/plugins"), Path("plugins-examples"))
+from scripts.check_deprecated_references import APPROVED_REFERENCERS, DEPRECATED_MODULES, SEARCH_ROOTS, _extract_references
 
 
-def _extract_imports(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    imports: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imports.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imports.add(node.module)
-    return imports
-
-
-def test_no_new_deprecated_imports_outside_compatibility_suite() -> None:
+def test_no_new_deprecated_references_outside_approved_shims() -> None:
     violations: list[str] = []
     for root in SEARCH_ROOTS:
         for path in root.rglob("*.py"):
-            if path in APPROVED_TEST_FILES:
+            if path in APPROVED_REFERENCERS:
                 continue
-            imports = _extract_imports(path)
-            bad = sorted(name for name in imports if name in DEPRECATED_IMPORTS)
+            bad = sorted(name for name in _extract_references(path) if name in DEPRECATED_MODULES)
             if bad:
                 violations.append(f"{path}: {bad}")
 

--- a/tests/test_deprecated_module_telemetry.py
+++ b/tests/test_deprecated_module_telemetry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+from pathlib import Path
+
+from genecoder.metrics import get_metrics, set_metrics_path
+
+
+MODULES_UNDER_TEST = [
+    "genecoder.api",
+    "genecoder.pipeline",
+    "genecoder.compat.channel_cli",
+    "genecoder.compat.channel_sim",
+    "genecoder.compat.error_simulation",
+]
+
+
+def test_deprecated_modules_emit_usage_telemetry(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "metrics.json"
+    set_metrics_path(metrics_path)
+    try:
+        for module_name in MODULES_UNDER_TEST:
+            importlib.invalidate_caches()
+            sys.modules.pop(module_name, None)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                importlib.import_module(module_name)
+
+        metrics = get_metrics()
+    finally:
+        set_metrics_path(None)
+
+    assert metrics["deprecated.module.total.imports"] >= len(MODULES_UNDER_TEST)
+    for module_name in MODULES_UNDER_TEST:
+        key = f"deprecated.module.{module_name.replace('_', '-')}.imports"
+        assert metrics[key] >= 1


### PR DESCRIPTION
### Motivation
- Reduce accidental expansion of deprecated public facades and gather structured telemetry to determine safe removal windows. 
- Ensure first-class package exports emphasize canonical `genecoder.app`/`genecoder.sdk` surfaces instead of legacy façades. 
- Prevent new references to deprecated modules outside approved compatibility shims via CI guardrails. 

### Description
- Remove the deprecated `SequencePipeline` top-level export from `src/genecoder/__init__.py` so package root only advertises canonical first-class APIs. 
- Add a shared deprecation helper `src/genecoder/_deprecation.py` that records structured counters (via `genecoder.metrics.increment`) and emits the warning, and wire it into deprecated facades and shims (updated files under `src/genecoder/pipeline.py`, `src/genecoder/api.py`, and `src/genecoder/compat/*`). 
- Add a small reference-scanner script `scripts/check_deprecated_references.py` and a CI workflow step to block new references to deprecated modules outside an approved list of compatibility shims/tests. 
- Publish a concrete, versioned migration schedule and replacement map in `docs/migration.md`. 
- Add parity and telemetry tests: `tests/test_canonical_interface_parity.py` validates the `genecoder.app` and `genecoder.sdk` surfaces provide equivalent workflow coverage; `tests/test_deprecated_module_telemetry.py` asserts deprecated modules increment telemetry counters; and update boundary tests (`tests/test_deprecated_import_boundaries.py`, `tests/test_compat_import_boundaries.py`) to enforce the new guardrails and allow documented exceptions. 

Files touched (high level): `src/genecoder/_deprecation.py`, `src/genecoder/__init__.py`, `src/genecoder/pipeline.py`, `src/genecoder/api.py`, `src/genecoder/compat/*`, `scripts/check_deprecated_references.py`, `docs/migration.md`, CI workflow `.github/workflows/python-ci.yml`, and test additions/updates under `tests/`.

### Testing
- Ran linter/auto-fixes with `ruff check --fix` across modified modules and the fixes were applied successfully. (Succeeded.)
- Ran focused unit tests with `pytest -q tests/test_deprecated_import_boundaries.py tests/test_compat_import_boundaries.py tests/test_deprecated_module_telemetry.py tests/test_canonical_interface_parity.py tests/test_sdk_api_compatibility.py` and all selected tests passed (10 passed, warnings only). (Succeeded.)
- Executed the new guardrail script directly with `python scripts/check_deprecated_references.py` to validate no unauthorized references exist in the tree. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babd775b708326ac992dcf1996ceed)