### PR TITLE
Refactor core orchestration into explicit runtime stage services

### DIFF
--- a/src/genecoder/compat/coding_stack.py
+++ b/src/genecoder/compat/coding_stack.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Compatibility facade for legacy coding stack compilation entrypoints."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from genecoder.coding.stack import compile_legacy_stack, compile_stack_from_config, plan_stack_from_config
+from genecoder.constraints import ConstraintPolicy
+
+
+def compile_legacy_coding_stack(
+    codec: str,
+    fec: str | None,
+    *,
+    constraint_policy: ConstraintPolicy | None = None,
+):
+    return compile_legacy_stack(codec, fec, constraint_policy=constraint_policy)
+
+
+def compile_coding_stack_from_config(
+    config: Mapping[str, Any],
+    *,
+    constraint_policy: ConstraintPolicy | None = None,
+):
+    return compile_stack_from_config(config, constraint_policy=constraint_policy)
+
+
+def plan_coding_stack(config: Mapping[str, Any], *, constraint_policy: ConstraintPolicy | None = None):
+    return plan_stack_from_config(config, constraint_policy=constraint_policy)
+
+
+__all__ = [
+    "compile_legacy_coding_stack",
+    "compile_coding_stack_from_config",
+    "plan_coding_stack",
+]

--- a/src/genecoder/core.py
+++ b/src/genecoder/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Simple encode/ECC/channel/decode pipeline utilities."""
 
 import json
-import inspect
 import time
 import warnings
 from collections import Counter
@@ -16,18 +15,23 @@ from .utils import get_max_homopolymer_length
 
 from .plugin_manager import init_plugins
 from .runtime import RunContext, make_run_context
-from .simulators import SIMULATOR_REGISTRY
-from .channel_engine import ChannelPipeline
-from .coding.stack import (
-    CodingContext,
-    build_layer_metric,
-    compile_legacy_stack,
-    compile_stack_from_config,
-    normalize_stack_metrics,
-    plan_stack_from_config,
+from .coding.stack import normalize_stack_metrics
+from .compat.coding_stack import (
+    compile_coding_stack_from_config,
+    plan_coding_stack,
 )
-from .formats import SequenceBatch, SequenceOligo
-from .constraints import ConstraintPolicy, ConstraintRepairPipeline, load_constraint_policy
+from .formats import SequenceBatch
+from .constraints import ConstraintPolicy
+from .runtime.models import DecodeStageInput, EncodeStageInput, SimulateStageInput
+from .runtime.stages import (
+    DecodeStageService,
+    EncodeStageService,
+    SimulateStageService,
+    batch_for_decode,
+    estimate_coverage,
+    parse_bool,
+    wrap_single_sequence,
+)
 from .simulators.batch_utils import (
     RESULT_COVERAGE_KEY,
     RESULT_DROPOUT_FLAG_KEY,
@@ -260,124 +264,7 @@ def _wrap_single_sequence(
     batch_id: str = "sequence",
     codec: str | None = None,
 ) -> SequenceBatch:
-    """Return a :class:`SequenceBatch` for a legacy string ``sequence``."""
-
-    tokens = [f"batch_id={batch_id}", "oligo_index=1"]
-    if codec:
-        tokens.append(f"codec={codec}")
-    header = " ".join(tokens)
-    batch = SequenceBatch.build([(header, sequence)], batch_id=batch_id)
-    if codec:
-        batch.metadata.setdefault("codec", codec)
-    return batch
-
-
-def _resolve_constraint_policy(raw: Mapping[str, Any] | None) -> ConstraintPolicy | None:
-    if not raw:
-        return None
-    policy_raw = raw.get("constraint_policy")
-    if policy_raw is None:
-        return None
-    if isinstance(policy_raw, ConstraintPolicy):
-        return policy_raw
-    if isinstance(policy_raw, Mapping):
-        return load_constraint_policy(policy_raw)
-    return None
-
-
-def _constraint_outcome_payload(result: object) -> dict[str, Any]:
-    from genecoder.constraints.repair_pipeline import RepairPipelineResult
-
-    if not isinstance(result, RepairPipelineResult):
-        return {}
-    return {
-        "stage": result.stage,
-        "violations": {
-            "before": result.report_before.count,
-            "after": result.report_after.count,
-            "pressure_before": result.report_before.pressure,
-            "pressure_after": result.report_after.pressure,
-        },
-        "repairs_applied": len(result.repair.changes) if result.repair is not None else 0,
-        "repair_strategy": result.repair.strategy if result.repair is not None else None,
-        "residual_risk": result.residual_risk,
-        "objective_score": result.objective_score,
-        "objective_tradeoff": dict(result.objective_tradeoff or {}),
-    }
-
-
-def _apply_constraint_stage_to_batch(
-    batch: SequenceBatch,
-    *,
-    policy: ConstraintPolicy,
-    stage: str,
-) -> dict[str, Any]:
-    pipeline = ConstraintRepairPipeline(policy)
-    primaries = batch.primary_oligos() or batch.oligos
-    outcomes = pipeline.repair_batch([ol.sequence for ol in primaries], stage=stage)
-    by_oligo: dict[str, dict[str, Any]] = {}
-    for idx, (oligo, outcome) in enumerate(zip(primaries, outcomes), start=1):
-        if outcome.sequence != oligo.sequence:
-            oligo.sequence = outcome.sequence
-        key = str(
-            oligo.metadata.get("oligo_id")
-            or oligo.oligo_id
-            or oligo.metadata.get("oligo_index")
-            or idx
-        )
-        by_oligo[key] = {
-            "oligo_index": idx,
-            "violations_before": outcome.report_before.count,
-            "violations_after": outcome.report_after.count,
-            "pressure_before": outcome.report_before.pressure,
-            "pressure_after": outcome.report_after.pressure,
-            "repair_strategy": outcome.repair.strategy if outcome.repair is not None else None,
-            "repairs_applied": len(outcome.repair.changes) if outcome.repair is not None else 0,
-            "residual_risk": outcome.residual_risk,
-            "objective_score": outcome.objective_score,
-            "objective_tradeoff": dict(outcome.objective_tradeoff or {}),
-            "stage": outcome.stage,
-        }
-    return {
-        "stage": stage,
-        "violations": {
-            "before": sum(item.report_before.count for item in outcomes),
-            "after": sum(item.report_after.count for item in outcomes),
-            "pressure_before": (
-                sum(item.report_before.pressure for item in outcomes) / len(outcomes)
-                if outcomes
-                else 0.0
-            ),
-            "pressure_after": (
-                sum(item.report_after.pressure for item in outcomes) / len(outcomes)
-                if outcomes
-                else 0.0
-            ),
-        },
-        "repairs_applied": sum(len(item.repair.changes) if item.repair is not None else 0 for item in outcomes),
-        "repair_strategy": (
-            outcomes[0].repair.strategy
-            if outcomes and outcomes[0].repair is not None
-            else None
-        ),
-        "residual_risk": (
-            sum(item.residual_risk for item in outcomes) / len(outcomes)
-            if outcomes
-            else 0.0
-        ),
-        "objective_score": (
-            sum(float(item.objective_score or 0.0) for item in outcomes) / len(outcomes)
-            if outcomes
-            else None
-        ),
-        "objective_tradeoff": {
-            "gc": (sum(float((item.objective_tradeoff or {}).get("gc_deviation", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
-            "homopolymer": (sum(float((item.objective_tradeoff or {}).get("homopolymer_excess", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
-            "redundancy": (sum(float((item.objective_tradeoff or {}).get("redundancy", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
-            "recovery": (sum(float((item.objective_tradeoff or {}).get("recovery_proxy", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
-        },
-        "by_oligo": by_oligo,
-    }
+    return wrap_single_sequence(sequence, batch_id=batch_id, codec=codec)
 
 
 def encode(
@@ -389,153 +276,24 @@ def encode(
     run_context: RunContext | None = None,
 ) -> Tuple[SequenceBatch, Mapping[str, Any] | None]:
     """Return encoded :class:`SequenceBatch` for ``data`` and optional FEC info."""
-
-    stack = compile_legacy_stack(codec, fec, constraint_policy=constraint_policy)
-    runtime_context = run_context or make_run_context()
-    context = CodingContext(
-        block_id="encode-0",
-        constraint_policy=constraint_policy,
-        metadata={"run_context": runtime_context},
+    output = EncodeStageService().run(
+        EncodeStageInput(
+            codec=codec,
+            fec=fec,
+            data=data,
+            constraint_policy=constraint_policy,
+            run_context=run_context,
+        )
     )
-    current: bytes | str | SequenceBatch = data
-    layer_info: dict[str, Mapping[str, Any]] = {}
-    layer_metrics: list[dict[str, Any]] = []
-    for layer in stack:
-        before_size = (
-            len(current)
-            if isinstance(current, (bytes, bytearray, str))
-            else len(current.combined_sequence())
-        )
-        started_at = time.perf_counter()
-        layer_out = layer.encode_block(current, context)
-        current = layer_out.payload
-        info_value = layer_out.metadata.get("fec_info")
-        if isinstance(info_value, Mapping):
-            layer_info[layer.name] = dict(info_value)
-        after_size = (
-            len(current)
-            if isinstance(current, (bytes, bytearray, str))
-            else len(current.combined_sequence())
-        )
-        layer_metrics.append(
-            build_layer_metric(
-                layer_name=layer.name,
-                layer_type="codec" if layer.name == codec else "fec",
-                stage="encode",
-                before_size=before_size,
-                after_size=after_size,
-                started_at=started_at,
-            )
-        )
-
-    encoded = current
-    if isinstance(encoded, SequenceBatch):
-        batch = encoded
-    elif isinstance(encoded, str):
-        batch = _wrap_single_sequence(encoded, batch_id=f"{codec}-batch", codec=codec)
-    else:
-        raise TypeError(
-            "Codec implementations must return a string or SequenceBatch"
-        )
-
-    constraint_outcomes: list[dict[str, Any]] = []
-    if constraint_policy is not None:
-        stage_outcome = _apply_constraint_stage_to_batch(
-            batch,
-            policy=constraint_policy,
-            stage="encode",
-        )
-        constraint_outcomes.append({k: v for k, v in stage_outcome.items() if k != "by_oligo"})
-
-    normalized_stack = normalize_stack_metrics(layer_metrics, "".join(ol.sequence for ol in batch.oligos))
-    batch.metadata.setdefault("coding_stack", normalized_stack)
-    if constraint_policy is not None:
-        batch.metadata["constraint_policy"] = constraint_policy.to_dict()
-        existing = batch.metadata.get("constraint_outcomes")
-        if isinstance(existing, Mapping):
-            merged = dict(existing)
-        else:
-            merged = {}
-        merged["by_oligo"] = stage_outcome.get("by_oligo", {})
-        merged["stages"] = constraint_outcomes
-        batch.metadata["constraint_outcomes"] = merged
-
-    fec_info: Mapping[str, Any] | None = None
-    if layer_info:
-        info_dict: dict[str, Any] = {
-            "layer_info": layer_info,
-            "coding_stack": normalized_stack,
-        }
-        if fec and fec in layer_info:
-            info_dict.update(dict(layer_info[fec]))
-        if constraint_policy is not None:
-            info_dict["constraint_policy"] = constraint_policy.to_dict()
-            info_dict["constraint_outcomes"] = dict(batch.metadata.get("constraint_outcomes", {}))
-        info_dict.setdefault("batch_id", batch.batch_id)
-        info_dict.setdefault("batch_metadata", dict(batch.metadata))
-        fec_info = info_dict
-
-    return batch, fec_info
+    return output.encoded_batch, output.fec_info
 
 
 def _parse_bool(value: object) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "y"}
-    return bool(value)
+    return parse_bool(value)
 
 
 def _batch_for_decode(batch: SequenceBatch, *, filter_mutated: bool) -> SequenceBatch:
-    filtered: list[SequenceOligo] = []
-    for oligo in batch.oligos:
-        dropout_flag = _parse_bool(oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY, False))
-        coverage_raw = oligo.metadata.get(RESULT_COVERAGE_KEY)
-        try:
-            coverage_int = int(coverage_raw) if coverage_raw is not None else None
-        except (TypeError, ValueError):
-            coverage_int = None
-
-        mutation_raw = oligo.metadata.get(RESULT_MUTATION_TOTALS_KEY)
-        mutation_flag = False
-        if mutation_raw not in (None, ""):
-            mutation_data: Mapping[str, Any] | None
-            if isinstance(mutation_raw, Mapping):
-                mutation_data = mutation_raw
-            elif isinstance(mutation_raw, str):
-                try:
-                    parsed = json.loads(mutation_raw)
-                except json.JSONDecodeError:
-                    mutation_data = None
-                else:
-                    mutation_data = parsed if isinstance(parsed, Mapping) else None
-            else:
-                mutation_data = None
-            if mutation_data is not None:
-                for key in ("substitutions", "insertions", "deletions"):
-                    try:
-                        if int(mutation_data.get(key, 0)) > 0:
-                            mutation_flag = True
-                            break
-                    except (TypeError, ValueError):
-                        continue
-
-        if dropout_flag:
-            continue
-        if coverage_int is not None and coverage_int <= 0:
-            continue
-        if filter_mutated and mutation_flag:
-            continue
-        filtered.append(oligo)
-
-    if len(filtered) == len(batch.oligos):
-        return batch
-    return SequenceBatch(
-        batch_id=batch.batch_id,
-        metadata=dict(batch.metadata),
-        seed=batch.seed,
-        oligos=list(filtered),
-    )
+    return batch_for_decode(batch, filter_mutated=filter_mutated)
 
 
 def run_canonical_pipeline(
@@ -557,67 +315,59 @@ def run_canonical_pipeline(
 
     total_started_at = time.perf_counter()
 
+    encode_service = EncodeStageService()
+    simulate_service = SimulateStageService()
+    decode_service = DecodeStageService()
+
     encode_started_at = time.perf_counter()
-    encoded_batch, fec_info = encode(codec, fec, original_data, run_context=runtime_context)
+    encode_result = encode_service.run(
+        EncodeStageInput(codec=codec, fec=fec, data=original_data, run_context=runtime_context)
+    )
+    encoded_batch = encode_result.encoded_batch
+    fec_info = encode_result.fec_info
     encode_seconds = time.perf_counter() - encode_started_at
 
     simulate_started_at = time.perf_counter()
-    try:
-        simulated, subs, ins, dels, coverage = simulate(
-            channel,
-            encoded_batch,
+    simulate_result = simulate_service.run(
+        SimulateStageInput(
+            channel=channel,
+            dna=encoded_batch,
             channel_parameters=channel_parameters,
             run_context=runtime_context,
         )
-    except TypeError as exc:
-        message = str(exc)
-        if "channel_parameters" in message:
-            try:
-                simulated, subs, ins, dels, coverage = simulate(
-                    channel,
-                    encoded_batch,
-                    run_context=runtime_context,
-                )
-            except TypeError as nested_exc:
-                if "run_context" not in str(nested_exc):
-                    raise
-                simulated, subs, ins, dels, coverage = simulate(channel, encoded_batch)
-        elif "run_context" in message:
-            simulated, subs, ins, dels, coverage = simulate(
-                channel,
-                encoded_batch,
-                channel_parameters=channel_parameters,
-            )
-        else:
-            raise
+    )
     simulate_seconds = time.perf_counter() - simulate_started_at
 
     simulated_batch = (
-        simulated if isinstance(simulated, SequenceBatch) else _wrap_single_sequence(str(simulated))
+        simulate_result.dna
+        if isinstance(simulate_result.dna, SequenceBatch)
+        else _wrap_single_sequence(str(simulate_result.dna))
     )
     decode_input = _batch_for_decode(simulated_batch, filter_mutated=filter_mutated)
 
     decode_started_at = time.perf_counter()
-    decoded = decode(
-        codec,
-        fec,
-        decode_input,
-        fec_info,
-        filter_mutated=filter_mutated,
-        survivor_batch=decode_input,
-        run_context=runtime_context,
+    decode_result = decode_service.run(
+        DecodeStageInput(
+            codec=codec,
+            fec=fec,
+            dna=decode_input,
+            fec_info=fec_info,
+            filter_mutated=filter_mutated,
+            survivor_batch=decode_input,
+            run_context=runtime_context,
+        )
     )
     decode_seconds = time.perf_counter() - decode_started_at
 
     metrics_dict = metrics(
         simulated_batch,
         original_data,
-        decoded,
+        decode_result.decoded,
         fec,
-        subs,
-        ins,
-        dels,
-        coverage,
+        simulate_result.substitutions,
+        simulate_result.insertions,
+        simulate_result.deletions,
+        simulate_result.coverage,
         stack_metrics=(dict(fec_info).get("coding_stack") if isinstance(fec_info, Mapping) else None),
         constraint_outcomes=(
             dict(fec_info).get("constraint_outcomes") if isinstance(fec_info, Mapping) else None
@@ -631,13 +381,13 @@ def run_canonical_pipeline(
         simulated_batch=simulated_batch,
         decode_input=decode_input,
         survivor_batch=decode_input,
-        decoded=decoded,
+        decoded=decode_result.decoded,
         metrics=metrics_dict,
         fec_info=fec_info,
-        substitutions=subs,
-        insertions=ins,
-        deletions=dels,
-        coverage=coverage,
+        substitutions=simulate_result.substitutions,
+        insertions=simulate_result.insertions,
+        deletions=simulate_result.deletions,
+        coverage=simulate_result.coverage,
         runtime={
             "total_seconds": total_seconds,
             "encode_seconds": encode_seconds,
@@ -648,46 +398,7 @@ def run_canonical_pipeline(
 
 
 def _estimate_coverage(batch: SequenceBatch) -> int | None:
-    meta_value = batch.metadata.get("sim_average_coverage")
-    if meta_value is not None:
-        try:
-            return int(round(float(meta_value)))
-        except (TypeError, ValueError):
-            pass
-
-    coverages: list[int] = []
-    for oligo in batch.primary_oligos():
-        cov_val = oligo.metadata.get(RESULT_COVERAGE_KEY)
-        if cov_val is None:
-            continue
-        try:
-            coverages.append(int(cov_val))
-        except (TypeError, ValueError):
-            continue
-    if coverages:
-        return int(round(sum(coverages) / len(coverages)))
-    return None
-
-
-def _apply_channel_constructor_parameters(simulator: object, parameters: Mapping[str, Any] | None) -> object:
-    if not parameters:
-        return simulator
-    signature = inspect.signature(type(simulator).__init__)
-    accepted = {
-        name
-        for name, param in signature.parameters.items()
-        if name != "self" and param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
-    }
-    kwargs = {key: value for key, value in parameters.items() if key in accepted}
-    if not kwargs:
-        return simulator
-    current_profile = getattr(simulator, "profile", None)
-    if "profile" in accepted and "profile" not in kwargs and current_profile is not None:
-        kwargs["profile"] = current_profile
-    try:
-        return type(simulator)(**kwargs)
-    except Exception:
-        return simulator
+    return estimate_coverage(batch)
 
 
 def simulate(
@@ -698,47 +409,21 @@ def simulate(
     run_context: RunContext | None = None,
 ) -> Tuple[SequenceBatch | str, int | None, int | None, int | None, int | None]:
     """Return ``dna`` possibly mutated by ``channel`` and error counts."""
-
-    runtime_context = run_context or make_run_context()
-    is_batch = isinstance(dna, SequenceBatch)
-    original_batch = dna if is_batch else _wrap_single_sequence(str(dna), batch_id="channel")
-
-    if channel and channel != "none":
-        if channel not in SIMULATOR_REGISTRY:
-            raise ValueError(f"Unknown channel: {channel}")
-        sim = _apply_channel_constructor_parameters(SIMULATOR_REGISTRY[channel], channel_parameters)
-        pipeline = ChannelPipeline.from_simulators([(channel, sim)])
-        mutated_batch, provenance = pipeline.run(
-            original_batch,
-            run_context=runtime_context,
+    output = SimulateStageService().run(
+        SimulateStageInput(
+            channel=channel,
+            dna=dna,
+            channel_parameters=channel_parameters,
+            run_context=run_context,
         )
-
-        mutated_batch.metadata["sim_stage_provenance"] = json.dumps(provenance)
-        if channel_parameters:
-            mutated_batch.metadata["sim_channel_parameters"] = json.dumps(dict(channel_parameters))
-
-        original_sequence = original_batch.combined_sequence()
-        mutated_sequence = mutated_batch.combined_sequence()
-        subs, ins, dels = _count_errors(original_sequence, mutated_sequence)
-
-        coverage = _estimate_coverage(mutated_batch)
-        if coverage is None:
-            cov_func = getattr(sim, "get_coverage", None)
-            if callable(cov_func):
-                try:
-                    coverage = int(cov_func(original_sequence))
-                except Exception:  # pragma: no cover - simulator failed
-                    coverage = None
-
-        return (
-            mutated_batch if is_batch else mutated_sequence,
-            subs,
-            ins,
-            dels,
-            coverage,
-        )
-
-    return (dna if is_batch else str(dna)), None, None, None, None
+    )
+    return (
+        output.dna,
+        output.substitutions,
+        output.insertions,
+        output.deletions,
+        output.coverage,
+    )
 
 
 def decode(
@@ -760,135 +445,19 @@ def decode(
             zero-coverage oligos. Set to ``False`` to retain mutated oligos.
     """
 
