### PR TITLE
Add runtime acceptance tests and CI artifacts for reproducibility and plugin registry policy

### DIFF
--- a/docs/capabilities.yaml
+++ b/docs/capabilities.yaml
@@ -113,7 +113,7 @@ phase_gates:
         docs_links:
           - docs/reproducibility.md
         evidence_artifacts:
-          - CI pytest logs
+          - artifacts/acceptance/deterministic-reproducibility-runtime.json
       - metric: Throughput median floor
         threshold: '>= 2.0 MB/s Base-4 encode throughput with BER observed at baseline
           0.0'
@@ -146,7 +146,7 @@ phase_gates:
         docs_links:
           - docs/development_roadmap.md
         evidence_artifacts:
-          - CI pytest summaries
+          - artifacts/acceptance/plugin-registry-policy-runtime.json
   - gate: Phase 4 release gate
     canonical_source: docs/strategy_model.yaml
     measurable_checks:
@@ -160,4 +160,4 @@ phase_gates:
         docs_links:
           - docs/plugins.md
         evidence_artifacts:
-          - CI logs and registry validation output
+          - artifacts/acceptance/plugin-registry-policy-runtime.json

--- a/docs/strategy_model.yaml
+++ b/docs/strategy_model.yaml
@@ -106,8 +106,7 @@ feature_capabilities:
           - type: junit_xml
             path: artifacts/acceptance/junit-deterministic-reproducibility.xml
             checks:
-              - tests.test_acceptance_deterministic_reproducibility_governance::test_validation_artifact_targets_dedicated_acceptance_module
-              - tests.test_acceptance_deterministic_reproducibility_governance::test_phase_two_gate_reproducibility_criterion_uses_deterministic_command
+              - tests.test_acceptance_deterministic_reproducibility_governance::test_deterministic_pipeline_run_is_byte_identical_and_preserves_seed_provenance
         pass_threshold: 100% listed JUnit test cases passed
   - id: benchmark_depth_and_parity
     name: Standardized benchmark depth and parity validation
@@ -177,8 +176,7 @@ feature_capabilities:
           - type: junit_xml
             path: artifacts/acceptance/junit-plugin-policy.xml
             checks:
-              - tests.test_acceptance_plugin_registry_policy_automation::test_suite_category_health_gate_criterion
-              - tests.test_acceptance_plugin_registry_policy_automation::test_phase_four_release_gate_readiness_conditions
+              - tests.test_acceptance_plugin_registry_policy_automation::test_signed_and_unsigned_registry_policy_runtime_paths
               - tests.test_plugin_supply_chain_policy::test_policy_requires_trust_root
               - tests.test_plugin_lifecycle_conformance::test_lifecycle_install_upgrade_disable_rollback_are_deterministic
               - tests.test_cli_plugin_registry::test_install_registry_with_flag
@@ -292,7 +290,7 @@ phase_gates:
         docs_links:
           - docs/reproducibility.md
         evidence_artifacts:
-          - CI pytest logs
+          - artifacts/acceptance/deterministic-reproducibility-runtime.json
       - metric: Throughput median floor
         threshold: ">= 2.0 MB/s Base-4 encode throughput with BER observed at baseline 0.0"
         tests_or_checks:
@@ -324,7 +322,7 @@ phase_gates:
         docs_links:
           - docs/development_roadmap.md
         evidence_artifacts:
-          - CI pytest summaries
+          - artifacts/acceptance/plugin-registry-policy-runtime.json
 
   - gate: "Phase 4 release gate"
     canonical_source: docs/strategy_model.yaml
@@ -337,4 +335,4 @@ phase_gates:
         docs_links:
           - docs/plugins.md
         evidence_artifacts:
-          - CI logs and registry validation output
+          - artifacts/acceptance/plugin-registry-policy-runtime.json

--- a/scripts/evaluate_benchmark_gates.py
+++ b/scripts/evaluate_benchmark_gates.py
@@ -146,6 +146,7 @@ def main() -> int:
     parser.add_argument("--stdout-file", type=Path)
     parser.add_argument("--artifact-json", type=Path)
     parser.add_argument("--output-json", required=True, type=Path)
+    parser.add_argument("--acceptance-output", type=Path)
     args = parser.parse_args()
 
     threshold_config = _load_threshold_config()
@@ -176,6 +177,20 @@ def main() -> int:
         "evidence_artifact": evidence,
         "passed": passed,
     }
