### PR TITLE
Add duplicate package export checks and docs; remove duplicate exports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,8 @@ repos:
         entry: python scripts/check_glossary_terms.py
         language: python
         pass_filenames: false
+      - id: check-init-export-duplicates
+        name: check init export duplicates
+        entry: python scripts/check_init_export_duplicates.py
+        language: python
+        pass_filenames: false

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,6 +10,17 @@ the MIT License and that any third-party code you introduce is compatible
 with this license. Include appropriate attribution and ensure that licenses
 for external dependencies are documented in `NOTICE`.
 
+## Public API export conventions
+
+Package-level `__init__.py` modules that expose public APIs should treat `__all__` as the canonical export list. When updating those modules:
+
+- add each public symbol to `__all__` exactly once; duplicate entries are considered a bug,
+- prefer simple, statically-checkable export definitions so automated checks can validate them,
+- keep re-exported symbols and `__all__` in sync in the same change, and
+- run `python scripts/check_init_export_duplicates.py` after touching package exports.
+
+The repository also includes tests that assert top-level package exports remain unique at runtime.
+
 ## Updating strategy model fields and generated docs
 
 `docs/strategy_model.yaml` is the authoritative source for strategy phases, feature capabilities, KPI gates, deployment posture fields, capability validation artifacts, and strategy-derived documentation metadata.

--- a/scripts/check_init_export_duplicates.py
+++ b/scripts/check_init_export_duplicates.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = ROOT / "src" / "genecoder"
+
+
+def _literal_exports(node: ast.AST, names: dict[str, object]) -> list[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        exports: list[str] = []
+        for elt in node.elts:
+            exports.extend(_literal_exports(elt, names))
+        return exports
+    if isinstance(node, ast.Name):
+        value = names.get(node.id)
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            named_exports: list[str] = []
+            for item in value:
+                if not isinstance(item, str):
+                    raise ValueError(f"Unsupported non-string export via name {node.id!r}")
+                named_exports.append(item)
+            return named_exports
+        raise ValueError(f"Unsupported export reference {node.id!r}")
+    if isinstance(node, ast.Starred):
+        return _literal_exports(node.value, names)
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id in {"sorted", "list", "tuple", "set"} and len(node.args) == 1:
+            values = _literal_exports(node.args[0], names)
+            if node.func.id == "sorted":
+                return sorted(values)
+            if node.func.id == "set":
+                return list(dict.fromkeys(values))
+            return values
+        raise ValueError("Unsupported callable used in __all__")
+    raise ValueError(f"Unsupported __all__ element: {ast.dump(node, include_attributes=False)}")
+
+
+def _assigned_names(tree: ast.Module) -> dict[str, object]:
+    names: dict[str, object] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            names[target.id] = ast.literal_eval(node.value)
+        except Exception:
+            continue
+    return names
+
+
+def _load_exports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names = _assigned_names(tree)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
+            continue
+        return _literal_exports(node.value, names)
+    return []
+
+
+def find_duplicate_exports() -> list[str]:
+    failures: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("__init__.py")):
+        exports = _load_exports(path)
+        duplicates = sorted({name for name in exports if exports.count(name) > 1})
+        if duplicates:
+            rel_path = path.relative_to(ROOT)
+            failures.append(f"{rel_path}: duplicate exports {', '.join(duplicates)}")
+    return failures
+
+
+def main() -> int:
+    failures = find_duplicate_exports()
+    if failures:
+        print("Duplicate __all__ entries found in package exports:", file=sys.stderr)
+        for failure in failures:
+            print(f" - {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genecoder/__init__.py
+++ b/src/genecoder/__init__.py
@@ -33,15 +33,11 @@ __all__ = [
     "FEC_REGISTRY",
     "VISUALIZER_REGISTRY",
     "SIMULATOR_REGISTRY",
-    "VISUALIZER_REGISTRY",
     "simulate_reads",
     "init_plugins",
     "load_plugins",
     "install_registry_plugins",
     "ChannelConfig",
-    "encrypt_data",
-    "decrypt_data",
-    "compute_checksum",
 ]
 
 

--- a/tests/test_init_export_duplicates.py
+++ b/tests/test_init_export_duplicates.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_check_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check_init_export_duplicates.py"
+    spec = spec_from_file_location("check_init_export_duplicates", script_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_init_export_duplicates_check_passes_for_repo() -> None:
+    checker = _load_check_module()
+    assert checker.find_duplicate_exports() == []

--- a/tests/test_public_api_exports.py
+++ b/tests/test_public_api_exports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import genecoder
+
+
+def _top_level_public_api_packages() -> list[str]:
+    packages = [genecoder.__name__]
+    for module_info in pkgutil.iter_modules(genecoder.__path__, prefix=f"{genecoder.__name__}."):
+        if module_info.ispkg:
+            packages.append(module_info.name)
+    return sorted(packages)
+
+
+def test_top_level_public_api_exports_are_unique() -> None:
+    for package_name in _top_level_public_api_packages():
+        module = importlib.import_module(package_name)
+        exports = getattr(module, "__all__", None)
+        if exports is None:
+            continue
+        assert len(exports) == len(set(exports)), package_name


### PR DESCRIPTION
### Motivation
- Prevent accidental duplicate entries in package `__all__` which can lead to confusing public APIs and break runtime uniqueness assumptions. 
- Provide an automated, statically-checkable mechanism and a small runtime test to catch regressions when package exports are edited. 
- Document the expected export conventions so contributors follow a consistent, checkable pattern.

### Description
- Remove duplicate exports from the top-level `genecoder` `__all__` (remove the repeated `VISUALIZER_REGISTRY` and redundant security names) in `src/genecoder/__init__.py` so the public API list is unique. 
- Add an AST-based checker `scripts/check_init_export_duplicates.py` that scans `src/genecoder/**/__init__.py` for duplicate `__all__` entries and returns non-zero on failure. 
- Add lightweight tests `tests/test_public_api_exports.py` and `tests/test_init_export_duplicates.py` that assert `__all__` uniqueness at runtime for top-level packages and that the static checker passes for the repository. 
- Update pre-commit hooks in `.pre-commit-config.yaml` to run the new checker, and document API export conventions in `docs/contributing.md` with guidance to keep `__all__` canonical and unique.

### Testing
- Ran `pytest -q tests/test_public_api_exports.py tests/test_init_export_duplicates.py` and both tests passed. 
- Ran `ruff check` on the changed files (`src/genecoder/__init__.py`, `scripts/check_init_export_duplicates.py`, and the two new tests) and the checks passed. 
- Ran `python scripts/check_init_export_duplicates.py` directly and it returned success (no duplicate exports found). 
- Ran `python -m mypy --show-error-codes --no-error-summary scripts/check_init_export_duplicates.py` and the new script type-checked cleanly; a full repo-wide `mypy` run still reports unrelated pre-existing type issues, so validation was scoped to the new checker and affected files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1038b8048326bd71e718ff3c0900)