### PR TITLE
Unify strategy document provenance via generated validation stamp

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Regenerate strategy-derived docs
         run: python scripts/generate_strategy_artifacts.py --write
       - name: Fail on generated-doc drift
-        run: git diff --exit-code -- docs/capabilities.yaml docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/capability_maturity_badges.md
+        run: git diff --exit-code -- docs/capabilities.yaml docs/strategy_validation.json docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/roadmap_execution.md docs/capability_maturity_badges.md
       - name: Build docs
         run: mkdocs build --strict
       - name: Upload PDF

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -214,7 +214,7 @@ jobs:
       run: python scripts/generate_strategy_artifacts.py --write
 
     - name: Fail on generated-doc drift
-      run: git diff --exit-code -- docs/capabilities.yaml docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/capability_maturity_badges.md
+      run: git diff --exit-code -- docs/capabilities.yaml docs/strategy_validation.json docs/product_strategy.md docs/vision.md docs/development_roadmap.md docs/roadmap_execution.md docs/capability_maturity_badges.md
 
   glossary:
     needs: [changes, check-comments, lint]

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -8,7 +8,10 @@ This roadmap tracks KPI gates from the canonical strategy model.
 ## KPI gates and evidence (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
+> Validation provenance: `docs/strategy_validation.json`
+> last_validated_commit: `cf5265a1d80442ce761d9f8a9218181c8acde3f7`
+> generated_at: `2026-03-24T15:29:37Z`
+> generator_version: `1.0.0`
 
 ### Phase 1 -> Phase 2
 