-    runtime_context = run_context or make_run_context()
-    policy = constraint_policy or _resolve_constraint_policy(fec_info)
-    stack = compile_legacy_stack(codec, fec, constraint_policy=policy)
-
-    batch = dna if isinstance(dna, SequenceBatch) else _wrap_single_sequence(str(dna))
-    if isinstance(dna, SequenceBatch):
-        filtered: list[SequenceOligo] = []
-        for oligo in dna.oligos:
-            dropout_flag = _parse_bool(oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY, False))
-            coverage_raw = oligo.metadata.get(RESULT_COVERAGE_KEY)
-            try:
-                coverage_int = int(coverage_raw) if coverage_raw is not None else None
-            except (TypeError, ValueError):
-                coverage_int = None
-            mutation_raw = oligo.metadata.get(RESULT_MUTATION_TOTALS_KEY)
-            mutation_flag = False
-            if mutation_raw not in (None, ""):
-                mutation_data: Mapping[str, Any] | None
-                if isinstance(mutation_raw, Mapping):
-                    mutation_data = mutation_raw
-                elif isinstance(mutation_raw, str):
-                    try:
-                        parsed = json.loads(mutation_raw)
-                    except json.JSONDecodeError:
-                        mutation_data = None
-                    else:
-                        mutation_data = parsed if isinstance(parsed, Mapping) else None
-                else:
-                    mutation_data = None
-                if mutation_data is not None:
-                    for key in ("substitutions", "insertions", "deletions"):
-                        try:
-                            if int(mutation_data.get(key, 0)) > 0:
-                                mutation_flag = True
-                                break
-                        except (TypeError, ValueError):
-                            continue
-            if dropout_flag or (coverage_int is not None and coverage_int <= 0) or (
-                filter_mutated and mutation_flag
-            ):
-                continue
-            filtered.append(oligo)
-        if len(filtered) != len(dna.oligos):
-            if not filtered:
-                raise ValueError(
-                    "No survivor oligos available after filtering; "
-                    "adjust channel conditions or disable --filter-mutated."
-                )
-            batch = SequenceBatch(
-                batch_id=dna.batch_id,
-                metadata=dict(dna.metadata),
-                seed=dna.seed,
-                oligos=list(filtered),
-            )
-    if survivor_batch is None and isinstance(dna, SequenceBatch):
-        survivor_batch = batch
-    if isinstance(batch, SequenceBatch) and not batch.oligos:
-        raise ValueError(
-            "No survivor oligos available after filtering; "
-            "adjust channel conditions or disable --filter-mutated."
+    output = DecodeStageService().run(
+        DecodeStageInput(
+            codec=codec,
+            fec=fec,
+            dna=dna,
+            fec_info=fec_info,
+            filter_mutated=filter_mutated,
+            survivor_batch=survivor_batch,
+            constraint_policy=constraint_policy,
+            run_context=run_context,
         )
-    constraint_outcomes: dict[str, Any] = {}
-    if policy is not None:
-        stage_outcome = _apply_constraint_stage_to_batch(
-            batch,
-            policy=policy,
-            stage="pre_decode",
-        )
-        constraint_outcomes = {
-            "by_oligo": stage_outcome.get("by_oligo", {}),
-            "stages": [{k: v for k, v in stage_outcome.items() if k != "by_oligo"}],
-        }
-    context_meta: dict[str, Any] = {"batch_id": batch.batch_id, **batch.metadata}
-    if fec_info:
-        context_meta.update(dict(fec_info))
-    if survivor_batch is not None:
-        context_meta["survivor_batch"] = survivor_batch
-    context = CodingContext(
-        block_id="decode-0",
-        metadata={**context_meta, "run_context": runtime_context},
-        constraint_policy=policy,
     )
-
-    current: bytes | str | SequenceBatch = batch
-    decode_metrics: list[dict[str, Any]] = []
-    codec_decoded = False
-    for layer in reversed(stack):
-        before_size = (
-            len(current)
-            if isinstance(current, (bytes, bytearray, str))
-            else len(current.combined_sequence())
-        )
-        if not codec_decoded and layer.name == codec:
-            layer_input: bytes | str | SequenceBatch = current
-            if isinstance(layer_input, bytes):
-                layer_input = layer_input.decode("utf-8")
-            started_at = time.perf_counter()
-            layer_out = layer.decode_block(layer_input, context)
-            codec_decoded = True
-        else:
-            if isinstance(current, str):
-                current = current.encode("utf-8")
-            started_at = time.perf_counter()
-            layer_out = layer.decode_block(current, context)
-        current = layer_out.payload
-        after_size = (
-            len(current)
-            if isinstance(current, (bytes, bytearray, str))
-            else len(current.combined_sequence())
-        )
-        decode_metrics.append(
-            build_layer_metric(
-                layer_name=layer.name,
-                layer_type="codec" if layer.name == codec else "fec",
-                stage="decode",
-                before_size=before_size,
-                after_size=after_size,
-                started_at=started_at,
-                corrections=int(layer_out.metadata.get("corrections", 0) or 0),
-            )
-        )
-
-    if not isinstance(current, (bytes, bytearray)):
-        raise TypeError("Decoded payload must be bytes")
-    if isinstance(fec_info, dict):
-        fec_info["coding_stack"] = normalize_stack_metrics(decode_metrics)
-        if constraint_outcomes:
-            fec_info["constraint_outcomes"] = dict(constraint_outcomes)
-    return bytes(current)
+    return output.decoded
 
 
 def metrics(
@@ -1177,7 +746,7 @@ def inspect_coding_plan(config: Mapping[str, Any]) -> dict[str, Any]:
     """Return planner diagnostics for why stack candidates were selected/rejected."""
 
     init_plugins()
-    plan = plan_stack_from_config(config)
+    plan = plan_coding_stack(config)
     return plan.summary()
 
 
@@ -1185,7 +754,7 @@ def compile_coding_stack(config: Mapping[str, Any]) -> list[object]:
     """Validate and compile a declarative coding stack from config."""
 
     init_plugins()
-    return list(compile_stack_from_config(config))
+    return list(compile_coding_stack_from_config(config))
 
 def run_pipeline(
     codec: str,

--- a/src/genecoder/runtime/models.py
+++ b/src/genecoder/runtime/models.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from genecoder.constraints import ConstraintPolicy
+from genecoder.formats import SequenceBatch
+from genecoder.runtime import RunContext
+
+
+@dataclass(slots=True)
+class EncodeStageInput:
+    codec: str
+    fec: str | None
+    data: bytes
+    constraint_policy: ConstraintPolicy | None = None
+    run_context: RunContext | None = None
+
+
+@dataclass(slots=True)
+class EncodeStageOutput:
+    encoded_batch: SequenceBatch
+    fec_info: Mapping[str, Any] | None
+
+
+@dataclass(slots=True)
+class SimulateStageInput:
+    channel: str | None
+    dna: SequenceBatch | str
+    channel_parameters: Mapping[str, Any] | None = None
+    run_context: RunContext | None = None
+
+
+@dataclass(slots=True)
+class SimulateStageOutput:
+    dna: SequenceBatch | str
+    substitutions: int | None
+    insertions: int | None
+    deletions: int | None
+    coverage: int | None
+
+
+@dataclass(slots=True)
+class DecodeStageInput:
+    codec: str
+    fec: str | None
+    dna: SequenceBatch | str
+    fec_info: Mapping[str, Any] | None
+    filter_mutated: bool = True
+    survivor_batch: SequenceBatch | None = None
+    constraint_policy: ConstraintPolicy | None = None
+    run_context: RunContext | None = None
+
+
+@dataclass(slots=True)
+class DecodeStageOutput:
+    decoded: bytes
+
+
+@dataclass(slots=True)
+class ConstraintStageInput:
+    batch: SequenceBatch
+    policy: ConstraintPolicy
+    stage: str
+
+
+@dataclass(slots=True)
+class ConstraintStageOutput:
+    payload: dict[str, Any]

--- a/src/genecoder/runtime/stages/__init__.py
+++ b/src/genecoder/runtime/stages/__init__.py
@@ -1,0 +1,16 @@
+from .constraints import ConstraintStageService, resolve_constraint_policy
+from .decode import DecodeStageService
+from .encode import EncodeStageService, wrap_single_sequence
+from .simulate import SimulateStageService, batch_for_decode, estimate_coverage, parse_bool
+
+__all__ = [
+    "ConstraintStageService",
+    "DecodeStageService",
+    "EncodeStageService",
+    "SimulateStageService",
+    "batch_for_decode",
+    "estimate_coverage",
+    "parse_bool",
+    "resolve_constraint_policy",
+    "wrap_single_sequence",
+]

--- a/src/genecoder/runtime/stages/constraints.py
+++ b/src/genecoder/runtime/stages/constraints.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from genecoder.constraints import ConstraintPolicy, ConstraintRepairPipeline, load_constraint_policy
+from genecoder.runtime.models import ConstraintStageInput, ConstraintStageOutput
+
+
+def resolve_constraint_policy(raw: Mapping[str, Any] | None) -> ConstraintPolicy | None:
+    if not raw:
+        return None
+    policy_raw = raw.get("constraint_policy")
+    if policy_raw is None:
+        return None
+    if isinstance(policy_raw, ConstraintPolicy):
+        return policy_raw
+    if isinstance(policy_raw, Mapping):
+        return load_constraint_policy(policy_raw)
+    return None
+
+
+class ConstraintStageService:
+    def run(self, payload: ConstraintStageInput) -> ConstraintStageOutput:
+        pipeline = ConstraintRepairPipeline(payload.policy)
+        primaries = payload.batch.primary_oligos() or payload.batch.oligos
+        outcomes = pipeline.repair_batch([ol.sequence for ol in primaries], stage=payload.stage)
+        by_oligo: dict[str, dict[str, Any]] = {}
+        for idx, (oligo, outcome) in enumerate(zip(primaries, outcomes), start=1):
+            if outcome.sequence != oligo.sequence:
+                oligo.sequence = outcome.sequence
+            key = str(
+                oligo.metadata.get("oligo_id")
+                or oligo.oligo_id
+                or oligo.metadata.get("oligo_index")
+                or idx
+            )
+            by_oligo[key] = {
+                "oligo_index": idx,
+                "violations_before": outcome.report_before.count,
+                "violations_after": outcome.report_after.count,
+                "pressure_before": outcome.report_before.pressure,
+                "pressure_after": outcome.report_after.pressure,
+                "repair_strategy": outcome.repair.strategy if outcome.repair is not None else None,
+                "repairs_applied": len(outcome.repair.changes) if outcome.repair is not None else 0,
+                "residual_risk": outcome.residual_risk,
+                "objective_score": outcome.objective_score,
+                "objective_tradeoff": dict(outcome.objective_tradeoff or {}),
+                "stage": outcome.stage,
+            }
+
+        result = {
+            "stage": payload.stage,
+            "violations": {
+                "before": sum(item.report_before.count for item in outcomes),
+                "after": sum(item.report_after.count for item in outcomes),
+                "pressure_before": (
+                    sum(item.report_before.pressure for item in outcomes) / len(outcomes)
+                    if outcomes
+                    else 0.0
+                ),
+                "pressure_after": (
+                    sum(item.report_after.pressure for item in outcomes) / len(outcomes)
+                    if outcomes
+                    else 0.0
+                ),
+            },
+            "repairs_applied": sum(len(item.repair.changes) if item.repair is not None else 0 for item in outcomes),
+            "repair_strategy": (
+                outcomes[0].repair.strategy if outcomes and outcomes[0].repair is not None else None
+            ),
+            "residual_risk": (
+                sum(item.residual_risk for item in outcomes) / len(outcomes) if outcomes else 0.0
+            ),
+            "objective_score": (
+                sum(float(item.objective_score or 0.0) for item in outcomes) / len(outcomes)
+                if outcomes
+                else None
+            ),
+            "objective_tradeoff": {
+                "gc": (sum(float((item.objective_tradeoff or {}).get("gc_deviation", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
+                "homopolymer": (sum(float((item.objective_tradeoff or {}).get("homopolymer_excess", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
+                "redundancy": (sum(float((item.objective_tradeoff or {}).get("redundancy", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
+                "recovery": (sum(float((item.objective_tradeoff or {}).get("recovery_proxy", 0.0)) for item in outcomes) / len(outcomes)) if outcomes else 0.0,
+            },
+            "by_oligo": by_oligo,
+        }
+        return ConstraintStageOutput(payload=result)

--- a/src/genecoder/runtime/stages/decode.py
+++ b/src/genecoder/runtime/stages/decode.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from genecoder.coding.stack import CodingContext, build_layer_metric, compile_stack_from_config, normalize_stack_metrics
+from genecoder.formats import SequenceBatch, SequenceOligo
+from genecoder.runtime import make_run_context
+from genecoder.runtime.models import ConstraintStageInput, DecodeStageInput, DecodeStageOutput
+from genecoder.runtime.stages.constraints import ConstraintStageService, resolve_constraint_policy
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+)
+from genecoder.runtime.stages.simulate import parse_bool
+
+from .encode import wrap_single_sequence
+
+
+class DecodeStageService:
+    def __init__(self, *, constraint_stage: ConstraintStageService | None = None) -> None:
+        self._constraint_stage = constraint_stage or ConstraintStageService()
+
+    def run(self, payload: DecodeStageInput) -> DecodeStageOutput:
+        runtime_context = payload.run_context or make_run_context()
+        policy = payload.constraint_policy or resolve_constraint_policy(payload.fec_info)
+        stack = compile_stack_from_config(
+            {"codec": payload.codec, "fec": payload.fec},
+            constraint_policy=policy,
+        )
+
+        batch = payload.dna if isinstance(payload.dna, SequenceBatch) else wrap_single_sequence(str(payload.dna))
+        if isinstance(payload.dna, SequenceBatch):
+            filtered: list[SequenceOligo] = []
+            for oligo in payload.dna.oligos:
+                dropout_flag = parse_bool(oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY, False))
+                coverage_raw = oligo.metadata.get(RESULT_COVERAGE_KEY)
+                try:
+                    coverage_int = int(coverage_raw) if coverage_raw is not None else None
+                except (TypeError, ValueError):
+                    coverage_int = None
+                mutation_raw = oligo.metadata.get(RESULT_MUTATION_TOTALS_KEY)
+                mutation_flag = False
+                if mutation_raw not in (None, ""):
+                    mutation_data: Mapping[str, Any] | None
+                    if isinstance(mutation_raw, Mapping):
+                        mutation_data = mutation_raw
+                    elif isinstance(mutation_raw, str):
+                        try:
+                            parsed = json.loads(mutation_raw)
+                        except json.JSONDecodeError:
+                            mutation_data = None
+                        else:
+                            mutation_data = parsed if isinstance(parsed, Mapping) else None
+                    else:
+                        mutation_data = None
+                    if mutation_data is not None:
+                        for key in ("substitutions", "insertions", "deletions"):
+                            try:
+                                if int(mutation_data.get(key, 0)) > 0:
+                                    mutation_flag = True
+                                    break
+                            except (TypeError, ValueError):
+                                continue
+                if dropout_flag or (coverage_int is not None and coverage_int <= 0) or (
+                    payload.filter_mutated and mutation_flag
+                ):
+                    continue
+                filtered.append(oligo)
+            if len(filtered) != len(payload.dna.oligos):
+                if not filtered:
+                    raise ValueError(
+                        "No survivor oligos available after filtering; "
+                        "adjust channel conditions or disable --filter-mutated."
+                    )
+                batch = SequenceBatch(
+                    batch_id=payload.dna.batch_id,
+                    metadata=dict(payload.dna.metadata),
+                    seed=payload.dna.seed,
+                    oligos=list(filtered),
+                )
+        survivor_batch = payload.survivor_batch
+        if survivor_batch is None and isinstance(payload.dna, SequenceBatch):
+            survivor_batch = batch
+        if isinstance(batch, SequenceBatch) and not batch.oligos:
+            raise ValueError(
+                "No survivor oligos available after filtering; "
+                "adjust channel conditions or disable --filter-mutated."
+            )
+
+        constraint_outcomes: dict[str, Any] = {}
+        if policy is not None:
+            stage_outcome = self._constraint_stage.run(
+                ConstraintStageInput(batch=batch, policy=policy, stage="pre_decode")
+            ).payload
+            constraint_outcomes = {
+                "by_oligo": stage_outcome.get("by_oligo", {}),
+                "stages": [{k: v for k, v in stage_outcome.items() if k != "by_oligo"}],
+            }
+
+        context_meta: dict[str, Any] = {"batch_id": batch.batch_id, **batch.metadata}
+        if payload.fec_info:
+            context_meta.update(dict(payload.fec_info))
+        if survivor_batch is not None:
+            context_meta["survivor_batch"] = survivor_batch
+        context = CodingContext(
+            block_id="decode-0",
+            metadata={**context_meta, "run_context": runtime_context},
+            constraint_policy=policy,
+        )
+
+        current: bytes | str | SequenceBatch = batch
+        decode_metrics: list[dict[str, Any]] = []
+        codec_decoded = False
+        for layer in reversed(stack):
+            before_size = (
+                len(current)
+                if isinstance(current, (bytes, bytearray, str))
+                else len(current.combined_sequence())
+            )
+            if not codec_decoded and layer.name == payload.codec:
+                layer_input: bytes | str | SequenceBatch = current
+                if isinstance(layer_input, bytes):
+                    layer_input = layer_input.decode("utf-8")
+                started_at = time.perf_counter()
+                layer_out = layer.decode_block(layer_input, context)
+                codec_decoded = True
+            else:
+                if isinstance(current, str):
+                    current = current.encode("utf-8")
+                started_at = time.perf_counter()
+                layer_out = layer.decode_block(current, context)
+            current = layer_out.payload
+            after_size = (
+                len(current)
+                if isinstance(current, (bytes, bytearray, str))
+                else len(current.combined_sequence())
+            )
+            decode_metrics.append(
+                build_layer_metric(
+                    layer_name=layer.name,
+                    layer_type="codec" if layer.name == payload.codec else "fec",
+                    stage="decode",
+                    before_size=before_size,
+                    after_size=after_size,
+                    started_at=started_at,
+                    corrections=int(layer_out.metadata.get("corrections", 0) or 0),
+                )
+            )
+
+        if not isinstance(current, (bytes, bytearray)):
+            raise TypeError("Decoded payload must be bytes")
+        if isinstance(payload.fec_info, dict):
+            payload.fec_info["coding_stack"] = normalize_stack_metrics(decode_metrics)
+            if constraint_outcomes:
+                payload.fec_info["constraint_outcomes"] = dict(constraint_outcomes)
+
+        return DecodeStageOutput(decoded=bytes(current))

--- a/src/genecoder/runtime/stages/encode.py
+++ b/src/genecoder/runtime/stages/encode.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from genecoder.coding.stack import CodingContext, build_layer_metric, compile_stack_from_config, normalize_stack_metrics
+from genecoder.formats import SequenceBatch
+from genecoder.runtime import make_run_context
+from genecoder.runtime.models import ConstraintStageInput, EncodeStageInput, EncodeStageOutput
+from genecoder.runtime.stages.constraints import ConstraintStageService
+
+
+def wrap_single_sequence(
+    sequence: str,
+    *,
+    batch_id: str = "sequence",
+    codec: str | None = None,
+) -> SequenceBatch:
+    tokens = [f"batch_id={batch_id}", "oligo_index=1"]
+    if codec:
+        tokens.append(f"codec={codec}")
+    header = " ".join(tokens)
+    batch = SequenceBatch.build([(header, sequence)], batch_id=batch_id)
+    if codec:
+        batch.metadata.setdefault("codec", codec)
+    return batch
+
+
+class EncodeStageService:
+    def __init__(self, *, constraint_stage: ConstraintStageService | None = None) -> None:
+        self._constraint_stage = constraint_stage or ConstraintStageService()
+
+    def run(self, payload: EncodeStageInput) -> EncodeStageOutput:
+        stack = compile_stack_from_config(
+            {"codec": payload.codec, "fec": payload.fec},
+            constraint_policy=payload.constraint_policy,
+        )
+        runtime_context = payload.run_context or make_run_context()
+        context = CodingContext(
+            block_id="encode-0",
+            constraint_policy=payload.constraint_policy,
+            metadata={"run_context": runtime_context},
+        )
+        current: bytes | str | SequenceBatch = payload.data
+        layer_info: dict[str, Mapping[str, Any]] = {}
+        layer_metrics: list[dict[str, Any]] = []
+        for layer in stack:
+            before_size = (
+                len(current)
+                if isinstance(current, (bytes, bytearray, str))
+                else len(current.combined_sequence())
+            )
+            started_at = time.perf_counter()
+            layer_out = layer.encode_block(current, context)
+            current = layer_out.payload
+            info_value = layer_out.metadata.get("fec_info")
+            if isinstance(info_value, Mapping):
+                layer_info[layer.name] = dict(info_value)
+            after_size = (
+                len(current)
+                if isinstance(current, (bytes, bytearray, str))
+                else len(current.combined_sequence())
+            )
+            layer_metrics.append(
+                build_layer_metric(
+                    layer_name=layer.name,
+                    layer_type="codec" if layer.name == payload.codec else "fec",
+                    stage="encode",
+                    before_size=before_size,
+                    after_size=after_size,
+                    started_at=started_at,
+                )
+            )
+
+        encoded = current
+        if isinstance(encoded, SequenceBatch):
+            batch = encoded
+        elif isinstance(encoded, str):
+            batch = wrap_single_sequence(encoded, batch_id=f"{payload.codec}-batch", codec=payload.codec)
+        else:
+            raise TypeError("Codec implementations must return a string or SequenceBatch")
+
+        constraint_outcomes: list[dict[str, Any]] = []
+        stage_outcome: dict[str, Any] = {}
+        if payload.constraint_policy is not None:
+            stage_outcome = self._constraint_stage.run(
+                ConstraintStageInput(
+                    batch=batch,
+                    policy=payload.constraint_policy,
+                    stage="encode",
+                )
+            ).payload
+            constraint_outcomes.append({k: v for k, v in stage_outcome.items() if k != "by_oligo"})
+
+        normalized_stack = normalize_stack_metrics(layer_metrics, "".join(ol.sequence for ol in batch.oligos))
+        batch.metadata.setdefault("coding_stack", normalized_stack)
+
+        if payload.constraint_policy is not None:
+            batch.metadata["constraint_policy"] = payload.constraint_policy.to_dict()
+            existing = batch.metadata.get("constraint_outcomes")
+            merged = dict(existing) if isinstance(existing, Mapping) else {}
+            merged["by_oligo"] = stage_outcome.get("by_oligo", {})
+            merged["stages"] = constraint_outcomes
+            batch.metadata["constraint_outcomes"] = merged
+
+        fec_info: Mapping[str, Any] | None = None
+        if layer_info:
+            info_dict: dict[str, Any] = {
+                "layer_info": layer_info,
+                "coding_stack": normalized_stack,
+            }
+            if payload.fec and payload.fec in layer_info:
+                info_dict.update(dict(layer_info[payload.fec]))
+            if payload.constraint_policy is not None:
+                info_dict["constraint_policy"] = payload.constraint_policy.to_dict()
+                info_dict["constraint_outcomes"] = dict(batch.metadata.get("constraint_outcomes", {}))
+            info_dict.setdefault("batch_id", batch.batch_id)
+            info_dict.setdefault("batch_metadata", dict(batch.metadata))
+            fec_info = info_dict
+
+        return EncodeStageOutput(encoded_batch=batch, fec_info=fec_info)

--- a/src/genecoder/runtime/stages/simulate.py
+++ b/src/genecoder/runtime/stages/simulate.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from genecoder.channel_engine import ChannelPipeline
+from genecoder.formats import SequenceBatch
+from genecoder.runtime import make_run_context
+from genecoder.runtime.models import SimulateStageInput, SimulateStageOutput
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.simulators.batch_utils import (
+    RESULT_COVERAGE_KEY,
+    RESULT_DROPOUT_FLAG_KEY,
+    RESULT_MUTATION_TOTALS_KEY,
+)
+
+from .encode import wrap_single_sequence
+
+
+def parse_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def batch_for_decode(batch: SequenceBatch, *, filter_mutated: bool) -> SequenceBatch:
+    filtered = []
+    for oligo in batch.oligos:
+        dropout_flag = parse_bool(oligo.metadata.get(RESULT_DROPOUT_FLAG_KEY, False))
+        coverage_raw = oligo.metadata.get(RESULT_COVERAGE_KEY)
+        try:
+            coverage_int = int(coverage_raw) if coverage_raw is not None else None
+        except (TypeError, ValueError):
+            coverage_int = None
+
+        mutation_raw = oligo.metadata.get(RESULT_MUTATION_TOTALS_KEY)
+        mutation_flag = False
+        if mutation_raw not in (None, ""):
+            mutation_data: Mapping[str, Any] | None
+            if isinstance(mutation_raw, Mapping):
+                mutation_data = mutation_raw
+            elif isinstance(mutation_raw, str):
+                try:
+                    parsed = json.loads(mutation_raw)
+                except json.JSONDecodeError:
+                    mutation_data = None
+                else:
+                    mutation_data = parsed if isinstance(parsed, Mapping) else None
+            else:
+                mutation_data = None
+            if mutation_data is not None:
+                for key in ("substitutions", "insertions", "deletions"):
+                    try:
+                        if int(mutation_data.get(key, 0)) > 0:
+                            mutation_flag = True
+                            break
+                    except (TypeError, ValueError):
+                        continue
+
+        if dropout_flag:
+            continue
+        if coverage_int is not None and coverage_int <= 0:
+            continue
+        if filter_mutated and mutation_flag:
+            continue
+        filtered.append(oligo)
+
+    if len(filtered) == len(batch.oligos):
+        return batch
+    return SequenceBatch(
+        batch_id=batch.batch_id,
+        metadata=dict(batch.metadata),
+        seed=batch.seed,
+        oligos=list(filtered),
+    )
+
+
+def estimate_coverage(batch: SequenceBatch) -> int | None:
+    meta_value = batch.metadata.get("sim_average_coverage")
+    if meta_value is not None:
+        try:
+            return int(round(float(meta_value)))
+        except (TypeError, ValueError):
+            pass
+
+    coverages: list[int] = []
+    for oligo in batch.primary_oligos():
+        cov_val = oligo.metadata.get(RESULT_COVERAGE_KEY)
+        if cov_val is None:
+            continue
+        try:
+            coverages.append(int(cov_val))
+        except (TypeError, ValueError):
+            continue
+    if coverages:
+        return int(round(sum(coverages) / len(coverages)))
+    return None
+
+
+def apply_channel_constructor_parameters(simulator: object, parameters: Mapping[str, Any] | None) -> object:
+    if not parameters:
+        return simulator
+    signature = inspect.signature(type(simulator).__init__)
+    accepted = {
+        name
+        for name, param in signature.parameters.items()
+        if name != "self" and param.kind in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+    }
+    kwargs = {key: value for key, value in parameters.items() if key in accepted}
+    if not kwargs:
+        return simulator
+    current_profile = getattr(simulator, "profile", None)
+    if "profile" in accepted and "profile" not in kwargs and current_profile is not None:
+        kwargs["profile"] = current_profile
+    try:
+        return type(simulator)(**kwargs)
+    except Exception:
+        return simulator
+
+
+class SimulateStageService:
+    def run(self, payload: SimulateStageInput) -> SimulateStageOutput:
+        runtime_context = payload.run_context or make_run_context()
+        is_batch = isinstance(payload.dna, SequenceBatch)
+        original_batch = payload.dna if is_batch else wrap_single_sequence(str(payload.dna), batch_id="channel")
+
+        if payload.channel and payload.channel != "none":
+            if payload.channel not in SIMULATOR_REGISTRY:
+                raise ValueError(f"Unknown channel: {payload.channel}")
+            sim = apply_channel_constructor_parameters(SIMULATOR_REGISTRY[payload.channel], payload.channel_parameters)
+            pipeline = ChannelPipeline.from_simulators([(payload.channel, sim)])
+            mutated_batch, provenance = pipeline.run(original_batch, run_context=runtime_context)
+
+            mutated_batch.metadata["sim_stage_provenance"] = json.dumps(provenance)
+            if payload.channel_parameters:
+                mutated_batch.metadata["sim_channel_parameters"] = json.dumps(dict(payload.channel_parameters))
+
+            original_sequence = original_batch.combined_sequence()
+            mutated_sequence = mutated_batch.combined_sequence()
+            from genecoder.core import _count_errors
+            subs, ins, dels = _count_errors(original_sequence, mutated_sequence)
+
+            coverage = estimate_coverage(mutated_batch)
+            if coverage is None:
+                cov_func = getattr(sim, "get_coverage", None)
+                if callable(cov_func):
+                    try:
+                        coverage = int(cov_func(original_sequence))
+                    except Exception:
+                        coverage = None
+
+            return SimulateStageOutput(
+                dna=(mutated_batch if is_batch else mutated_sequence),
+                substitutions=subs,
+                insertions=ins,
+                deletions=dels,
+                coverage=coverage,
+            )
+
+        return SimulateStageOutput(
+            dna=(payload.dna if is_batch else str(payload.dna)),
+            substitutions=None,
+            insertions=None,
+            deletions=None,
+            coverage=None,
+        )

--- a/tests/test_runtime_coordinator_parity.py
+++ b/tests/test_runtime_coordinator_parity.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from genecoder.core import run_canonical_pipeline
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.runtime.models import DecodeStageInput, EncodeStageInput, SimulateStageInput
+from genecoder.runtime.stages import DecodeStageService, EncodeStageService, SimulateStageService, batch_for_decode
+from genecoder.sdk.plugins import Codec
+from genecoder.simulators import SIMULATOR_REGISTRY
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+
+        return decode_base4_direct(encoded)[0]
+
+
+def _register_test_plugins() -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    SIMULATOR_REGISTRY["simple"] = type(SIMULATOR_REGISTRY["simple"])(error_rate=0.0)
+
+
+def test_canonical_coordinator_parity_with_stages() -> None:
+    _register_test_plugins()
+    payload = b"coordinator parity"
+
+    encode_out = EncodeStageService().run(EncodeStageInput(codec="base4", fec=None, data=payload))
+    simulate_out = SimulateStageService().run(
+        SimulateStageInput(channel="simple", dna=encode_out.encoded_batch)
+    )
+    decode_input = batch_for_decode(simulate_out.dna, filter_mutated=False)
+    decode_out = DecodeStageService().run(
+        DecodeStageInput(
+            codec="base4",
+            fec=None,
+            dna=decode_input,
+            fec_info=encode_out.fec_info,
+            filter_mutated=False,
+            survivor_batch=decode_input,
+        )
+    )
+
+    coordinated = run_canonical_pipeline("base4", None, "simple", payload, filter_mutated=False)
+
+    assert coordinated.decoded == decode_out.decoded
+    assert coordinated.encoded_batch.combined_sequence() == encode_out.encoded_batch.combined_sequence()
+    assert coordinated.simulated_batch.combined_sequence() == simulate_out.dna.combined_sequence()

--- a/tests/test_runtime_stage_services.py
+++ b/tests/test_runtime_stage_services.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from genecoder.formats import SequenceBatch
+from genecoder.plugin_manager import CODEC_REGISTRY, init_plugins
+from genecoder.runtime.models import DecodeStageInput, EncodeStageInput, SimulateStageInput
+from genecoder.runtime.stages.decode import DecodeStageService
+from genecoder.runtime.stages.encode import EncodeStageService
+from genecoder.runtime.stages.simulate import SimulateStageService, batch_for_decode
+from genecoder.sdk.plugins import Codec
+from genecoder.simulators import SIMULATOR_REGISTRY
+from genecoder.simulators.batch_utils import RESULT_DROPOUT_FLAG_KEY
+
+
+class _Base4Codec(Codec):
+    def encode(self, data: bytes) -> str:  # type: ignore[override]
+        from genecoder.encoders import encode_base4_direct
+
+        return encode_base4_direct(data)  # type: ignore[return-value]
+
+    def decode(self, encoded: str) -> bytes:  # type: ignore[override]
+        from genecoder.encoders import decode_base4_direct
+
+        return decode_base4_direct(encoded)[0]
+
+
+def _register_test_plugins() -> None:
+    init_plugins()
+    CODEC_REGISTRY["base4"] = {"encode": _Base4Codec().encode, "decode": _Base4Codec().decode}
+    SIMULATOR_REGISTRY["simple"] = type(SIMULATOR_REGISTRY["simple"])(error_rate=0.0)
+
+
+def test_encode_stage_service_roundtrip_payload() -> None:
+    _register_test_plugins()
+    service = EncodeStageService()
+    result = service.run(EncodeStageInput(codec="base4", fec=None, data=b"payload"))
+    assert isinstance(result.encoded_batch, SequenceBatch)
+    assert result.encoded_batch.primary_sequence()
+
+
+def test_simulate_stage_service_passthrough_none_channel() -> None:
+    service = SimulateStageService()
+    result = service.run(SimulateStageInput(channel=None, dna="ACGT"))
+    assert result.dna == "ACGT"
+    assert result.substitutions is None
+    assert result.coverage is None
+
+
+def test_decode_stage_service_roundtrip() -> None:
+    _register_test_plugins()
+    encode_result = EncodeStageService().run(EncodeStageInput(codec="base4", fec=None, data=b"decode me"))
+    decode_result = DecodeStageService().run(
+        DecodeStageInput(
+            codec="base4",
+            fec=None,
+            dna=encode_result.encoded_batch,
+            fec_info=encode_result.fec_info,
+        )
+    )
+    assert decode_result.decoded == b"decode me"
+
+
+def test_batch_for_decode_filters_dropout() -> None:
+    batch = SequenceBatch.build(
+        [
+            ("batch_id=test oligo_index=1", "ACGT"),
+            ("batch_id=test oligo_index=2", "TGCA"),
+        ],
+        batch_id="test",
+    )
+    batch.oligos[1].metadata[RESULT_DROPOUT_FLAG_KEY] = True
+    filtered = batch_for_decode(batch, filter_mutated=False)
+    assert len(filtered.oligos) == 1


### PR DESCRIPTION
### Motivation

- Break up monolithic `genecoder.core` pipeline logic into explicit stage services to improve separation of concerns and make each stage independently testable. 
- Introduce strongly typed payloads for stage inputs/outputs to clarify runtime boundaries and reduce adapter coupling.  
- Preserve backward compatibility for legacy stack compilation while keeping the canonical runtime adapter-free and coordinator-focused.

### Description

- Extracted stage implementations into `src/genecoder/runtime/stages/encode.py`, `simulate.py`, `decode.py`, and `constraints.py` and added `src/genecoder/runtime/stages/__init__.py` to export services and helpers.  
- Added typed dataclasses for stage payloads in `src/genecoder/runtime/models.py` (`EncodeStageInput/Output`, `SimulateStageInput/Output`, `DecodeStageInput/Output`, and constraint payloads).  
- Converted `encode`, `simulate`, and `decode` top-level helpers in `core.py` into thin compatibility wrappers that delegate to the new stage services, and refactored `run_canonical_pipeline` into a thin coordinator composing `EncodeStageService`, `SimulateStageService`, and `DecodeStageService`.  
- Moved legacy stack compilation entrypoints behind a compatibility facade in `src/genecoder/compat/coding_stack.py` and routed `compile_coding_stack` / `inspect_coding_plan` through that facade.  
- Added tests: per-stage unit tests in `tests/test_runtime_stage_services.py` and an integration parity test `tests/test_runtime_coordinator_parity.py` that verifies coordinator output matches staged composition.

### Testing

- Ran linter checks with `ruff check src/genecoder/core.py src/genecoder/runtime/models.py src/genecoder/runtime/stages src/genecoder/compat/coding_stack.py tests/test_runtime_stage_services.py tests/test_runtime_coordinator_parity.py` and all checks passed.  
- Ran unit/integration tests with `python -m pytest tests/test_runtime_stage_services.py tests/test_runtime_coordinator_parity.py tests/test_core_pipeline.py -q` which completed successfully (selected suite: 17 passed, 1 skipped, with expected warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e3f5e7e48326a56ffa92212f9a88)