### PR TITLE
Remove deprecated shim modules from simulator plugin entry points

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -4,9 +4,11 @@ GeneCoder supports both built-in error models and adapters to external nanopore 
 
 ## Built-in simulators
 
-- **simple** — random substitutions. Use `genecli channel --sub-prob`
-  (and optionally `--ins-prob`/`--del-prob`) or `--simulator simple`.
-- **indel** — introduces insertions and deletions in addition to substitutions.
+- **simple** — random substitutions (entry point: `genecoder.simulators.simple`).
+  Use `genecli channel --sub-prob` (and optionally `--ins-prob`/`--del-prob`)
+  or `--simulator simple`.
+- **indel** — introduces insertions and deletions in addition to substitutions
+  (entry point: `genecoder.simulators.indel`).
 - **none** — disable simulation (the default).
 - **illumina** — simple Illumina read errors. Customize rates with
   `--illumina-sub-rate`, `--illumina-ins-rate` and `--illumina-del-rate`. Depth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,8 @@ nanopore = "genecoder.simulators.nanopore"
 d2sim = "genecoder.d2sim_adapter"
 dnarsim = "genecoder.dnarsim_adapter"
 squigulator = "genecoder.squigulator_adapter"
-simple = "genecoder.error_simulation"
-indel = "genecoder.error_simulation"
+simple = "genecoder.simulators.simple"
+indel = "genecoder.simulators.indel"
 illumina = "genecoder.simulators.illumina"
 
 [tool.poetry.extras]

--- a/src/genecoder/simulators/indel.py
+++ b/src/genecoder/simulators/indel.py
@@ -1,0 +1,14 @@
+"""Canonical indel simulator plugin entry point."""
+from __future__ import annotations
+
+from typing import Callable
+
+from genecoder.plugin_api import Simulator
+from genecoder.channel_engine.legacy_adapter import Channel as _LegacyChannel
+from genecoder.simulators import register_simulator as _register_simulator
+
+
+def register(registrar: Callable[[str, Simulator], None] = _register_simulator) -> None:
+    """Register the built-in ``indel`` simulator."""
+
+    registrar("indel", _LegacyChannel())

--- a/src/genecoder/simulators/simple.py
+++ b/src/genecoder/simulators/simple.py
@@ -1,0 +1,14 @@
+"""Canonical simple simulator plugin entry point."""
+from __future__ import annotations
+
+from typing import Callable
+
+from genecoder.plugin_api import Simulator
+from genecoder.channel_engine.legacy_adapter import Channel as _LegacyChannel
+from genecoder.simulators import register_simulator as _register_simulator
+
+
+def register(registrar: Callable[[str, Simulator], None] = _register_simulator) -> None:
+    """Register the built-in ``simple`` simulator."""
+
+    registrar("simple", _LegacyChannel(substitution_prob=0.05))

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -1,3 +1,6 @@
+import tomllib
+from pathlib import Path
+
 import pytest
 from genecoder import (
     CODEC_REGISTRY,
@@ -88,3 +91,22 @@ def test_load_plugins_idempotent() -> None:
     assert set(FEC_REGISTRY) == fec_keys
     assert set(SIMULATOR_REGISTRY) == sim_keys
 
+
+
+
+def test_simulator_entry_points_avoid_deprecated_shims() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    simulators = data["tool"]["poetry"]["plugins"]["genecoder.simulators"]
+
+    deprecated_modules = {
+        "genecoder.error_simulation",
+        "genecoder.channel_sim",
+        "genecoder.compat.error_simulation",
+        "genecoder.compat.channel_sim",
+    }
+    for module_path in simulators.values():
+        assert module_path not in deprecated_modules
+
+    assert simulators["simple"] == "genecoder.simulators.simple"
+    assert simulators["indel"] == "genecoder.simulators.indel"

--- a/tests/test_public_api_exports.py
+++ b/tests/test_public_api_exports.py
@@ -21,3 +21,23 @@ def test_top_level_public_api_exports_are_unique() -> None:
         if exports is None:
             continue
         assert len(exports) == len(set(exports)), package_name
+
+
+
+def test_canonical_simple_indel_modules_exist() -> None:
+    simple = importlib.import_module("genecoder.simulators.simple")
+    indel = importlib.import_module("genecoder.simulators.indel")
+
+    assert hasattr(simple, "register")
+    assert hasattr(indel, "register")
+
+
+def test_canonical_simulator_modules_are_not_deprecated_shims() -> None:
+    deprecated_prefixes = ("genecoder.compat",)
+    deprecated_exact = {"genecoder.error_simulation", "genecoder.channel_sim"}
+
+    for module_name in ("genecoder.simulators.simple", "genecoder.simulators.indel"):
+        module = importlib.import_module(module_name)
+        assert module.__name__ == module_name
+        assert module.__name__ not in deprecated_exact
+        assert not module.__name__.startswith(deprecated_prefixes)


### PR DESCRIPTION
### Motivation
- Prevent installed plugin entry points from resolving to deprecated shim modules and make `simple`/`indel` canonical first-class simulator modules under `genecoder.simulators`.
- Keep backward-compatibility shims solely under `genecoder.compat.*` and ensure new installs do not target those deprecated paths.

### Description
- Added canonical simulator entry-point modules `src/genecoder/simulators/simple.py` and `src/genecoder/simulators/indel.py` that expose a `register()` function and register the built-in simulators via `genecoder.channel_engine.legacy_adapter.Channel`.
- Updated the Poetry entry-point mapping in `pyproject.toml` under `[tool.poetry.plugins."genecoder.simulators"]` so `simple` and `indel` point to `genecoder.simulators.simple` and `genecoder.simulators.indel` respectively.
- Added regression tests in `tests/test_plugin_loading.py` and `tests/test_public_api_exports.py` to assert entry points do not reference deprecated shim modules and that canonical modules exist and export `register()`.
- Updated simulator documentation in `docs/simulators.md` to reference the canonical entry-point modules for `simple` and `indel` while leaving compatibility shims intact under `genecoder.compat.*` (deprecated with warnings).

### Testing
- Ran `pytest -q tests/test_plugin_loading.py tests/test_public_api_exports.py` and the test suite completed successfully (`9 passed`) with expected deprecation warnings recorded.
- Ran `ruff check` on the new modules and modified tests using `ruff check src/genecoder/simulators/simple.py src/genecoder/simulators/indel.py tests/test_plugin_loading.py tests/test_public_api_exports.py` and linting passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cae749988326bbae6f5375fa1edd)