--- a/docs/product_strategy.md
+++ b/docs/product_strategy.md
@@ -8,7 +8,10 @@ This document includes generated strategy metadata. Update `docs/strategy_model.
 ## Strategy model snapshot (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
+> Validation provenance: `docs/strategy_validation.json`
+> last_validated_commit: `cf5265a1d80442ce761d9f8a9218181c8acde3f7`
+> generated_at: `2026-03-24T15:29:37Z`
+> generator_version: `1.0.0`
 
 ### Phase definitions
 

--- a/docs/roadmap_execution.md
+++ b/docs/roadmap_execution.md
@@ -1,26 +1,38 @@
+<!-- GENERATED FILE: derived from docs/strategy_model.yaml; edit docs/strategy_model.yaml and rerun `python scripts/generate_strategy_artifacts.py --write`. -->
+
 # Roadmap Execution
 
-> last_validated_commit: `4eb89f0cde3b7d75fcaf8311634be19ec56b90f0`
+This execution checklist is generated from the canonical strategy model.
 
-## Execution summary
+<!-- strategy:execution:start -->
+## Execution summary (generated)
+
+> Source of truth: `docs/strategy_model.yaml`
+> Validation provenance: `docs/strategy_validation.json`
+> last_validated_commit: `cf5265a1d80442ce761d9f8a9218181c8acde3f7`
+> generated_at: `2026-03-24T15:29:37Z`
+> generator_version: `1.0.0`
+
+### Phase execution focus
 
 - **Phase 1 — Foundation sustainment**: Stabilize shipped bundles, manifests, and dashboard compatibility.
 - **Phase 2 — Robust encoding pipeline**: Increase simulator profile coverage without violating runtime budgets.
 - **Phase 3 — Simulation and analysis**: Enforce BER, throughput, and category-level CI guardrails.
 - **Phase 4 — Ecosystem and automation**: Keep registry publication and execution policy checks continuously green.
 
-## KPI gate checklist
+### KPI gate checklist
 
-### Phase 1 -> Phase 2
+#### Phase 1 -> Phase 2
 - Weekly usage (oligos_per_week): **>= 1,000 simulated oligos/week for 4 consecutive ISO weeks**
 
-### Phase 2 -> Phase 3
+#### Phase 2 -> Phase 3
 - Deterministic reproducibility stability: **100% deterministic seed/profile checks for 2 consecutive weeks**
-- Throughput floor: **>= 2.0 MB/s Base-4 encode throughput**
+- Throughput floor: **>= 2.0 MB/s Base-4 encode throughput with BER observed at baseline 0.0**
 
-### Phase 3 -> Phase 4
+#### Phase 3 -> Phase 4
 - BER baseline quality: **<= 0.01 BER on baseline profile/seed**
 - Suite category health: **Green CI across CLI/API, pipeline/simulation, and plugins/security suites**
 
-### Phase 4 release gate
+#### Phase 4 release gate
 - Plugin policy compliance: **100% pass on plugin spec/security checks before publication**
+<!-- strategy:execution:end -->

--- a/docs/strategy_validation.json
+++ b/docs/strategy_validation.json
@@ -1,0 +1,5 @@
+{
+  "last_validated_commit": "cf5265a1d80442ce761d9f8a9218181c8acde3f7",
+  "generated_at": "2026-03-24T15:29:37Z",
+  "generator_version": "1.0.0"
+}

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -13,7 +13,10 @@ GeneCoder aims to make DNA data storage experimentation practical and reproducib
 ## Strategy-aligned phase and capability narrative (generated)
 
 > Source of truth: `docs/strategy_model.yaml`
-> last_validated_commit: `f62498d40dd487eca4eff0cd1f41a42cc056eaed`
+> Validation provenance: `docs/strategy_validation.json`
+> last_validated_commit: `cf5265a1d80442ce761d9f8a9218181c8acde3f7`
+> generated_at: `2026-03-24T15:29:37Z`
+> generator_version: `1.0.0`
 
 ### Phase intent
 

--- a/scripts/check_strategy_docs_sync.py
+++ b/scripts/check_strategy_docs_sync.py
@@ -3,9 +3,70 @@
 
 from __future__ import annotations
 
+import json
+import re
 import sys
 
-from render_strategy_docs import main
+from render_strategy_docs import ROOT, VALIDATION_PATH, main as render_main
+
+DOCS_TO_VERIFY = (
+    ROOT / "docs" / "product_strategy.md",
+    ROOT / "docs" / "development_roadmap.md",
+    ROOT / "docs" / "vision.md",
+    ROOT / "docs" / "roadmap_execution.md",
+)
+COMMIT_PATTERN = re.compile(r"last_validated_commit:\s*`([0-9a-f]{7,40})`")
+
+
+def _load_validation_commit() -> str:
+    if not VALIDATION_PATH.exists():
+        raise FileNotFoundError(
+            "Missing docs/strategy_validation.json. "
+            "Run `python scripts/generate_strategy_artifacts.py --write`."
+        )
+
+    payload = json.loads(VALIDATION_PATH.read_text(encoding="utf-8"))
+    commit = payload.get("last_validated_commit")
+    if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{7,40}", commit):
+        raise ValueError(
+            "docs/strategy_validation.json contains an invalid last_validated_commit. "
+            "Run `python scripts/generate_strategy_artifacts.py --write`."
+        )
+    return commit
+
+
+def _verify_embedded_commits() -> int:
+    expected_commit = _load_validation_commit()
+    failures: list[str] = []
+
+    for doc_path in DOCS_TO_VERIFY:
+        content = doc_path.read_text(encoding="utf-8")
+        found_commits = COMMIT_PATTERN.findall(content)
+        if not found_commits:
+            failures.append(f"{doc_path.relative_to(ROOT)} (missing last_validated_commit)")
+            continue
+
+        divergent = sorted({commit for commit in found_commits if commit != expected_commit})
+        if divergent:
+            failures.append(
+                f"{doc_path.relative_to(ROOT)} (expected {expected_commit}, found {', '.join(divergent)})"
+            )
+
+    if failures:
+        print("Strategy docs embed divergent last_validated_commit values:")
+        for failure in failures:
+            print(f" - {failure}")
+        print("Regenerate with `python scripts/generate_strategy_artifacts.py --write`.")
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    render_status = render_main()
+    if render_status != 0:
+        return render_status
+    return _verify_embedded_commits()
 
 
 if __name__ == "__main__":

--- a/scripts/generate_strategy_artifacts.py
+++ b/scripts/generate_strategy_artifacts.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
+import json
 from pathlib import Path
 import subprocess
 import sys
@@ -13,6 +15,8 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
 CAPABILITIES_PATH = ROOT / "docs" / "capabilities.yaml"
+VALIDATION_PATH = ROOT / "docs" / "strategy_validation.json"
+GENERATOR_VERSION = "1.0.0"
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "python-ci.yml"
 BADGES_PATH = ROOT / "docs" / "capability_maturity_badges.md"
 
@@ -64,6 +68,27 @@ def render_capabilities_yaml(model: dict) -> str:
     return _render_generated_yaml(payload)
 
 
+def git_head_commit() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Unable to resolve git commit: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def build_strategy_validation(commit_sha: str) -> dict[str, str]:
+    return {
+        "last_validated_commit": commit_sha,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "generator_version": GENERATOR_VERSION,
+    }
+
+
 def _run(cmd: list[str]) -> None:
     result = subprocess.run(cmd, cwd=ROOT, check=False, text=True, capture_output=True)
     if result.returncode != 0:
@@ -85,6 +110,17 @@ def main() -> int:
             print("  python scripts/generate_strategy_artifacts.py --write")
             return 1
         CAPABILITIES_PATH.write_text(rendered_capabilities, encoding="utf-8")
+
+    if args.write:
+        strategy_validation = build_strategy_validation(git_head_commit())
+        rendered_validation = json.dumps(strategy_validation, indent=2) + "\n"
+        existing_validation = VALIDATION_PATH.read_text(encoding="utf-8") if VALIDATION_PATH.exists() else ""
+        if existing_validation != rendered_validation:
+            VALIDATION_PATH.write_text(rendered_validation, encoding="utf-8")
+    elif not VALIDATION_PATH.exists():
+        print("Missing docs/strategy_validation.json. Run:")
+        print("  python scripts/generate_strategy_artifacts.py --write")
+        return 1
 
     try:
         if args.write:

--- a/scripts/render_strategy_docs.py
+++ b/scripts/render_strategy_docs.py
@@ -4,14 +4,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
-import subprocess
 import sys
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 MODEL_PATH = ROOT / "docs" / "strategy_model.yaml"
+VALIDATION_PATH = ROOT / "docs" / "strategy_validation.json"
 
 DOC_CONFIGS = {
     ROOT / "docs" / "product_strategy.md": {
@@ -23,6 +24,9 @@ DOC_CONFIGS = {
     ROOT / "docs" / "development_roadmap.md": {
         "marker": "strategy:roadmap",
     },
+    ROOT / "docs" / "roadmap_execution.md": {
+        "marker": "strategy:execution",
+    },
 }
 
 GENERATED_HEADER = (
@@ -32,17 +36,23 @@ GENERATED_HEADER = (
 )
 
 
-def git_head_commit() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"Unable to resolve git commit: {result.stderr.strip()}")
-    return result.stdout.strip()
+def load_strategy_validation() -> dict[str, str]:
+    if not VALIDATION_PATH.exists():
+        raise FileNotFoundError(
+            "Missing docs/strategy_validation.json. "
+            "Run `python scripts/generate_strategy_artifacts.py --write`."
+        )
+
+    payload = json.loads(VALIDATION_PATH.read_text(encoding="utf-8"))
+    required_keys = {"last_validated_commit", "generated_at", "generator_version"}
+    missing = sorted(required_keys - payload.keys())
+    if missing:
+        missing_text = ", ".join(missing)
+        raise ValueError(
+            f"docs/strategy_validation.json is missing required keys: {missing_text}. "
+            "Run `python scripts/generate_strategy_artifacts.py --write`."
+        )
+    return payload
 
 
 def _replace_marker_block(content: str, marker: str, new_block: str) -> tuple[str, bool]:
@@ -82,13 +92,22 @@ def _render_capability_table(capabilities: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _render_product_strategy(model: dict, commit_sha: str) -> str:
+def _provenance_lines(validation: dict[str, str]) -> list[str]:
+    return [
+        "> Source of truth: `docs/strategy_model.yaml`",
+        "> Validation provenance: `docs/strategy_validation.json`",
+        f"> last_validated_commit: `{validation['last_validated_commit']}`",
+        f"> generated_at: `{validation['generated_at']}`",
+        f"> generator_version: `{validation['generator_version']}`",
+    ]
+
+
+def _render_product_strategy(model: dict, validation: dict[str, str]) -> str:
     return "\n".join(
         [
             "## Strategy model snapshot (generated)",
             "",
-            "> Source of truth: `docs/strategy_model.yaml`",
-            f"> last_validated_commit: `{commit_sha}`",
+            *_provenance_lines(validation),
             "",
             "### Phase definitions",
             "",
@@ -112,13 +131,12 @@ def _render_product_strategy(model: dict, commit_sha: str) -> str:
     )
 
 
-def _render_vision(model: dict, commit_sha: str) -> str:
+def _render_vision(model: dict, validation: dict[str, str]) -> str:
     return "\n".join(
         [
             "## Strategy-aligned phase and capability narrative (generated)",
             "",
-            "> Source of truth: `docs/strategy_model.yaml`",
-            f"> last_validated_commit: `{commit_sha}`",
+            *_provenance_lines(validation),
             "",
             "### Phase intent",
             "",
@@ -135,12 +153,11 @@ def _render_vision(model: dict, commit_sha: str) -> str:
     )
 
 
-def _render_development_roadmap(model: dict, commit_sha: str) -> str:
+def _render_development_roadmap(model: dict, validation: dict[str, str]) -> str:
     blocks = [
         "## KPI gates and evidence (generated)",
         "",
-        "> Source of truth: `docs/strategy_model.yaml`",
-        f"> last_validated_commit: `{commit_sha}`",
+        *_provenance_lines(validation),
         "",
     ]
     for gate in model["kpi_gates"]:
@@ -148,11 +165,36 @@ def _render_development_roadmap(model: dict, commit_sha: str) -> str:
     return "\n".join(blocks).rstrip()
 
 
-def render_sections(model: dict, commit_sha: str) -> dict[Path, str]:
+def _render_roadmap_execution(model: dict, validation: dict[str, str]) -> str:
+    blocks = [
+        "## Execution summary (generated)",
+        "",
+        *_provenance_lines(validation),
+        "",
+        "### Phase execution focus",
+        "",
+        *[
+            f"- **Phase {phase['id']} — {phase['name']}**: {phase['execution_focus']}"
+            for phase in model["phases"]
+        ],
+        "",
+        "### KPI gate checklist",
+        "",
+    ]
+    for gate in model["kpi_gates"]:
+        blocks.append(f"#### {gate['gate']}")
+        for check in gate["checks"]:
+            blocks.append(f"- {check['metric']}: **{check['threshold']}**")
+        blocks.append("")
+    return "\n".join(blocks).rstrip()
+
+
+def render_sections(model: dict, validation: dict[str, str]) -> dict[Path, str]:
     return {
-        ROOT / "docs" / "product_strategy.md": _render_product_strategy(model, commit_sha),
-        ROOT / "docs" / "vision.md": _render_vision(model, commit_sha),
-        ROOT / "docs" / "development_roadmap.md": _render_development_roadmap(model, commit_sha),
+        ROOT / "docs" / "product_strategy.md": _render_product_strategy(model, validation),
+        ROOT / "docs" / "vision.md": _render_vision(model, validation),
+        ROOT / "docs" / "development_roadmap.md": _render_development_roadmap(model, validation),
+        ROOT / "docs" / "roadmap_execution.md": _render_roadmap_execution(model, validation),
     }
 
 
@@ -162,8 +204,8 @@ def main() -> int:
     args = parser.parse_args()
 
     model = yaml.safe_load(MODEL_PATH.read_text(encoding="utf-8"))
-    commit_sha = git_head_commit()
-    rendered_by_doc = render_sections(model, commit_sha)
+    validation = load_strategy_validation()
+    rendered_by_doc = render_sections(model, validation)
 
     changed_files: list[Path] = []
     for doc_path, rendered in rendered_by_doc.items():


### PR DESCRIPTION
### Motivation
- Ensure a single authoritative provenance source for all generated strategy sections so documents consistently reference the same validation stamp.
- Prevent accidental drift where different generated docs embed divergent `last_validated_commit` values.

### Description
- Add a generated provenance file `docs/strategy_validation.json` produced by `scripts/generate_strategy_artifacts.py` that contains `last_validated_commit`, `generated_at`, and `generator_version`.
- Update the renderer `scripts/render_strategy_docs.py` to require and read `docs/strategy_validation.json` and include its provenance lines in generated blocks, and to manage the generated block for `docs/roadmap_execution.md` in addition to the existing docs.
- Replace the simple stamping check with a stricter CI-time verifier `scripts/check_strategy_docs_sync.py` that runs the renderer and then fails if any strategy doc embeds a `last_validated_commit` that diverges from `docs/strategy_validation.json`.
- Regenerate the affected docs (`docs/product_strategy.md`, `docs/development_roadmap.md`, `docs/vision.md`, `docs/roadmap_execution.md`) so their generated sections reference the unified provenance file, and update CI workflow checks to include `docs/strategy_validation.json` and `docs/roadmap_execution.md` in the generated-drift diff.

### Testing
- Ran the linter: `python -m ruff check scripts/generate_strategy_artifacts.py scripts/render_strategy_docs.py scripts/check_strategy_docs_sync.py` and it passed after a trivial unused-import fix. (Passed)
- Executed the renderer and sync check: `python scripts/check_strategy_docs_sync.py` which invoked the renderer and then verified embedded commits; the command exited successfully. (Passed)
- Generated artifacts with `python scripts/generate_strategy_artifacts.py --write` to produce `docs/strategy_validation.json` and updated docs; generation completed without error. (Passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c2ad4a52dc83269c8df6fbf4975fda)