+
+
+    acceptance_output = args.acceptance_output or Path("artifacts") / "acceptance" / f"benchmark-gate-{args.benchmark}.json"
+    acceptance_report = {
+        "suite": "benchmark_gate_evaluation",
+        "benchmark": args.benchmark,
+        "passed": passed,
+        "gate": benchmark_config["gate"],
+        "metric": benchmark_config["metric"],
+        "evidence_artifact": evidence,
+        "checks": checks,
+    }
+    acceptance_output.parent.mkdir(parents=True, exist_ok=True)
+    acceptance_output.write_text(json.dumps(acceptance_report, indent=2, sort_keys=True), encoding="utf-8")
 
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")

--- a/tests/data/acceptance/plugin_registry_policy_reject.yaml
+++ b/tests/data/acceptance/plugin_registry_policy_reject.yaml
@@ -1,0 +1,9 @@
+packages:
+  - spec: file:///tmp/placeholder.whl
+    package: fixture-plugin
+    version: 1.0.0
+    license: Proprietary
+    checksum: deadbeef
+    signature: ZHVtbXk=
+    provenance_publisher: fixture-lab
+    provenance_channel: stable

--- a/tests/data/acceptance/plugin_registry_signed.yaml
+++ b/tests/data/acceptance/plugin_registry_signed.yaml
@@ -1,0 +1,9 @@
+packages:
+  - spec: file:///tmp/placeholder.whl
+    package: fixture-plugin
+    version: 1.0.0
+    license: MIT
+    checksum: deadbeef
+    signature: ZHVtbXk=
+    provenance_publisher: fixture-lab
+    provenance_channel: stable

--- a/tests/data/acceptance/plugin_registry_unsigned.yaml
+++ b/tests/data/acceptance/plugin_registry_unsigned.yaml
@@ -1,0 +1,7 @@
+packages:
+  - spec: file:///tmp/placeholder.whl
+    package: fixture-plugin
+    version: 1.0.0
+    license: MIT
+    provenance_publisher: fixture-lab
+    provenance_channel: stable

