### PR TITLE
Add reproducibility attestation and run_fingerprint to RunPipelineUseCase

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -200,3 +200,161 @@ seed** and enforces deterministic/tolerance checks from
   (for example `decode_success == true`) were violated.
 - `comparisons[].metric_checks[]`: per-metric baseline/candidate values and
   whether each check stayed within tolerance.
+
+## Runtime reproducibility attestation
+
+Every `RunPipelineUseCase` execution now emits a first-class attestation in the
+canonical run schema and, when manifest output is enabled, in the generated
+manifest. The top-level `run_fingerprint` is a SHA-256 digest of the canonical
+attestation payload, not of wall-clock runtime fields. Re-running the same input
+content, resolved configuration, profile parameters, seed provenance, package
+versions and plugin lock state in the same environment produces the same
+fingerprint even if artifact file names differ.
+
+### Expected attestation schema
+
+The run schema contains these top-level fields:
+
+```json
+{
+  "run_fingerprint": "<64 lowercase hex sha256>",
+  "attestation": {
+    "schema_version": "genecoder.reproducibility.attestation.v1",
+    "canonicalization": "json-sort-keys-separators-comma-colon-utf8",
+    "hash_algorithm": "sha256",
+    "payload": {
+      "schema_version": "genecoder.reproducibility.attestation.v1",
+      "config": {
+        "codec": "reverse",
+        "fec": null,
+        "channel": "simple",
+        "resolved_channel": "simple",
+        "filter_mutated": false,
+        "constraints": {},
+        "sweep": {},
+        "input": {
+          "basename": "input.bin",
+          "sha256": "<input content sha256>"
+        }
+      },
+      "resolved_profiles": {
+        "encoding": "reverse",
+        "simulation": "simple",
+        "decode": "reverse",
+        "channel_profile": {
+          "requested_name": "simple",
+          "resolved_name": "simple",
+          "parameters": {"substitution_prob": 0.0}
+        }
+      },
+      "seed_provenance": {},
+      "package_versions": {},
+      "plugin_lock_state": []
+    },
+    "run_fingerprint": "<64 lowercase hex sha256>",
+    "signature": {
+      "algorithm": "RSASSA-PKCS1v15-SHA256",
+      "padding_scheme": "pkcs1",
+      "signature": "<base64 signature over canonical payload bytes>",
+      "public_key_sha256": "<sha256 of signer public key pem>",
+      "path": "artifacts/run.attestation.sig.json"
+    }
+  }
+}
+```
+
+The same `run_fingerprint` and `attestation` object are copied into the manifest
+JSON when `emit_manifest` is enabled.
+
+### Verify a fingerprint
+
+Use the canonicalization string recorded in the attestation: JSON with sorted
+keys, compact comma/colon separators and UTF-8 bytes.
+
+```bash
+python - <<'PY'
+import hashlib
+import json
+from pathlib import Path
+
+run = json.loads(Path("artifacts/runs/example/metrics.json").read_text())
+payload = run["attestation"]["payload"]
+canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+fingerprint = hashlib.sha256(canonical).hexdigest()
+assert fingerprint == run["run_fingerprint"] == run["attestation"]["run_fingerprint"]
+print(fingerprint)
+PY
+```
+
+If a manifest was emitted, verify that it carries the identical attestation:
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+
+run = json.loads(Path("artifacts/runs/example/metrics.json").read_text())
+manifest = json.loads(Path("artifacts/runs/example/metrics.manifest.json").read_text())
+assert manifest["run_fingerprint"] == run["run_fingerprint"]
+assert manifest["attestation"] == run["attestation"]
+print("manifest attestation matches run schema")
+PY
+```
+
+### Sign and verify an attestation payload
+
+When `ArtifactOutputPolicy.attestation_private_key_path` is set, GeneCoder signs
+the canonical attestation payload with the existing SHA-256 security primitives.
+RSA private keys use PKCS#1 v1.5 signatures; ECDSA private keys use ECDSA with
+SHA-256. If `ArtifactOutputPolicy.attestation_signature_path` is also set, a
+copy of the detached signature metadata is written to that path.
+
+Generate a local test key and run through the SDK/YAML path:
+
+```bash
+openssl genrsa -out artifacts/repro-attest-private.pem 2048
+openssl rsa -in artifacts/repro-attest-private.pem -pubout -out artifacts/repro-attest-public.pem
+cat > artifacts/repro-attest-request.yaml <<'YAML'
+codec: reverse
+input_path: examples/pipeline_demo_input.txt
+output_path: artifacts/runs/repro-attest/decoded.txt
+channel: none
+seeds:
+  global_seed: 42
+artifacts:
+  metrics_path: artifacts/runs/repro-attest/metrics.json
+  emit_manifest: true
+  attestation_private_key_path: artifacts/repro-attest-private.pem
+  attestation_signature_path: artifacts/runs/repro-attest/attestation.sig.json
+YAML
+python - <<'PY'
+from genecoder.sdk import run_experiment
+run_experiment("artifacts/repro-attest-request.yaml")
+PY
+```
+
+Verify the signature with `genecoder.plugin_security.verify_signature`, which is
+the same verification helper used by plugin supply-chain checks:
+
+```bash
+python - <<'PY'
+import base64
+import json
+from pathlib import Path
+from genecoder.plugin_security import verify_signature
+
+run = json.loads(Path("artifacts/runs/repro-attest/metrics.json").read_text())
+attestation = run["attestation"]
+canonical = json.dumps(attestation["payload"], sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+signature = base64.b64decode(attestation["signature"]["signature"])
+public_key = Path("artifacts/repro-attest-public.pem").read_bytes()
+verified_digest = verify_signature(
+    canonical,
+    signature,
+    public_key,
+    padding_scheme=attestation["signature"].get("padding_scheme", "pkcs1"),
+    expected_checksum=run["run_fingerprint"],
+)
+print(verified_digest)
+PY
+```

--- a/src/genecoder/app/pipeline_use_case.py
+++ b/src/genecoder/app/pipeline_use_case.py
@@ -9,9 +9,12 @@ from the canonical runtime model (`genecoder.core.CanonicalRuntimeResult`).
 """
 
 from dataclasses import dataclass, field
+import base64
+import hashlib
+from importlib import metadata
 import json
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 from genecoder.manifest import generate_manifest
 from .pipeline_runtime import ProfileParameterOverrides, run_pipeline
@@ -54,6 +57,8 @@ class ArtifactOutputPolicy:
     metrics_path: str | None = None
     emit_manifest: bool = True
     emit_html_report: bool = False
+    attestation_private_key_path: str | None = None
+    attestation_signature_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -80,6 +85,155 @@ class RunPipelineResponse:
     metrics_path: str
     manifest_path: str | None
     html_report_path: str | None
+
+
+_PACKAGE_VERSION_NAMES: tuple[str, ...] = (
+    "GeneCoder",
+    "cryptography",
+    "reedsolo",
+    "PyYAML",
+    "portalocker",
+    "httpx",
+    "jsonschema",
+    "numpy",
+    "pandas",
+    "dnachisel",
+    "chamaeleo",
+    "bchlib",
+    "raptorq",
+)
+
+
+def _normalize_for_attestation(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_for_attestation(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_for_attestation(item) for item in value]
+    if isinstance(value, Path):
+        return value.as_posix()
+    return value
+
+
+def _canonical_attestation_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        _normalize_for_attestation(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _package_versions() -> dict[str, str | None]:
+    versions: dict[str, str | None] = {}
+    for name in _PACKAGE_VERSION_NAMES:
+        try:
+            versions[name] = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            versions[name] = None
+    return versions
+
+
+def _plugin_lock_state() -> list[dict[str, Any]]:
+    try:
+        from genecoder.plugin_supply_chain.service import PLUGIN_LOCK
+    except Exception:  # pragma: no cover - defensive import isolation
+        return []
+    return [dict(entry) for entry in PLUGIN_LOCK]
+
+
+def _file_sha256(path: str) -> str | None:
+    file_path = Path(path)
+    if not file_path.exists() or not file_path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sign_attestation(payload_bytes: bytes, private_key_path: str) -> dict[str, Any]:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+    key_bytes = Path(private_key_path).read_bytes()
+    private_key = serialization.load_pem_private_key(key_bytes, password=None)
+    if isinstance(private_key, rsa.RSAPrivateKey):
+        signature = private_key.sign(payload_bytes, padding.PKCS1v15(), hashes.SHA256())
+        algorithm = "RSASSA-PKCS1v15-SHA256"
+        padding_scheme = "pkcs1"
+    elif isinstance(private_key, ec.EllipticCurvePrivateKey):
+        signature = private_key.sign(payload_bytes, ec.ECDSA(hashes.SHA256()))
+        algorithm = "ECDSA-SHA256"
+        padding_scheme = "ecdsa"
+    else:  # pragma: no cover - unsupported key type
+        raise ValueError("Unsupported attestation private key type")
+
+    public_key_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return {
+        "algorithm": algorithm,
+        "padding_scheme": padding_scheme,
+        "signature": base64.b64encode(signature).decode("ascii"),
+        "public_key_sha256": hashlib.sha256(public_key_bytes).hexdigest(),
+    }
+
+
+def _build_attestation_payload(
+    *,
+    request: RunPipelineRequest,
+    resolved_channel_name: str | None,
+    resolved_profile_name: str | None,
+    applied_channel_parameters: object,
+    seed_provenance: Mapping[str, Any],
+) -> dict[str, object]:
+    constraints = (
+        {
+            "min_length": request.constraints.min_length,
+            "max_length": request.constraints.max_length,
+            "gc_min": request.constraints.gc_min,
+            "gc_max": request.constraints.gc_max,
+            "max_homopolymer": request.constraints.max_homopolymer,
+        }
+        if request.constraints
+        else {}
+    )
+    payload: dict[str, object] = {
+        "schema_version": "genecoder.reproducibility.attestation.v1",
+        "config": {
+            "codec": request.codec,
+            "fec": request.fec,
+            "channel": request.channel,
+            "resolved_channel": resolved_channel_name,
+            "filter_mutated": request.filter_mutated,
+            "constraints": constraints,
+            "sweep": dict(request.matrix.axes) if request.matrix else {},
+            "input": {
+                "basename": Path(request.input_path).name,
+                "sha256": _file_sha256(request.input_path),
+            },
+        },
+        "resolved_profiles": {
+            "encoding": request.codec,
+            "simulation": resolved_profile_name if resolved_profile_name else resolved_channel_name,
+            "decode": request.codec,
+            "channel_profile": (
+                {
+                    "requested_name": request.profile.name,
+                    "resolved_name": resolved_profile_name or request.profile.name,
+                    "parameters": dict(applied_channel_parameters) if isinstance(applied_channel_parameters, Mapping) else {},
+                }
+                if request.profile
+                else None
+            ),
+        },
+        "seed_provenance": dict(seed_provenance),
+        "package_versions": _package_versions(),
+        "plugin_lock_state": _plugin_lock_state(),
+    }
+    return cast(dict[str, object], _normalize_for_attestation(payload))
 
 
 class RunPipelineUseCase:
@@ -113,15 +267,54 @@ class RunPipelineUseCase:
         runtime_metrics = metrics.pop("_runtime", {})
         applied_channel_parameters = metrics.pop("_applied_channel_parameters", dict(request.profile.parameters) if request.profile else {})
 
-        constraint_outcomes_payload = metrics.get("constraint_outcomes") if isinstance(metrics.get("constraint_outcomes"), Mapping) else {}
-        constraint_by_oligo = constraint_outcomes_payload.get("by_oligo") if isinstance(constraint_outcomes_payload.get("by_oligo"), Mapping) else {}
-        constraint_stage_breakdown = constraint_outcomes_payload.get("stages") if isinstance(constraint_outcomes_payload.get("stages"), list) else []
+        constraint_outcomes_raw = metrics.get("constraint_outcomes")
+        constraint_outcomes_payload = (
+            constraint_outcomes_raw if isinstance(constraint_outcomes_raw, Mapping) else {}
+        )
+        constraint_by_oligo_raw = constraint_outcomes_payload.get("by_oligo")
+        constraint_by_oligo = (
+            constraint_by_oligo_raw if isinstance(constraint_by_oligo_raw, Mapping) else {}
+        )
+        constraint_stage_breakdown_raw = constraint_outcomes_payload.get("stages")
+        constraint_stage_breakdown = (
+            constraint_stage_breakdown_raw
+            if isinstance(constraint_stage_breakdown_raw, list)
+            else []
+        )
+
+        seed_provenance = run_context.seed_provenance()
+        attestation_payload = _build_attestation_payload(
+            request=request,
+            resolved_channel_name=resolved_channel_name,
+            resolved_profile_name=resolved_profile_name,
+            applied_channel_parameters=applied_channel_parameters,
+            seed_provenance=seed_provenance,
+        )
+        attestation_bytes = _canonical_attestation_bytes(attestation_payload)
+        run_fingerprint = hashlib.sha256(attestation_bytes).hexdigest()
+        attestation: dict[str, Any] = {
+            "schema_version": "genecoder.reproducibility.attestation.v1",
+            "canonicalization": "json-sort-keys-separators-comma-colon-utf8",
+            "hash_algorithm": "sha256",
+            "payload": attestation_payload,
+            "run_fingerprint": run_fingerprint,
+        }
+        if request.artifacts.attestation_private_key_path:
+            signature = _sign_attestation(attestation_bytes, request.artifacts.attestation_private_key_path)
+            attestation["signature"] = signature
+            if request.artifacts.attestation_signature_path:
+                signature_path = Path(request.artifacts.attestation_signature_path)
+                signature_path.parent.mkdir(parents=True, exist_ok=True)
+                signature_path.write_text(json.dumps(signature, indent=2, sort_keys=True), encoding="utf-8")
+                attestation["signature"]["path"] = str(signature_path)
 
         metrics_path = Path(request.artifacts.metrics_path or str(request.output_path) + ".json")
         run_schema: dict[str, Any] = {
             "schema_version": RUN_SCHEMA_VERSION,
             "source_format": "pipeline_use_case",
             "run_id": Path(request.output_path).stem,
+            "run_fingerprint": run_fingerprint,
+            "attestation": attestation,
             "profiles": {
                 "encoding": request.codec,
                 "simulation": resolved_profile_name if resolved_profile_name else resolved_channel_name,
@@ -132,7 +325,7 @@ class RunPipelineUseCase:
                 "encode": run_context.encode_seed,
                 "simulate": run_context.simulate_seed,
                 "decode": run_context.decode_seed,
-                "provenance": run_context.seed_provenance(),
+                "provenance": seed_provenance,
             },
             "runtime": {
                 "total_seconds": runtime_metrics.get("total_seconds"),
@@ -225,9 +418,11 @@ class RunPipelineUseCase:
         if request.artifacts.emit_manifest:
             manifest = generate_manifest(
                 request.input_path,
-                {"method": request.codec, "fec": request.fec, "channel": resolved_channel_name, "seeds": run_context.seed_provenance()},
+                {"method": request.codec, "fec": request.fec, "channel": resolved_channel_name, "seeds": seed_provenance},
                 dashboard_metrics,
             )
+            manifest["run_fingerprint"] = run_fingerprint
+            manifest["attestation"] = attestation
             manifest_file = metrics_path.with_suffix(".manifest.json")
             manifest_file.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
             manifest_path = str(manifest_file)

--- a/src/genecoder/sdk/api.py
+++ b/src/genecoder/sdk/api.py
@@ -130,6 +130,16 @@ def _request_from_mapping(raw: Mapping[str, Any]) -> ExperimentRequest:
             metrics_path=(str(artifacts_raw["metrics_path"]) if artifacts_raw.get("metrics_path") else None),
             emit_manifest=bool(artifacts_raw.get("emit_manifest", True)),
             emit_html_report=bool(artifacts_raw.get("emit_html_report", False)),
+            attestation_private_key_path=(
+                str(artifacts_raw["attestation_private_key_path"])
+                if artifacts_raw.get("attestation_private_key_path")
+                else None
+            ),
+            attestation_signature_path=(
+                str(artifacts_raw["attestation_signature_path"])
+                if artifacts_raw.get("attestation_signature_path")
+                else None
+            ),
         ),
     )
 

--- a/tests/test_pipeline_reproducibility_attestation.py
+++ b/tests/test_pipeline_reproducibility_attestation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genecoder.app.pipeline_use_case import (
+    ArtifactOutputPolicy,
+    ChannelProfile,
+    RunPipelineRequest,
+    RunPipelineUseCase,
+    SeedProfile,
+)
+
+
+FAKE_METRICS = {
+    "gc_content": 0.5,
+    "gc_variance": 0.0,
+    "max_homopolymer": 2,
+    "substitutions": 0,
+    "insertions": 0,
+    "deletions": 0,
+    "coverage": 1,
+    "dropout_count": 0,
+    "dropout_fraction": 0.0,
+    "decode_success": True,
+    "decode_success_rate": 1.0,
+    "ecc_success_rates": {},
+    "constraint_violations": 0,
+    "constraint_outcomes": {"by_oligo": {}, "stages": []},
+    "_runtime": {
+        "total_seconds": 0.1,
+        "encode_seconds": 0.01,
+        "simulate_seconds": 0.02,
+        "decode_seconds": 0.03,
+    },
+    "_sim_stage_provenance": [{"stage": "simulate", "profile": "simple"}],
+    "_sim_stage_metrics": [{"stage": "simulate", "coverage": 1}],
+    "_applied_channel_parameters": {"substitution_prob": 0.0},
+}
+
+
+def _fake_runtime(**kwargs: object):
+    metrics = dict(FAKE_METRICS)
+    metrics["_applied_channel_parameters"] = dict(kwargs.get("profile_parameter_overrides") or {})
+    return b"attested", metrics, None
+
+
+def _request(tmp_path: Path, *, metrics_name: str, output_name: str, substitution_prob: float = 0.0) -> RunPipelineRequest:
+    source = tmp_path / "input.bin"
+    source.write_bytes(b"same reproducibility input")
+    return RunPipelineRequest(
+        codec="reverse",
+        input_path=str(source),
+        output_path=str(tmp_path / output_name),
+        channel="simple",
+        profile=ChannelProfile(name="simple", parameters={"substitution_prob": substitution_prob}),
+        seeds=SeedProfile(global_seed=123, encode_seed=124, simulate_seed=125, decode_seed=126),
+        artifacts=ArtifactOutputPolicy(metrics_path=str(tmp_path / metrics_name), emit_manifest=True),
+    )
+
+
+def test_identical_inputs_produce_same_reproducibility_fingerprint(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+
+    first = RunPipelineUseCase().execute(_request(tmp_path, metrics_name="first.json", output_name="first.out"))
+    second = RunPipelineUseCase().execute(_request(tmp_path, metrics_name="second.json", output_name="second.out"))
+
+    assert first.run_schema["run_fingerprint"] == second.run_schema["run_fingerprint"]
+    assert first.run_schema["attestation"]["payload"] == second.run_schema["attestation"]["payload"]
+
+    manifest = json.loads(Path(first.manifest_path or "").read_text(encoding="utf-8"))
+    assert manifest["run_fingerprint"] == first.run_schema["run_fingerprint"]
+    assert manifest["attestation"]["payload"]["seed_provenance"] == first.run_schema["seeds"]["provenance"]
+
+
+def test_config_drift_changes_reproducibility_fingerprint(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+
+    baseline = RunPipelineUseCase().execute(_request(tmp_path, metrics_name="baseline.json", output_name="baseline.out"))
+    drifted = RunPipelineUseCase().execute(
+        _request(
+            tmp_path,
+            metrics_name="drifted.json",
+            output_name="drifted.out",
+            substitution_prob=0.01,
+        )
+    )
+
+    assert baseline.run_schema["run_fingerprint"] != drifted.run_schema["run_fingerprint"]
+    assert baseline.run_schema["attestation"]["payload"]["resolved_profiles"]["channel_profile"]["parameters"] != drifted.run_schema["attestation"]["payload"]["resolved_profiles"]["channel_profile"]["parameters"]
+
+
+def test_attestation_signature_metadata_is_embedded_and_written(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("genecoder.app.pipeline_use_case.run_pipeline", _fake_runtime)
+
+    def _fake_sign(payload_bytes: bytes, private_key_path: str) -> dict[str, str]:
+        assert payload_bytes
+        assert private_key_path == str(tmp_path / "private.pem")
+        return {
+            "algorithm": "test-sha256",
+            "padding_scheme": "pkcs1",
+            "signature": "c2ln",
+            "public_key_sha256": "0" * 64,
+        }
+
+    monkeypatch.setattr("genecoder.app.pipeline_use_case._sign_attestation", _fake_sign)
+    request = _request(tmp_path, metrics_name="signed.json", output_name="signed.out")
+    request = RunPipelineRequest(
+        codec=request.codec,
+        input_path=request.input_path,
+        output_path=request.output_path,
+        channel=request.channel,
+        profile=request.profile,
+        seeds=request.seeds,
+        artifacts=ArtifactOutputPolicy(
+            metrics_path=request.artifacts.metrics_path,
+            emit_manifest=True,
+            attestation_private_key_path=str(tmp_path / "private.pem"),
+            attestation_signature_path=str(tmp_path / "nested" / "attestation.sig.json"),
+        ),
+    )
+
+    response = RunPipelineUseCase().execute(request)
+
+    signature = response.run_schema["attestation"]["signature"]
+    assert signature["signature"] == "c2ln"
+    assert signature["path"] == str(tmp_path / "nested" / "attestation.sig.json")
+    detached = json.loads((tmp_path / "nested" / "attestation.sig.json").read_text(encoding="utf-8"))
+    assert detached["public_key_sha256"] == "0" * 64
+    manifest = json.loads(Path(response.manifest_path or "").read_text(encoding="utf-8"))
+    assert manifest["attestation"]["signature"] == signature


### PR DESCRIPTION
### Motivation
- Provide a canonical, normalized reproducibility attestation for pipeline runs so identical inputs + resolved configuration produce a stable, tamper-evident fingerprint. 
- Allow optional signing of the canonical payload to support verification and supply-chain style assurances for run bundles.

### Description
- Add canonical attestation generation in `RunPipelineUseCase` that normalizes config, resolved profiles/parameters, seed provenance, input content SHA-256, package versions and plugin lock state and produces canonical bytes for hashing. 
- Compute a SHA-256 `run_fingerprint` from the canonical payload and embed both `run_fingerprint` and a full `attestation` object into the run schema and into any emitted manifest. 
- Add optional signing support using existing cryptography helpers via two new artifact paths: `ArtifactOutputPolicy.attestation_private_key_path` (to sign) and `attestation_signature_path` (to write detached signature metadata). 
- Pass attestation artifact fields through the SDK YAML/mapping path so CLI/SDK requests can enable signing, update `docs/reproducibility.md` with verification commands and expected attestation schema, and add `tests/test_pipeline_reproducibility_attestation.py` to cover fingerprint stability, config-drift detection, and signature metadata emission.

### Testing
- Ran `python -m pytest tests/test_pipeline_reproducibility_attestation.py tests/test_canonical_interface_parity.py tests/test_pipeline_profile_parameters.py -q` and the targeted suites passed (all tests passed).
- Ran `python -m ruff check .` and linting passed with no new issues.
- Ran full `python -m pytest -q` which aborted during collection on a pre-existing unrelated `ImportError` in `tests/test_illumina_profile_stats.py` (no failure introduced by this change). 
- Ran `python -m mypy --follow-imports=skip src/genecoder/app/pipeline_use_case.py src/genecoder/sdk/api.py` which reported pre-existing typing/stub issues in the broader repo (third-party stubs and SDK typing); the new pipeline code does not introduce new mypy regressions under these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297d76d5908326aa7fab781c2cf4a6)