--- a/tests/test_acceptance_deterministic_reproducibility_governance.py
+++ b/tests/test_acceptance_deterministic_reproducibility_governance.py
@@ -1,41 +1,80 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
-import yaml
+from genecoder.app.pipeline_use_case import (
+    ArtifactOutputPolicy,
+    ChannelProfile,
+    RunPipelineRequest,
+    RunPipelineUseCase,
+    SeedProfile,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
-MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
+ACCEPTANCE_ARTIFACT_PATH = ROOT / "artifacts" / "acceptance" / "deterministic-reproducibility-runtime.json"
 
 
-def _load_capabilities() -> dict:
-    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+def _emit_acceptance_artifact(payload: dict) -> None:
+    ACCEPTANCE_ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ACCEPTANCE_ARTIFACT_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def _partial_capability(data: dict, capability_id: str) -> dict:
-    for capability in data["feature_capabilities"]:
-        if capability["id"] == capability_id:
-            return capability
-    raise AssertionError(f"Missing capability {capability_id!r}")
+def _run_pipeline(use_case: RunPipelineUseCase, *, input_path: Path, output_path: Path, metrics_path: Path) -> tuple[bytes, dict]:
+    request = RunPipelineRequest(
+        codec="reverse",
+        input_path=str(input_path),
+        output_path=str(output_path),
+        channel="simple",
+        profile=ChannelProfile(
+            name="simple",
+            parameters={
+                "substitution_prob": 0.0,
+                "insertion_prob": 0.0,
+                "deletion_prob": 0.0,
+                "dropout_prob": 0.0,
+            },
+        ),
+        seeds=SeedProfile(global_seed=2026, encode_seed=2201, simulate_seed=2202, decode_seed=2203),
+        artifacts=ArtifactOutputPolicy(metrics_path=str(metrics_path), emit_manifest=False, emit_html_report=False),
+    )
+    response = use_case.execute(request)
+    return response.decoded, dict(response.run_schema)
 
 
-def test_validation_artifact_targets_dedicated_acceptance_module():
-    data = _load_capabilities()
-    capability = _partial_capability(data, "deterministic_reproducibility_governance")
+def test_deterministic_pipeline_run_is_byte_identical_and_preserves_seed_provenance(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.bin"
+    input_path.write_bytes(b"acceptance-deterministic-workflow")
 
-    assert capability["validation_artifacts"] == [
-        {
-            "type": "acceptance_test",
-            "path": "tests/test_acceptance_deterministic_reproducibility_governance.py",
-        }
-    ]
-
-
-def test_phase_two_gate_reproducibility_criterion_uses_deterministic_command():
-    data = _load_capabilities()
-    phase_two_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 2 -> Phase 3")
-    reproducibility_metric = next(
-        m for m in phase_two_gate["measurable_checks"] if m["metric"] == "Reproducibility pass rate"
+    use_case = RunPipelineUseCase()
+    decoded_first, run_schema_first = _run_pipeline(
+        use_case,
+        input_path=input_path,
+        output_path=tmp_path / "decoded-first.bin",
+        metrics_path=tmp_path / "metrics-first.json",
+    )
+    decoded_second, run_schema_second = _run_pipeline(
+        use_case,
+        input_path=input_path,
+        output_path=tmp_path / "decoded-second.bin",
+        metrics_path=tmp_path / "metrics-second.json",
     )
 
-    assert reproducibility_metric["tests_or_checks"] == [
-        "pytest -q tests/test_acceptance_deterministic_reproducibility_governance.py"
-    ]
+    assert decoded_first == decoded_second
+    assert run_schema_first["seeds"]["provenance"] == run_schema_second["seeds"]["provenance"]
+    assert run_schema_first["stages"]["simulate"]["metrics"] == run_schema_second["stages"]["simulate"]["metrics"]
+
+    _emit_acceptance_artifact(
+        {
+            "suite": "deterministic_reproducibility_governance",
+            "passed": True,
+            "evidence": {
+                "decoded_sha256_equal": True,
+                "seed_provenance_equal": True,
+                "simulate_stage_metrics_equal": True,
+            },
+            "run_ids": [run_schema_first["run_id"], run_schema_second["run_id"]],
+            "seed_provenance": run_schema_first["seeds"]["provenance"],
+            "simulate_stage_metrics": run_schema_first["stages"]["simulate"]["metrics"],
+        }
+    )

--- a/tests/test_acceptance_plugin_registry_policy_automation.py
+++ b/tests/test_acceptance_plugin_registry_policy_automation.py
@@ -1,51 +1,121 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
+import pytest
 import yaml
 
+from genecoder.plugin_runtime.descriptors import PluginLifecycleState
+from genecoder.plugin_supply_chain import service as supply_chain
+
 ROOT = Path(__file__).resolve().parents[1]
-MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
+FIXTURE_DIR = ROOT / "tests" / "data" / "acceptance"
+ACCEPTANCE_ARTIFACT_PATH = ROOT / "artifacts" / "acceptance" / "plugin-registry-policy-runtime.json"
 
 
-def _load_capabilities() -> dict:
-    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+class RecordingInstaller:
+    def __init__(self) -> None:
+        self.installed_targets: list[str] = []
+
+    def install(self, target: str) -> None:
+        self.installed_targets.append(target)
 
 
-def test_validation_artifact_targets_dedicated_acceptance_module():
-    data = _load_capabilities()
-    capability = next(c for c in data["feature_capabilities"] if c["id"] == "plugin_registry_policy_automation")
-
-    assert capability["validation_artifacts"] == [
-        {
-            "type": "acceptance_test",
-            "path": "tests/test_acceptance_plugin_registry_policy_automation.py",
-        }
-    ]
+def _emit_acceptance_artifact(payload: dict) -> None:
+    ACCEPTANCE_ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ACCEPTANCE_ARTIFACT_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def test_suite_category_health_gate_criterion():
-    data = _load_capabilities()
-    phase_three_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 3 -> Phase 4")
-    suite_health_metric = next(
-        m for m in phase_three_gate["measurable_checks"] if m["metric"] == "Suite category health"
+def test_signed_and_unsigned_registry_policy_runtime_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    package_path = tmp_path / "fixture-plugin.whl"
+    package_path.write_bytes(b"fixture-wheel-payload")
+
+    unsigned_registry = yaml.safe_load((FIXTURE_DIR / "plugin_registry_unsigned.yaml").read_text(encoding="utf-8"))
+    unsigned_registry["packages"][0]["spec"] = package_path.as_uri()
+
+    signed_registry = yaml.safe_load((FIXTURE_DIR / "plugin_registry_signed.yaml").read_text(encoding="utf-8"))
+    signed_registry["packages"][0]["spec"] = package_path.as_uri()
+
+    unsigned_registry_path = tmp_path / "unsigned-registry.yaml"
+    signed_registry_path = tmp_path / "signed-registry.yaml"
+    unsigned_registry_path.write_text(yaml.safe_dump(unsigned_registry), encoding="utf-8")
+    signed_registry_path.write_text(yaml.safe_dump(signed_registry), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Signed metadata and checksum are required"):
+        supply_chain.install_registry_plugins(
+            unsigned_registry_path,
+            offline=False,
+            allow_network=False,
+            yaml_module=yaml,
+            installer=RecordingInstaller(),
+        )
+
+    monkeypatch.setattr(supply_chain, "_verify_payload", lambda *_args, **_kwargs: None)
+    installer = RecordingInstaller()
+    descriptors = supply_chain.install_registry_plugins(
+        signed_registry_path,
+        offline=False,
+        allow_network=False,
+        yaml_module=yaml,
+        installer=installer,
     )
 
-    assert suite_health_metric["tests_or_checks"] == [
-        "pytest -q tests/test_acceptance_plugin_registry_policy_automation.py"
-    ]
+    assert len(descriptors) == 1
+    assert descriptors[0].state == PluginLifecycleState.LOADED
+    assert descriptors[0].signature is not None
+    assert installer.installed_targets
 
+    policy_registry = yaml.safe_load((FIXTURE_DIR / "plugin_registry_policy_reject.yaml").read_text(encoding="utf-8"))
+    policy_registry["packages"][0]["spec"] = package_path.as_uri()
+    policy_registry_path = tmp_path / "policy-registry.yaml"
+    policy_registry_path.write_text(yaml.safe_dump(policy_registry), encoding="utf-8")
 
-def test_phase_four_release_gate_readiness_conditions():
-    data = _load_capabilities()
-    phase_four_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 4 release gate")
-    checks = {m["metric"]: m for m in phase_four_gate["measurable_checks"]}
+    with pytest.raises(ValueError, match="Disallowed license"):
+        supply_chain.install_registry_plugins(
+            policy_registry_path,
+            offline=False,
+            allow_network=False,
+            yaml_module=yaml,
+            installer=RecordingInstaller(),
+        )
 
-    expected_checks = {
-        "Plugin policy compliance": [
-            "pytest -q tests/test_acceptance_plugin_registry_policy_automation.py -k phase_four_release_gate_readiness_conditions",
-            "pytest -q tests/test_plugin_supply_chain_policy.py tests/test_plugin_lifecycle_conformance.py tests/test_cli_plugin_registry.py",
-        ],
+    missing_provenance = {
+        "packages": [
+            {
+                "spec": package_path.as_uri(),
+                "package": "fixture-plugin",
+                "version": "1.0.0",
+                "license": "MIT",
+                "checksum": "deadbeef",
+                "signature": "ZHVtbXk=",
+                "provenance_channel": "stable",
+            }
+        ]
     }
+    missing_provenance_path = tmp_path / "missing-provenance.yaml"
+    missing_provenance_path.write_text(yaml.safe_dump(missing_provenance), encoding="utf-8")
 
-    assert set(checks) == set(expected_checks)
-    for metric, commands in expected_checks.items():
-        assert checks[metric]["tests_or_checks"] == commands
+    with pytest.raises(ValueError, match="Missing provenance_publisher"):
+        supply_chain.install_registry_plugins(
+            missing_provenance_path,
+            offline=False,
+            allow_network=False,
+            yaml_module=yaml,
+            installer=RecordingInstaller(),
+        )
+
+    _emit_acceptance_artifact(
+        {
+            "suite": "plugin_registry_policy_automation",
+            "passed": True,
+            "evidence": {
+                "unsigned_entries_hard_fail": True,
+                "signed_entries_install_and_load": True,
+                "policy_rejection_reason_disallowed_license": True,
+                "policy_rejection_reason_missing_provenance": True,
+            },
+            "installed_specs": [d.source for d in descriptors],
+            "lifecycle_states": [d.state.value for d in descriptors],
+        }
+    )

--- a/tests/test_docs_contract_acceptance_suites.py
+++ b/tests/test_docs_contract_acceptance_suites.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
+
+
+def _load_capabilities() -> dict:
+    return yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
+
+
+def test_deterministic_repro_validation_artifact_metadata() -> None:
+    data = _load_capabilities()
+    capability = next(c for c in data["feature_capabilities"] if c["id"] == "deterministic_reproducibility_governance")
+
+    assert capability["validation_artifacts"] == [
+        {
+            "type": "acceptance_test",
+            "path": "tests/test_acceptance_deterministic_reproducibility_governance.py",
+        }
+    ]
+
+
+def test_deterministic_repro_phase_gate_metadata() -> None:
+    data = _load_capabilities()
+    phase_two_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 2 -> Phase 3")
+    reproducibility_metric = next(
+        m for m in phase_two_gate["measurable_checks"] if m["metric"] == "Reproducibility pass rate"
+    )
+
+    assert reproducibility_metric["tests_or_checks"] == [
+        "pytest -q tests/test_acceptance_deterministic_reproducibility_governance.py"
+    ]
+
+
+def test_plugin_policy_validation_artifact_metadata() -> None:
+    data = _load_capabilities()
+    capability = next(c for c in data["feature_capabilities"] if c["id"] == "plugin_registry_policy_automation")
+
+    assert capability["validation_artifacts"] == [
+        {
+            "type": "acceptance_test",
+            "path": "tests/test_acceptance_plugin_registry_policy_automation.py",
+        }
+    ]
+
+
+def test_plugin_policy_phase_gate_metadata() -> None:
+    data = _load_capabilities()
+    phase_three_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 3 -> Phase 4")
+    suite_health_metric = next(
+        m for m in phase_three_gate["measurable_checks"] if m["metric"] == "Suite category health"
+    )
+
+    assert suite_health_metric["tests_or_checks"] == [
+        "pytest -q tests/test_acceptance_plugin_registry_policy_automation.py"
+    ]
+
+
+def test_plugin_policy_release_gate_metadata() -> None:
+    data = _load_capabilities()
+    phase_four_gate = next(g for g in data["phase_gates"] if g["gate"] == "Phase 4 release gate")
+    checks = {m["metric"]: m for m in phase_four_gate["measurable_checks"]}
+
+    assert checks["Plugin policy compliance"]["tests_or_checks"] == [
+        "pytest -q tests/test_acceptance_plugin_registry_policy_automation.py -k phase_four_release_gate_readiness_conditions",
+        "pytest -q tests/test_plugin_supply_chain_policy.py tests/test_plugin_lifecycle_conformance.py tests/test_cli_plugin_registry.py",
+    ]


### PR DESCRIPTION
### Motivation
- Replace fragile YAML-only assertions of test command text with runtime acceptance suites that execute canonical workflows and provide measurable evidence. 
- Surface real policy enforcement behavior for plugin registries (signed vs unsigned, policy rejection reasons) rather than only documenting expected commands. 
- Emit machine-readable acceptance artifacts so CI gate automation can consume deterministic evidence rather than human-readable logs. 

### Description
- Add runtime acceptance test `tests/test_acceptance_deterministic_reproducibility_governance.py` that runs the canonical pipeline twice with fixed seeds/profile and asserts byte-identical decoded output, identical run-schema seed provenance, and identical simulator-stage metrics, and writes `artifacts/acceptance/deterministic-reproducibility-runtime.json`. 
- Add runtime acceptance test `tests/test_acceptance_plugin_registry_policy_automation.py` that uses unsigned/signed/policy-reject fixture registries in `tests/data/acceptance/` to assert unsigned entries hard-fail, signed entries install/load and reach `LOADED` lifecycle state, and policy rejection reasons (disallowed license, missing provenance) are surfaced; it writes `artifacts/acceptance/plugin-registry-policy-runtime.json`. 
- Move YAML/metadata assertions into a new docs contract suite `tests/test_docs_contract_acceptance_suites.py` so strategy docs metadata remain validated but separate from runtime behavior tests. 
- Update `docs/strategy_model.yaml` and `docs/capabilities.yaml` to point capability completion criteria and phase-gate evidence to the new runtime acceptance artifacts and runtime test cases. 
- Update `scripts/evaluate_benchmark_gates.py` to accept `--acceptance-output` (optional) and to emit machine-readable acceptance JSON to `artifacts/acceptance/benchmark-gate-<benchmark>.json` alongside the existing report. 

### Testing
- Ran `pytest -q tests/test_acceptance_deterministic_reproducibility_governance.py tests/test_acceptance_plugin_registry_policy_automation.py tests/test_docs_contract_acceptance_suites.py tests/test_capability_docs_sync.py tests/test_strategy_docs_sync.py` and the suite completed successfully (`9 passed`). 
- Ran `pytest -q tests/test_evaluate_benchmark_gates.py` and it completed successfully (`2 passed`). 
- Ran `ruff check tests/test_acceptance_deterministic_reproducibility_governance.py tests/test_acceptance_plugin_registry_policy_automation.py tests/test_docs_contract_acceptance_suites.py scripts/evaluate_benchmark_gates.py` and lint checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2aabb3fb08326895de78c997b6903)